### PR TITLE
fix(cognito): populate LambdaConfig in DescribeUserPool response

### DIFF
--- a/internal/service/cognito/handlers.go
+++ b/internal/service/cognito/handlers.go
@@ -434,7 +434,39 @@ func userPoolToOutput(pool *UserPool) *UserPoolOutput {
 		}
 	}
 
+	if pool.LambdaConfig != nil {
+		output.LambdaConfig = convertLambdaConfigToOutput(pool.LambdaConfig)
+	}
+
+	if pool.EmailConfiguration != nil {
+		output.EmailConfiguration = &EmailConfigurationOutput{
+			SourceArn:           pool.EmailConfiguration.SourceArn,
+			ReplyToEmailAddress: pool.EmailConfiguration.ReplyToEmailAddress,
+			EmailSendingAccount: pool.EmailConfiguration.EmailSendingAccount,
+		}
+	}
+
 	return output
+}
+
+// convertLambdaConfigToOutput converts LambdaConfig to LambdaConfigOutput.
+func convertLambdaConfigToOutput(config *LambdaConfig) *LambdaConfigOutput {
+	if config == nil {
+		return nil
+	}
+
+	return &LambdaConfigOutput{
+		PreSignUp:               config.PreSignUp,
+		CustomMessage:           config.CustomMessage,
+		PostConfirmation:        config.PostConfirmation,
+		PreAuthentication:       config.PreAuthentication,
+		PostAuthentication:      config.PostAuthentication,
+		DefineAuthChallenge:     config.DefineAuthChallenge,
+		CreateAuthChallenge:     config.CreateAuthChallenge,
+		VerifyAuthChallengeResp: config.VerifyAuthChallengeResp,
+		PreTokenGeneration:      config.PreTokenGeneration,
+		UserMigration:           config.UserMigration,
+	}
 }
 
 // userPoolClientToOutput converts a UserPoolClient to UserPoolClientOutput.

--- a/internal/service/cognito/storage.go
+++ b/internal/service/cognito/storage.go
@@ -110,6 +110,18 @@ func (s *MemoryStorage) CreateUserPool(_ context.Context, req *CreateUserPoolReq
 		pool.UsernameAttributes = req.UsernameAttributes
 	}
 
+	if req.LambdaConfig != nil {
+		pool.LambdaConfig = convertLambdaConfigInputToLambdaConfig(req.LambdaConfig)
+	}
+
+	if req.EmailConfiguration != nil {
+		pool.EmailConfiguration = &EmailConfiguration{
+			SourceArn:           req.EmailConfiguration.SourceArn,
+			ReplyToEmailAddress: req.EmailConfiguration.ReplyToEmailAddress,
+			EmailSendingAccount: req.EmailConfiguration.EmailSendingAccount,
+		}
+	}
+
 	s.userPools[poolID] = pool
 	s.users[poolID] = make(map[string]*User)
 
@@ -567,4 +579,24 @@ func generateToken() string {
 	_, _ = rand.Read(b)
 
 	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// convertLambdaConfigInputToLambdaConfig converts LambdaConfigInput to LambdaConfig.
+func convertLambdaConfigInputToLambdaConfig(input *LambdaConfigInput) *LambdaConfig {
+	if input == nil {
+		return nil
+	}
+
+	return &LambdaConfig{
+		PreSignUp:               input.PreSignUp,
+		CustomMessage:           input.CustomMessage,
+		PostConfirmation:        input.PostConfirmation,
+		PreAuthentication:       input.PreAuthentication,
+		PostAuthentication:      input.PostAuthentication,
+		DefineAuthChallenge:     input.DefineAuthChallenge,
+		CreateAuthChallenge:     input.CreateAuthChallenge,
+		VerifyAuthChallengeResp: input.VerifyAuthChallengeResp,
+		PreTokenGeneration:      input.PreTokenGeneration,
+		UserMigration:           input.UserMigration,
+	}
 }


### PR DESCRIPTION
## Summary
- Add `convertLambdaConfigToOutput` function to convert `LambdaConfig` to `LambdaConfigOutput`
- Add `convertLambdaConfigInputToLambdaConfig` function to convert input to storage format
- Store `LambdaConfig` and `EmailConfiguration` when creating a user pool
- Include `LambdaConfig` and `EmailConfiguration` in `DescribeUserPool` response

## Test plan
- [ ] Build passes (`go build ./...`)
- [ ] Existing tests pass
- [ ] LambdaConfig is properly stored when creating a user pool with Lambda triggers
- [ ] LambdaConfig is included in DescribeUserPool response

Closes #269