### PR TITLE
feat(s3): add multipart upload support

### DIFF
--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -39,12 +39,13 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("DELETE", "/{bucket}", s.DeleteBucket)
 	r.Handle("HEAD", "/{bucket}", s.HeadBucket)
 
-	// Object list (must be before object operations to handle query params)
+	// Bucket-level GET handles ListObjects, ListMultipartUploads, versioning queries
 	r.Handle("GET", "/{bucket}", s.handleBucketGet)
 
-	// Object operations
-	r.Handle("PUT", "/{bucket}/{key...}", s.PutObject)
-	r.Handle("GET", "/{bucket}/{key...}", s.GetObject)
-	r.Handle("DELETE", "/{bucket}/{key...}", s.DeleteObject)
+	// Object operations with multipart upload support
+	r.Handle("PUT", "/{bucket}/{key...}", s.handleObjectPut)
+	r.Handle("GET", "/{bucket}/{key...}", s.handleObjectGet)
+	r.Handle("DELETE", "/{bucket}/{key...}", s.handleObjectDelete)
 	r.Handle("HEAD", "/{bucket}/{key...}", s.HeadObject)
+	r.Handle("POST", "/{bucket}/{key...}", s.handleObjectPost)
 }

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -139,3 +139,106 @@ type DeleteMarkerInfo struct {
 	LastModified string `xml:"LastModified"`
 	Owner        Owner  `xml:"Owner"`
 }
+
+// Multipart Upload Types
+
+// MultipartUpload represents an in-progress multipart upload.
+type MultipartUpload struct {
+	Bucket    string
+	Key       string
+	UploadID  string
+	Initiated time.Time
+	Parts     map[int]*Part // partNumber -> Part
+}
+
+// Part represents a part in a multipart upload.
+type Part struct {
+	PartNumber   int
+	ETag         string
+	Size         int64
+	LastModified time.Time
+	Body         []byte
+}
+
+// InitiateMultipartUploadResult is the response for CreateMultipartUpload.
+type InitiateMultipartUploadResult struct {
+	XMLName  xml.Name `xml:"InitiateMultipartUploadResult"`
+	Xmlns    string   `xml:"xmlns,attr"`
+	Bucket   string   `xml:"Bucket"`
+	Key      string   `xml:"Key"`
+	UploadID string   `xml:"UploadId"`
+}
+
+// CompleteMultipartUploadRequest is the request body for CompleteMultipartUpload.
+type CompleteMultipartUploadRequest struct {
+	XMLName xml.Name      `xml:"CompleteMultipartUpload"`
+	Parts   []PartRequest `xml:"Part"`
+}
+
+// PartRequest represents a part in the complete request.
+type PartRequest struct {
+	PartNumber int    `xml:"PartNumber"`
+	ETag       string `xml:"ETag"`
+}
+
+// CompleteMultipartUploadResult is the response for CompleteMultipartUpload.
+type CompleteMultipartUploadResult struct {
+	XMLName  xml.Name `xml:"CompleteMultipartUploadResult"`
+	Xmlns    string   `xml:"xmlns,attr"`
+	Location string   `xml:"Location"`
+	Bucket   string   `xml:"Bucket"`
+	Key      string   `xml:"Key"`
+	ETag     string   `xml:"ETag"`
+}
+
+// ListMultipartUploadsResult is the response for ListMultipartUploads.
+type ListMultipartUploadsResult struct {
+	XMLName            xml.Name       `xml:"ListMultipartUploadsResult"`
+	Xmlns              string         `xml:"xmlns,attr"`
+	Bucket             string         `xml:"Bucket"`
+	KeyMarker          string         `xml:"KeyMarker,omitempty"`
+	UploadIDMarker     string         `xml:"UploadIdMarker,omitempty"`
+	NextKeyMarker      string         `xml:"NextKeyMarker,omitempty"`
+	NextUploadIDMarker string         `xml:"NextUploadIdMarker,omitempty"`
+	MaxUploads         int            `xml:"MaxUploads"`
+	IsTruncated        bool           `xml:"IsTruncated"`
+	Uploads            []UploadInfo   `xml:"Upload"`
+	CommonPrefixes     []CommonPrefix `xml:"CommonPrefixes,omitempty"`
+}
+
+// UploadInfo represents a multipart upload in the list response.
+type UploadInfo struct {
+	Key       string `xml:"Key"`
+	UploadID  string `xml:"UploadId"`
+	Initiated string `xml:"Initiated"`
+}
+
+// ListPartsResult is the response for ListParts.
+type ListPartsResult struct {
+	XMLName              xml.Name   `xml:"ListPartsResult"`
+	Xmlns                string     `xml:"xmlns,attr"`
+	Bucket               string     `xml:"Bucket"`
+	Key                  string     `xml:"Key"`
+	UploadID             string     `xml:"UploadId"`
+	PartNumberMarker     int        `xml:"PartNumberMarker"`
+	NextPartNumberMarker int        `xml:"NextPartNumberMarker"`
+	MaxParts             int        `xml:"MaxParts"`
+	IsTruncated          bool       `xml:"IsTruncated"`
+	Parts                []PartInfo `xml:"Part"`
+}
+
+// PartInfo represents a part in the list parts response.
+type PartInfo struct {
+	PartNumber   int    `xml:"PartNumber"`
+	LastModified string `xml:"LastModified"`
+	ETag         string `xml:"ETag"`
+	Size         int64  `xml:"Size"`
+}
+
+// CopyPartResult is the response for UploadPartCopy.
+type CopyPartResult struct {
+	XMLName      xml.Name `xml:"CopyPartResult"`
+	Xmlns        string   `xml:"xmlns,attr"`
+	LastModified string   `xml:"LastModified"`
+	ETag         string   `xml:"ETag"`
+}


