### PR TITLE
fix(lint): resolve lint issues in ACM and X-Ray services

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -137,6 +137,10 @@ linters:
       - path: internal/service/xray/types\.go
         linters:
           - tagliatelle
+      # AWS X-Ray segment document uses snake_case field names.
+      - path: internal/service/xray/storage\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/internal/service/xray/handlers.go
+++ b/internal/service/xray/handlers.go
@@ -61,27 +61,27 @@ func (s *Service) GetTraceSummaries(w http.ResponseWriter, r *http.Request) {
 
 	responses := make([]TraceSummaryResponse, 0, len(summaries))
 
-	for _, summary := range summaries {
+	for i := range summaries {
 		responses = append(responses, TraceSummaryResponse{
-			ID:                summary.ID,
-			Duration:          summary.Duration,
-			ResponseTime:      summary.ResponseTime,
-			HasFault:          summary.HasFault,
-			HasError:          summary.HasError,
-			HasThrottle:       summary.HasThrottle,
-			IsPartial:         summary.IsPartial,
-			HTTP:              summary.HTTP,
-			Annotations:       summary.Annotations,
-			Users:             summary.Users,
-			ServiceIDs:        summary.ServiceIDs,
-			EntryPoint:        summary.EntryPoint,
-			FaultRootCauses:   summary.FaultRootCauses,
-			ErrorRootCauses:   summary.ErrorRootCauses,
-			AvailabilityZones: summary.AvailabilityZones,
-			InstanceIDs:       summary.InstanceIDs,
-			ResourceARNs:      summary.ResourceARNs,
-			MatchedEventTime:  summary.MatchedEventTime,
-			Revision:          summary.Revision,
+			ID:                summaries[i].ID,
+			Duration:          summaries[i].Duration,
+			ResponseTime:      summaries[i].ResponseTime,
+			HasFault:          summaries[i].HasFault,
+			HasError:          summaries[i].HasError,
+			HasThrottle:       summaries[i].HasThrottle,
+			IsPartial:         summaries[i].IsPartial,
+			HTTP:              summaries[i].HTTP,
+			Annotations:       summaries[i].Annotations,
+			Users:             summaries[i].Users,
+			ServiceIDs:        summaries[i].ServiceIDs,
+			EntryPoint:        summaries[i].EntryPoint,
+			FaultRootCauses:   summaries[i].FaultRootCauses,
+			ErrorRootCauses:   summaries[i].ErrorRootCauses,
+			AvailabilityZones: summaries[i].AvailabilityZones,
+			InstanceIDs:       summaries[i].InstanceIDs,
+			ResourceARNs:      summaries[i].ResourceARNs,
+			MatchedEventTime:  summaries[i].MatchedEventTime,
+			Revision:          summaries[i].Revision,
 		})
 	}
 

--- a/internal/service/xray/storage.go
+++ b/internal/service/xray/storage.go
@@ -154,6 +154,7 @@ func (s *MemoryStorage) GetTraceSummaries(_ context.Context, _, _ time.Time) ([]
 					HTTPMethod: segDoc.HTTP.Request.Method,
 					HTTPURL:    segDoc.HTTP.Request.URL,
 					ClientIP:   segDoc.HTTP.Request.ClientIP,
+					//nolint:gosec // G115: HTTP status codes are always in range 100-599, safe for int32.
 					HTTPStatus: int32(segDoc.HTTP.Response.Status),
 				}
 			}
@@ -207,6 +208,7 @@ func (s *MemoryStorage) GetServiceGraph(_ context.Context, _, _ time.Time, _ str
 
 			if _, exists := serviceMap[serviceName]; !exists {
 				serviceMap[serviceName] = &ServiceNode{
+					//nolint:gosec // G115: Service count is bounded by trace data, won't exceed int32 range.
 					ReferenceID: int32(len(serviceMap) + 1),
 					Name:        serviceName,
 					Type:        segDoc.Origin,


### PR DESCRIPTION
## Summary
- Fix lint issues introduced in recently merged PRs (ACM #222, X-Ray #224)

## Changes
- **ACM**: Extract `buildDomainValidations` helper to fix `funlen` (73 > 60)
- **ACM**: Preallocate domains slice to fix `prealloc`
- **X-Ray**: Use index-based iteration to fix `rangeValCopy` (248 bytes per iteration)
- **X-Ray**: Add tagliatelle exclusion for storage.go (segment document format uses snake_case)
- **X-Ray**: Add nolint comments for gosec G115 safe int conversions

## Test plan
- [ ] CI lint check passes
- [ ] All existing tests continue to pass