### PR TITLE
fix(secretsmanager): add Type field and rotation metadata to ListSecrets response

### DIFF
--- a/internal/service/secretsmanager/handlers.go
+++ b/internal/service/secretsmanager/handlers.go
@@ -228,16 +228,19 @@ func convertSecretsToListEntries(secrets []*Secret) []SecretListEntry {
 
 	for _, secret := range secrets {
 		entry := SecretListEntry{
-			ARN:             secret.ARN,
-			Name:            secret.Name,
-			Description:     secret.Description,
-			KmsKeyID:        secret.KmsKeyID,
-			RotationEnabled: secret.RotationEnabled,
-			RotationRules:   secret.RotationRules,
-			Tags:            secret.Tags,
-			CreatedDate:     float64(secret.CreatedDate.Unix()),
-			PrimaryRegion:   secret.PrimaryRegion,
-			OwningService:   secret.OwningService,
+			ARN:                            secret.ARN,
+			Name:                           secret.Name,
+			Description:                    secret.Description,
+			KmsKeyID:                       secret.KmsKeyID,
+			RotationEnabled:                secret.RotationEnabled,
+			RotationRules:                  secret.RotationRules,
+			Tags:                           secret.Tags,
+			CreatedDate:                    float64(secret.CreatedDate.Unix()),
+			PrimaryRegion:                  secret.PrimaryRegion,
+			OwningService:                  secret.OwningService,
+			Type:                           secret.Type,
+			ExternalSecretRotationMetadata: secret.ExternalSecretRotationMetadata,
+			ExternalSecretRotationRoleArn:  secret.ExternalSecretRotationRoleArn,
 		}
 
 		if secret.LastChangedDate.Unix() > 0 {

--- a/internal/service/secretsmanager/types.go
+++ b/internal/service/secretsmanager/types.go
@@ -7,29 +7,32 @@ import (
 
 // Secret represents a secret in Secrets Manager.
 type Secret struct {
-	ARN                   string
-	Name                  string
-	Description           string
-	KmsKeyID              string
-	VersionID             string
-	SecretString          string
-	SecretBinary          []byte
-	CreatedDate           time.Time
-	LastChangedDate       time.Time
-	LastAccessedDate      *time.Time
-	DeletedDate           *time.Time
-	Tags                  []Tag
-	VersionIDs            map[string]*SecretVersion
-	RotationEnabled       bool
-	RotationLambdaARN     string
-	RotationRules         *RotationRules
-	PrimaryRegion         string
-	ReplicationStatus     []ReplicationStatus
-	OwningService         string
-	NextRotationDate      *time.Time
-	LastRotationDate      *time.Time
-	RecoveryWindowInDays  int64
-	ScheduledDeletionDate *time.Time
+	ARN                            string
+	Name                           string
+	Description                    string
+	KmsKeyID                       string
+	VersionID                      string
+	SecretString                   string
+	SecretBinary                   []byte
+	CreatedDate                    time.Time
+	LastChangedDate                time.Time
+	LastAccessedDate               *time.Time
+	DeletedDate                    *time.Time
+	Tags                           []Tag
+	VersionIDs                     map[string]*SecretVersion
+	RotationEnabled                bool
+	RotationLambdaARN              string
+	RotationRules                  *RotationRules
+	PrimaryRegion                  string
+	ReplicationStatus              []ReplicationStatus
+	OwningService                  string
+	NextRotationDate               *time.Time
+	LastRotationDate               *time.Time
+	RecoveryWindowInDays           int64
+	ScheduledDeletionDate          *time.Time
+	Type                           string
+	ExternalSecretRotationMetadata []ExternalSecretRotationMetadataItem
+	ExternalSecretRotationRoleArn  string
 }
 
 // SecretVersion represents a version of a secret.
@@ -163,23 +166,26 @@ type ListSecretsResponse struct {
 
 // SecretListEntry represents a secret in list response.
 type SecretListEntry struct {
-	ARN                    string              `json:"ARN"`
-	Name                   string              `json:"Name"`
-	Description            string              `json:"Description,omitempty"`
-	KmsKeyID               string              `json:"KmsKeyId,omitempty"`
-	RotationEnabled        bool                `json:"RotationEnabled"`
-	RotationLambdaARN      string              `json:"RotationLambdaARN,omitempty"`
-	RotationRules          *RotationRules      `json:"RotationRules,omitempty"`
-	LastRotatedDate        *float64            `json:"LastRotatedDate,omitempty"`
-	LastChangedDate        *float64            `json:"LastChangedDate,omitempty"`
-	LastAccessedDate       *float64            `json:"LastAccessedDate,omitempty"`
-	DeletedDate            *float64            `json:"DeletedDate,omitempty"`
-	NextRotationDate       *float64            `json:"NextRotationDate,omitempty"`
-	Tags                   []Tag               `json:"Tags,omitempty"`
-	SecretVersionsToStages map[string][]string `json:"SecretVersionsToStages,omitempty"`
-	OwningService          string              `json:"OwningService,omitempty"`
-	CreatedDate            float64             `json:"CreatedDate"`
-	PrimaryRegion          string              `json:"PrimaryRegion,omitempty"`
+	ARN                            string                               `json:"ARN"`
+	Name                           string                               `json:"Name"`
+	Description                    string                               `json:"Description,omitempty"`
+	KmsKeyID                       string                               `json:"KmsKeyId,omitempty"`
+	RotationEnabled                bool                                 `json:"RotationEnabled"`
+	RotationLambdaARN              string                               `json:"RotationLambdaARN,omitempty"`
+	RotationRules                  *RotationRules                       `json:"RotationRules,omitempty"`
+	LastRotatedDate                *float64                             `json:"LastRotatedDate,omitempty"`
+	LastChangedDate                *float64                             `json:"LastChangedDate,omitempty"`
+	LastAccessedDate               *float64                             `json:"LastAccessedDate,omitempty"`
+	DeletedDate                    *float64                             `json:"DeletedDate,omitempty"`
+	NextRotationDate               *float64                             `json:"NextRotationDate,omitempty"`
+	Tags                           []Tag                                `json:"Tags,omitempty"`
+	SecretVersionsToStages         map[string][]string                  `json:"SecretVersionsToStages,omitempty"`
+	OwningService                  string                               `json:"OwningService,omitempty"`
+	CreatedDate                    float64                              `json:"CreatedDate"`
+	PrimaryRegion                  string                               `json:"PrimaryRegion,omitempty"`
+	Type                           string                               `json:"Type,omitempty"`
+	ExternalSecretRotationMetadata []ExternalSecretRotationMetadataItem `json:"ExternalSecretRotationMetadata,omitempty"`
+	ExternalSecretRotationRoleArn  string                               `json:"ExternalSecretRotationRoleArn,omitempty"`
 }
 
 // DescribeSecretRequest is the request for DescribeSecret.
@@ -241,4 +247,10 @@ type SecretError struct {
 // Error implements the error interface.
 func (e *SecretError) Error() string {
 	return e.Message
+}
+
+// ExternalSecretRotationMetadataItem represents the metadata for external secret rotation.
+type ExternalSecretRotationMetadataItem struct {
+	Key   string `json:"Key,omitempty"`
+	Value string `json:"Value,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Add missing `Type` field to `SecretListEntry` struct for identifying third-party partners in managed external secrets
- Add `ExternalSecretRotationMetadata` field for managed external secret rotation metadata
- Add `ExternalSecretRotationRoleArn` field for external secret rotation role ARN
- Update `convertSecretsToListEntries` function to populate the new fields

These fields are present in the AWS SDK v2 `SecretListEntry` type but were missing from awsim.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Verify ListSecrets response includes the new fields when populated

Closes #266