### PR TITLE
fix(organizations): add State field to ListAccounts response

### DIFF
--- a/internal/service/organizations/storage.go
+++ b/internal/service/organizations/storage.go
@@ -39,6 +39,11 @@ const (
 	accountStatusActive = "ACTIVE"
 )
 
+// Account state values.
+const (
+	accountStateActive = "ACTIVE"
+)
+
 // Joined method values.
 const (
 	joinedMethodCreated = "CREATED"
@@ -182,6 +187,7 @@ func (m *MemoryStorage) CreateOrganization(_ context.Context, featureSet string)
 		JoinedMethod:    joinedMethodCreated,
 		JoinedTimestamp: ToAWSTimestamp(time.Now()),
 		Name:            "Management Account",
+		State:           accountStateActive,
 		Status:          accountStatusActive,
 	}
 
@@ -259,6 +265,7 @@ func (m *MemoryStorage) CreateAccount(_ context.Context, req *CreateAccountInput
 		JoinedMethod:    joinedMethodCreated,
 		JoinedTimestamp: ToAWSTimestamp(now),
 		Name:            req.AccountName,
+		State:           accountStateActive,
 		Status:          accountStatusActive,
 	}
 

--- a/internal/service/organizations/types.go
+++ b/internal/service/organizations/types.go
@@ -52,6 +52,7 @@ type Account struct {
 	JoinedMethod    string       `json:"JoinedMethod,omitempty"`
 	JoinedTimestamp AWSTimestamp `json:"JoinedTimestamp,omitempty"`
 	Name            string       `json:"Name,omitempty"`
+	State           string       `json:"State,omitempty"`
 	Status          string       `json:"Status,omitempty"`
 }
 

--- a/test/integration/organizations_test.go
+++ b/test/integration/organizations_test.go
@@ -110,6 +110,11 @@ func TestOrganizations_WithOrganization(t *testing.T) {
 		listOutput, err := client.ListAccounts(ctx, &organizations.ListAccountsInput{})
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, len(listOutput.Accounts), 1) // At least management account
+
+		// Verify State field is present and valid for all accounts
+		for _, account := range listOutput.Accounts {
+			assert.Equal(t, types.AccountStateActive, account.State)
+		}
 	})
 
 	t.Run("CreateAccount", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `State` field to the Account type in Organizations service
- Populate State field with "ACTIVE" when creating accounts
- Add integration test to verify State field is returned in ListAccounts response

This aligns the awsim Organizations service with AWS API which includes `State` (ACTIVE, SUSPENDED, PENDING_CLOSURE, etc.) in addition to the deprecated `Status` field.

## Test plan

- [x] Build succeeds
- [x] go vet passes
- [x] Integration tests compile successfully
- [ ] Run integration tests with awsim server to verify State field is returned

Closes #262