### PR TITLE
feat(glue): add basic Glue service implementation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -129,6 +129,10 @@ linters:
       - path: internal/service/acm/types\.go
         linters:
           - tagliatelle
+      # AWS Glue API requires PascalCase JSON field names.
+      - path: internal/service/glue/types\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/eks"
 	_ "github.com/sivchari/awsim/internal/service/eventbridge"
 	_ "github.com/sivchari/awsim/internal/service/globalaccelerator"
+	_ "github.com/sivchari/awsim/internal/service/glue"
 	_ "github.com/sivchari/awsim/internal/service/iam"
 	_ "github.com/sivchari/awsim/internal/service/kinesis"
 	_ "github.com/sivchari/awsim/internal/service/kms"

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.80.0
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.18
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.35.11
+	github.com/aws/aws-sdk-go-v2/service/glue v1.137.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.2
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/kms v1.49.5

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.18 h1:Zqe/Mbpjy3Vk0IKreW4
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.18/go.mod h1:oGNgLQOntNCt7Tl3d1NQu5QKFxdufg4huUAmyNECPDU=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.35.11 h1:4eqAOfI1HxSdRcJ6k9+0yBRvkyAqf7bIN1QoJY9Jql0=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.35.11/go.mod h1:Hzu4FMuPwTHEigK/DAFx2cOTNqRKFmIm+YQiOcmI7oA=
+github.com/aws/aws-sdk-go-v2/service/glue v1.137.0 h1:gPQ3FlHOFQELCiNSc76CS9B1G7wBT73PktKG64Q3tRc=
+github.com/aws/aws-sdk-go-v2/service/glue v1.137.0/go.mod h1:B6g7dsUUg4QUcH6zou32L1LDXjgtk/YjVFcu09jXv10=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.2 h1:62G6btFUwAa5uR5iPlnlNVAM0zJSLbWgDfKOfUC7oW4=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.2/go.mod h1:av9clChrbZbJ5E21msSsiT2oghl2BJHfQGhCkXmhyu8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 h1:0ryTNEdJbzUCEWkVXEXoqlXV72J5keC1GvILMOuD00E=

