### PR TITLE
feat(sqs): add FIFO queue support

### DIFF
--- a/internal/service/sqs/handlers.go
+++ b/internal/service/sqs/handlers.go
@@ -152,7 +152,7 @@ func (s *Service) SendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	msg, err := s.storage.SendMessage(r.Context(), req.QueueURL, req.MessageBody, req.DelaySeconds, req.MessageAttributes)
+	msg, err := s.storage.SendMessage(r.Context(), req.QueueURL, req.MessageBody, req.DelaySeconds, req.MessageAttributes, req.MessageGroupID, req.MessageDeduplicationID)
 	if err != nil {
 		var qErr *QueueError
 		if errors.As(err, &qErr) {
@@ -169,6 +169,7 @@ func (s *Service) SendMessage(w http.ResponseWriter, r *http.Request) {
 	writeJSONResponse(w, SendMessageResponse{
 		MessageID:        msg.MessageID,
 		MD5OfMessageBody: msg.MD5OfBody,
+		SequenceNumber:   msg.SequenceNumber,
 	})
 }
 
@@ -227,6 +228,7 @@ func convertMessagesToResponse(messages []*Message) []MessageResponse {
 			Body:              msg.Body,
 			Attributes:        msg.Attributes,
 			MessageAttributes: msg.MessageAttributes,
+			SequenceNumber:    msg.SequenceNumber,
 		}
 	}
 

--- a/internal/service/sqs/types.go
+++ b/internal/service/sqs/types.go
@@ -7,29 +7,34 @@ import (
 
 // Queue represents an SQS queue.
 type Queue struct {
-	Name                   string
-	URL                    string
-	ARN                    string
-	CreatedTimestamp       time.Time
-	LastModifiedTimestamp  time.Time
-	VisibilityTimeout      int
-	MessageRetentionPeriod int
-	DelaySeconds           int
-	MaxMessageSize         int
-	ReceiveWaitTimeSeconds int
+	Name                      string
+	URL                       string
+	ARN                       string
+	CreatedTimestamp          time.Time
+	LastModifiedTimestamp     time.Time
+	VisibilityTimeout         int
+	MessageRetentionPeriod    int
+	DelaySeconds              int
+	MaxMessageSize            int
+	ReceiveWaitTimeSeconds    int
+	FifoQueue                 bool
+	ContentBasedDeduplication bool
 }
 
 // Message represents an SQS message.
 type Message struct {
-	MessageID         string
-	ReceiptHandle     string
-	Body              string
-	MD5OfBody         string
-	Attributes        map[string]string
-	MessageAttributes map[string]MessageAttributeValue
-	SentTimestamp     time.Time
-	VisibleAt         time.Time
-	ReceiveCount      int
+	MessageID              string
+	ReceiptHandle          string
+	Body                   string
+	MD5OfBody              string
+	Attributes             map[string]string
+	MessageAttributes      map[string]MessageAttributeValue
+	SentTimestamp          time.Time
+	VisibleAt              time.Time
+	ReceiveCount           int
+	MessageGroupID         string
+	MessageDeduplicationID string
+	SequenceNumber         string
 }
 
 // MessageAttributeValue represents a message attribute.
@@ -127,6 +132,7 @@ type MessageResponse struct {
 	Attributes             map[string]string                `json:"Attributes,omitempty"`
 	MD5OfMessageAttributes string                           `json:"MD5OfMessageAttributes,omitempty"`
 	MessageAttributes      map[string]MessageAttributeValue `json:"MessageAttributes,omitempty"`
+	SequenceNumber         string                           `json:"SequenceNumber,omitempty"`
 }
 
 // DeleteMessageRequest is the request for DeleteMessage.


### PR DESCRIPTION
## Summary

- Add FIFO queue support for SQS service (Issue #10)
- Implement `.fifo` suffix validation for queue names
- Add MessageGroupId requirement for FIFO queues
- Implement MessageDeduplicationId with 5-minute deduplication window
- Support ContentBasedDeduplication using SHA-256 hash
- Generate and return SequenceNumber for FIFO messages

## Changes

### types.go
- Add `FifoQueue` and `ContentBasedDeduplication` fields to `Queue` struct
- Add `MessageGroupID`, `MessageDeduplicationID`, `SequenceNumber` fields to `Message` struct
- Add `SequenceNumber` to `MessageResponse` struct

### storage.go
- Add `deduplicationEntry` type for tracking message deduplication
- Add `deduplicationCache` and `sequenceCounter` to `queueData`
- Implement FIFO validation in `CreateQueue` (`.fifo` suffix required)
- Implement `validateFIFO` helper for deduplication logic
- Update `SendMessage` to handle FIFO parameters
- Update `GetQueueAttributes` to return FIFO attributes

### handlers.go
- Pass `MessageGroupID` and `MessageDeduplicationID` to storage
- Include `SequenceNumber` in `SendMessageResponse` and `MessageResponse`

### test/integration/sqs_test.go
- Add `TestSQS_FIFOQueue_CreateAndSendMessage`
- Add `TestSQS_FIFOQueue_GetAttributes`
- Add `TestSQS_FIFOQueue_MissingMessageGroupId`
- Add `TestSQS_FIFOQueue_ExplicitDeduplicationId`
- Add `TestSQS_FIFOQueue_MissingDeduplicationId`

## Test plan

- [x] Unit build passes
- [x] Lint passes
- [ ] Integration tests pass (requires running awsim server)

Closes #10