### PR TITLE
fix(ecs): add maxResults validation to ListClusters

### DIFF
--- a/internal/service/ecs/handlers.go
+++ b/internal/service/ecs/handlers.go
@@ -141,6 +141,13 @@ func (s *Service) ListClusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate maxResults: must be between 1 and 100 if specified
+	if req.MaxResults != 0 && (req.MaxResults < 1 || req.MaxResults > 100) {
+		writeECSError(w, "InvalidParameterException", "maxResults must be between 1 and 100", http.StatusBadRequest)
+
+		return
+	}
+
 	clusterArns, nextToken, err := s.storage.ListClusters(r.Context(), req.MaxResults, req.NextToken)
 	if err != nil {
 		writeECSError(w, "InternalServerError", "Internal server error", http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

- Add validation for maxResults parameter in ListClusters API
- Return InvalidParameterException when maxResults is outside the valid range (1-100)
- Aligns with AWS API behavior

## Test plan

- [ ] Verify ListClusters works normally without maxResults
- [ ] Verify ListClusters works with valid maxResults (1-100)
- [ ] Verify InvalidParameterException is returned for maxResults < 1
- [ ] Verify InvalidParameterException is returned for maxResults > 100

Closes #267