### PR TITLE
feat(release): add Homebrew support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,3 +78,13 @@ docker_manifests:
     image_templates:
       - "ghcr.io/sivchari/awsim:{{ .Version }}-amd64"
       - "ghcr.io/sivchari/awsim:{{ .Version }}-arm64"
+
+brews:
+  - name: awsim
+    repository:
+      owner: sivchari
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/sivchari/awsim
+    description: "A lightweight AWS service emulator for CI/CD environments"
+    license: MIT


### PR DESCRIPTION
## Summary

- Add `brews` section to goreleaser configuration
- Enable installation via Homebrew tap (`sivchari/homebrew-tap`)

## Prerequisites

1. Create `sivchari/homebrew-tap` repository (if not exists)
2. Add `HOMEBREW_TAP_GITHUB_TOKEN` secret to GitHub Actions

## Installation (after release)

```bash
brew install sivchari/tap/awsim
```