### PR TITLE
feat(sagemaker): add SageMaker service basic implementation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -218,6 +218,10 @@ linters:
       - path: internal/service/dlm/types\.go
         linters:
           - tagliatelle
+      # AWS SageMaker API requires PascalCase JSON field names.
+      - path: internal/service/sagemaker/types\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/route53"
 	_ "github.com/sivchari/awsim/internal/service/s3"
 	_ "github.com/sivchari/awsim/internal/service/s3tables"
+	_ "github.com/sivchari/awsim/internal/service/sagemaker"
 	_ "github.com/sivchari/awsim/internal/service/scheduler"
 	_ "github.com/sivchari/awsim/internal/service/secretsmanager"
 	_ "github.com/sivchari/awsim/internal/service/servicequotas"

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.14.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.233.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.19
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.34.2

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 h1:oeu8VPlOre74lBA/PMhxa5vewaMIM
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0/go.mod h1:5jggDlZ2CLQhwJBiZJb4vfk4f0GxWdEDruWKEJ1xOdo=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.14.0 h1:PrT+91Zc0K7w7v71PkvhxrblCSpl92kuiIveQ6Dnz8U=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.14.0/go.mod h1:1nxPz+DecxdsuL/ykEU9EN3WoaMhpX8K6S9CHbms6Eg=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.233.1 h1:Wx9PBanAjQoaTic4/syMZkvDhwYQ35uHHFiHANHR4vA=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.233.1/go.mod h1:vHHLHyX3/W2ju1unIDtxTdWMJEQ9wLWf0/WXzB7aYOM=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.19 h1:Jsz0LdqfucS8YM1E6pbcuURBo+Z1mFWJIfxzCEYDMJA=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.19/go.mod h1:LbJJ7RHzglcg4ogjIOMsyuw+GSAYXipEaikJGDkKAxY=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1 h1:72DBkm/CCuWx2LMHAXvLDkZfzopT3psfAeyZDIt1/yE=