--- a/internal/service/glue/handlers.go
+++ b/internal/service/glue/handlers.go
@@ -1,0 +1,476 @@
+package glue
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// handleRequest routes Glue requests based on the X-Amz-Target header.
+func (s *Service) handleRequest(w http.ResponseWriter, r *http.Request) {
+	target := r.Header.Get("X-Amz-Target")
+	if target == "" {
+		writeError(w, errInvalidInput, "Missing X-Amz-Target header", http.StatusBadRequest)
+
+		return
+	}
+
+	// Extract operation from target (e.g., "AWSGlue.CreateDatabase").
+	parts := strings.Split(target, ".")
+	if len(parts) != 2 {
+		writeError(w, errInvalidInput, "Invalid X-Amz-Target header", http.StatusBadRequest)
+
+		return
+	}
+
+	operation := parts[1]
+
+	switch operation {
+	case "CreateDatabase":
+		s.CreateDatabase(w, r)
+	case "GetDatabase":
+		s.GetDatabase(w, r)
+	case "GetDatabases":
+		s.GetDatabases(w, r)
+	case "DeleteDatabase":
+		s.DeleteDatabase(w, r)
+	case "CreateTable":
+		s.CreateTable(w, r)
+	case "GetTable":
+		s.GetTable(w, r)
+	case "GetTables":
+		s.GetTables(w, r)
+	case "DeleteTable":
+		s.DeleteTable(w, r)
+	case "CreateJob":
+		s.CreateJob(w, r)
+	case "DeleteJob":
+		s.DeleteJob(w, r)
+	case "StartJobRun":
+		s.StartJobRun(w, r)
+	default:
+		writeError(w, errInvalidInput, fmt.Sprintf("Unknown operation: %s", operation), http.StatusBadRequest)
+	}
+}
+
+// CreateDatabase handles the CreateDatabase operation.
+func (s *Service) CreateDatabase(w http.ResponseWriter, r *http.Request) {
+	var req CreateDatabaseInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DatabaseInput == nil {
+		writeError(w, errInvalidInput, "DatabaseInput is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.CreateDatabase(r.Context(), req.CatalogID, req.DatabaseInput); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, struct{}{})
+}
+
+// GetDatabase handles the GetDatabase operation.
+func (s *Service) GetDatabase(w http.ResponseWriter, r *http.Request) {
+	var req GetDatabaseInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Name == "" {
+		writeError(w, errInvalidInput, "Name is required", http.StatusBadRequest)
+
+		return
+	}
+
+	db, err := s.storage.GetDatabase(r.Context(), req.CatalogID, req.Name)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	createTime := db.CreateTime
+	writeJSONResponse(w, GetDatabaseOutput{
+		Database: &DatabaseResponse{
+			Name:            db.Name,
+			Description:     db.Description,
+			LocationURI:     db.LocationURI,
+			Parameters:      db.Parameters,
+			CreateTime:      &createTime,
+			CatalogID:       db.CatalogID,
+			CreateTableMode: db.CreateTableMode,
+		},
+	})
+}
+
+// GetDatabases handles the GetDatabases operation.
+func (s *Service) GetDatabases(w http.ResponseWriter, r *http.Request) {
+	var req GetDatabasesInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	databases, nextToken, err := s.storage.GetDatabases(r.Context(), req.CatalogID, req.MaxResults, req.NextToken)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	dbResponses := make([]*DatabaseResponse, 0, len(databases))
+
+	for _, db := range databases {
+		createTime := db.CreateTime
+		dbResponses = append(dbResponses, &DatabaseResponse{
+			Name:            db.Name,
+			Description:     db.Description,
+			LocationURI:     db.LocationURI,
+			Parameters:      db.Parameters,
+			CreateTime:      &createTime,
+			CatalogID:       db.CatalogID,
+			CreateTableMode: db.CreateTableMode,
+		})
+	}
+
+	writeJSONResponse(w, GetDatabasesOutput{
+		DatabaseList: dbResponses,
+		NextToken:    nextToken,
+	})
+}
+
+// DeleteDatabase handles the DeleteDatabase operation.
+func (s *Service) DeleteDatabase(w http.ResponseWriter, r *http.Request) {
+	var req DeleteDatabaseInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Name == "" {
+		writeError(w, errInvalidInput, "Name is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteDatabase(r.Context(), req.CatalogID, req.Name); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, struct{}{})
+}
+
+// CreateTable handles the CreateTable operation.
+func (s *Service) CreateTable(w http.ResponseWriter, r *http.Request) {
+	var req CreateTableInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DatabaseName == "" {
+		writeError(w, errInvalidInput, "DatabaseName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.TableInput == nil {
+		writeError(w, errInvalidInput, "TableInput is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.CreateTable(r.Context(), req.CatalogID, req.DatabaseName, req.TableInput); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, struct{}{})
+}
+
+// GetTable handles the GetTable operation.
+func (s *Service) GetTable(w http.ResponseWriter, r *http.Request) {
+	var req GetTableInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DatabaseName == "" {
+		writeError(w, errInvalidInput, "DatabaseName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Name == "" {
+		writeError(w, errInvalidInput, "Name is required", http.StatusBadRequest)
+
+		return
+	}
+
+	table, err := s.storage.GetTable(r.Context(), req.CatalogID, req.DatabaseName, req.Name)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	createTime := table.CreateTime
+	updateTime := table.UpdateTime
+	writeJSONResponse(w, GetTableOutput{
+		Table: &TableResponse{
+			Name:              table.Name,
+			DatabaseName:      table.DatabaseName,
+			Description:       table.Description,
+			Owner:             table.Owner,
+			CreateTime:        &createTime,
+			UpdateTime:        &updateTime,
+			LastAccessTime:    table.LastAccessTime,
+			LastAnalyzedTime:  table.LastAnalyzedTime,
+			Retention:         table.Retention,
+			StorageDescriptor: table.StorageDescriptor,
+			PartitionKeys:     table.PartitionKeys,
+			ViewOriginalText:  table.ViewOriginalText,
+			ViewExpandedText:  table.ViewExpandedText,
+			TableType:         table.TableType,
+			Parameters:        table.Parameters,
+			CatalogID:         table.CatalogID,
+		},
+	})
+}
+
+// GetTables handles the GetTables operation.
+func (s *Service) GetTables(w http.ResponseWriter, r *http.Request) {
+	var req GetTablesInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DatabaseName == "" {
+		writeError(w, errInvalidInput, "DatabaseName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	tables, nextToken, err := s.storage.GetTables(r.Context(), req.CatalogID, req.DatabaseName, req.MaxResults, req.NextToken)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	tableResponses := make([]*TableResponse, 0, len(tables))
+
+	for _, table := range tables {
+		createTime := table.CreateTime
+		updateTime := table.UpdateTime
+		tableResponses = append(tableResponses, &TableResponse{
+			Name:              table.Name,
+			DatabaseName:      table.DatabaseName,
+			Description:       table.Description,
+			Owner:             table.Owner,
+			CreateTime:        &createTime,
+			UpdateTime:        &updateTime,
+			LastAccessTime:    table.LastAccessTime,
+			LastAnalyzedTime:  table.LastAnalyzedTime,
+			Retention:         table.Retention,
+			StorageDescriptor: table.StorageDescriptor,
+			PartitionKeys:     table.PartitionKeys,
+			ViewOriginalText:  table.ViewOriginalText,
+			ViewExpandedText:  table.ViewExpandedText,
+			TableType:         table.TableType,
+			Parameters:        table.Parameters,
+			CatalogID:         table.CatalogID,
+		})
+	}
+
+	writeJSONResponse(w, GetTablesOutput{
+		TableList: tableResponses,
+		NextToken: nextToken,
+	})
+}
+
+// DeleteTable handles the DeleteTable operation.
+func (s *Service) DeleteTable(w http.ResponseWriter, r *http.Request) {
+	var req DeleteTableInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DatabaseName == "" {
+		writeError(w, errInvalidInput, "DatabaseName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Name == "" {
+		writeError(w, errInvalidInput, "Name is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteTable(r.Context(), req.CatalogID, req.DatabaseName, req.Name); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, struct{}{})
+}
+
+// CreateJob handles the CreateJob operation.
+func (s *Service) CreateJob(w http.ResponseWriter, r *http.Request) {
+	var req CreateJobInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	job, err := s.storage.CreateJob(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, CreateJobOutput{
+		Name: job.Name,
+	})
+}
+
+// DeleteJob handles the DeleteJob operation.
+func (s *Service) DeleteJob(w http.ResponseWriter, r *http.Request) {
+	var req DeleteJobInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.JobName == "" {
+		writeError(w, errInvalidInput, "JobName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteJob(r.Context(), req.JobName); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, DeleteJobOutput(req))
+}
+
+// StartJobRun handles the StartJobRun operation.
+func (s *Service) StartJobRun(w http.ResponseWriter, r *http.Request) {
+	var req StartJobRunInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.JobName == "" {
+		writeError(w, errInvalidInput, "JobName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	jobRun, err := s.storage.StartJobRun(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, StartJobRunOutput{
+		JobRunID: jobRun.ID,
+	})
+}
+
+// Helper functions.
+
+// readJSONRequest reads and decodes JSON request body.
+func readJSONRequest(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return nil
+}
+
+// writeJSONResponse writes a JSON response with HTTP 200 OK.
+func writeJSONResponse(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+
+	if v != nil {
+		_ = json.NewEncoder(w).Encode(v)
+	}
+}
+
+// writeError writes an error response.
+func writeError(w http.ResponseWriter, code, message string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{
+		Type:    code,
+		Message: message,
+	})
+}
+
+// handleStorageError handles storage errors and writes appropriate response.
+func handleStorageError(w http.ResponseWriter, err error) {
+	var glueErr *Error
+	if errors.As(err, &glueErr) {
+		status := http.StatusBadRequest
+		if glueErr.Code == errEntityNotFound {
+			status = http.StatusNotFound
+		}
+
+		writeError(w, glueErr.Code, glueErr.Message, status)
+
+		return
+	}
+
+	writeError(w, "InternalServiceError", "Internal server error", http.StatusInternalServerError)
+}

--- a/internal/service/glue/service.go
+++ b/internal/service/glue/service.go
@@ -1,0 +1,38 @@
+package glue
+
+import (
+	"github.com/sivchari/awsim/internal/service"
+)
+
+func init() {
+	service.Register(New(NewMemoryStorage()))
+}
+
+// Service implements the Glue service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new Glue service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "glue"
+}
+
+// Prefix returns the URL prefix for this service.
+func (s *Service) Prefix() string {
+	return ""
+}
+
+// RegisterRoutes registers the Glue routes.
+// Glue uses AWS JSON 1.1 protocol with X-Amz-Target header.
+func (s *Service) RegisterRoutes(r service.Router) {
+	// Glue uses POST requests with X-Amz-Target header for all operations.
+	r.HandleFunc("POST", "/", s.handleRequest)
+}

--- a/internal/service/glue/storage.go
+++ b/internal/service/glue/storage.go
@@ -1,0 +1,400 @@
+package glue
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Error codes.
+const (
+	errEntityNotFound = "EntityNotFoundException"
+	errAlreadyExists  = "AlreadyExistsException"
+	errInvalidInput   = "InvalidInputException"
+)
+
+const defaultCatalogID = "default"
+
+// Storage defines the interface for Glue storage operations.
+type Storage interface {
+	CreateDatabase(ctx context.Context, catalogID string, input *DatabaseInput) error
+	GetDatabase(ctx context.Context, catalogID, name string) (*Database, error)
+	GetDatabases(ctx context.Context, catalogID string, maxResults int32, nextToken string) ([]*Database, string, error)
+	DeleteDatabase(ctx context.Context, catalogID, name string) error
+
+	CreateTable(ctx context.Context, catalogID, databaseName string, input *TableInput) error
+	GetTable(ctx context.Context, catalogID, databaseName, name string) (*Table, error)
+	GetTables(ctx context.Context, catalogID, databaseName string, maxResults int32, nextToken string) ([]*Table, string, error)
+	DeleteTable(ctx context.Context, catalogID, databaseName, name string) error
+
+	CreateJob(ctx context.Context, input *CreateJobInput) (*Job, error)
+	DeleteJob(ctx context.Context, jobName string) error
+	StartJobRun(ctx context.Context, input *StartJobRunInput) (*JobRun, error)
+}
+
+// MemoryStorage implements Storage with in-memory data structures.
+type MemoryStorage struct {
+	mu        sync.RWMutex
+	databases map[string]*Database // key: catalogID/databaseName
+	tables    map[string]*Table    // key: catalogID/databaseName/tableName
+	jobs      map[string]*Job      // key: jobName
+	jobRuns   map[string]*JobRun   // key: jobRunID
+}
+
+// NewMemoryStorage creates a new in-memory storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		databases: make(map[string]*Database),
+		tables:    make(map[string]*Table),
+		jobs:      make(map[string]*Job),
+		jobRuns:   make(map[string]*JobRun),
+	}
+}
+
+func databaseKey(catalogID, name string) string {
+	if catalogID == "" {
+		catalogID = defaultCatalogID
+	}
+
+	return catalogID + "/" + name
+}
+
+func tableKey(catalogID, databaseName, tableName string) string {
+	if catalogID == "" {
+		catalogID = defaultCatalogID
+	}
+
+	return catalogID + "/" + databaseName + "/" + tableName
+}
+
+// CreateDatabase creates a new database.
+func (s *MemoryStorage) CreateDatabase(_ context.Context, catalogID string, input *DatabaseInput) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if input.Name == "" {
+		return &Error{
+			Code:    errInvalidInput,
+			Message: "Database name is required",
+		}
+	}
+
+	key := databaseKey(catalogID, input.Name)
+
+	if _, exists := s.databases[key]; exists {
+		return &Error{
+			Code:    errAlreadyExists,
+			Message: fmt.Sprintf("Database %s already exists", input.Name),
+		}
+	}
+
+	db := &Database{
+		Name:            input.Name,
+		Description:     input.Description,
+		LocationURI:     input.LocationURI,
+		Parameters:      input.Parameters,
+		CreateTime:      time.Now(),
+		CatalogID:       catalogID,
+		CreateTableMode: input.CreateTableMode,
+	}
+
+	s.databases[key] = db
+
+	return nil
+}
+
+// GetDatabase retrieves a database.
+func (s *MemoryStorage) GetDatabase(_ context.Context, catalogID, name string) (*Database, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := databaseKey(catalogID, name)
+	db, exists := s.databases[key]
+
+	if !exists {
+		return nil, &Error{
+			Code:    errEntityNotFound,
+			Message: fmt.Sprintf("Database %s not found", name),
+		}
+	}
+
+	return db, nil
+}
+
+// GetDatabases lists all databases.
+func (s *MemoryStorage) GetDatabases(_ context.Context, catalogID string, maxResults int32, _ string) ([]*Database, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults <= 0 {
+		maxResults = 100
+	}
+
+	if catalogID == "" {
+		catalogID = defaultCatalogID
+	}
+
+	prefix := catalogID + "/"
+	databases := make([]*Database, 0)
+
+	for key, db := range s.databases {
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			databases = append(databases, db)
+
+			if len(databases) >= int(maxResults) {
+				break
+			}
+		}
+	}
+
+	return databases, "", nil
+}
+
+// DeleteDatabase deletes a database.
+func (s *MemoryStorage) DeleteDatabase(_ context.Context, catalogID, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := databaseKey(catalogID, name)
+
+	if _, exists := s.databases[key]; !exists {
+		return &Error{
+			Code:    errEntityNotFound,
+			Message: fmt.Sprintf("Database %s not found", name),
+		}
+	}
+
+	delete(s.databases, key)
+
+	return nil
+}
+
+// CreateTable creates a new table.
+func (s *MemoryStorage) CreateTable(_ context.Context, catalogID, databaseName string, input *TableInput) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if input.Name == "" {
+		return &Error{
+			Code:    errInvalidInput,
+			Message: "Table name is required",
+		}
+	}
+
+	// Check if database exists.
+	dbKey := databaseKey(catalogID, databaseName)
+	if _, exists := s.databases[dbKey]; !exists {
+		return &Error{
+			Code:    errEntityNotFound,
+			Message: fmt.Sprintf("Database %s not found", databaseName),
+		}
+	}
+
+	key := tableKey(catalogID, databaseName, input.Name)
+
+	if _, exists := s.tables[key]; exists {
+		return &Error{
+			Code:    errAlreadyExists,
+			Message: fmt.Sprintf("Table %s already exists", input.Name),
+		}
+	}
+
+	now := time.Now()
+	table := &Table{
+		Name:              input.Name,
+		DatabaseName:      databaseName,
+		Description:       input.Description,
+		Owner:             input.Owner,
+		CreateTime:        now,
+		UpdateTime:        now,
+		Retention:         input.Retention,
+		StorageDescriptor: input.StorageDescriptor,
+		PartitionKeys:     input.PartitionKeys,
+		ViewOriginalText:  input.ViewOriginalText,
+		ViewExpandedText:  input.ViewExpandedText,
+		TableType:         input.TableType,
+		Parameters:        input.Parameters,
+		CatalogID:         catalogID,
+	}
+
+	s.tables[key] = table
+
+	return nil
+}
+
+// GetTable retrieves a table.
+func (s *MemoryStorage) GetTable(_ context.Context, catalogID, databaseName, name string) (*Table, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := tableKey(catalogID, databaseName, name)
+	table, exists := s.tables[key]
+
+	if !exists {
+		return nil, &Error{
+			Code:    errEntityNotFound,
+			Message: fmt.Sprintf("Table %s not found", name),
+		}
+	}
+
+	return table, nil
+}
+
+// GetTables lists tables in a database.
+func (s *MemoryStorage) GetTables(_ context.Context, catalogID, databaseName string, maxResults int32, _ string) ([]*Table, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults <= 0 {
+		maxResults = 100
+	}
+
+	if catalogID == "" {
+		catalogID = defaultCatalogID
+	}
+
+	prefix := catalogID + "/" + databaseName + "/"
+	tables := make([]*Table, 0)
+
+	for key, table := range s.tables {
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			tables = append(tables, table)
+
+			if len(tables) >= int(maxResults) {
+				break
+			}
+		}
+	}
+
+	return tables, "", nil
+}
+
+// DeleteTable deletes a table.
+func (s *MemoryStorage) DeleteTable(_ context.Context, catalogID, databaseName, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := tableKey(catalogID, databaseName, name)
+
+	if _, exists := s.tables[key]; !exists {
+		return &Error{
+			Code:    errEntityNotFound,
+			Message: fmt.Sprintf("Table %s not found", name),
+		}
+	}
+
+	delete(s.tables, key)
+
+	return nil
+}
+
+// CreateJob creates a new job.
+func (s *MemoryStorage) CreateJob(_ context.Context, input *CreateJobInput) (*Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if input.Name == "" {
+		return nil, &Error{
+			Code:    errInvalidInput,
+			Message: "Job name is required",
+		}
+	}
+
+	if input.Role == "" {
+		return nil, &Error{
+			Code:    errInvalidInput,
+			Message: "Role is required",
+		}
+	}
+
+	if _, exists := s.jobs[input.Name]; exists {
+		return nil, &Error{
+			Code:    errAlreadyExists,
+			Message: fmt.Sprintf("Job %s already exists", input.Name),
+		}
+	}
+
+	now := time.Now()
+	job := &Job{
+		Name:                    input.Name,
+		Description:             input.Description,
+		Role:                    input.Role,
+		Command:                 input.Command,
+		DefaultArguments:        input.DefaultArguments,
+		NonOverridableArguments: input.NonOverridableArguments,
+		MaxRetries:              input.MaxRetries,
+		AllocatedCapacity:       input.AllocatedCapacity,
+		Timeout:                 input.Timeout,
+		MaxCapacity:             input.MaxCapacity,
+		WorkerType:              input.WorkerType,
+		NumberOfWorkers:         input.NumberOfWorkers,
+		GlueVersion:             input.GlueVersion,
+		CreatedOn:               now,
+		LastModifiedOn:          now,
+		ExecutionProperty:       input.ExecutionProperty,
+	}
+
+	s.jobs[input.Name] = job
+
+	return job, nil
+}
+
+// DeleteJob deletes a job.
+func (s *MemoryStorage) DeleteJob(_ context.Context, jobName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.jobs[jobName]; !exists {
+		return &Error{
+			Code:    errEntityNotFound,
+			Message: fmt.Sprintf("Job %s not found", jobName),
+		}
+	}
+
+	delete(s.jobs, jobName)
+
+	return nil
+}
+
+// StartJobRun starts a job run.
+func (s *MemoryStorage) StartJobRun(_ context.Context, input *StartJobRunInput) (*JobRun, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	job, exists := s.jobs[input.JobName]
+	if !exists {
+		return nil, &Error{
+			Code:    errEntityNotFound,
+			Message: fmt.Sprintf("Job %s not found", input.JobName),
+		}
+	}
+
+	runID := input.JobRunID
+	if runID == "" {
+		runID = "jr_" + uuid.New().String()
+	}
+
+	now := time.Now()
+	jobRun := &JobRun{
+		ID:                runID,
+		Attempt:           0,
+		JobName:           input.JobName,
+		StartedOn:         now,
+		LastModifiedOn:    now,
+		JobRunState:       "RUNNING",
+		Arguments:         input.Arguments,
+		AllocatedCapacity: input.AllocatedCapacity,
+		Timeout:           input.Timeout,
+		MaxCapacity:       input.MaxCapacity,
+		WorkerType:        input.WorkerType,
+		NumberOfWorkers:   input.NumberOfWorkers,
+		GlueVersion:       job.GlueVersion,
+	}
+
+	s.jobRuns[runID] = jobRun
+
+	return jobRun, nil
+}

--- a/internal/service/glue/types.go
+++ b/internal/service/glue/types.go
@@ -1,0 +1,337 @@
+// Package glue provides AWS Glue service emulation for awsim.
+package glue
+
+import "time"
+
+// Database represents a Glue database.
+type Database struct {
+	Name            string
+	Description     string
+	LocationURI     string
+	Parameters      map[string]string
+	CreateTime      time.Time
+	CatalogID       string
+	CreateTableMode string
+}
+
+// DatabaseInput represents input for creating/updating a database.
+type DatabaseInput struct {
+	Name            string            `json:"Name"`
+	Description     string            `json:"Description,omitempty"`
+	LocationURI     string            `json:"LocationUri,omitempty"`
+	Parameters      map[string]string `json:"Parameters,omitempty"`
+	CreateTableMode string            `json:"CreateTableDefaultPermissions,omitempty"`
+}
+
+// Table represents a Glue table.
+type Table struct {
+	Name              string
+	DatabaseName      string
+	Description       string
+	Owner             string
+	CreateTime        time.Time
+	UpdateTime        time.Time
+	LastAccessTime    *time.Time
+	LastAnalyzedTime  *time.Time
+	Retention         int32
+	StorageDescriptor *StorageDescriptor
+	PartitionKeys     []Column
+	ViewOriginalText  string
+	ViewExpandedText  string
+	TableType         string
+	Parameters        map[string]string
+	CatalogID         string
+}
+
+// TableInput represents input for creating/updating a table.
+type TableInput struct {
+	Name              string             `json:"Name"`
+	Description       string             `json:"Description,omitempty"`
+	Owner             string             `json:"Owner,omitempty"`
+	Retention         int32              `json:"Retention,omitempty"`
+	StorageDescriptor *StorageDescriptor `json:"StorageDescriptor,omitempty"`
+	PartitionKeys     []Column           `json:"PartitionKeys,omitempty"`
+	ViewOriginalText  string             `json:"ViewOriginalText,omitempty"`
+	ViewExpandedText  string             `json:"ViewExpandedText,omitempty"`
+	TableType         string             `json:"TableType,omitempty"`
+	Parameters        map[string]string  `json:"Parameters,omitempty"`
+}
+
+// StorageDescriptor describes the physical storage of table data.
+type StorageDescriptor struct {
+	Columns                []Column          `json:"Columns,omitempty"`
+	Location               string            `json:"Location,omitempty"`
+	InputFormat            string            `json:"InputFormat,omitempty"`
+	OutputFormat           string            `json:"OutputFormat,omitempty"`
+	Compressed             bool              `json:"Compressed,omitempty"`
+	NumberOfBuckets        int32             `json:"NumberOfBuckets,omitempty"`
+	SerdeInfo              *SerDeInfo        `json:"SerdeInfo,omitempty"`
+	BucketColumns          []string          `json:"BucketColumns,omitempty"`
+	SortColumns            []SortColumn      `json:"SortColumns,omitempty"`
+	Parameters             map[string]string `json:"Parameters,omitempty"`
+	StoredAsSubDirectories bool              `json:"StoredAsSubDirectories,omitempty"`
+}
+
+// Column represents a column in a table.
+type Column struct {
+	Name       string            `json:"Name"`
+	Type       string            `json:"Type,omitempty"`
+	Comment    string            `json:"Comment,omitempty"`
+	Parameters map[string]string `json:"Parameters,omitempty"`
+}
+
+// SerDeInfo contains serialization/deserialization information.
+type SerDeInfo struct {
+	Name                 string            `json:"Name,omitempty"`
+	SerializationLibrary string            `json:"SerializationLibrary,omitempty"`
+	Parameters           map[string]string `json:"Parameters,omitempty"`
+}
+
+// SortColumn specifies a column for sorting.
+type SortColumn struct {
+	Column    string `json:"Column"`
+	SortOrder int32  `json:"SortOrder"`
+}
+
+// Job represents a Glue job.
+type Job struct {
+	Name                    string
+	Description             string
+	Role                    string
+	Command                 *JobCommand
+	DefaultArguments        map[string]string
+	NonOverridableArguments map[string]string
+	MaxRetries              int32
+	AllocatedCapacity       int32
+	Timeout                 int32
+	MaxCapacity             float64
+	WorkerType              string
+	NumberOfWorkers         int32
+	GlueVersion             string
+	CreatedOn               time.Time
+	LastModifiedOn          time.Time
+	ExecutionProperty       *ExecutionProperty
+}
+
+// JobCommand specifies the job command.
+type JobCommand struct {
+	Name           string `json:"Name,omitempty"`
+	ScriptLocation string `json:"ScriptLocation,omitempty"`
+	PythonVersion  string `json:"PythonVersion,omitempty"`
+	Runtime        string `json:"Runtime,omitempty"`
+}
+
+// ExecutionProperty specifies execution properties.
+type ExecutionProperty struct {
+	MaxConcurrentRuns int32 `json:"MaxConcurrentRuns,omitempty"`
+}
+
+// JobRun represents a job run.
+type JobRun struct {
+	ID                string
+	Attempt           int32
+	PreviousRunID     string
+	TriggerName       string
+	JobName           string
+	StartedOn         time.Time
+	LastModifiedOn    time.Time
+	CompletedOn       *time.Time
+	JobRunState       string
+	Arguments         map[string]string
+	ErrorMessage      string
+	PredecessorRuns   []Predecessor
+	AllocatedCapacity int32
+	ExecutionTime     int32
+	Timeout           int32
+	MaxCapacity       float64
+	WorkerType        string
+	NumberOfWorkers   int32
+	GlueVersion       string
+}
+
+// Predecessor represents a predecessor job run.
+type Predecessor struct {
+	JobName string `json:"JobName,omitempty"`
+	RunID   string `json:"RunId,omitempty"`
+}
+
+// CreateDatabaseInput is the request for CreateDatabase.
+type CreateDatabaseInput struct {
+	CatalogID     string         `json:"CatalogId,omitempty"`
+	DatabaseInput *DatabaseInput `json:"DatabaseInput"`
+}
+
+// GetDatabaseInput is the request for GetDatabase.
+type GetDatabaseInput struct {
+	CatalogID string `json:"CatalogId,omitempty"`
+	Name      string `json:"Name"`
+}
+
+// GetDatabaseOutput is the response for GetDatabase.
+type GetDatabaseOutput struct {
+	Database *DatabaseResponse `json:"Database,omitempty"`
+}
+
+// DatabaseResponse represents a database in API responses.
+type DatabaseResponse struct {
+	Name            string            `json:"Name,omitempty"`
+	Description     string            `json:"Description,omitempty"`
+	LocationURI     string            `json:"LocationUri,omitempty"`
+	Parameters      map[string]string `json:"Parameters,omitempty"`
+	CreateTime      *time.Time        `json:"CreateTime,omitempty"`
+	CatalogID       string            `json:"CatalogId,omitempty"`
+	CreateTableMode string            `json:"CreateTableDefaultPermissions,omitempty"`
+}
+
+// GetDatabasesInput is the request for GetDatabases.
+type GetDatabasesInput struct {
+	CatalogID  string `json:"CatalogId,omitempty"`
+	NextToken  string `json:"NextToken,omitempty"`
+	MaxResults int32  `json:"MaxResults,omitempty"`
+}
+
+// GetDatabasesOutput is the response for GetDatabases.
+type GetDatabasesOutput struct {
+	DatabaseList []*DatabaseResponse `json:"DatabaseList,omitempty"`
+	NextToken    string              `json:"NextToken,omitempty"`
+}
+
+// DeleteDatabaseInput is the request for DeleteDatabase.
+type DeleteDatabaseInput struct {
+	CatalogID string `json:"CatalogId,omitempty"`
+	Name      string `json:"Name"`
+}
+
+// CreateTableInput is the request for CreateTable.
+type CreateTableInput struct {
+	CatalogID    string      `json:"CatalogId,omitempty"`
+	DatabaseName string      `json:"DatabaseName"`
+	TableInput   *TableInput `json:"TableInput"`
+}
+
+// GetTableInput is the request for GetTable.
+type GetTableInput struct {
+	CatalogID    string `json:"CatalogId,omitempty"`
+	DatabaseName string `json:"DatabaseName"`
+	Name         string `json:"Name"`
+}
+
+// GetTableOutput is the response for GetTable.
+type GetTableOutput struct {
+	Table *TableResponse `json:"Table,omitempty"`
+}
+
+// TableResponse represents a table in API responses.
+type TableResponse struct {
+	Name              string             `json:"Name,omitempty"`
+	DatabaseName      string             `json:"DatabaseName,omitempty"`
+	Description       string             `json:"Description,omitempty"`
+	Owner             string             `json:"Owner,omitempty"`
+	CreateTime        *time.Time         `json:"CreateTime,omitempty"`
+	UpdateTime        *time.Time         `json:"UpdateTime,omitempty"`
+	LastAccessTime    *time.Time         `json:"LastAccessTime,omitempty"`
+	LastAnalyzedTime  *time.Time         `json:"LastAnalyzedTime,omitempty"`
+	Retention         int32              `json:"Retention,omitempty"`
+	StorageDescriptor *StorageDescriptor `json:"StorageDescriptor,omitempty"`
+	PartitionKeys     []Column           `json:"PartitionKeys,omitempty"`
+	ViewOriginalText  string             `json:"ViewOriginalText,omitempty"`
+	ViewExpandedText  string             `json:"ViewExpandedText,omitempty"`
+	TableType         string             `json:"TableType,omitempty"`
+	Parameters        map[string]string  `json:"Parameters,omitempty"`
+	CatalogID         string             `json:"CatalogId,omitempty"`
+}
+
+// GetTablesInput is the request for GetTables.
+type GetTablesInput struct {
+	CatalogID    string `json:"CatalogId,omitempty"`
+	DatabaseName string `json:"DatabaseName"`
+	Expression   string `json:"Expression,omitempty"`
+	NextToken    string `json:"NextToken,omitempty"`
+	MaxResults   int32  `json:"MaxResults,omitempty"`
+}
+
+// GetTablesOutput is the response for GetTables.
+type GetTablesOutput struct {
+	TableList []*TableResponse `json:"TableList,omitempty"`
+	NextToken string           `json:"NextToken,omitempty"`
+}
+
+// DeleteTableInput is the request for DeleteTable.
+type DeleteTableInput struct {
+	CatalogID    string `json:"CatalogId,omitempty"`
+	DatabaseName string `json:"DatabaseName"`
+	Name         string `json:"Name"`
+}
+
+// CreateJobInput is the request for CreateJob.
+type CreateJobInput struct {
+	Name                    string             `json:"Name"`
+	Description             string             `json:"Description,omitempty"`
+	Role                    string             `json:"Role"`
+	Command                 *JobCommand        `json:"Command"`
+	DefaultArguments        map[string]string  `json:"DefaultArguments,omitempty"`
+	NonOverridableArguments map[string]string  `json:"NonOverridableArguments,omitempty"`
+	MaxRetries              int32              `json:"MaxRetries,omitempty"`
+	AllocatedCapacity       int32              `json:"AllocatedCapacity,omitempty"`
+	Timeout                 int32              `json:"Timeout,omitempty"`
+	MaxCapacity             float64            `json:"MaxCapacity,omitempty"`
+	WorkerType              string             `json:"WorkerType,omitempty"`
+	NumberOfWorkers         int32              `json:"NumberOfWorkers,omitempty"`
+	GlueVersion             string             `json:"GlueVersion,omitempty"`
+	ExecutionProperty       *ExecutionProperty `json:"ExecutionProperty,omitempty"`
+}
+
+// CreateJobOutput is the response for CreateJob.
+type CreateJobOutput struct {
+	Name string `json:"Name,omitempty"`
+}
+
+// DeleteJobInput is the request for DeleteJob.
+type DeleteJobInput struct {
+	JobName string `json:"JobName"`
+}
+
+// DeleteJobOutput is the response for DeleteJob.
+type DeleteJobOutput struct {
+	JobName string `json:"JobName,omitempty"`
+}
+
+// StartJobRunInput is the request for StartJobRun.
+type StartJobRunInput struct {
+	JobName              string            `json:"JobName"`
+	JobRunID             string            `json:"JobRunId,omitempty"`
+	Arguments            map[string]string `json:"Arguments,omitempty"`
+	AllocatedCapacity    int32             `json:"AllocatedCapacity,omitempty"`
+	Timeout              int32             `json:"Timeout,omitempty"`
+	MaxCapacity          float64           `json:"MaxCapacity,omitempty"`
+	WorkerType           string            `json:"WorkerType,omitempty"`
+	NumberOfWorkers      int32             `json:"NumberOfWorkers,omitempty"`
+	NotificationProperty *NotificationProp `json:"NotificationProperty,omitempty"`
+}
+
+// NotificationProp specifies notification properties.
+type NotificationProp struct {
+	NotifyDelayAfter int32 `json:"NotifyDelayAfter,omitempty"`
+}
+
+// StartJobRunOutput is the response for StartJobRun.
+type StartJobRunOutput struct {
+	JobRunID string `json:"JobRunId,omitempty"`
+}
+
+// ErrorResponse represents a Glue error response.
+type ErrorResponse struct {
+	Type    string `json:"__type"`
+	Message string `json:"message"`
+}
+
+// Error represents a Glue error.
+type Error struct {
+	Code    string
+	Message string
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return e.Message
+}

--- a/test/integration/glue_test.go
+++ b/test/integration/glue_test.go
@@ -1,0 +1,463 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	"github.com/aws/aws-sdk-go-v2/service/glue/types"
+)
+
+func newGlueClient(t *testing.T) *glue.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	return glue.NewFromConfig(cfg, func(o *glue.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestGlue_CreateAndGetDatabase(t *testing.T) {
+	client := newGlueClient(t)
+	ctx := t.Context()
+
+	dbName := "test_database"
+
+	// Create database.
+	_, err := client.CreateDatabase(ctx, &glue.CreateDatabaseInput{
+		DatabaseInput: &types.DatabaseInput{
+			Name:        aws.String(dbName),
+			Description: aws.String("Test database"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+
+	t.Logf("Created database: %s", dbName)
+
+	// Get database.
+	getOutput, err := client.GetDatabase(ctx, &glue.GetDatabaseInput{
+		Name: aws.String(dbName),
+	})
+	if err != nil {
+		t.Fatalf("failed to get database: %v", err)
+	}
+
+	if getOutput.Database == nil {
+		t.Fatal("database is nil")
+	}
+
+	if *getOutput.Database.Name != dbName {
+		t.Errorf("name mismatch: got %s, want %s", *getOutput.Database.Name, dbName)
+	}
+
+	if *getOutput.Database.Description != "Test database" {
+		t.Errorf("description mismatch: got %s, want Test database", *getOutput.Database.Description)
+	}
+
+	t.Logf("Retrieved database: %s", dbName)
+}
+
+func TestGlue_GetDatabases(t *testing.T) {
+	client := newGlueClient(t)
+	ctx := t.Context()
+
+	// Create a database.
+	dbName := "list_test_database"
+	_, err := client.CreateDatabase(ctx, &glue.CreateDatabaseInput{
+		DatabaseInput: &types.DatabaseInput{
+			Name: aws.String(dbName),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+
+	// Get databases.
+	listOutput, err := client.GetDatabases(ctx, &glue.GetDatabasesInput{
+		MaxResults: aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("failed to get databases: %v", err)
+	}
+
+	if len(listOutput.DatabaseList) == 0 {
+		t.Fatal("no databases returned")
+	}
+
+	// Find our database.
+	found := false
+
+	for _, db := range listOutput.DatabaseList {
+		if db.Name != nil && *db.Name == dbName {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("database %s not found in list", dbName)
+	}
+
+	t.Logf("Listed %d databases", len(listOutput.DatabaseList))
+}
+
+func TestGlue_DeleteDatabase(t *testing.T) {
+	client := newGlueClient(t)
+	ctx := t.Context()
+
+	dbName := "delete_test_database"
+
+	// Create a database.
+	_, err := client.CreateDatabase(ctx, &glue.CreateDatabaseInput{
+		DatabaseInput: &types.DatabaseInput{
+			Name: aws.String(dbName),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+
+	// Delete the database.
+	_, err = client.DeleteDatabase(ctx, &glue.DeleteDatabaseInput{
+		Name: aws.String(dbName),
+	})
+	if err != nil {
+		t.Fatalf("failed to delete database: %v", err)
+	}
+
+	t.Logf("Deleted database: %s", dbName)
+
+	// Verify it's deleted.
+	_, err = client.GetDatabase(ctx, &glue.GetDatabaseInput{
+		Name: aws.String(dbName),
+	})
+	if err == nil {
+		t.Fatal("expected error when getting deleted database")
+	}
+
+	t.Logf("Verified database is deleted")
+}
+
+func TestGlue_CreateAndGetTable(t *testing.T) {
+	client := newGlueClient(t)
+	ctx := t.Context()
+
+	dbName := "table_test_database"
+	tableName := "test_table"
+
+	// Create database first.
+	_, err := client.CreateDatabase(ctx, &glue.CreateDatabaseInput{
+		DatabaseInput: &types.DatabaseInput{
+			Name: aws.String(dbName),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+
+	// Create table.
+	_, err = client.CreateTable(ctx, &glue.CreateTableInput{
+		DatabaseName: aws.String(dbName),
+		TableInput: &types.TableInput{
+			Name:        aws.String(tableName),
+			Description: aws.String("Test table"),
+			TableType:   aws.String("EXTERNAL_TABLE"),
+			StorageDescriptor: &types.StorageDescriptor{
+				Columns: []types.Column{
+					{
+						Name: aws.String("id"),
+						Type: aws.String("int"),
+					},
+					{
+						Name: aws.String("name"),
+						Type: aws.String("string"),
+					},
+				},
+				Location:     aws.String("s3://test-bucket/data/"),
+				InputFormat:  aws.String("org.apache.hadoop.mapred.TextInputFormat"),
+				OutputFormat: aws.String("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	t.Logf("Created table: %s", tableName)
+
+	// Get table.
+	getOutput, err := client.GetTable(ctx, &glue.GetTableInput{
+		DatabaseName: aws.String(dbName),
+		Name:         aws.String(tableName),
+	})
+	if err != nil {
+		t.Fatalf("failed to get table: %v", err)
+	}
+
+	if getOutput.Table == nil {
+		t.Fatal("table is nil")
+	}
+
+	if *getOutput.Table.Name != tableName {
+		t.Errorf("name mismatch: got %s, want %s", *getOutput.Table.Name, tableName)
+	}
+
+	if *getOutput.Table.TableType != "EXTERNAL_TABLE" {
+		t.Errorf("table type mismatch: got %s, want EXTERNAL_TABLE", *getOutput.Table.TableType)
+	}
+
+	t.Logf("Retrieved table: %s", tableName)
+}
+
+func TestGlue_GetTables(t *testing.T) {
+	client := newGlueClient(t)
+	ctx := t.Context()
+
+	dbName := "get_tables_database"
+	tableName := "list_test_table"
+
+	// Create database.
+	_, err := client.CreateDatabase(ctx, &glue.CreateDatabaseInput{
+		DatabaseInput: &types.DatabaseInput{
+			Name: aws.String(dbName),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+
+	// Create table.
+	_, err = client.CreateTable(ctx, &glue.CreateTableInput{
+		DatabaseName: aws.String(dbName),
+		TableInput: &types.TableInput{
+			Name: aws.String(tableName),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	// Get tables.
+	listOutput, err := client.GetTables(ctx, &glue.GetTablesInput{
+		DatabaseName: aws.String(dbName),
+		MaxResults:   aws.Int32(10),
+	})
+	if err != nil {
+		t.Fatalf("failed to get tables: %v", err)
+	}
+
+	if len(listOutput.TableList) == 0 {
+		t.Fatal("no tables returned")
+	}
+
+	// Find our table.
+	found := false
+
+	for _, table := range listOutput.TableList {
+		if table.Name != nil && *table.Name == tableName {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("table %s not found in list", tableName)
+	}
+
+	t.Logf("Listed %d tables", len(listOutput.TableList))
+}
+
+func TestGlue_DeleteTable(t *testing.T) {
+	client := newGlueClient(t)
+	ctx := t.Context()
+
+	dbName := "delete_table_database"
+	tableName := "delete_test_table"
+
+	// Create database.
+	_, err := client.CreateDatabase(ctx, &glue.CreateDatabaseInput{
+		DatabaseInput: &types.DatabaseInput{
+			Name: aws.String(dbName),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+
+	// Create table.
+	_, err = client.CreateTable(ctx, &glue.CreateTableInput{
+		DatabaseName: aws.String(dbName),
+		TableInput: &types.TableInput{
+			Name: aws.String(tableName),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	// Delete table.
+	_, err = client.DeleteTable(ctx, &glue.DeleteTableInput{
+		DatabaseName: aws.String(dbName),
+		Name:         aws.String(tableName),
+	})
+	if err != nil {
+		t.Fatalf("failed to delete table: %v", err)
+	}
+
+	t.Logf("Deleted table: %s", tableName)
+
+	// Verify it's deleted.
+	_, err = client.GetTable(ctx, &glue.GetTableInput{
+		DatabaseName: aws.String(dbName),
+		Name:         aws.String(tableName),
+	})
+	if err == nil {
+		t.Fatal("expected error when getting deleted table")
+	}
+
+	t.Logf("Verified table is deleted")
+}
+
+func TestGlue_CreateAndDeleteJob(t *testing.T) {
+	client := newGlueClient(t)
+	ctx := t.Context()
+
+	jobName := "test_job"
+
+	// Create job.
+	createOutput, err := client.CreateJob(ctx, &glue.CreateJobInput{
+		Name:        aws.String(jobName),
+		Description: aws.String("Test ETL job"),
+		Role:        aws.String("arn:aws:iam::000000000000:role/GlueRole"),
+		Command: &types.JobCommand{
+			Name:           aws.String("glueetl"),
+			ScriptLocation: aws.String("s3://test-bucket/scripts/etl.py"),
+			PythonVersion:  aws.String("3"),
+		},
+		GlueVersion:     aws.String("3.0"),
+		NumberOfWorkers: aws.Int32(10),
+		WorkerType:      types.WorkerTypeG1x,
+	})
+	if err != nil {
+		t.Fatalf("failed to create job: %v", err)
+	}
+
+	if createOutput.Name == nil || *createOutput.Name != jobName {
+		t.Errorf("job name mismatch: got %v, want %s", createOutput.Name, jobName)
+	}
+
+	t.Logf("Created job: %s", jobName)
+
+	// Delete job.
+	deleteOutput, err := client.DeleteJob(ctx, &glue.DeleteJobInput{
+		JobName: aws.String(jobName),
+	})
+	if err != nil {
+		t.Fatalf("failed to delete job: %v", err)
+	}
+
+	if deleteOutput.JobName == nil || *deleteOutput.JobName != jobName {
+		t.Errorf("job name mismatch: got %v, want %s", deleteOutput.JobName, jobName)
+	}
+
+	t.Logf("Deleted job: %s", jobName)
+}
+
+func TestGlue_StartJobRun(t *testing.T) {
+	client := newGlueClient(t)
+	ctx := t.Context()
+
+	jobName := "run_test_job"
+
+	// Create job first.
+	_, err := client.CreateJob(ctx, &glue.CreateJobInput{
+		Name: aws.String(jobName),
+		Role: aws.String("arn:aws:iam::000000000000:role/GlueRole"),
+		Command: &types.JobCommand{
+			Name:           aws.String("glueetl"),
+			ScriptLocation: aws.String("s3://test-bucket/scripts/etl.py"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create job: %v", err)
+	}
+
+	// Start job run.
+	runOutput, err := client.StartJobRun(ctx, &glue.StartJobRunInput{
+		JobName: aws.String(jobName),
+		Arguments: map[string]string{
+			"--input":  "s3://test-bucket/input/",
+			"--output": "s3://test-bucket/output/",
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to start job run: %v", err)
+	}
+
+	if runOutput.JobRunId == nil {
+		t.Fatal("job run ID is nil")
+	}
+
+	t.Logf("Started job run: %s", *runOutput.JobRunId)
+}
+
+func TestGlue_GetNonExistentDatabase(t *testing.T) {
+	client := newGlueClient(t)
+	ctx := t.Context()
+
+	// Try to get a non-existent database.
+	_, err := client.GetDatabase(ctx, &glue.GetDatabaseInput{
+		Name: aws.String("non_existent_database"),
+	})
+	if err == nil {
+		t.Fatal("expected error when getting non-existent database")
+	}
+
+	t.Logf("Got expected error: %v", err)
+}
+
+func TestGlue_CreateDuplicateDatabase(t *testing.T) {
+	client := newGlueClient(t)
+	ctx := t.Context()
+
+	dbName := "duplicate_test_database"
+
+	// Create database.
+	_, err := client.CreateDatabase(ctx, &glue.CreateDatabaseInput{
+		DatabaseInput: &types.DatabaseInput{
+			Name: aws.String(dbName),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+
+	// Try to create the same database again.
+	_, err = client.CreateDatabase(ctx, &glue.CreateDatabaseInput{
+		DatabaseInput: &types.DatabaseInput{
+			Name: aws.String(dbName),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when creating duplicate database")
+	}
+
+	t.Logf("Got expected error: %v", err)
+}


### PR DESCRIPTION
## Summary
Implement AWS Glue service emulation with basic operations for databases, tables, and jobs.

## Changes
- Add Glue service with in-memory storage
- Implement database operations: CreateDatabase, GetDatabase, GetDatabases, DeleteDatabase
- Implement table operations: CreateTable, GetTable, GetTables, DeleteTable
- Implement job operations: CreateJob, DeleteJob, StartJobRun
- Add integration tests using AWS SDK v2

## Features
- Catalog ID support with default fallback
- Table storage descriptors and column definitions
- Job command configuration (script location, Python version, etc.)
- Execution properties for concurrent job runs
- AWS JSON 1.1 protocol via X-Amz-Target header routing

## Test Plan
- [x] Unit tests pass
- [x] Lint passes
- [ ] Integration tests pass

Closes #35