### PR TITLE
feat(elasticache): add ElastiCache service basic implementation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -161,6 +161,10 @@ linters:
       - path: internal/service/rds/types\.go
         linters:
           - tagliatelle
+      # AWS ElastiCache API requires PascalCase JSON field names.
+      - path: internal/service/elasticache/types\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/ecr"
 	_ "github.com/sivchari/awsim/internal/service/ecs"
 	_ "github.com/sivchari/awsim/internal/service/eks"
+	_ "github.com/sivchari/awsim/internal/service/elasticache"
 	_ "github.com/sivchari/awsim/internal/service/eventbridge"
 	_ "github.com/sivchari/awsim/internal/service/firehose"
 	_ "github.com/sivchari/awsim/internal/service/globalaccelerator"

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.80.0
+	github.com/aws/aws-sdk-go-v2/service/elasticache v1.51.9
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.18
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.9
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.35.11

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.71.0 h1:MzP/ElwTpINq+hS80ZQz4epKVnUT
 github.com/aws/aws-sdk-go-v2/service/ecs v1.71.0/go.mod h1:pMlGFDpHoLTJOIZHGdJOAWmi+xeIlQXuFTuQxs1epYE=
 github.com/aws/aws-sdk-go-v2/service/eks v1.80.0 h1:moQGV8cPbVTN7r2Xte1Mybku35QDePSJEd3onYVmBtY=
 github.com/aws/aws-sdk-go-v2/service/eks v1.80.0/go.mod h1:Qg678m+87sCuJhcsZojenz8mblYG+Tq86V4m3hjVz0s=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.51.9 h1:hTgZLyNoDWphZUtTtcvQh0LP6TZO0mtdSfZK/GObDLk=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.51.9/go.mod h1:91RkIYy9ubykxB50XGYDsbljLZnrZ6rp/Urt4rZrbwQ=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.18 h1:Zqe/Mbpjy3Vk0IKreW4cdxz2PBb0JNCeMwYAKbuBnvg=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.18/go.mod h1:oGNgLQOntNCt7Tl3d1NQu5QKFxdufg4huUAmyNECPDU=
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.9 h1:nFzEdq+y0lvgnSbYtRkgsSDFI7awmCrihWHFxWg8OQ0=

