### PR TITLE
fix(eks): fix nextToken handling and add maxResults validation

### DIFF
--- a/internal/service/eks/handlers.go
+++ b/internal/service/eks/handlers.go
@@ -94,11 +94,17 @@ func (s *Service) DescribeCluster(w http.ResponseWriter, r *http.Request) {
 
 // ListClusters handles the ListClusters operation.
 func (s *Service) ListClusters(w http.ResponseWriter, r *http.Request) {
-	maxResults := 100
+	const maxResultsLimit = 100
+
+	maxResults := maxResultsLimit
 
 	if v := r.URL.Query().Get("maxResults"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			maxResults = n
+			// Enforce upper limit per AWS API specification.
+			if maxResults > maxResultsLimit {
+				maxResults = maxResultsLimit
+			}
 		}
 	}
 
@@ -111,10 +117,14 @@ func (s *Service) ListClusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, &ListClustersResponse{
-		Clusters:  clusters,
-		NextToken: next,
-	})
+	resp := &ListClustersResponse{
+		Clusters: clusters,
+	}
+	if next != "" {
+		resp.NextToken = &next
+	}
+
+	writeJSON(w, resp)
 }
 
 // CreateNodegroup handles the CreateNodegroup operation.
@@ -210,11 +220,17 @@ func (s *Service) ListNodegroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	maxResults := 100
+	const maxResultsLimit = 100
+
+	maxResults := maxResultsLimit
 
 	if v := r.URL.Query().Get("maxResults"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			maxResults = n
+			// Enforce upper limit per AWS API specification.
+			if maxResults > maxResultsLimit {
+				maxResults = maxResultsLimit
+			}
 		}
 	}
 
@@ -227,10 +243,14 @@ func (s *Service) ListNodegroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, &ListNodegroupsResponse{
+	resp := &ListNodegroupsResponse{
 		Nodegroups: nodegroups,
-		NextToken:  next,
-	})
+	}
+	if next != "" {
+		resp.NextToken = &next
+	}
+
+	writeJSON(w, resp)
 }
 
 // extractClusterName extracts the cluster name from the URL path.

--- a/internal/service/eks/types.go
+++ b/internal/service/eks/types.go
@@ -363,7 +363,7 @@ type DescribeClusterResponse struct {
 // ListClustersResponse represents a ListClusters response.
 type ListClustersResponse struct {
 	Clusters  []string `json:"clusters"`
-	NextToken string   `json:"nextToken,omitempty"`
+	NextToken *string  `json:"nextToken"`
 }
 
 // CreateNodegroupResponse represents a CreateNodegroup response.
@@ -384,7 +384,7 @@ type DescribeNodegroupResponse struct {
 // ListNodegroupsResponse represents a ListNodegroups response.
 type ListNodegroupsResponse struct {
 	Nodegroups []string `json:"nodegroups"`
-	NextToken  string   `json:"nextToken,omitempty"`
+	NextToken  *string  `json:"nextToken"`
 }
 
 // Error types.


### PR DESCRIPTION
## Summary
- Change `NextToken` field type from `string` to `*string` in `ListClustersResponse` and `ListNodegroupsResponse` to properly handle `nil` when there are no more pages
- Remove `omitempty` from `NextToken` JSON tag to ensure proper serialization with AWS SDK v2
- Add `maxResults` upper limit validation (max 100) per AWS API specification

## Test plan
- [ ] Verify EKS ListClusters pagination works correctly with AWS SDK v2
- [ ] Verify EKS ListNodegroups pagination works correctly with AWS SDK v2
- [ ] Verify maxResults values above 100 are capped to 100

Closes #259