### PR TITLE
refactor(service): add auto-registration via init()

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,6 +41,7 @@ type Server struct {
 }
 
 // New creates a new server with the given configuration.
+// Services registered via init() are automatically loaded.
 func New(config Config) *Server {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: config.LogLevel,
@@ -49,12 +50,19 @@ func New(config Config) *Server {
 	registry := service.NewRegistry()
 	router := NewRouter(logger)
 
-	return &Server{
+	srv := &Server{
 		config:   config,
 		router:   router,
 		registry: registry,
 		logger:   logger,
 	}
+
+	// Auto-register services from global registry
+	for _, svc := range service.Services() {
+		srv.RegisterService(svc)
+	}
+
+	return srv
 }
 
 // Registry returns the service registry.

--- a/internal/service/registry.go
+++ b/internal/service/registry.go
@@ -4,6 +4,20 @@ import (
 	"sync"
 )
 
+// globalRegistry is the default registry for auto-registration via init().
+var globalRegistry = NewRegistry()
+
+// Register adds a service to the global registry.
+// This is typically called from init() in each service package.
+func Register(svc Service) {
+	globalRegistry.Register(svc)
+}
+
+// Services returns all services from the global registry.
+func Services() []Service {
+	return globalRegistry.All()
+}
+
 // Registry manages service registration and discovery.
 type Registry struct {
 	mu       sync.RWMutex


### PR DESCRIPTION
## Summary
- Add global registry with `Register()` and `Services()` functions
- `Server.New()` auto-registers services from global registry
- Enables services to self-register via `init()` without modifying main.go

## Usage

```go
// internal/service/s3/init.go
package s3

import "github.com/sivchari/awsim/internal/service"

func init() {
    service.Register(New(NewMemoryStorage()))
}
```

## Benefits
- **Zero conflicts**: Each service PR only modifies its own directory
- **Explicit**: Blank imports make enabled services clear at a glance
- **Testable**: Services are not registered unless imported

## Test plan
- [x] `make lint` passes
- [x] `go build ./...` passes
- [ ] CI passes