--- a/internal/service/elasticache/handlers.go
+++ b/internal/service/elasticache/handlers.go
@@ -1,0 +1,665 @@
+// Package elasticache implements the ElastiCache service handlers.
+package elasticache
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const elasticacheXMLNS = "http://elasticache.amazonaws.com/doc/2015-02-02/"
+
+// DispatchAction routes the request to the appropriate handler based on Action parameter.
+func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
+	action := extractAction(r)
+
+	switch action {
+	case "CreateCacheCluster":
+		s.CreateCacheCluster(w, r)
+	case "DeleteCacheCluster":
+		s.DeleteCacheCluster(w, r)
+	case "DescribeCacheClusters":
+		s.DescribeCacheClusters(w, r)
+	case "ModifyCacheCluster":
+		s.ModifyCacheCluster(w, r)
+	case "CreateReplicationGroup":
+		s.CreateReplicationGroup(w, r)
+	case "DeleteReplicationGroup":
+		s.DeleteReplicationGroup(w, r)
+	case "DescribeReplicationGroups":
+		s.DescribeReplicationGroups(w, r)
+	default:
+		writeError(w, errInvalidParameterValue, fmt.Sprintf("The action '%s' is not valid", action), http.StatusBadRequest)
+	}
+}
+
+// CreateCacheCluster handles the CreateCacheCluster action.
+func (s *Service) CreateCacheCluster(w http.ResponseWriter, r *http.Request) {
+	var req CreateCacheClusterInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.CacheClusterID == "" {
+		writeError(w, errInvalidParameterValue, "CacheClusterId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.CacheNodeType == "" {
+		writeError(w, errInvalidParameterValue, "CacheNodeType is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Engine == "" {
+		writeError(w, errInvalidParameterValue, "Engine is required", http.StatusBadRequest)
+
+		return
+	}
+
+	cluster, err := s.storage.CreateCacheCluster(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLCreateCacheClusterResponse{
+		Xmlns:        elasticacheXMLNS,
+		CacheCluster: convertToXMLCacheCluster(cluster),
+		RequestID:    uuid.New().String(),
+	})
+}
+
+// DeleteCacheCluster handles the DeleteCacheCluster action.
+func (s *Service) DeleteCacheCluster(w http.ResponseWriter, r *http.Request) {
+	var req DeleteCacheClusterInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.CacheClusterID == "" {
+		writeError(w, errInvalidParameterValue, "CacheClusterId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	cluster, err := s.storage.DeleteCacheCluster(r.Context(), req.CacheClusterID)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLDeleteCacheClusterResponse{
+		Xmlns:        elasticacheXMLNS,
+		CacheCluster: convertToXMLCacheCluster(cluster),
+		RequestID:    uuid.New().String(),
+	})
+}
+
+// DescribeCacheClusters handles the DescribeCacheClusters action.
+func (s *Service) DescribeCacheClusters(w http.ResponseWriter, r *http.Request) {
+	var req DescribeCacheClustersInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	clusters, err := s.storage.DescribeCacheClusters(r.Context(), req.CacheClusterID, req.ShowCacheNodeInfo)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	xmlClusters := make([]XMLCacheCluster, 0, len(clusters))
+	for i := range clusters {
+		xmlClusters = append(xmlClusters, convertToXMLCacheCluster(&clusters[i]))
+	}
+
+	writeXMLResponse(w, XMLDescribeCacheClustersResponse{
+		Xmlns:         elasticacheXMLNS,
+		CacheClusters: XMLCacheClusters{Items: xmlClusters},
+		RequestID:     uuid.New().String(),
+	})
+}
+
+// ModifyCacheCluster handles the ModifyCacheCluster action.
+func (s *Service) ModifyCacheCluster(w http.ResponseWriter, r *http.Request) {
+	var req ModifyCacheClusterInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.CacheClusterID == "" {
+		writeError(w, errInvalidParameterValue, "CacheClusterId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	cluster, err := s.storage.ModifyCacheCluster(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLModifyCacheClusterResponse{
+		Xmlns:        elasticacheXMLNS,
+		CacheCluster: convertToXMLCacheCluster(cluster),
+		RequestID:    uuid.New().String(),
+	})
+}
+
+// CreateReplicationGroup handles the CreateReplicationGroup action.
+func (s *Service) CreateReplicationGroup(w http.ResponseWriter, r *http.Request) {
+	var req CreateReplicationGroupInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ReplicationGroupID == "" {
+		writeError(w, errInvalidParameterValue, "ReplicationGroupId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ReplicationGroupDescription == "" {
+		writeError(w, errInvalidParameterValue, "ReplicationGroupDescription is required", http.StatusBadRequest)
+
+		return
+	}
+
+	group, err := s.storage.CreateReplicationGroup(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLCreateReplicationGroupResponse{
+		Xmlns:            elasticacheXMLNS,
+		ReplicationGroup: convertToXMLReplicationGroup(group),
+		RequestID:        uuid.New().String(),
+	})
+}
+
+// DeleteReplicationGroup handles the DeleteReplicationGroup action.
+func (s *Service) DeleteReplicationGroup(w http.ResponseWriter, r *http.Request) {
+	var req DeleteReplicationGroupInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ReplicationGroupID == "" {
+		writeError(w, errInvalidParameterValue, "ReplicationGroupId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	group, err := s.storage.DeleteReplicationGroup(r.Context(), req.ReplicationGroupID)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLDeleteReplicationGroupResponse{
+		Xmlns:            elasticacheXMLNS,
+		ReplicationGroup: convertToXMLReplicationGroup(group),
+		RequestID:        uuid.New().String(),
+	})
+}
+
+// DescribeReplicationGroups handles the DescribeReplicationGroups action.
+func (s *Service) DescribeReplicationGroups(w http.ResponseWriter, r *http.Request) {
+	var req DescribeReplicationGroupsInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	groups, err := s.storage.DescribeReplicationGroups(r.Context(), req.ReplicationGroupID)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	xmlGroups := make([]XMLReplicationGroup, 0, len(groups))
+	for i := range groups {
+		xmlGroups = append(xmlGroups, convertToXMLReplicationGroup(&groups[i]))
+	}
+
+	writeXMLResponse(w, XMLDescribeReplicationGroupsResponse{
+		Xmlns:             elasticacheXMLNS,
+		ReplicationGroups: XMLReplicationGroups{Items: xmlGroups},
+		RequestID:         uuid.New().String(),
+	})
+}
+
+// Helper functions.
+
+func extractAction(r *http.Request) string {
+	target := r.Header.Get("X-Amz-Target")
+	if target != "" {
+		if idx := strings.LastIndex(target, "."); idx >= 0 {
+			return target[idx+1:]
+		}
+	}
+
+	return r.URL.Query().Get("Action")
+}
+
+func readJSONRequest(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return nil
+}
+
+func writeXMLResponse(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, code, message string, status int) {
+	requestID := uuid.New().String()
+
+	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	w.Header().Set("x-amzn-RequestId", requestID)
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(XMLErrorResponse{
+		Error: XMLError{
+			Code:    code,
+			Message: message,
+		},
+		RequestID: requestID,
+	})
+}
+
+func handleError(w http.ResponseWriter, err error) {
+	var ecErr *Error
+	if errors.As(err, &ecErr) {
+		status := http.StatusBadRequest
+		if ecErr.Code == errCacheClusterNotFound || ecErr.Code == errReplicationGroupNotFound {
+			status = http.StatusNotFound
+		}
+
+		writeError(w, ecErr.Code, ecErr.Message, status)
+
+		return
+	}
+
+	writeError(w, "InternalServiceError", "Internal server error", http.StatusInternalServerError)
+}
+
+// Conversion functions.
+
+func convertToXMLCacheCluster(cluster *CacheCluster) XMLCacheCluster {
+	var configEndpoint *XMLEndpoint
+	if cluster.ConfigurationEndpoint != nil {
+		configEndpoint = &XMLEndpoint{
+			Address: cluster.ConfigurationEndpoint.Address,
+			Port:    cluster.ConfigurationEndpoint.Port,
+		}
+	}
+
+	cacheNodes := make([]XMLCacheNode, 0, len(cluster.CacheNodes))
+	for _, node := range cluster.CacheNodes {
+		cacheNodes = append(cacheNodes, convertToXMLCacheNode(&node))
+	}
+
+	securityGroups := make([]XMLSecurityGroupMembership, 0, len(cluster.SecurityGroups))
+	for _, sg := range cluster.SecurityGroups {
+		securityGroups = append(securityGroups, XMLSecurityGroupMembership(sg))
+	}
+
+	return XMLCacheCluster{
+		CacheClusterID:             cluster.CacheClusterID,
+		CacheClusterStatus:         cluster.CacheClusterStatus,
+		CacheNodeType:              cluster.CacheNodeType,
+		Engine:                     cluster.Engine,
+		EngineVersion:              cluster.EngineVersion,
+		NumCacheNodes:              cluster.NumCacheNodes,
+		PreferredAvailabilityZone:  cluster.PreferredAvailabilityZone,
+		CacheClusterCreateTime:     cluster.CacheClusterCreateTime.Format("2006-01-02T15:04:05.000Z"),
+		PreferredMaintenanceWindow: cluster.PreferredMaintenanceWindow,
+		CacheSubnetGroupName:       cluster.CacheSubnetGroupName,
+		AutoMinorVersionUpgrade:    cluster.AutoMinorVersionUpgrade,
+		SnapshotRetentionLimit:     cluster.SnapshotRetentionLimit,
+		SnapshotWindow:             cluster.SnapshotWindow,
+		ARN:                        cluster.ARN,
+		CacheNodes:                 XMLCacheNodes{Items: cacheNodes},
+		SecurityGroups:             XMLSecurityGroups{Items: securityGroups},
+		ConfigurationEndpoint:      configEndpoint,
+	}
+}
+
+func convertToXMLCacheNode(node *CacheNode) XMLCacheNode {
+	var endpoint *XMLEndpoint
+	if node.Endpoint != nil {
+		endpoint = &XMLEndpoint{
+			Address: node.Endpoint.Address,
+			Port:    node.Endpoint.Port,
+		}
+	}
+
+	return XMLCacheNode{
+		CacheNodeID:              node.CacheNodeID,
+		CacheNodeStatus:          node.CacheNodeStatus,
+		CacheNodeCreateTime:      node.CacheNodeCreateTime.Format("2006-01-02T15:04:05.000Z"),
+		Endpoint:                 endpoint,
+		ParameterGroupStatus:     node.ParameterGroupStatus,
+		CustomerAvailabilityZone: node.CustomerAvailabilityZone,
+	}
+}
+
+func convertToXMLReplicationGroup(group *ReplicationGroup) XMLReplicationGroup {
+	var configEndpoint *XMLEndpoint
+	if group.ConfigurationEndpoint != nil {
+		configEndpoint = &XMLEndpoint{
+			Address: group.ConfigurationEndpoint.Address,
+			Port:    group.ConfigurationEndpoint.Port,
+		}
+	}
+
+	nodeGroups := make([]XMLNodeGroup, 0, len(group.NodeGroups))
+	for _, ng := range group.NodeGroups {
+		nodeGroups = append(nodeGroups, convertToXMLNodeGroup(&ng))
+	}
+
+	return XMLReplicationGroup{
+		ReplicationGroupID:         group.ReplicationGroupID,
+		Description:                group.Description,
+		Status:                     group.Status,
+		MemberClusters:             XMLMemberClusters{Items: group.MemberClusters},
+		NodeGroups:                 XMLNodeGroups{Items: nodeGroups},
+		AutomaticFailover:          group.AutomaticFailover,
+		MultiAZ:                    group.MultiAZ,
+		SnapshotRetentionLimit:     group.SnapshotRetentionLimit,
+		SnapshotWindow:             group.SnapshotWindow,
+		ClusterEnabled:             group.ClusterEnabled,
+		CacheNodeType:              group.CacheNodeType,
+		AuthTokenEnabled:           group.AuthTokenEnabled,
+		TransitEncryptionEnabled:   group.TransitEncryptionEnabled,
+		AtRestEncryptionEnabled:    group.AtRestEncryptionEnabled,
+		ARN:                        group.ARN,
+		ConfigurationEndpoint:      configEndpoint,
+		ReplicationGroupCreateTime: group.ReplicationGroupCreateTime.Format("2006-01-02T15:04:05.000Z"),
+		AutoMinorVersionUpgrade:    group.AutoMinorVersionUpgrade,
+		PreferredMaintenanceWindow: group.PreferredMaintenanceWindow,
+	}
+}
+
+func convertToXMLNodeGroup(ng *NodeGroup) XMLNodeGroup {
+	var primaryEndpoint, readerEndpoint *XMLEndpoint
+	if ng.PrimaryEndpoint != nil {
+		primaryEndpoint = &XMLEndpoint{
+			Address: ng.PrimaryEndpoint.Address,
+			Port:    ng.PrimaryEndpoint.Port,
+		}
+	}
+
+	if ng.ReaderEndpoint != nil {
+		readerEndpoint = &XMLEndpoint{
+			Address: ng.ReaderEndpoint.Address,
+			Port:    ng.ReaderEndpoint.Port,
+		}
+	}
+
+	members := make([]XMLNodeGroupMember, 0, len(ng.NodeGroupMembers))
+	for _, m := range ng.NodeGroupMembers {
+		members = append(members, convertToXMLNodeGroupMember(&m))
+	}
+
+	return XMLNodeGroup{
+		NodeGroupID:      ng.NodeGroupID,
+		Status:           ng.Status,
+		PrimaryEndpoint:  primaryEndpoint,
+		ReaderEndpoint:   readerEndpoint,
+		NodeGroupMembers: XMLNodeGroupMembers{Items: members},
+	}
+}
+
+func convertToXMLNodeGroupMember(m *NodeGroupMember) XMLNodeGroupMember {
+	var readEndpoint *XMLEndpoint
+	if m.ReadEndpoint != nil {
+		readEndpoint = &XMLEndpoint{
+			Address: m.ReadEndpoint.Address,
+			Port:    m.ReadEndpoint.Port,
+		}
+	}
+
+	return XMLNodeGroupMember{
+		CacheClusterID:            m.CacheClusterID,
+		CacheNodeID:               m.CacheNodeID,
+		ReadEndpoint:              readEndpoint,
+		PreferredAvailabilityZone: m.PreferredAvailabilityZone,
+		CurrentRole:               m.CurrentRole,
+	}
+}
+
+// XML response types.
+
+// XMLCreateCacheClusterResponse is the XML response for CreateCacheCluster.
+type XMLCreateCacheClusterResponse struct {
+	XMLName      xml.Name        `xml:"CreateCacheClusterResponse"`
+	Xmlns        string          `xml:"xmlns,attr"`
+	CacheCluster XMLCacheCluster `xml:"CreateCacheClusterResult>CacheCluster"`
+	RequestID    string          `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLDeleteCacheClusterResponse is the XML response for DeleteCacheCluster.
+type XMLDeleteCacheClusterResponse struct {
+	XMLName      xml.Name        `xml:"DeleteCacheClusterResponse"`
+	Xmlns        string          `xml:"xmlns,attr"`
+	CacheCluster XMLCacheCluster `xml:"DeleteCacheClusterResult>CacheCluster"`
+	RequestID    string          `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLDescribeCacheClustersResponse is the XML response for DescribeCacheClusters.
+type XMLDescribeCacheClustersResponse struct {
+	XMLName       xml.Name         `xml:"DescribeCacheClustersResponse"`
+	Xmlns         string           `xml:"xmlns,attr"`
+	CacheClusters XMLCacheClusters `xml:"DescribeCacheClustersResult>CacheClusters"`
+	RequestID     string           `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLModifyCacheClusterResponse is the XML response for ModifyCacheCluster.
+type XMLModifyCacheClusterResponse struct {
+	XMLName      xml.Name        `xml:"ModifyCacheClusterResponse"`
+	Xmlns        string          `xml:"xmlns,attr"`
+	CacheCluster XMLCacheCluster `xml:"ModifyCacheClusterResult>CacheCluster"`
+	RequestID    string          `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLCreateReplicationGroupResponse is the XML response for CreateReplicationGroup.
+type XMLCreateReplicationGroupResponse struct {
+	XMLName          xml.Name            `xml:"CreateReplicationGroupResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ReplicationGroup XMLReplicationGroup `xml:"CreateReplicationGroupResult>ReplicationGroup"`
+	RequestID        string              `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLDeleteReplicationGroupResponse is the XML response for DeleteReplicationGroup.
+type XMLDeleteReplicationGroupResponse struct {
+	XMLName          xml.Name            `xml:"DeleteReplicationGroupResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ReplicationGroup XMLReplicationGroup `xml:"DeleteReplicationGroupResult>ReplicationGroup"`
+	RequestID        string              `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLDescribeReplicationGroupsResponse is the XML response for DescribeReplicationGroups.
+type XMLDescribeReplicationGroupsResponse struct {
+	XMLName           xml.Name             `xml:"DescribeReplicationGroupsResponse"`
+	Xmlns             string               `xml:"xmlns,attr"`
+	ReplicationGroups XMLReplicationGroups `xml:"DescribeReplicationGroupsResult>ReplicationGroups"`
+	RequestID         string               `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLCacheCluster is the XML representation of a cache cluster.
+type XMLCacheCluster struct {
+	CacheClusterID             string            `xml:"CacheClusterId"`
+	CacheClusterStatus         string            `xml:"CacheClusterStatus"`
+	CacheNodeType              string            `xml:"CacheNodeType"`
+	Engine                     string            `xml:"Engine"`
+	EngineVersion              string            `xml:"EngineVersion,omitempty"`
+	NumCacheNodes              int32             `xml:"NumCacheNodes"`
+	PreferredAvailabilityZone  string            `xml:"PreferredAvailabilityZone,omitempty"`
+	CacheClusterCreateTime     string            `xml:"CacheClusterCreateTime"`
+	PreferredMaintenanceWindow string            `xml:"PreferredMaintenanceWindow,omitempty"`
+	CacheSubnetGroupName       string            `xml:"CacheSubnetGroupName,omitempty"`
+	AutoMinorVersionUpgrade    bool              `xml:"AutoMinorVersionUpgrade"`
+	SnapshotRetentionLimit     int32             `xml:"SnapshotRetentionLimit"`
+	SnapshotWindow             string            `xml:"SnapshotWindow,omitempty"`
+	ARN                        string            `xml:"ARN"`
+	CacheNodes                 XMLCacheNodes     `xml:"CacheNodes"`
+	SecurityGroups             XMLSecurityGroups `xml:"SecurityGroups"`
+	ConfigurationEndpoint      *XMLEndpoint      `xml:"ConfigurationEndpoint,omitempty"`
+}
+
+// XMLCacheClusters is a list of XML cache clusters.
+type XMLCacheClusters struct {
+	Items []XMLCacheCluster `xml:"CacheCluster"`
+}
+
+// XMLCacheNode is the XML representation of a cache node.
+type XMLCacheNode struct {
+	CacheNodeID              string       `xml:"CacheNodeId"`
+	CacheNodeStatus          string       `xml:"CacheNodeStatus"`
+	CacheNodeCreateTime      string       `xml:"CacheNodeCreateTime"`
+	Endpoint                 *XMLEndpoint `xml:"Endpoint,omitempty"`
+	ParameterGroupStatus     string       `xml:"ParameterGroupStatus,omitempty"`
+	CustomerAvailabilityZone string       `xml:"CustomerAvailabilityZone,omitempty"`
+}
+
+// XMLCacheNodes is a list of XML cache nodes.
+type XMLCacheNodes struct {
+	Items []XMLCacheNode `xml:"CacheNode"`
+}
+
+// XMLEndpoint is the XML representation of an endpoint.
+type XMLEndpoint struct {
+	Address string `xml:"Address"`
+	Port    int32  `xml:"Port"`
+}
+
+// XMLSecurityGroupMembership is the XML representation of a security group membership.
+type XMLSecurityGroupMembership struct {
+	SecurityGroupID string `xml:"SecurityGroupId"`
+	Status          string `xml:"Status"`
+}
+
+// XMLSecurityGroups is a list of security group memberships.
+type XMLSecurityGroups struct {
+	Items []XMLSecurityGroupMembership `xml:"member"`
+}
+
+// XMLReplicationGroup is the XML representation of a replication group.
+type XMLReplicationGroup struct {
+	ReplicationGroupID         string            `xml:"ReplicationGroupId"`
+	Description                string            `xml:"Description"`
+	Status                     string            `xml:"Status"`
+	MemberClusters             XMLMemberClusters `xml:"MemberClusters"`
+	NodeGroups                 XMLNodeGroups     `xml:"NodeGroups"`
+	AutomaticFailover          string            `xml:"AutomaticFailover"`
+	MultiAZ                    string            `xml:"MultiAZ"`
+	SnapshotRetentionLimit     int32             `xml:"SnapshotRetentionLimit"`
+	SnapshotWindow             string            `xml:"SnapshotWindow,omitempty"`
+	ClusterEnabled             bool              `xml:"ClusterEnabled"`
+	CacheNodeType              string            `xml:"CacheNodeType,omitempty"`
+	AuthTokenEnabled           bool              `xml:"AuthTokenEnabled"`
+	TransitEncryptionEnabled   bool              `xml:"TransitEncryptionEnabled"`
+	AtRestEncryptionEnabled    bool              `xml:"AtRestEncryptionEnabled"`
+	ARN                        string            `xml:"ARN"`
+	ConfigurationEndpoint      *XMLEndpoint      `xml:"ConfigurationEndpoint,omitempty"`
+	ReplicationGroupCreateTime string            `xml:"ReplicationGroupCreateTime"`
+	AutoMinorVersionUpgrade    bool              `xml:"AutoMinorVersionUpgrade"`
+	PreferredMaintenanceWindow string            `xml:"PreferredMaintenanceWindow,omitempty"`
+}
+
+// XMLReplicationGroups is a list of XML replication groups.
+type XMLReplicationGroups struct {
+	Items []XMLReplicationGroup `xml:"ReplicationGroup"`
+}
+
+// XMLMemberClusters is a list of member cluster IDs.
+type XMLMemberClusters struct {
+	Items []string `xml:"ClusterId"`
+}
+
+// XMLNodeGroup is the XML representation of a node group.
+type XMLNodeGroup struct {
+	NodeGroupID      string              `xml:"NodeGroupId"`
+	Status           string              `xml:"Status"`
+	PrimaryEndpoint  *XMLEndpoint        `xml:"PrimaryEndpoint,omitempty"`
+	ReaderEndpoint   *XMLEndpoint        `xml:"ReaderEndpoint,omitempty"`
+	NodeGroupMembers XMLNodeGroupMembers `xml:"NodeGroupMembers"`
+}
+
+// XMLNodeGroups is a list of XML node groups.
+type XMLNodeGroups struct {
+	Items []XMLNodeGroup `xml:"NodeGroup"`
+}
+
+// XMLNodeGroupMember is the XML representation of a node group member.
+type XMLNodeGroupMember struct {
+	CacheClusterID            string       `xml:"CacheClusterId"`
+	CacheNodeID               string       `xml:"CacheNodeId"`
+	ReadEndpoint              *XMLEndpoint `xml:"ReadEndpoint,omitempty"`
+	PreferredAvailabilityZone string       `xml:"PreferredAvailabilityZone,omitempty"`
+	CurrentRole               string       `xml:"CurrentRole,omitempty"`
+}
+
+// XMLNodeGroupMembers is a list of XML node group members.
+type XMLNodeGroupMembers struct {
+	Items []XMLNodeGroupMember `xml:"NodeGroupMember"`
+}
+
+// XMLErrorResponse is the XML error response.
+type XMLErrorResponse struct {
+	XMLName   xml.Name `xml:"ErrorResponse"`
+	Error     XMLError `xml:"Error"`
+	RequestID string   `xml:"RequestId"`
+}
+
+// XMLError is an XML error.
+type XMLError struct {
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}

--- a/internal/service/elasticache/service.go
+++ b/internal/service/elasticache/service.go
@@ -1,0 +1,60 @@
+package elasticache
+
+import (
+	"github.com/sivchari/awsim/internal/service"
+)
+
+func init() {
+	storage := NewMemoryStorage()
+	service.Register(New(storage))
+}
+
+// Service implements the ElastiCache service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new ElastiCache service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "elasticache"
+}
+
+// Prefix returns the URL prefix for the service.
+func (s *Service) Prefix() string {
+	return ""
+}
+
+// RegisterRoutes registers routes with the router.
+// ElastiCache uses Query protocol, so routes are registered via DispatchAction.
+func (s *Service) RegisterRoutes(_ service.Router) {
+	// ElastiCache uses Query protocol, routing is handled by DispatchAction.
+}
+
+// TargetPrefix returns the X-Amz-Target header prefix for ElastiCache.
+// ElastiCache uses Action parameter instead of X-Amz-Target header.
+func (s *Service) TargetPrefix() string {
+	return "AmazonElastiCacheV9"
+}
+
+// Actions returns the list of action names this service handles.
+func (s *Service) Actions() []string {
+	return []string{
+		"CreateCacheCluster",
+		"DeleteCacheCluster",
+		"DescribeCacheClusters",
+		"ModifyCacheCluster",
+		"CreateReplicationGroup",
+		"DeleteReplicationGroup",
+		"DescribeReplicationGroups",
+	}
+}
+
+// QueryProtocol is a marker method that indicates ElastiCache uses AWS Query protocol.
+func (s *Service) QueryProtocol() {}

--- a/internal/service/elasticache/storage.go
+++ b/internal/service/elasticache/storage.go
@@ -1,0 +1,446 @@
+package elasticache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	defaultAccountID = "000000000000"
+	defaultRegion    = "us-east-1"
+)
+
+// Storage defines the ElastiCache storage interface.
+type Storage interface {
+	CreateCacheCluster(ctx context.Context, input *CreateCacheClusterInput) (*CacheCluster, error)
+	DeleteCacheCluster(ctx context.Context, clusterID string) (*CacheCluster, error)
+	DescribeCacheClusters(ctx context.Context, clusterID string, showNodeInfo bool) ([]CacheCluster, error)
+	ModifyCacheCluster(ctx context.Context, input *ModifyCacheClusterInput) (*CacheCluster, error)
+	CreateReplicationGroup(ctx context.Context, input *CreateReplicationGroupInput) (*ReplicationGroup, error)
+	DeleteReplicationGroup(ctx context.Context, groupID string) (*ReplicationGroup, error)
+	DescribeReplicationGroups(ctx context.Context, groupID string) ([]ReplicationGroup, error)
+}
+
+// MemoryStorage implements Storage with in-memory data.
+type MemoryStorage struct {
+	mu                sync.RWMutex
+	cacheClusters     map[string]*CacheCluster
+	replicationGroups map[string]*ReplicationGroup
+}
+
+// NewMemoryStorage creates a new MemoryStorage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		cacheClusters:     make(map[string]*CacheCluster),
+		replicationGroups: make(map[string]*ReplicationGroup),
+	}
+}
+
+// CreateCacheCluster creates a new cache cluster.
+func (m *MemoryStorage) CreateCacheCluster(_ context.Context, input *CreateCacheClusterInput) (*CacheCluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.cacheClusters[input.CacheClusterID]; exists {
+		return nil, &Error{
+			Code:    errCacheClusterAlreadyExists,
+			Message: fmt.Sprintf("Cache cluster already exists: %s", input.CacheClusterID),
+		}
+	}
+
+	cluster := m.buildCacheCluster(input)
+	m.cacheClusters[input.CacheClusterID] = cluster
+
+	return cluster, nil
+}
+
+func (m *MemoryStorage) buildCacheCluster(input *CreateCacheClusterInput) *CacheCluster {
+	numNodes := input.NumCacheNodes
+	if numNodes == 0 {
+		numNodes = 1
+	}
+
+	az := input.PreferredAvailabilityZone
+	if az == "" {
+		az = defaultRegion + "a"
+	}
+
+	port := input.Port
+	if port == 0 {
+		port = m.getDefaultPort(input.Engine)
+	}
+
+	now := time.Now()
+
+	cluster := &CacheCluster{
+		CacheClusterID:             input.CacheClusterID,
+		CacheClusterStatus:         CacheClusterStatusAvailable,
+		CacheNodeType:              input.CacheNodeType,
+		Engine:                     input.Engine,
+		EngineVersion:              input.EngineVersion,
+		NumCacheNodes:              numNodes,
+		PreferredAvailabilityZone:  az,
+		CacheClusterCreateTime:     now,
+		PreferredMaintenanceWindow: input.PreferredMaintenanceWindow,
+		CacheSubnetGroupName:       input.CacheSubnetGroupName,
+		AutoMinorVersionUpgrade:    input.AutoMinorVersionUpgrade,
+		SnapshotRetentionLimit:     input.SnapshotRetentionLimit,
+		SnapshotWindow:             input.SnapshotWindow,
+		ARN:                        m.cacheClusterArn(input.CacheClusterID),
+		CacheNodes:                 m.buildCacheNodes(numNodes, az, port, now),
+		SecurityGroups:             buildSecurityGroups(input.SecurityGroupIDs),
+		ConfigurationEndpoint: &Endpoint{
+			Address: fmt.Sprintf("%s.%s.cfg.%s.cache.amazonaws.com", input.CacheClusterID, generateID(), defaultRegion),
+			Port:    port,
+		},
+	}
+
+	return cluster
+}
+
+func (m *MemoryStorage) buildCacheNodes(numNodes int32, az string, port int32, createTime time.Time) []CacheNode {
+	nodes := make([]CacheNode, 0, numNodes)
+
+	for i := range numNodes {
+		nodeID := fmt.Sprintf("%04d", i+1)
+		nodes = append(nodes, CacheNode{
+			CacheNodeID:              nodeID,
+			CacheNodeStatus:          CacheClusterStatusAvailable,
+			CacheNodeCreateTime:      createTime,
+			CustomerAvailabilityZone: az,
+			ParameterGroupStatus:     "in-sync",
+			Endpoint: &Endpoint{
+				Address: fmt.Sprintf("%s.%s.%s.cache.amazonaws.com", nodeID, generateID(), defaultRegion),
+				Port:    port,
+			},
+		})
+	}
+
+	return nodes
+}
+
+// DeleteCacheCluster deletes a cache cluster.
+func (m *MemoryStorage) DeleteCacheCluster(_ context.Context, clusterID string) (*CacheCluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cluster, exists := m.cacheClusters[clusterID]
+	if !exists {
+		return nil, &Error{
+			Code:    errCacheClusterNotFound,
+			Message: fmt.Sprintf("Cache cluster not found: %s", clusterID),
+		}
+	}
+
+	cluster.CacheClusterStatus = CacheClusterStatusDeleting
+
+	delete(m.cacheClusters, clusterID)
+
+	return cluster, nil
+}
+
+// DescribeCacheClusters describes cache clusters.
+func (m *MemoryStorage) DescribeCacheClusters(_ context.Context, clusterID string, showNodeInfo bool) ([]CacheCluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if clusterID != "" {
+		cluster, exists := m.cacheClusters[clusterID]
+		if !exists {
+			return nil, &Error{
+				Code:    errCacheClusterNotFound,
+				Message: fmt.Sprintf("Cache cluster not found: %s", clusterID),
+			}
+		}
+
+		result := *cluster
+		if !showNodeInfo {
+			result.CacheNodes = nil
+		}
+
+		return []CacheCluster{result}, nil
+	}
+
+	clusters := make([]CacheCluster, 0, len(m.cacheClusters))
+
+	for _, cluster := range m.cacheClusters {
+		result := *cluster
+		if !showNodeInfo {
+			result.CacheNodes = nil
+		}
+
+		clusters = append(clusters, result)
+	}
+
+	return clusters, nil
+}
+
+// ModifyCacheCluster modifies a cache cluster.
+func (m *MemoryStorage) ModifyCacheCluster(_ context.Context, input *ModifyCacheClusterInput) (*CacheCluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cluster, exists := m.cacheClusters[input.CacheClusterID]
+	if !exists {
+		return nil, &Error{
+			Code:    errCacheClusterNotFound,
+			Message: fmt.Sprintf("Cache cluster not found: %s", input.CacheClusterID),
+		}
+	}
+
+	applyCacheClusterModifications(cluster, input)
+
+	return cluster, nil
+}
+
+func applyCacheClusterModifications(cluster *CacheCluster, input *ModifyCacheClusterInput) {
+	if input.CacheNodeType != "" {
+		cluster.CacheNodeType = input.CacheNodeType
+	}
+
+	if input.EngineVersion != "" {
+		cluster.EngineVersion = input.EngineVersion
+	}
+
+	if input.NumCacheNodes != nil {
+		cluster.NumCacheNodes = *input.NumCacheNodes
+	}
+
+	if input.PreferredMaintenanceWindow != "" {
+		cluster.PreferredMaintenanceWindow = input.PreferredMaintenanceWindow
+	}
+
+	if input.AutoMinorVersionUpgrade != nil {
+		cluster.AutoMinorVersionUpgrade = *input.AutoMinorVersionUpgrade
+	}
+
+	if input.SnapshotRetentionLimit != nil {
+		cluster.SnapshotRetentionLimit = *input.SnapshotRetentionLimit
+	}
+
+	if input.SnapshotWindow != "" {
+		cluster.SnapshotWindow = input.SnapshotWindow
+	}
+
+	if len(input.SecurityGroupIDs) > 0 {
+		cluster.SecurityGroups = buildSecurityGroups(input.SecurityGroupIDs)
+	}
+}
+
+// CreateReplicationGroup creates a new replication group.
+func (m *MemoryStorage) CreateReplicationGroup(_ context.Context, input *CreateReplicationGroupInput) (*ReplicationGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.replicationGroups[input.ReplicationGroupID]; exists {
+		return nil, &Error{
+			Code:    errReplicationGroupAlreadyExists,
+			Message: fmt.Sprintf("Replication group already exists: %s", input.ReplicationGroupID),
+		}
+	}
+
+	group := m.buildReplicationGroup(input)
+	m.replicationGroups[input.ReplicationGroupID] = group
+
+	return group, nil
+}
+
+func (m *MemoryStorage) buildReplicationGroup(input *CreateReplicationGroupInput) *ReplicationGroup {
+	port := input.Port
+	if port == 0 {
+		port = m.getDefaultPort(input.Engine)
+	}
+
+	now := time.Now()
+
+	group := &ReplicationGroup{
+		ReplicationGroupID:         input.ReplicationGroupID,
+		Description:                input.ReplicationGroupDescription,
+		Status:                     ReplicationGroupStatusAvailable,
+		CacheNodeType:              input.CacheNodeType,
+		AutomaticFailover:          automaticFailoverStatus(input.AutomaticFailoverEnabled),
+		MultiAZ:                    multiAZStatus(input.MultiAZEnabled),
+		SnapshotRetentionLimit:     input.SnapshotRetentionLimit,
+		SnapshotWindow:             input.SnapshotWindow,
+		ClusterEnabled:             input.NumNodeGroups > 0,
+		TransitEncryptionEnabled:   input.TransitEncryptionEnabled,
+		AtRestEncryptionEnabled:    input.AtRestEncryptionEnabled,
+		ARN:                        m.replicationGroupArn(input.ReplicationGroupID),
+		ReplicationGroupCreateTime: now,
+		AutoMinorVersionUpgrade:    input.AutoMinorVersionUpgrade,
+		PreferredMaintenanceWindow: input.PreferredMaintenanceWindow,
+		ConfigurationEndpoint: &Endpoint{
+			Address: fmt.Sprintf("%s.%s.clustercfg.%s.cache.amazonaws.com", input.ReplicationGroupID, generateID(), defaultRegion),
+			Port:    port,
+		},
+		NodeGroups: m.buildNodeGroups(input, port),
+	}
+
+	return group
+}
+
+func (m *MemoryStorage) buildNodeGroups(input *CreateReplicationGroupInput, port int32) []NodeGroup {
+	numGroups := input.NumNodeGroups
+	if numGroups == 0 {
+		numGroups = 1
+	}
+
+	replicas := input.ReplicasPerNodeGroup
+
+	groups := make([]NodeGroup, 0, numGroups)
+
+	for i := range numGroups {
+		groupID := fmt.Sprintf("%04d", i+1)
+		nodeGroup := NodeGroup{
+			NodeGroupID: groupID,
+			Status:      ReplicationGroupStatusAvailable,
+			PrimaryEndpoint: &Endpoint{
+				Address: fmt.Sprintf("%s-%s.%s.%s.cache.amazonaws.com", input.ReplicationGroupID, groupID, generateID(), defaultRegion),
+				Port:    port,
+			},
+			ReaderEndpoint: &Endpoint{
+				Address: fmt.Sprintf("%s-%s-ro.%s.%s.cache.amazonaws.com", input.ReplicationGroupID, groupID, generateID(), defaultRegion),
+				Port:    port,
+			},
+			NodeGroupMembers: m.buildNodeGroupMembers(input.ReplicationGroupID, groupID, replicas, port),
+		}
+		groups = append(groups, nodeGroup)
+	}
+
+	return groups
+}
+
+func (m *MemoryStorage) buildNodeGroupMembers(rgID, ngID string, replicas, port int32) []NodeGroupMember {
+	// Primary + replicas
+	totalNodes := 1 + replicas
+	members := make([]NodeGroupMember, 0, totalNodes)
+
+	for i := range totalNodes {
+		role := "replica"
+		if i == 0 {
+			role = "primary"
+		}
+
+		nodeID := fmt.Sprintf("%04d", i+1)
+		clusterID := fmt.Sprintf("%s-%s-%s", rgID, ngID, nodeID)
+
+		members = append(members, NodeGroupMember{
+			CacheClusterID:            clusterID,
+			CacheNodeID:               nodeID,
+			PreferredAvailabilityZone: defaultRegion + "a",
+			CurrentRole:               role,
+			ReadEndpoint: &Endpoint{
+				Address: fmt.Sprintf("%s.%s.%s.cache.amazonaws.com", clusterID, generateID(), defaultRegion),
+				Port:    port,
+			},
+		})
+	}
+
+	return members
+}
+
+// DeleteReplicationGroup deletes a replication group.
+func (m *MemoryStorage) DeleteReplicationGroup(_ context.Context, groupID string) (*ReplicationGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	group, exists := m.replicationGroups[groupID]
+	if !exists {
+		return nil, &Error{
+			Code:    errReplicationGroupNotFound,
+			Message: fmt.Sprintf("Replication group not found: %s", groupID),
+		}
+	}
+
+	group.Status = ReplicationGroupStatusDeleting
+
+	delete(m.replicationGroups, groupID)
+
+	return group, nil
+}
+
+// DescribeReplicationGroups describes replication groups.
+func (m *MemoryStorage) DescribeReplicationGroups(_ context.Context, groupID string) ([]ReplicationGroup, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if groupID != "" {
+		group, exists := m.replicationGroups[groupID]
+		if !exists {
+			return nil, &Error{
+				Code:    errReplicationGroupNotFound,
+				Message: fmt.Sprintf("Replication group not found: %s", groupID),
+			}
+		}
+
+		return []ReplicationGroup{*group}, nil
+	}
+
+	groups := make([]ReplicationGroup, 0, len(m.replicationGroups))
+	for _, group := range m.replicationGroups {
+		groups = append(groups, *group)
+	}
+
+	return groups, nil
+}
+
+// Helper functions.
+
+func (m *MemoryStorage) cacheClusterArn(clusterID string) string {
+	return fmt.Sprintf("arn:aws:elasticache:%s:%s:cluster:%s", defaultRegion, defaultAccountID, clusterID)
+}
+
+func (m *MemoryStorage) replicationGroupArn(groupID string) string {
+	return fmt.Sprintf("arn:aws:elasticache:%s:%s:replicationgroup:%s", defaultRegion, defaultAccountID, groupID)
+}
+
+func (m *MemoryStorage) getDefaultPort(engine string) int32 {
+	switch engine {
+	case "redis", "valkey":
+		return 6379
+	case "memcached":
+		return 11211
+	default:
+		return 6379
+	}
+}
+
+func generateID() string {
+	return uuid.New().String()[:8]
+}
+
+func buildSecurityGroups(sgIDs []string) []SecurityGroupMembership {
+	if len(sgIDs) == 0 {
+		return nil
+	}
+
+	groups := make([]SecurityGroupMembership, 0, len(sgIDs))
+	for _, sgID := range sgIDs {
+		groups = append(groups, SecurityGroupMembership{
+			SecurityGroupID: sgID,
+			Status:          "active",
+		})
+	}
+
+	return groups
+}
+
+func automaticFailoverStatus(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+
+	return "disabled"
+}
+
+func multiAZStatus(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+
+	return "disabled"
+}

--- a/internal/service/elasticache/types.go
+++ b/internal/service/elasticache/types.go
@@ -1,0 +1,269 @@
+package elasticache
+
+import (
+	"time"
+)
+
+// CacheCluster represents an ElastiCache cluster.
+type CacheCluster struct {
+	CacheClusterID             string
+	CacheClusterStatus         string
+	CacheNodeType              string
+	Engine                     string
+	EngineVersion              string
+	NumCacheNodes              int32
+	PreferredAvailabilityZone  string
+	CacheClusterCreateTime     time.Time
+	PreferredMaintenanceWindow string
+	CacheSubnetGroupName       string
+	AutoMinorVersionUpgrade    bool
+	SnapshotRetentionLimit     int32
+	SnapshotWindow             string
+	ARN                        string
+	CacheNodes                 []CacheNode
+	CacheSecurityGroups        []CacheSecurityGroupMembership
+	SecurityGroups             []SecurityGroupMembership
+	CacheParameterGroup        *CacheParameterGroupStatus
+	ConfigurationEndpoint      *Endpoint
+}
+
+// CacheNode represents a node in a cache cluster.
+type CacheNode struct {
+	CacheNodeID              string
+	CacheNodeStatus          string
+	CacheNodeCreateTime      time.Time
+	Endpoint                 *Endpoint
+	ParameterGroupStatus     string
+	CustomerAvailabilityZone string
+}
+
+// ReplicationGroup represents an ElastiCache replication group.
+type ReplicationGroup struct {
+	ReplicationGroupID         string
+	Description                string
+	Status                     string
+	MemberClusters             []string
+	NodeGroups                 []NodeGroup
+	AutomaticFailover          string
+	MultiAZ                    string
+	SnapshotRetentionLimit     int32
+	SnapshotWindow             string
+	ClusterEnabled             bool
+	CacheNodeType              string
+	AuthTokenEnabled           bool
+	TransitEncryptionEnabled   bool
+	AtRestEncryptionEnabled    bool
+	ARN                        string
+	ConfigurationEndpoint      *Endpoint
+	ReplicationGroupCreateTime time.Time
+	AutoMinorVersionUpgrade    bool
+	PreferredMaintenanceWindow string
+}
+
+// NodeGroup represents a node group in a replication group.
+type NodeGroup struct {
+	NodeGroupID      string
+	Status           string
+	PrimaryEndpoint  *Endpoint
+	ReaderEndpoint   *Endpoint
+	NodeGroupMembers []NodeGroupMember
+}
+
+// NodeGroupMember represents a member of a node group.
+type NodeGroupMember struct {
+	CacheClusterID            string
+	CacheNodeID               string
+	ReadEndpoint              *Endpoint
+	PreferredAvailabilityZone string
+	CurrentRole               string
+}
+
+// Endpoint represents an endpoint.
+type Endpoint struct {
+	Address string
+	Port    int32
+}
+
+// CacheSecurityGroupMembership represents a cache security group membership.
+type CacheSecurityGroupMembership struct {
+	CacheSecurityGroupName string
+	Status                 string
+}
+
+// SecurityGroupMembership represents a security group membership.
+type SecurityGroupMembership struct {
+	SecurityGroupID string
+	Status          string
+}
+
+// CacheParameterGroupStatus represents a cache parameter group status.
+type CacheParameterGroupStatus struct {
+	CacheParameterGroupName string
+	ParameterApplyStatus    string
+	CacheNodeIDsToReboot    []string
+}
+
+// Request types.
+
+// CreateCacheClusterInput represents the input for CreateCacheCluster.
+type CreateCacheClusterInput struct {
+	CacheClusterID             string   `json:"CacheClusterId"`
+	CacheNodeType              string   `json:"CacheNodeType"`
+	Engine                     string   `json:"Engine"`
+	EngineVersion              string   `json:"EngineVersion,omitempty"`
+	NumCacheNodes              int32    `json:"NumCacheNodes,omitempty"`
+	PreferredAvailabilityZone  string   `json:"PreferredAvailabilityZone,omitempty"`
+	PreferredMaintenanceWindow string   `json:"PreferredMaintenanceWindow,omitempty"`
+	CacheSubnetGroupName       string   `json:"CacheSubnetGroupName,omitempty"`
+	SecurityGroupIDs           []string `json:"SecurityGroupIds,omitempty"`
+	AutoMinorVersionUpgrade    bool     `json:"AutoMinorVersionUpgrade,omitempty"`
+	SnapshotRetentionLimit     int32    `json:"SnapshotRetentionLimit,omitempty"`
+	SnapshotWindow             string   `json:"SnapshotWindow,omitempty"`
+	ReplicationGroupID         string   `json:"ReplicationGroupId,omitempty"`
+	Port                       int32    `json:"Port,omitempty"`
+}
+
+// CreateCacheClusterOutput represents the output for CreateCacheCluster.
+type CreateCacheClusterOutput struct {
+	CacheCluster *CacheCluster `json:"CacheCluster,omitempty"`
+}
+
+// DeleteCacheClusterInput represents the input for DeleteCacheCluster.
+type DeleteCacheClusterInput struct {
+	CacheClusterID          string `json:"CacheClusterId"`
+	FinalSnapshotIdentifier string `json:"FinalSnapshotIdentifier,omitempty"`
+}
+
+// DeleteCacheClusterOutput represents the output for DeleteCacheCluster.
+type DeleteCacheClusterOutput struct {
+	CacheCluster *CacheCluster `json:"CacheCluster,omitempty"`
+}
+
+// DescribeCacheClustersInput represents the input for DescribeCacheClusters.
+type DescribeCacheClustersInput struct {
+	CacheClusterID    string `json:"CacheClusterId,omitempty"`
+	MaxRecords        int32  `json:"MaxRecords,omitempty"`
+	Marker            string `json:"Marker,omitempty"`
+	ShowCacheNodeInfo bool   `json:"ShowCacheNodeInfo,omitempty"`
+}
+
+// DescribeCacheClustersOutput represents the output for DescribeCacheClusters.
+type DescribeCacheClustersOutput struct {
+	CacheClusters []CacheCluster `json:"CacheClusters,omitempty"`
+	Marker        string         `json:"Marker,omitempty"`
+}
+
+// ModifyCacheClusterInput represents the input for ModifyCacheCluster.
+type ModifyCacheClusterInput struct {
+	CacheClusterID             string   `json:"CacheClusterId"`
+	NumCacheNodes              *int32   `json:"NumCacheNodes,omitempty"`
+	CacheNodeIDsToRemove       []string `json:"CacheNodeIdsToRemove,omitempty"`
+	EngineVersion              string   `json:"EngineVersion,omitempty"`
+	CacheNodeType              string   `json:"CacheNodeType,omitempty"`
+	PreferredMaintenanceWindow string   `json:"PreferredMaintenanceWindow,omitempty"`
+	AutoMinorVersionUpgrade    *bool    `json:"AutoMinorVersionUpgrade,omitempty"`
+	SnapshotRetentionLimit     *int32   `json:"SnapshotRetentionLimit,omitempty"`
+	SnapshotWindow             string   `json:"SnapshotWindow,omitempty"`
+	SecurityGroupIDs           []string `json:"SecurityGroupIds,omitempty"`
+	ApplyImmediately           bool     `json:"ApplyImmediately,omitempty"`
+}
+
+// ModifyCacheClusterOutput represents the output for ModifyCacheCluster.
+type ModifyCacheClusterOutput struct {
+	CacheCluster *CacheCluster `json:"CacheCluster,omitempty"`
+}
+
+// CreateReplicationGroupInput represents the input for CreateReplicationGroup.
+type CreateReplicationGroupInput struct {
+	ReplicationGroupID          string   `json:"ReplicationGroupId"`
+	ReplicationGroupDescription string   `json:"ReplicationGroupDescription"`
+	PrimaryClusterID            string   `json:"PrimaryClusterId,omitempty"`
+	AutomaticFailoverEnabled    bool     `json:"AutomaticFailoverEnabled,omitempty"`
+	MultiAZEnabled              bool     `json:"MultiAZEnabled,omitempty"`
+	NumCacheClusters            int32    `json:"NumCacheClusters,omitempty"`
+	NumNodeGroups               int32    `json:"NumNodeGroups,omitempty"`
+	ReplicasPerNodeGroup        int32    `json:"ReplicasPerNodeGroup,omitempty"`
+	CacheNodeType               string   `json:"CacheNodeType,omitempty"`
+	Engine                      string   `json:"Engine,omitempty"`
+	EngineVersion               string   `json:"EngineVersion,omitempty"`
+	CacheSubnetGroupName        string   `json:"CacheSubnetGroupName,omitempty"`
+	SecurityGroupIDs            []string `json:"SecurityGroupIds,omitempty"`
+	PreferredMaintenanceWindow  string   `json:"PreferredMaintenanceWindow,omitempty"`
+	SnapshotRetentionLimit      int32    `json:"SnapshotRetentionLimit,omitempty"`
+	SnapshotWindow              string   `json:"SnapshotWindow,omitempty"`
+	AutoMinorVersionUpgrade     bool     `json:"AutoMinorVersionUpgrade,omitempty"`
+	TransitEncryptionEnabled    bool     `json:"TransitEncryptionEnabled,omitempty"`
+	AtRestEncryptionEnabled     bool     `json:"AtRestEncryptionEnabled,omitempty"`
+	Port                        int32    `json:"Port,omitempty"`
+}
+
+// CreateReplicationGroupOutput represents the output for CreateReplicationGroup.
+type CreateReplicationGroupOutput struct {
+	ReplicationGroup *ReplicationGroup `json:"ReplicationGroup,omitempty"`
+}
+
+// DeleteReplicationGroupInput represents the input for DeleteReplicationGroup.
+type DeleteReplicationGroupInput struct {
+	ReplicationGroupID      string `json:"ReplicationGroupId"`
+	RetainPrimaryCluster    bool   `json:"RetainPrimaryCluster,omitempty"`
+	FinalSnapshotIdentifier string `json:"FinalSnapshotIdentifier,omitempty"`
+}
+
+// DeleteReplicationGroupOutput represents the output for DeleteReplicationGroup.
+type DeleteReplicationGroupOutput struct {
+	ReplicationGroup *ReplicationGroup `json:"ReplicationGroup,omitempty"`
+}
+
+// DescribeReplicationGroupsInput represents the input for DescribeReplicationGroups.
+type DescribeReplicationGroupsInput struct {
+	ReplicationGroupID string `json:"ReplicationGroupId,omitempty"`
+	MaxRecords         int32  `json:"MaxRecords,omitempty"`
+	Marker             string `json:"Marker,omitempty"`
+}
+
+// DescribeReplicationGroupsOutput represents the output for DescribeReplicationGroups.
+type DescribeReplicationGroupsOutput struct {
+	ReplicationGroups []ReplicationGroup `json:"ReplicationGroups,omitempty"`
+	Marker            string             `json:"Marker,omitempty"`
+}
+
+// Error types.
+
+// Error represents an ElastiCache error.
+type Error struct {
+	Code    string
+	Message string
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return e.Message
+}
+
+// Error codes.
+const (
+	errCacheClusterNotFound          = "CacheClusterNotFoundFault"
+	errCacheClusterAlreadyExists     = "CacheClusterAlreadyExistsFault"
+	errReplicationGroupNotFound      = "ReplicationGroupNotFoundFault"
+	errReplicationGroupAlreadyExists = "ReplicationGroupAlreadyExistsFault"
+	errInvalidCacheClusterState      = "InvalidCacheClusterStateFault"
+	errInvalidReplicationGroupState  = "InvalidReplicationGroupStateFault"
+	errInvalidParameterValue         = "InvalidParameterValue"
+	errInvalidParameterCombination   = "InvalidParameterCombination"
+)
+
+// Cache cluster states.
+const (
+	CacheClusterStatusAvailable = "available"
+	CacheClusterStatusCreating  = "creating"
+	CacheClusterStatusDeleting  = "deleting"
+	CacheClusterStatusModifying = "modifying"
+)
+
+// Replication group states.
+const (
+	ReplicationGroupStatusAvailable = "available"
+	ReplicationGroupStatusCreating  = "creating"
+	ReplicationGroupStatusDeleting  = "deleting"
+	ReplicationGroupStatusModifying = "modifying"
+)

--- a/test/integration/elasticache_test.go
+++ b/test/integration/elasticache_test.go
@@ -1,0 +1,278 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+)
+
+func newElastiCacheClient(t *testing.T) *elasticache.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	return elasticache.NewFromConfig(cfg, func(o *elasticache.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestElastiCache_CreateAndDescribeCacheCluster(t *testing.T) {
+	client := newElastiCacheClient(t)
+	ctx := t.Context()
+
+	clusterID := "test-cache-cluster"
+
+	// Create cache cluster
+	createResult, err := client.CreateCacheCluster(ctx, &elasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String(clusterID),
+		CacheNodeType:  aws.String("cache.t3.micro"),
+		Engine:         aws.String("redis"),
+		NumCacheNodes:  aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("failed to create cache cluster: %v", err)
+	}
+
+	if createResult.CacheCluster == nil {
+		t.Fatal("expected CacheCluster in response, got nil")
+	}
+
+	if *createResult.CacheCluster.CacheClusterId != clusterID {
+		t.Errorf("expected identifier %s, got %s", clusterID, *createResult.CacheCluster.CacheClusterId)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteCacheCluster(ctx, &elasticache.DeleteCacheClusterInput{
+			CacheClusterId: aws.String(clusterID),
+		})
+	})
+
+	// Describe cache clusters
+	descResult, err := client.DescribeCacheClusters(ctx, &elasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String(clusterID),
+	})
+	if err != nil {
+		t.Fatalf("failed to describe cache clusters: %v", err)
+	}
+
+	if len(descResult.CacheClusters) != 1 {
+		t.Errorf("expected 1 cluster, got %d", len(descResult.CacheClusters))
+	}
+
+	if *descResult.CacheClusters[0].CacheClusterId != clusterID {
+		t.Errorf("expected identifier %s, got %s", clusterID, *descResult.CacheClusters[0].CacheClusterId)
+	}
+}
+
+func TestElastiCache_ModifyCacheCluster(t *testing.T) {
+	client := newElastiCacheClient(t)
+	ctx := t.Context()
+
+	clusterID := "test-modify-cache-cluster"
+
+	// Create cache cluster
+	_, err := client.CreateCacheCluster(ctx, &elasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String(clusterID),
+		CacheNodeType:  aws.String("cache.t3.micro"),
+		Engine:         aws.String("redis"),
+		NumCacheNodes:  aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("failed to create cache cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteCacheCluster(ctx, &elasticache.DeleteCacheClusterInput{
+			CacheClusterId: aws.String(clusterID),
+		})
+	})
+
+	// Modify cache cluster
+	modifyResult, err := client.ModifyCacheCluster(ctx, &elasticache.ModifyCacheClusterInput{
+		CacheClusterId:   aws.String(clusterID),
+		CacheNodeType:    aws.String("cache.t3.small"),
+		ApplyImmediately: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("failed to modify cache cluster: %v", err)
+	}
+
+	if *modifyResult.CacheCluster.CacheNodeType != "cache.t3.small" {
+		t.Errorf("expected node type cache.t3.small, got %s", *modifyResult.CacheCluster.CacheNodeType)
+	}
+}
+
+func TestElastiCache_DeleteCacheCluster(t *testing.T) {
+	client := newElastiCacheClient(t)
+	ctx := t.Context()
+
+	clusterID := "test-delete-cache-cluster"
+
+	// Create cache cluster
+	_, err := client.CreateCacheCluster(ctx, &elasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String(clusterID),
+		CacheNodeType:  aws.String("cache.t3.micro"),
+		Engine:         aws.String("redis"),
+		NumCacheNodes:  aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("failed to create cache cluster: %v", err)
+	}
+
+	// Delete cache cluster
+	deleteResult, err := client.DeleteCacheCluster(ctx, &elasticache.DeleteCacheClusterInput{
+		CacheClusterId: aws.String(clusterID),
+	})
+	if err != nil {
+		t.Fatalf("failed to delete cache cluster: %v", err)
+	}
+
+	if *deleteResult.CacheCluster.CacheClusterId != clusterID {
+		t.Errorf("expected identifier %s, got %s", clusterID, *deleteResult.CacheCluster.CacheClusterId)
+	}
+
+	// Verify cluster is deleted
+	_, err = client.DescribeCacheClusters(ctx, &elasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String(clusterID),
+	})
+	if err == nil {
+		t.Error("expected error when describing deleted cluster, got nil")
+	}
+}
+
+func TestElastiCache_CreateAndDescribeReplicationGroup(t *testing.T) {
+	client := newElastiCacheClient(t)
+	ctx := t.Context()
+
+	groupID := "test-replication-group"
+
+	// Create replication group
+	createResult, err := client.CreateReplicationGroup(ctx, &elasticache.CreateReplicationGroupInput{
+		ReplicationGroupId:          aws.String(groupID),
+		ReplicationGroupDescription: aws.String("Test replication group"),
+		CacheNodeType:               aws.String("cache.t3.micro"),
+		Engine:                      aws.String("redis"),
+		NumCacheClusters:            aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("failed to create replication group: %v", err)
+	}
+
+	if createResult.ReplicationGroup == nil {
+		t.Fatal("expected ReplicationGroup in response, got nil")
+	}
+
+	if *createResult.ReplicationGroup.ReplicationGroupId != groupID {
+		t.Errorf("expected identifier %s, got %s", groupID, *createResult.ReplicationGroup.ReplicationGroupId)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteReplicationGroup(ctx, &elasticache.DeleteReplicationGroupInput{
+			ReplicationGroupId: aws.String(groupID),
+		})
+	})
+
+	// Describe replication groups
+	descResult, err := client.DescribeReplicationGroups(ctx, &elasticache.DescribeReplicationGroupsInput{
+		ReplicationGroupId: aws.String(groupID),
+	})
+	if err != nil {
+		t.Fatalf("failed to describe replication groups: %v", err)
+	}
+
+	if len(descResult.ReplicationGroups) != 1 {
+		t.Errorf("expected 1 group, got %d", len(descResult.ReplicationGroups))
+	}
+
+	if *descResult.ReplicationGroups[0].ReplicationGroupId != groupID {
+		t.Errorf("expected identifier %s, got %s", groupID, *descResult.ReplicationGroups[0].ReplicationGroupId)
+	}
+}
+
+func TestElastiCache_DeleteReplicationGroup(t *testing.T) {
+	client := newElastiCacheClient(t)
+	ctx := t.Context()
+
+	groupID := "test-delete-replication-group"
+
+	// Create replication group
+	_, err := client.CreateReplicationGroup(ctx, &elasticache.CreateReplicationGroupInput{
+		ReplicationGroupId:          aws.String(groupID),
+		ReplicationGroupDescription: aws.String("Test replication group for deletion"),
+		CacheNodeType:               aws.String("cache.t3.micro"),
+		Engine:                      aws.String("redis"),
+	})
+	if err != nil {
+		t.Fatalf("failed to create replication group: %v", err)
+	}
+
+	// Delete replication group
+	deleteResult, err := client.DeleteReplicationGroup(ctx, &elasticache.DeleteReplicationGroupInput{
+		ReplicationGroupId: aws.String(groupID),
+	})
+	if err != nil {
+		t.Fatalf("failed to delete replication group: %v", err)
+	}
+
+	if *deleteResult.ReplicationGroup.ReplicationGroupId != groupID {
+		t.Errorf("expected identifier %s, got %s", groupID, *deleteResult.ReplicationGroup.ReplicationGroupId)
+	}
+
+	// Verify group is deleted
+	_, err = client.DescribeReplicationGroups(ctx, &elasticache.DescribeReplicationGroupsInput{
+		ReplicationGroupId: aws.String(groupID),
+	})
+	if err == nil {
+		t.Error("expected error when describing deleted group, got nil")
+	}
+}
+
+func TestElastiCache_DescribeCacheClusters_All(t *testing.T) {
+	client := newElastiCacheClient(t)
+	ctx := t.Context()
+
+	// Create multiple cache clusters
+	clusterIDs := []string{"test-cache-cluster-1", "test-cache-cluster-2"}
+	for _, id := range clusterIDs {
+		_, err := client.CreateCacheCluster(ctx, &elasticache.CreateCacheClusterInput{
+			CacheClusterId: aws.String(id),
+			CacheNodeType:  aws.String("cache.t3.micro"),
+			Engine:         aws.String("redis"),
+			NumCacheNodes:  aws.Int32(1),
+		})
+		if err != nil {
+			t.Fatalf("failed to create cache cluster %s: %v", id, err)
+		}
+	}
+
+	t.Cleanup(func() {
+		for _, id := range clusterIDs {
+			_, _ = client.DeleteCacheCluster(ctx, &elasticache.DeleteCacheClusterInput{
+				CacheClusterId: aws.String(id),
+			})
+		}
+	})
+
+	// Describe all cache clusters
+	descResult, err := client.DescribeCacheClusters(ctx, &elasticache.DescribeCacheClustersInput{})
+	if err != nil {
+		t.Fatalf("failed to describe cache clusters: %v", err)
+	}
+
+	if len(descResult.CacheClusters) < 2 {
+		t.Errorf("expected at least 2 clusters, got %d", len(descResult.CacheClusters))
+	}
+}


### PR DESCRIPTION
## Summary
- Add ElastiCache service with support for cache clusters and replication groups
- Implemented APIs: CreateCacheCluster, DeleteCacheCluster, DescribeCacheClusters, ModifyCacheCluster, CreateReplicationGroup, DeleteReplicationGroup, DescribeReplicationGroups
- Uses Query Protocol with XML responses, following existing service patterns

## Test plan
- [x] Lint passes
- [x] Tests pass
- [ ] Integration tests with AWS SDK v2

Closes #25