### PR TITLE
fix(acm): add missing fields to ListCertificates response

### DIFF
--- a/internal/service/acm/handlers.go
+++ b/internal/service/acm/handlers.go
@@ -140,6 +140,18 @@ func (s *Service) ListCertificates(w http.ResponseWriter, r *http.Request) {
 	summaries := make([]CertificateSummary, 0, len(certs))
 
 	for _, cert := range certs {
+		// Convert KeyUsages to string slice
+		keyUsages := make([]string, 0, len(cert.KeyUsages))
+		for _, ku := range cert.KeyUsages {
+			keyUsages = append(keyUsages, ku.Name)
+		}
+
+		// Convert ExtendedKeyUsages to string slice
+		extendedKeyUsages := make([]string, 0, len(cert.ExtendedKeyUsages))
+		for _, eku := range cert.ExtendedKeyUsages {
+			extendedKeyUsages = append(extendedKeyUsages, eku.Name)
+		}
+
 		summary := CertificateSummary{
 			CertificateArn:          cert.CertificateArn,
 			DomainName:              cert.DomainName,
@@ -153,7 +165,10 @@ func (s *Service) ListCertificates(w http.ResponseWriter, r *http.Request) {
 			NotBefore:               ToAWSTimestampPtr(cert.NotBefore),
 			NotAfter:                ToAWSTimestampPtr(cert.NotAfter),
 			RenewalEligibility:      cert.RenewalEligibility,
+			Exported:                cert.Type == "IMPORTED",
 			InUse:                   len(cert.InUseBy) > 0,
+			KeyUsages:               keyUsages,
+			ExtendedKeyUsages:       extendedKeyUsages,
 		}
 
 		summaries = append(summaries, summary)

--- a/internal/service/acm/types.go
+++ b/internal/service/acm/types.go
@@ -206,6 +206,8 @@ type CertificateSummary struct {
 	RenewalEligibility      string        `json:"RenewalEligibility,omitempty"`
 	Exported                bool          `json:"Exported,omitempty"`
 	InUse                   bool          `json:"InUse,omitempty"`
+	KeyUsages               []string      `json:"KeyUsages,omitempty"`
+	ExtendedKeyUsages       []string      `json:"ExtendedKeyUsages,omitempty"`
 }
 
 // DeleteCertificateInput is the request for DeleteCertificate.


### PR DESCRIPTION
## Summary
- Add `KeyUsages` field to `CertificateSummary` to return key usage names
- Add `ExtendedKeyUsages` field to `CertificateSummary` to return extended key usage names
- Set `Exported` field to `true` when the certificate type is `IMPORTED`

These fields were previously defined in the struct but not populated in the ListCertificates handler.

## Test plan
- [ ] Verify that `ListCertificates` API returns the new fields in the response
- [ ] Verify that `Exported` is `true` for imported certificates
- [ ] Verify that `KeyUsages` and `ExtendedKeyUsages` contain the correct values from the certificate

Closes #270