### PR TITLE
fix(cloudwatch): add OwningAccounts field to ListMetrics response

### DIFF
--- a/internal/service/cloudwatch/handlers.go
+++ b/internal/service/cloudwatch/handlers.go
@@ -133,8 +133,9 @@ func (s *Service) ListMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSONResponse(w, ListMetricsResponse{
-		Metrics:   result.Metrics,
-		NextToken: result.NextToken,
+		Metrics:        result.Metrics,
+		NextToken:      result.NextToken,
+		OwningAccounts: result.OwningAccounts,
 	})
 }
 
@@ -478,8 +479,9 @@ func (s *Service) ListMetricsCBOR(w http.ResponseWriter, r *http.Request) {
 	}
 
 	server.WriteCBORResponse(w, ListMetricsResponse{
-		Metrics:   result.Metrics,
-		NextToken: result.NextToken,
+		Metrics:        result.Metrics,
+		NextToken:      result.NextToken,
+		OwningAccounts: result.OwningAccounts,
 	})
 }
 

--- a/internal/service/cloudwatch/storage.go
+++ b/internal/service/cloudwatch/storage.go
@@ -10,6 +10,9 @@ import (
 	"time"
 )
 
+// defaultAccountID is the default AWS account ID used in the emulator.
+const defaultAccountID = "000000000000"
+
 // Storage defines the CloudWatch storage interface.
 type Storage interface {
 	PutMetricData(ctx context.Context, namespace string, metricData []MetricDatum) error
@@ -248,8 +251,16 @@ func (s *MemoryStorage) ListMetrics(_ context.Context, req *ListMetricsRequest) 
 		return metrics[i].MetricName < metrics[j].MetricName
 	})
 
+	// Build owning accounts list.
+	// In a single-account emulator, all metrics are owned by the default account.
+	var owningAccounts []string
+	if len(metrics) > 0 {
+		owningAccounts = []string{defaultAccountID}
+	}
+
 	return &ListMetricsResult{
-		Metrics: metrics,
+		Metrics:        metrics,
+		OwningAccounts: owningAccounts,
 	}, nil
 }
 
@@ -259,7 +270,7 @@ func (s *MemoryStorage) PutMetricAlarm(_ context.Context, req *PutMetricAlarmReq
 	defer s.mu.Unlock()
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	alarmARN := fmt.Sprintf("arn:aws:cloudwatch:us-east-1:000000000000:alarm:%s", req.AlarmName)
+	alarmARN := fmt.Sprintf("arn:aws:cloudwatch:us-east-1:%s:alarm:%s", defaultAccountID, req.AlarmName)
 
 	actionsEnabled := true
 	if req.ActionsEnabled != nil {

--- a/internal/service/cloudwatch/types.go
+++ b/internal/service/cloudwatch/types.go
@@ -209,8 +209,9 @@ type Datapoint struct {
 
 // ListMetricsResponse is the response for ListMetrics.
 type ListMetricsResponse struct {
-	Metrics   []Metric `json:"Metrics"`
-	NextToken string   `json:"NextToken,omitempty"`
+	Metrics        []Metric `json:"Metrics"`
+	NextToken      string   `json:"NextToken,omitempty"`
+	OwningAccounts []string `json:"OwningAccounts,omitempty"`
 }
 
 // DescribeAlarmsResponse is the response for DescribeAlarms.
@@ -358,8 +359,9 @@ type GetMetricStatisticsResult struct {
 
 // ListMetricsResult is the result for ListMetrics storage operation.
 type ListMetricsResult struct {
-	Metrics   []Metric
-	NextToken string
+	Metrics        []Metric
+	NextToken      string
+	OwningAccounts []string
 }
 
 // DescribeAlarmsResult is the result for DescribeAlarms storage operation.


### PR DESCRIPTION
## Summary
- Add `OwningAccounts` field to `ListMetricsResponse` and `ListMetricsResult` types
- Populate the field with the default account ID when metrics are returned
- Refactor to use a `defaultAccountID` constant for consistency

## Test plan
- [x] Build passes: `go build ./internal/service/cloudwatch/...`
- [x] Vet passes: `go vet ./internal/service/cloudwatch/...`
- [ ] Integration tests pass (if applicable)

Closes #271