### PR DESCRIPTION
## Summary

Implement S3 Multipart Upload APIs to support uploading large files in parts.

## Changes

### APIs Implemented
- **CreateMultipartUpload**: Initiate a multipart upload and get upload ID
- **UploadPart**: Upload a single part (part number 1-10000)
- **CompleteMultipartUpload**: Complete upload by assembling parts
- **AbortMultipartUpload**: Cancel an in-progress upload
- **ListMultipartUploads**: List in-progress uploads in a bucket
- **ListParts**: List uploaded parts for a multipart upload

### Implementation Details
- Add multipart upload types (MultipartUpload, Part, PartRequest)
- Add XML response types for all 6 APIs
- Implement in-memory storage with multipart upload tracking
- Add route dispatchers to handle query parameter-based routing
  - `?uploads` → CreateMultipartUpload
  - `?uploadId=X&partNumber=Y` → UploadPart
  - `?uploadId=X` (POST) → CompleteMultipartUpload
  - `?uploadId=X` (DELETE) → AbortMultipartUpload
  - `?uploads` (GET bucket) → ListMultipartUploads
  - `?uploadId=X` (GET object) → ListParts
- Calculate multipart ETag as `MD5-of-MD5s-N` format
- Add 4 comprehensive integration tests

### Files Changed
- `internal/service/s3/types.go`: +103 lines (multipart types)
- `internal/service/s3/storage.go`: +294 lines (storage implementation)
- `internal/service/s3/handlers.go`: +382 lines (handlers + dispatchers)
- `internal/service/s3/service.go`: +13 lines (route registration)
- `test/integration/s3_test.go`: +323 lines (4 tests)

## Testing

All integration tests pass:
- ✅ TestS3_MultipartUpload_BasicFlow (10MB upload in 2 parts)
- ✅ TestS3_MultipartUpload_AbortUpload (abort verification)
- ✅ TestS3_MultipartUpload_ListMultipartUploads (list in-progress)
- ✅ TestS3_MultipartUpload_ListParts (list uploaded parts)
- ✅ All existing S3 tests still pass

## Closes

Closes #3