--- a/internal/service/sagemaker/handlers.go
+++ b/internal/service/sagemaker/handlers.go
@@ -1,0 +1,479 @@
+package sagemaker
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// Error codes for SageMaker handlers.
+const (
+	errInvalidAction = "UnknownOperationException"
+)
+
+// DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.
+func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
+	target := r.Header.Get("X-Amz-Target")
+	action := strings.TrimPrefix(target, "SageMaker.")
+
+	switch action {
+	case "CreateNotebookInstance":
+		s.CreateNotebookInstance(w, r)
+	case "DeleteNotebookInstance":
+		s.DeleteNotebookInstance(w, r)
+	case "DescribeNotebookInstance":
+		s.DescribeNotebookInstance(w, r)
+	case "ListNotebookInstances":
+		s.ListNotebookInstances(w, r)
+	case "CreateTrainingJob":
+		s.CreateTrainingJob(w, r)
+	case "DescribeTrainingJob":
+		s.DescribeTrainingJob(w, r)
+	case "CreateModel":
+		s.CreateModel(w, r)
+	case "DeleteModel":
+		s.DeleteModel(w, r)
+	case "CreateEndpoint":
+		s.CreateEndpoint(w, r)
+	case "DeleteEndpoint":
+		s.DeleteEndpoint(w, r)
+	case "DescribeEndpoint":
+		s.DescribeEndpoint(w, r)
+	default:
+		writeError(w, errInvalidAction, "Unknown operation: "+action, http.StatusBadRequest)
+	}
+}
+
+// CreateNotebookInstance handles the CreateNotebookInstance action.
+func (s *Service) CreateNotebookInstance(w http.ResponseWriter, r *http.Request) {
+	var req CreateNotebookInstanceRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.NotebookInstanceName == "" {
+		writeError(w, errValidationException, "NotebookInstanceName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.InstanceType == "" {
+		writeError(w, errValidationException, "InstanceType is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RoleArn == "" {
+		writeError(w, errValidationException, "RoleArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	instance, err := s.storage.CreateNotebookInstance(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, CreateNotebookInstanceResponse{
+		NotebookInstanceArn: instance.NotebookInstanceArn,
+	})
+}
+
+// DeleteNotebookInstance handles the DeleteNotebookInstance action.
+func (s *Service) DeleteNotebookInstance(w http.ResponseWriter, r *http.Request) {
+	var req DeleteNotebookInstanceRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.NotebookInstanceName == "" {
+		writeError(w, errValidationException, "NotebookInstanceName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteNotebookInstance(r.Context(), req.NotebookInstanceName); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, struct{}{})
+}
+
+// DescribeNotebookInstance handles the DescribeNotebookInstance action.
+func (s *Service) DescribeNotebookInstance(w http.ResponseWriter, r *http.Request) {
+	var req DescribeNotebookInstanceRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.NotebookInstanceName == "" {
+		writeError(w, errValidationException, "NotebookInstanceName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	instance, err := s.storage.DescribeNotebookInstance(r.Context(), req.NotebookInstanceName)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, DescribeNotebookInstanceResponse{
+		NotebookInstanceName:   instance.NotebookInstanceName,
+		NotebookInstanceArn:    instance.NotebookInstanceArn,
+		NotebookInstanceStatus: instance.NotebookInstanceStatus,
+		URL:                    instance.URL,
+		InstanceType:           instance.InstanceType,
+		RoleArn:                instance.RoleArn,
+		KmsKeyID:               instance.KmsKeyID,
+		SubnetID:               instance.SubnetID,
+		SecurityGroups:         instance.SecurityGroups,
+		DirectInternetAccess:   instance.DirectInternetAccess,
+		VolumeSizeInGB:         instance.VolumeSizeInGB,
+		RootAccess:             instance.RootAccess,
+		CreationTime:           float64(instance.CreationTime.Unix()),
+		LastModifiedTime:       float64(instance.LastModifiedTime.Unix()),
+	})
+}
+
+// ListNotebookInstances handles the ListNotebookInstances action.
+func (s *Service) ListNotebookInstances(w http.ResponseWriter, r *http.Request) {
+	var req ListNotebookInstancesRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	instances, nextToken, err := s.storage.ListNotebookInstances(r.Context(), req.MaxResults, req.NextToken)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	summaries := make([]NotebookInstanceSummary, 0, len(instances))
+
+	for _, instance := range instances {
+		summaries = append(summaries, NotebookInstanceSummary{
+			NotebookInstanceName:   instance.NotebookInstanceName,
+			NotebookInstanceArn:    instance.NotebookInstanceArn,
+			NotebookInstanceStatus: instance.NotebookInstanceStatus,
+			URL:                    instance.URL,
+			InstanceType:           instance.InstanceType,
+			CreationTime:           float64(instance.CreationTime.Unix()),
+			LastModifiedTime:       float64(instance.LastModifiedTime.Unix()),
+		})
+	}
+
+	writeJSONResponse(w, ListNotebookInstancesResponse{
+		NotebookInstances: summaries,
+		NextToken:         nextToken,
+	})
+}
+
+// CreateTrainingJob handles the CreateTrainingJob action.
+func (s *Service) CreateTrainingJob(w http.ResponseWriter, r *http.Request) {
+	var req CreateTrainingJobRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.TrainingJobName == "" {
+		writeError(w, errValidationException, "TrainingJobName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RoleArn == "" {
+		writeError(w, errValidationException, "RoleArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	job, err := s.storage.CreateTrainingJob(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, CreateTrainingJobResponse{
+		TrainingJobArn: job.TrainingJobArn,
+	})
+}
+
+// DescribeTrainingJob handles the DescribeTrainingJob action.
+func (s *Service) DescribeTrainingJob(w http.ResponseWriter, r *http.Request) {
+	var req DescribeTrainingJobRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.TrainingJobName == "" {
+		writeError(w, errValidationException, "TrainingJobName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	job, err := s.storage.DescribeTrainingJob(r.Context(), req.TrainingJobName)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	resp := DescribeTrainingJobResponse{
+		TrainingJobName:   job.TrainingJobName,
+		TrainingJobArn:    job.TrainingJobArn,
+		TrainingJobStatus: job.TrainingJobStatus,
+		SecondaryStatus:   job.SecondaryStatus,
+		AlgorithmSpec:     job.AlgorithmSpec,
+		RoleArn:           job.RoleArn,
+		InputDataConfig:   job.InputDataConfig,
+		OutputDataConfig:  job.OutputDataConfig,
+		ResourceConfig:    job.ResourceConfig,
+		StoppingCondition: job.StoppingCondition,
+		CreationTime:      float64(job.CreationTime.Unix()),
+		FailureReason:     job.FailureReason,
+	}
+
+	if job.TrainingStartTime != nil {
+		startTime := float64(job.TrainingStartTime.Unix())
+		resp.TrainingStartTime = &startTime
+	}
+
+	if job.TrainingEndTime != nil {
+		endTime := float64(job.TrainingEndTime.Unix())
+		resp.TrainingEndTime = &endTime
+	}
+
+	writeJSONResponse(w, resp)
+}
+
+// CreateModel handles the CreateModel action.
+func (s *Service) CreateModel(w http.ResponseWriter, r *http.Request) {
+	var req CreateModelRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ModelName == "" {
+		writeError(w, errValidationException, "ModelName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ExecutionRoleArn == "" {
+		writeError(w, errValidationException, "ExecutionRoleArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	model, err := s.storage.CreateModel(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, CreateModelResponse{
+		ModelArn: model.ModelArn,
+	})
+}
+
+// DeleteModel handles the DeleteModel action.
+func (s *Service) DeleteModel(w http.ResponseWriter, r *http.Request) {
+	var req DeleteModelRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ModelName == "" {
+		writeError(w, errValidationException, "ModelName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteModel(r.Context(), req.ModelName); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, struct{}{})
+}
+
+// CreateEndpoint handles the CreateEndpoint action.
+func (s *Service) CreateEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req CreateEndpointRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.EndpointName == "" {
+		writeError(w, errValidationException, "EndpointName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.EndpointConfigName == "" {
+		writeError(w, errValidationException, "EndpointConfigName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	endpoint, err := s.storage.CreateEndpoint(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, CreateEndpointResponse{
+		EndpointArn: endpoint.EndpointArn,
+	})
+}
+
+// DeleteEndpoint handles the DeleteEndpoint action.
+func (s *Service) DeleteEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req DeleteEndpointRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.EndpointName == "" {
+		writeError(w, errValidationException, "EndpointName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteEndpoint(r.Context(), req.EndpointName); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, struct{}{})
+}
+
+// DescribeEndpoint handles the DescribeEndpoint action.
+func (s *Service) DescribeEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req DescribeEndpointRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.EndpointName == "" {
+		writeError(w, errValidationException, "EndpointName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	endpoint, err := s.storage.DescribeEndpoint(r.Context(), req.EndpointName)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, DescribeEndpointResponse{
+		EndpointName:       endpoint.EndpointName,
+		EndpointArn:        endpoint.EndpointArn,
+		EndpointConfigName: endpoint.EndpointConfigName,
+		EndpointStatus:     endpoint.EndpointStatus,
+		CreationTime:       float64(endpoint.CreationTime.Unix()),
+		LastModifiedTime:   float64(endpoint.LastModifiedTime.Unix()),
+		FailureReason:      endpoint.FailureReason,
+	})
+}
+
+// readJSONRequest reads and decodes JSON request body.
+func readJSONRequest(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return nil
+}
+
+// writeJSONResponse writes a JSON response with HTTP 200 OK.
+func writeJSONResponse(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeError writes an error response.
+func writeError(w http.ResponseWriter, code, message string, status int) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{
+		Type:    code,
+		Message: message,
+	})
+}
+
+// handleError handles service errors.
+func handleError(w http.ResponseWriter, err error) {
+	var sErr *Error
+	if errors.As(err, &sErr) {
+		status := http.StatusBadRequest
+
+		switch sErr.Code {
+		case errResourceNotFound:
+			status = http.StatusNotFound
+		case errResourceInUse:
+			status = http.StatusConflict
+		case errInternalFailure:
+			status = http.StatusInternalServerError
+		}
+
+		writeError(w, sErr.Code, sErr.Message, status)
+
+		return
+	}
+
+	writeError(w, errInternalFailure, "Internal server error", http.StatusInternalServerError)
+}

--- a/internal/service/sagemaker/service.go
+++ b/internal/service/sagemaker/service.go
@@ -1,0 +1,53 @@
+// Package sagemaker provides SageMaker service emulation for awsim.
+package sagemaker
+
+import (
+	"github.com/sivchari/awsim/internal/service"
+)
+
+func init() {
+	service.Register(New(NewMemoryStorage()))
+}
+
+// Service implements the SageMaker service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new SageMaker service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "sagemaker"
+}
+
+// Prefix returns the URL prefix for this service.
+func (s *Service) Prefix() string {
+	return ""
+}
+
+// RegisterRoutes registers the SageMaker routes.
+// Note: SageMaker uses AWS JSON 1.1 protocol via the JSONProtocolService interface,
+// so no direct routes are registered here.
+func (s *Service) RegisterRoutes(_ service.Router) {
+	// No routes to register - SageMaker uses JSON protocol dispatcher
+}
+
+// TargetPrefix returns the X-Amz-Target header prefix for SageMaker.
+func (s *Service) TargetPrefix() string {
+	return "SageMaker"
+}
+
+// JSONProtocol is a marker method that indicates SageMaker uses AWS JSON 1.1 protocol.
+func (s *Service) JSONProtocol() {}
+
+// Ensure Service implements service.Service and service.JSONProtocolService.
+var (
+	_ service.Service             = (*Service)(nil)
+	_ service.JSONProtocolService = (*Service)(nil)
+)

--- a/internal/service/sagemaker/storage.go
+++ b/internal/service/sagemaker/storage.go
@@ -1,0 +1,350 @@
+package sagemaker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Error codes.
+const (
+	errResourceNotFound    = "ResourceNotFound"
+	errResourceInUse       = "ResourceInUse"
+	errValidationException = "ValidationException"
+	errInternalFailure     = "InternalFailure"
+)
+
+// Default values.
+const (
+	defaultRegion    = "us-east-1"
+	defaultAccountID = "123456789012"
+)
+
+// Notebook instance statuses.
+const statusInService = "InService"
+
+// Training job statuses.
+const trainingStatusCompleted = "Completed"
+
+// Endpoint statuses.
+const endpointStatusInService = "InService"
+
+// Storage defines the SageMaker service storage interface.
+type Storage interface {
+	// Notebook instance operations
+	CreateNotebookInstance(ctx context.Context, req *CreateNotebookInstanceRequest) (*NotebookInstance, error)
+	DeleteNotebookInstance(ctx context.Context, name string) error
+	DescribeNotebookInstance(ctx context.Context, name string) (*NotebookInstance, error)
+	ListNotebookInstances(ctx context.Context, maxResults int32, nextToken string) ([]*NotebookInstance, string, error)
+
+	// Training job operations
+	CreateTrainingJob(ctx context.Context, req *CreateTrainingJobRequest) (*TrainingJob, error)
+	DescribeTrainingJob(ctx context.Context, name string) (*TrainingJob, error)
+
+	// Model operations
+	CreateModel(ctx context.Context, req *CreateModelRequest) (*Model, error)
+	DeleteModel(ctx context.Context, name string) error
+
+	// Endpoint operations
+	CreateEndpoint(ctx context.Context, req *CreateEndpointRequest) (*Endpoint, error)
+	DeleteEndpoint(ctx context.Context, name string) error
+	DescribeEndpoint(ctx context.Context, name string) (*Endpoint, error)
+}
+
+// MemoryStorage implements Storage with in-memory data.
+type MemoryStorage struct {
+	mu                sync.RWMutex
+	notebookInstances map[string]*NotebookInstance
+	trainingJobs      map[string]*TrainingJob
+	models            map[string]*Model
+	endpoints         map[string]*Endpoint
+	region            string
+	accountID         string
+}
+
+// NewMemoryStorage creates a new MemoryStorage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		notebookInstances: make(map[string]*NotebookInstance),
+		trainingJobs:      make(map[string]*TrainingJob),
+		models:            make(map[string]*Model),
+		endpoints:         make(map[string]*Endpoint),
+		region:            defaultRegion,
+		accountID:         defaultAccountID,
+	}
+}
+
+// CreateNotebookInstance creates a new notebook instance.
+func (m *MemoryStorage) CreateNotebookInstance(_ context.Context, req *CreateNotebookInstanceRequest) (*NotebookInstance, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.notebookInstances[req.NotebookInstanceName]; exists {
+		return nil, &Error{
+			Code:    errResourceInUse,
+			Message: fmt.Sprintf("Notebook instance %s already exists", req.NotebookInstanceName),
+		}
+	}
+
+	now := time.Now()
+	arn := fmt.Sprintf("arn:aws:sagemaker:%s:%s:notebook-instance/%s", m.region, m.accountID, req.NotebookInstanceName)
+
+	instance := &NotebookInstance{
+		NotebookInstanceName:   req.NotebookInstanceName,
+		NotebookInstanceArn:    arn,
+		NotebookInstanceStatus: statusInService,
+		InstanceType:           req.InstanceType,
+		RoleArn:                req.RoleArn,
+		KmsKeyID:               req.KmsKeyID,
+		SubnetID:               req.SubnetID,
+		SecurityGroups:         req.SecurityGroupIDs,
+		DirectInternetAccess:   req.DirectInternetAccess,
+		VolumeSizeInGB:         req.VolumeSizeInGB,
+		AcceleratorTypes:       req.AcceleratorTypes,
+		DefaultCodeRepository:  req.DefaultCodeRepository,
+		AdditionalCodeRepos:    req.AdditionalCodeRepos,
+		RootAccess:             req.RootAccess,
+		PlatformIdentifier:     req.PlatformIdentifier,
+		InstanceMetadataConfig: req.InstanceMetadataConfig,
+		CreationTime:           now,
+		LastModifiedTime:       now,
+	}
+
+	// Set default volume size if not specified.
+	if instance.VolumeSizeInGB == 0 {
+		instance.VolumeSizeInGB = 5
+	}
+
+	// Set default direct internet access.
+	if instance.DirectInternetAccess == "" {
+		instance.DirectInternetAccess = "Enabled"
+	}
+
+	// Set default root access.
+	if instance.RootAccess == "" {
+		instance.RootAccess = "Enabled"
+	}
+
+	m.notebookInstances[req.NotebookInstanceName] = instance
+
+	return instance, nil
+}
+
+// DeleteNotebookInstance deletes a notebook instance.
+func (m *MemoryStorage) DeleteNotebookInstance(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.notebookInstances[name]; !exists {
+		return &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Notebook instance %s not found", name),
+		}
+	}
+
+	delete(m.notebookInstances, name)
+
+	return nil
+}
+
+// DescribeNotebookInstance describes a notebook instance.
+func (m *MemoryStorage) DescribeNotebookInstance(_ context.Context, name string) (*NotebookInstance, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	instance, exists := m.notebookInstances[name]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Notebook instance %s not found", name),
+		}
+	}
+
+	return instance, nil
+}
+
+// ListNotebookInstances lists notebook instances.
+func (m *MemoryStorage) ListNotebookInstances(_ context.Context, maxResults int32, _ string) ([]*NotebookInstance, string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if maxResults <= 0 {
+		maxResults = 100
+	}
+
+	result := make([]*NotebookInstance, 0, len(m.notebookInstances))
+
+	for _, instance := range m.notebookInstances {
+		result = append(result, instance)
+
+		if len(result) >= int(maxResults) {
+			break
+		}
+	}
+
+	return result, "", nil
+}
+
+// CreateTrainingJob creates a new training job.
+func (m *MemoryStorage) CreateTrainingJob(_ context.Context, req *CreateTrainingJobRequest) (*TrainingJob, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.trainingJobs[req.TrainingJobName]; exists {
+		return nil, &Error{
+			Code:    errResourceInUse,
+			Message: fmt.Sprintf("Training job %s already exists", req.TrainingJobName),
+		}
+	}
+
+	now := time.Now()
+	arn := fmt.Sprintf("arn:aws:sagemaker:%s:%s:training-job/%s", m.region, m.accountID, req.TrainingJobName)
+
+	job := &TrainingJob{
+		TrainingJobName:   req.TrainingJobName,
+		TrainingJobArn:    arn,
+		TrainingJobStatus: trainingStatusCompleted,
+		SecondaryStatus:   "Completed",
+		AlgorithmSpec:     req.AlgorithmSpec,
+		RoleArn:           req.RoleArn,
+		InputDataConfig:   req.InputDataConfig,
+		OutputDataConfig:  req.OutputDataConfig,
+		ResourceConfig:    req.ResourceConfig,
+		StoppingCondition: req.StoppingCondition,
+		CreationTime:      now,
+		TrainingStartTime: &now,
+		TrainingEndTime:   &now,
+	}
+
+	m.trainingJobs[req.TrainingJobName] = job
+
+	return job, nil
+}
+
+// DescribeTrainingJob describes a training job.
+func (m *MemoryStorage) DescribeTrainingJob(_ context.Context, name string) (*TrainingJob, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	job, exists := m.trainingJobs[name]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Training job %s not found", name),
+		}
+	}
+
+	return job, nil
+}
+
+// CreateModel creates a new model.
+func (m *MemoryStorage) CreateModel(_ context.Context, req *CreateModelRequest) (*Model, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.models[req.ModelName]; exists {
+		return nil, &Error{
+			Code:    errResourceInUse,
+			Message: fmt.Sprintf("Model %s already exists", req.ModelName),
+		}
+	}
+
+	now := time.Now()
+	arn := fmt.Sprintf("arn:aws:sagemaker:%s:%s:model/%s", m.region, m.accountID, req.ModelName)
+
+	model := &Model{
+		ModelName:              req.ModelName,
+		ModelArn:               arn,
+		PrimaryContainer:       req.PrimaryContainer,
+		ExecutionRoleArn:       req.ExecutionRoleArn,
+		EnableNetworkIsolation: req.EnableNetworkIsolation,
+		CreationTime:           now,
+	}
+
+	m.models[req.ModelName] = model
+
+	return model, nil
+}
+
+// DeleteModel deletes a model.
+func (m *MemoryStorage) DeleteModel(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.models[name]; !exists {
+		return &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Model %s not found", name),
+		}
+	}
+
+	delete(m.models, name)
+
+	return nil
+}
+
+// CreateEndpoint creates a new endpoint.
+func (m *MemoryStorage) CreateEndpoint(_ context.Context, req *CreateEndpointRequest) (*Endpoint, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.endpoints[req.EndpointName]; exists {
+		return nil, &Error{
+			Code:    errResourceInUse,
+			Message: fmt.Sprintf("Endpoint %s already exists", req.EndpointName),
+		}
+	}
+
+	now := time.Now()
+	arn := fmt.Sprintf("arn:aws:sagemaker:%s:%s:endpoint/%s", m.region, m.accountID, req.EndpointName)
+
+	endpoint := &Endpoint{
+		EndpointName:       req.EndpointName,
+		EndpointArn:        arn,
+		EndpointConfigName: req.EndpointConfigName,
+		EndpointStatus:     endpointStatusInService,
+		CreationTime:       now,
+		LastModifiedTime:   now,
+	}
+
+	m.endpoints[req.EndpointName] = endpoint
+
+	return endpoint, nil
+}
+
+// DeleteEndpoint deletes an endpoint.
+func (m *MemoryStorage) DeleteEndpoint(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.endpoints[name]; !exists {
+		return &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Endpoint %s not found", name),
+		}
+	}
+
+	delete(m.endpoints, name)
+
+	return nil
+}
+
+// DescribeEndpoint describes an endpoint.
+func (m *MemoryStorage) DescribeEndpoint(_ context.Context, name string) (*Endpoint, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	endpoint, exists := m.endpoints[name]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Endpoint %s not found", name),
+		}
+	}
+
+	return endpoint, nil
+}
+
+// Ensure MemoryStorage implements Storage.
+var _ Storage = (*MemoryStorage)(nil)

