### PR TITLE
fix(cloudfront): add missing fields to ListDistributions response

### DIFF
--- a/internal/service/cloudfront/handlers.go
+++ b/internal/service/cloudfront/handlers.go
@@ -527,17 +527,26 @@ func buildDistributionListXML(dists []*Distribution, marker string, maxItems int
 
 func buildDistributionSummaryXML(d *Distribution) DistributionSummaryXML {
 	summary := DistributionSummaryXML{
-		ID:               d.ID,
-		ARN:              d.ARN,
-		Status:           d.Status,
-		LastModifiedTime: d.LastModifiedTime.Format(time.RFC3339),
-		DomainName:       d.DomainName,
-		Enabled:          d.DistributionConfig.Enabled,
-		Comment:          d.DistributionConfig.Comment,
-		PriceClass:       d.DistributionConfig.PriceClass,
-		HTTPVersion:      d.DistributionConfig.HTTPVersion,
-		IsIPV6Enabled:    d.DistributionConfig.IsIPV6Enabled,
-		CacheBehaviors:   &CacheBehaviorsXML{Quantity: 0},
+		ID:                   d.ID,
+		ARN:                  d.ARN,
+		Status:               d.Status,
+		LastModifiedTime:     d.LastModifiedTime.Format(time.RFC3339),
+		DomainName:           d.DomainName,
+		Enabled:              d.DistributionConfig.Enabled,
+		Comment:              d.DistributionConfig.Comment,
+		PriceClass:           d.DistributionConfig.PriceClass,
+		HTTPVersion:          d.DistributionConfig.HTTPVersion,
+		IsIPV6Enabled:        d.DistributionConfig.IsIPV6Enabled,
+		CacheBehaviors:       &CacheBehaviorsXML{Quantity: 0},
+		CustomErrorResponses: &CustomErrorResponsesXML{Quantity: 0},
+		Restrictions: &RestrictionsXML{
+			GeoRestriction: &GeoRestrictionXML{
+				RestrictionType: "none",
+				Quantity:        0,
+			},
+		},
+		WebACLId: "",
+		Staging:  false,
 	}
 
 	summary.Aliases = buildSummaryAliasesXML(d.DistributionConfig.Aliases)

--- a/internal/service/cloudfront/types.go
+++ b/internal/service/cloudfront/types.go
@@ -400,6 +400,23 @@ type CacheBehaviorsXML struct {
 	Quantity int `xml:"Quantity"`
 }
 
+// RestrictionsXML represents restrictions in XML format.
+type RestrictionsXML struct {
+	GeoRestriction *GeoRestrictionXML `xml:"GeoRestriction"`
+}
+
+// GeoRestrictionXML represents geo restriction in XML format.
+type GeoRestrictionXML struct {
+	RestrictionType string   `xml:"RestrictionType"`
+	Quantity        int      `xml:"Quantity"`
+	Items           []string `xml:"Items>Location,omitempty"`
+}
+
+// CustomErrorResponsesXML represents custom error responses in XML format.
+type CustomErrorResponsesXML struct {
+	Quantity int `xml:"Quantity"`
+}
+
 // ViewerCertificateXML represents viewer certificate in XML format.
 type ViewerCertificateXML struct {
 	CloudFrontDefaultCertificate bool   `xml:"CloudFrontDefaultCertificate,omitempty"`
@@ -437,12 +454,16 @@ type DistributionSummaryXML struct {
 	Origins              *OriginsXML              `xml:"Origins"`
 	DefaultCacheBehavior *DefaultCacheBehaviorXML `xml:"DefaultCacheBehavior"`
 	CacheBehaviors       *CacheBehaviorsXML       `xml:"CacheBehaviors"`
+	CustomErrorResponses *CustomErrorResponsesXML `xml:"CustomErrorResponses"`
 	Comment              string                   `xml:"Comment"`
 	PriceClass           string                   `xml:"PriceClass"`
 	Enabled              bool                     `xml:"Enabled"`
 	ViewerCertificate    *ViewerCertificateXML    `xml:"ViewerCertificate"`
+	Restrictions         *RestrictionsXML         `xml:"Restrictions"`
+	WebACLId             string                   `xml:"WebACLId"`
 	HTTPVersion          string                   `xml:"HttpVersion"`
 	IsIPV6Enabled        bool                     `xml:"IsIPV6Enabled"`
+	Staging              bool                     `xml:"Staging"`
 }
 
 // GetDistributionResult is the response for GetDistribution.


### PR DESCRIPTION
## Summary
- Add missing fields to CloudFront ListDistributions API response
- Fields added: Restrictions, CustomErrorResponses, WebACLId, Staging
- Populate with appropriate defaults for AWS SDK compatibility

## Changes
- Add `RestrictionsXML`, `GeoRestrictionXML`, and `CustomErrorResponsesXML` types in `types.go`
- Add new fields to `DistributionSummaryXML` struct
- Update `buildDistributionSummaryXML` function to populate new fields with defaults

## Test plan
- [x] Verify build succeeds (`go build ./...`)
- [x] Run CloudFront tests (`go test -race ./internal/service/cloudfront/...`)
- [x] Run go vet (`go vet ./...`)

Closes #264