### PR TITLE
fix(eventbridge): add ManagedBy field to ListEventBuses response

### DIFF
--- a/internal/service/eventbridge/handlers.go
+++ b/internal/service/eventbridge/handlers.go
@@ -134,6 +134,7 @@ func (s *Service) ListEventBuses(w http.ResponseWriter, r *http.Request) {
 			Name:        eb.Name,
 			Arn:         eb.Arn,
 			Description: eb.Description,
+			ManagedBy:   eb.ManagedBy,
 		}
 	}
 

--- a/internal/service/eventbridge/types.go
+++ b/internal/service/eventbridge/types.go
@@ -27,6 +27,7 @@ type EventBus struct {
 	Name         string
 	Arn          string
 	Description  string
+	ManagedBy    string
 	CreationTime time.Time
 	LastModified time.Time
 }
@@ -114,6 +115,7 @@ type EventBusOutput struct {
 	Name        string `json:"Name,omitempty"`
 	Arn         string `json:"Arn,omitempty"`
 	Description string `json:"Description,omitempty"`
+	ManagedBy   string `json:"ManagedBy,omitempty"`
 }
 
 // ListEventBusesResponse is the response for ListEventBuses.


### PR DESCRIPTION
## Summary
- Add `ManagedBy` field to `EventBus` struct (internal storage type)
- Add `ManagedBy` field to `EventBusOutput` struct (API response type)
- Populate `ManagedBy` in `ListEventBuses` handler response

This change aligns the EventBridge ListEventBuses API response with the AWS API specification. The `ManagedBy` field indicates the service that manages the event bus (e.g., `events.amazonaws.com` for AWS-managed event buses).

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `make test` passes

Closes #263