--- a/internal/service/sagemaker/types.go
+++ b/internal/service/sagemaker/types.go
@@ -1,0 +1,315 @@
+package sagemaker
+
+import "time"
+
+// NotebookInstance represents a SageMaker notebook instance.
+type NotebookInstance struct {
+	NotebookInstanceName   string
+	NotebookInstanceArn    string
+	NotebookInstanceStatus string
+	URL                    string
+	InstanceType           string
+	RoleArn                string
+	KmsKeyID               string
+	SubnetID               string
+	SecurityGroups         []string
+	DirectInternetAccess   string
+	VolumeSizeInGB         int32
+	AcceleratorTypes       []string
+	DefaultCodeRepository  string
+	AdditionalCodeRepos    []string
+	RootAccess             string
+	PlatformIdentifier     string
+	InstanceMetadataConfig *InstanceMetadataConfig
+	CreationTime           time.Time
+	LastModifiedTime       time.Time
+}
+
+// InstanceMetadataConfig represents instance metadata service configuration.
+type InstanceMetadataConfig struct {
+	MinimumInstanceMetadataServiceVersion string `json:"MinimumInstanceMetadataServiceVersion"`
+}
+
+// TrainingJob represents a SageMaker training job.
+type TrainingJob struct {
+	TrainingJobName   string
+	TrainingJobArn    string
+	TrainingJobStatus string
+	SecondaryStatus   string
+	AlgorithmSpec     *AlgorithmSpecification
+	RoleArn           string
+	InputDataConfig   []Channel
+	OutputDataConfig  *OutputDataConfig
+	ResourceConfig    *ResourceConfig
+	StoppingCondition *StoppingCondition
+	CreationTime      time.Time
+	TrainingStartTime *time.Time
+	TrainingEndTime   *time.Time
+	FailureReason     string
+}
+
+// AlgorithmSpecification represents the algorithm specification for a training job.
+type AlgorithmSpecification struct {
+	TrainingImage     string `json:"TrainingImage"`
+	TrainingInputMode string `json:"TrainingInputMode"`
+	AlgorithmName     string `json:"AlgorithmName,omitempty"`
+}
+
+// Channel represents an input data channel for a training job.
+type Channel struct {
+	ChannelName string      `json:"ChannelName"`
+	DataSource  *DataSource `json:"DataSource"`
+	ContentType string      `json:"ContentType,omitempty"`
+}
+
+// DataSource represents the data source for a channel.
+type DataSource struct {
+	S3DataSource *S3DataSource `json:"S3DataSource,omitempty"`
+}
+
+// S3DataSource represents an S3 data source.
+type S3DataSource struct {
+	S3DataType             string `json:"S3DataType"`
+	S3Uri                  string `json:"S3Uri"`
+	S3DataDistributionType string `json:"S3DataDistributionType,omitempty"`
+}
+
+// OutputDataConfig represents output data configuration.
+type OutputDataConfig struct {
+	S3OutputPath string `json:"S3OutputPath"`
+	KmsKeyID     string `json:"KmsKeyId,omitempty"`
+}
+
+// ResourceConfig represents resource configuration for training.
+type ResourceConfig struct {
+	InstanceType   string `json:"InstanceType"`
+	InstanceCount  int32  `json:"InstanceCount"`
+	VolumeSizeInGB int32  `json:"VolumeSizeInGB"`
+}
+
+// StoppingCondition represents stopping conditions for a training job.
+type StoppingCondition struct {
+	MaxRuntimeInSeconds int32 `json:"MaxRuntimeInSeconds"`
+}
+
+// Model represents a SageMaker model.
+type Model struct {
+	ModelName              string
+	ModelArn               string
+	PrimaryContainer       *ContainerDefinition
+	ExecutionRoleArn       string
+	EnableNetworkIsolation bool
+	CreationTime           time.Time
+}
+
+// ContainerDefinition represents a container definition.
+type ContainerDefinition struct {
+	Image             string            `json:"Image"`
+	Mode              string            `json:"Mode,omitempty"`
+	ModelDataURL      string            `json:"ModelDataUrl,omitempty"`
+	Environment       map[string]string `json:"Environment,omitempty"`
+	ContainerHostname string            `json:"ContainerHostname,omitempty"`
+}
+
+// Endpoint represents a SageMaker endpoint.
+type Endpoint struct {
+	EndpointName       string
+	EndpointArn        string
+	EndpointConfigName string
+	EndpointStatus     string
+	CreationTime       time.Time
+	LastModifiedTime   time.Time
+	FailureReason      string
+}
+
+// Error represents a service error.
+type Error struct {
+	Code    string
+	Message string
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return e.Code + ": " + e.Message
+}
+
+// ErrorResponse represents an error response.
+type ErrorResponse struct {
+	Type    string `json:"__type"`
+	Message string `json:"message"`
+}
+
+// CreateNotebookInstanceRequest represents a CreateNotebookInstance request.
+type CreateNotebookInstanceRequest struct {
+	NotebookInstanceName   string                  `json:"NotebookInstanceName"`
+	InstanceType           string                  `json:"InstanceType"`
+	RoleArn                string                  `json:"RoleArn"`
+	SubnetID               string                  `json:"SubnetId,omitempty"`
+	SecurityGroupIDs       []string                `json:"SecurityGroupIds,omitempty"`
+	KmsKeyID               string                  `json:"KmsKeyId,omitempty"`
+	DirectInternetAccess   string                  `json:"DirectInternetAccess,omitempty"`
+	VolumeSizeInGB         int32                   `json:"VolumeSizeInGB,omitempty"`
+	AcceleratorTypes       []string                `json:"AcceleratorTypes,omitempty"`
+	DefaultCodeRepository  string                  `json:"DefaultCodeRepository,omitempty"`
+	AdditionalCodeRepos    []string                `json:"AdditionalCodeRepositories,omitempty"`
+	RootAccess             string                  `json:"RootAccess,omitempty"`
+	PlatformIdentifier     string                  `json:"PlatformIdentifier,omitempty"`
+	InstanceMetadataConfig *InstanceMetadataConfig `json:"InstanceMetadataServiceConfiguration,omitempty"`
+	Tags                   []Tag                   `json:"Tags,omitempty"`
+}
+
+// Tag represents a key-value tag.
+type Tag struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+// CreateNotebookInstanceResponse represents a CreateNotebookInstance response.
+type CreateNotebookInstanceResponse struct {
+	NotebookInstanceArn string `json:"NotebookInstanceArn"`
+}
+
+// DeleteNotebookInstanceRequest represents a DeleteNotebookInstance request.
+type DeleteNotebookInstanceRequest struct {
+	NotebookInstanceName string `json:"NotebookInstanceName"`
+}
+
+// DescribeNotebookInstanceRequest represents a DescribeNotebookInstance request.
+type DescribeNotebookInstanceRequest struct {
+	NotebookInstanceName string `json:"NotebookInstanceName"`
+}
+
+// DescribeNotebookInstanceResponse represents a DescribeNotebookInstance response.
+type DescribeNotebookInstanceResponse struct {
+	NotebookInstanceName   string   `json:"NotebookInstanceName"`
+	NotebookInstanceArn    string   `json:"NotebookInstanceArn"`
+	NotebookInstanceStatus string   `json:"NotebookInstanceStatus"`
+	URL                    string   `json:"Url,omitempty"`
+	InstanceType           string   `json:"InstanceType"`
+	RoleArn                string   `json:"RoleArn"`
+	KmsKeyID               string   `json:"KmsKeyId,omitempty"`
+	SubnetID               string   `json:"SubnetId,omitempty"`
+	SecurityGroups         []string `json:"SecurityGroups,omitempty"`
+	DirectInternetAccess   string   `json:"DirectInternetAccess,omitempty"`
+	VolumeSizeInGB         int32    `json:"VolumeSizeInGB,omitempty"`
+	RootAccess             string   `json:"RootAccess,omitempty"`
+	CreationTime           float64  `json:"CreationTime"`
+	LastModifiedTime       float64  `json:"LastModifiedTime"`
+}
+
+// ListNotebookInstancesRequest represents a ListNotebookInstances request.
+type ListNotebookInstancesRequest struct {
+	MaxResults int32  `json:"MaxResults,omitempty"`
+	NextToken  string `json:"NextToken,omitempty"`
+	SortBy     string `json:"SortBy,omitempty"`
+	SortOrder  string `json:"SortOrder,omitempty"`
+}
+
+// NotebookInstanceSummary represents a notebook instance summary.
+type NotebookInstanceSummary struct {
+	NotebookInstanceName   string  `json:"NotebookInstanceName"`
+	NotebookInstanceArn    string  `json:"NotebookInstanceArn"`
+	NotebookInstanceStatus string  `json:"NotebookInstanceStatus"`
+	URL                    string  `json:"Url,omitempty"`
+	InstanceType           string  `json:"InstanceType"`
+	CreationTime           float64 `json:"CreationTime"`
+	LastModifiedTime       float64 `json:"LastModifiedTime"`
+}
+
+// ListNotebookInstancesResponse represents a ListNotebookInstances response.
+type ListNotebookInstancesResponse struct {
+	NotebookInstances []NotebookInstanceSummary `json:"NotebookInstances"`
+	NextToken         string                    `json:"NextToken,omitempty"`
+}
+
+// CreateTrainingJobRequest represents a CreateTrainingJob request.
+type CreateTrainingJobRequest struct {
+	TrainingJobName   string                  `json:"TrainingJobName"`
+	AlgorithmSpec     *AlgorithmSpecification `json:"AlgorithmSpecification"`
+	RoleArn           string                  `json:"RoleArn"`
+	InputDataConfig   []Channel               `json:"InputDataConfig,omitempty"`
+	OutputDataConfig  *OutputDataConfig       `json:"OutputDataConfig"`
+	ResourceConfig    *ResourceConfig         `json:"ResourceConfig"`
+	StoppingCondition *StoppingCondition      `json:"StoppingCondition"`
+	Tags              []Tag                   `json:"Tags,omitempty"`
+}
+
+// CreateTrainingJobResponse represents a CreateTrainingJob response.
+type CreateTrainingJobResponse struct {
+	TrainingJobArn string `json:"TrainingJobArn"`
+}
+
+// DescribeTrainingJobRequest represents a DescribeTrainingJob request.
+type DescribeTrainingJobRequest struct {
+	TrainingJobName string `json:"TrainingJobName"`
+}
+
+// DescribeTrainingJobResponse represents a DescribeTrainingJob response.
+type DescribeTrainingJobResponse struct {
+	TrainingJobName   string                  `json:"TrainingJobName"`
+	TrainingJobArn    string                  `json:"TrainingJobArn"`
+	TrainingJobStatus string                  `json:"TrainingJobStatus"`
+	SecondaryStatus   string                  `json:"SecondaryStatus"`
+	AlgorithmSpec     *AlgorithmSpecification `json:"AlgorithmSpecification,omitempty"`
+	RoleArn           string                  `json:"RoleArn"`
+	InputDataConfig   []Channel               `json:"InputDataConfig,omitempty"`
+	OutputDataConfig  *OutputDataConfig       `json:"OutputDataConfig,omitempty"`
+	ResourceConfig    *ResourceConfig         `json:"ResourceConfig,omitempty"`
+	StoppingCondition *StoppingCondition      `json:"StoppingCondition,omitempty"`
+	CreationTime      float64                 `json:"CreationTime"`
+	TrainingStartTime *float64                `json:"TrainingStartTime,omitempty"`
+	TrainingEndTime   *float64                `json:"TrainingEndTime,omitempty"`
+	FailureReason     string                  `json:"FailureReason,omitempty"`
+}
+
+// CreateModelRequest represents a CreateModel request.
+type CreateModelRequest struct {
+	ModelName              string               `json:"ModelName"`
+	PrimaryContainer       *ContainerDefinition `json:"PrimaryContainer"`
+	ExecutionRoleArn       string               `json:"ExecutionRoleArn"`
+	EnableNetworkIsolation bool                 `json:"EnableNetworkIsolation,omitempty"`
+	Tags                   []Tag                `json:"Tags,omitempty"`
+}
+
+// CreateModelResponse represents a CreateModel response.
+type CreateModelResponse struct {
+	ModelArn string `json:"ModelArn"`
+}
+
+// DeleteModelRequest represents a DeleteModel request.
+type DeleteModelRequest struct {
+	ModelName string `json:"ModelName"`
+}
+
+// CreateEndpointRequest represents a CreateEndpoint request.
+type CreateEndpointRequest struct {
+	EndpointName       string `json:"EndpointName"`
+	EndpointConfigName string `json:"EndpointConfigName"`
+	Tags               []Tag  `json:"Tags,omitempty"`
+}
+
+// CreateEndpointResponse represents a CreateEndpoint response.
+type CreateEndpointResponse struct {
+	EndpointArn string `json:"EndpointArn"`
+}
+
+// DeleteEndpointRequest represents a DeleteEndpoint request.
+type DeleteEndpointRequest struct {
+	EndpointName string `json:"EndpointName"`
+}
+
+// DescribeEndpointRequest represents a DescribeEndpoint request.
+type DescribeEndpointRequest struct {
+	EndpointName string `json:"EndpointName"`
+}
+
+// DescribeEndpointResponse represents a DescribeEndpoint response.
+type DescribeEndpointResponse struct {
+	EndpointName       string  `json:"EndpointName"`
+	EndpointArn        string  `json:"EndpointArn"`
+	EndpointConfigName string  `json:"EndpointConfigName"`
+	EndpointStatus     string  `json:"EndpointStatus"`
+	CreationTime       float64 `json:"CreationTime"`
+	LastModifiedTime   float64 `json:"LastModifiedTime"`
+	FailureReason      string  `json:"FailureReason,omitempty"`
+}

