### PR TITLE
chore: bump version to v0.1.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@
 package awsim
 
 // Version is the current version of awsim.
-const Version = "0.0.2"
+const Version = "0.1.0"


### PR DESCRIPTION
## Summary
- Bump version from 0.0.2 to 0.1.0 for tagpr release

## Test plan
- [ ] Verify tagpr detects version change and creates release PR