--- a/test/integration/sagemaker_test.go
+++ b/test/integration/sagemaker_test.go
@@ -1,0 +1,236 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	"github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
+	"github.com/stretchr/testify/require"
+)
+
+func newSageMakerClient(t *testing.T) *sagemaker.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	require.NoError(t, err)
+
+	return sagemaker.NewFromConfig(cfg, func(o *sagemaker.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestSageMaker_CreateAndDeleteNotebookInstance(t *testing.T) {
+	client := newSageMakerClient(t)
+	ctx := t.Context()
+
+	instanceName := "test-notebook"
+
+	// Create notebook instance.
+	createOutput, err := client.CreateNotebookInstance(ctx, &sagemaker.CreateNotebookInstanceInput{
+		NotebookInstanceName: aws.String(instanceName),
+		InstanceType:         types.InstanceTypeMlT2Medium,
+		RoleArn:              aws.String("arn:aws:iam::123456789012:role/sagemaker-role"),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, createOutput.NotebookInstanceArn)
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteNotebookInstance(ctx, &sagemaker.DeleteNotebookInstanceInput{
+			NotebookInstanceName: aws.String(instanceName),
+		})
+	})
+
+	// Describe notebook instance.
+	descOutput, err := client.DescribeNotebookInstance(ctx, &sagemaker.DescribeNotebookInstanceInput{
+		NotebookInstanceName: aws.String(instanceName),
+	})
+	require.NoError(t, err)
+	require.Equal(t, instanceName, *descOutput.NotebookInstanceName)
+	require.Equal(t, types.InstanceTypeMlT2Medium, descOutput.InstanceType)
+
+	// Delete notebook instance.
+	_, err = client.DeleteNotebookInstance(ctx, &sagemaker.DeleteNotebookInstanceInput{
+		NotebookInstanceName: aws.String(instanceName),
+	})
+	require.NoError(t, err)
+
+	// Verify notebook instance is deleted.
+	_, err = client.DescribeNotebookInstance(ctx, &sagemaker.DescribeNotebookInstanceInput{
+		NotebookInstanceName: aws.String(instanceName),
+	})
+	require.Error(t, err)
+}
+
+func TestSageMaker_ListNotebookInstances(t *testing.T) {
+	client := newSageMakerClient(t)
+	ctx := t.Context()
+
+	// Create multiple notebook instances.
+	instanceNames := []string{"test-notebook-1", "test-notebook-2"}
+
+	for _, name := range instanceNames {
+		_, err := client.CreateNotebookInstance(ctx, &sagemaker.CreateNotebookInstanceInput{
+			NotebookInstanceName: aws.String(name),
+			InstanceType:         types.InstanceTypeMlT2Medium,
+			RoleArn:              aws.String("arn:aws:iam::123456789012:role/sagemaker-role"),
+		})
+		require.NoError(t, err)
+	}
+
+	t.Cleanup(func() {
+		for _, name := range instanceNames {
+			_, _ = client.DeleteNotebookInstance(ctx, &sagemaker.DeleteNotebookInstanceInput{
+				NotebookInstanceName: aws.String(name),
+			})
+		}
+	})
+
+	// List notebook instances.
+	listOutput, err := client.ListNotebookInstances(ctx, &sagemaker.ListNotebookInstancesInput{})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(listOutput.NotebookInstances), 2)
+}
+
+func TestSageMaker_CreateAndDescribeTrainingJob(t *testing.T) {
+	client := newSageMakerClient(t)
+	ctx := t.Context()
+
+	jobName := "test-training-job"
+
+	// Create training job.
+	createOutput, err := client.CreateTrainingJob(ctx, &sagemaker.CreateTrainingJobInput{
+		TrainingJobName: aws.String(jobName),
+		AlgorithmSpecification: &types.AlgorithmSpecification{
+			TrainingImage:     aws.String("123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:latest"),
+			TrainingInputMode: types.TrainingInputModeFile,
+		},
+		RoleArn: aws.String("arn:aws:iam::123456789012:role/sagemaker-role"),
+		OutputDataConfig: &types.OutputDataConfig{
+			S3OutputPath: aws.String("s3://my-bucket/output"),
+		},
+		ResourceConfig: &types.ResourceConfig{
+			InstanceType:   types.TrainingInstanceTypeMlM4Xlarge,
+			InstanceCount:  aws.Int32(1),
+			VolumeSizeInGB: aws.Int32(50),
+		},
+		StoppingCondition: &types.StoppingCondition{
+			MaxRuntimeInSeconds: aws.Int32(3600),
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, createOutput.TrainingJobArn)
+
+	// Describe training job.
+	descOutput, err := client.DescribeTrainingJob(ctx, &sagemaker.DescribeTrainingJobInput{
+		TrainingJobName: aws.String(jobName),
+	})
+	require.NoError(t, err)
+	require.Equal(t, jobName, *descOutput.TrainingJobName)
+	require.Equal(t, types.TrainingJobStatusCompleted, descOutput.TrainingJobStatus)
+}
+
+func TestSageMaker_CreateAndDeleteModel(t *testing.T) {
+	client := newSageMakerClient(t)
+	ctx := t.Context()
+
+	modelName := "test-model"
+
+	// Create model.
+	createOutput, err := client.CreateModel(ctx, &sagemaker.CreateModelInput{
+		ModelName: aws.String(modelName),
+		PrimaryContainer: &types.ContainerDefinition{
+			Image: aws.String("123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:latest"),
+		},
+		ExecutionRoleArn: aws.String("arn:aws:iam::123456789012:role/sagemaker-role"),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, createOutput.ModelArn)
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteModel(ctx, &sagemaker.DeleteModelInput{
+			ModelName: aws.String(modelName),
+		})
+	})
+
+	// Delete model.
+	_, err = client.DeleteModel(ctx, &sagemaker.DeleteModelInput{
+		ModelName: aws.String(modelName),
+	})
+	require.NoError(t, err)
+
+	// Try to delete again (should fail).
+	_, err = client.DeleteModel(ctx, &sagemaker.DeleteModelInput{
+		ModelName: aws.String(modelName),
+	})
+	require.Error(t, err)
+}
+
+func TestSageMaker_CreateAndDeleteEndpoint(t *testing.T) {
+	client := newSageMakerClient(t)
+	ctx := t.Context()
+
+	endpointName := "test-endpoint"
+	endpointConfigName := "test-endpoint-config"
+
+	// Create endpoint.
+	createOutput, err := client.CreateEndpoint(ctx, &sagemaker.CreateEndpointInput{
+		EndpointName:       aws.String(endpointName),
+		EndpointConfigName: aws.String(endpointConfigName),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, createOutput.EndpointArn)
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteEndpoint(ctx, &sagemaker.DeleteEndpointInput{
+			EndpointName: aws.String(endpointName),
+		})
+	})
+
+	// Describe endpoint.
+	descOutput, err := client.DescribeEndpoint(ctx, &sagemaker.DescribeEndpointInput{
+		EndpointName: aws.String(endpointName),
+	})
+	require.NoError(t, err)
+	require.Equal(t, endpointName, *descOutput.EndpointName)
+	require.Equal(t, endpointConfigName, *descOutput.EndpointConfigName)
+	require.Equal(t, types.EndpointStatusInService, descOutput.EndpointStatus)
+
+	// Delete endpoint.
+	_, err = client.DeleteEndpoint(ctx, &sagemaker.DeleteEndpointInput{
+		EndpointName: aws.String(endpointName),
+	})
+	require.NoError(t, err)
+
+	// Verify endpoint is deleted.
+	_, err = client.DescribeEndpoint(ctx, &sagemaker.DescribeEndpointInput{
+		EndpointName: aws.String(endpointName),
+	})
+	require.Error(t, err)
+}
+
+func TestSageMaker_NotebookInstanceNotFound(t *testing.T) {
+	client := newSageMakerClient(t)
+	ctx := t.Context()
+
+	// Describe non-existent notebook instance.
+	_, err := client.DescribeNotebookInstance(ctx, &sagemaker.DescribeNotebookInstanceInput{
+		NotebookInstanceName: aws.String("non-existent-notebook"),
+	})
+	require.Error(t, err)
+
+	// Delete non-existent notebook instance.
+	_, err = client.DeleteNotebookInstance(ctx, &sagemaker.DeleteNotebookInstanceInput{
+		NotebookInstanceName: aws.String("non-existent-notebook"),
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- Implement AWS SageMaker service with basic APIs
- Uses AWS JSON 1.1 protocol with X-Amz-Target header routing

### Implemented Operations
**Notebook Instance Operations:**
- CreateNotebookInstance
- DeleteNotebookInstance
- DescribeNotebookInstance
- ListNotebookInstances

**Training Job Operations:**
- CreateTrainingJob
- DescribeTrainingJob

**Model Operations:**
- CreateModel
- DeleteModel

**Endpoint Operations:**
- CreateEndpoint
- DeleteEndpoint
- DescribeEndpoint

## Test plan
- [x] Build passes
- [x] Integration tests added for all operations
- [ ] CI lint check
- [ ] CI test check

Closes #42