### PR TITLE
feat(ds): implement AWS Directory Service

### DIFF
--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/cognito"
 	_ "github.com/sivchari/awsim/internal/service/configservice"
 	_ "github.com/sivchari/awsim/internal/service/dlm"
+	_ "github.com/sivchari/awsim/internal/service/ds"
 	_ "github.com/sivchari/awsim/internal/service/dynamodb"
 	_ "github.com/sivchari/awsim/internal/service/ec2"
 	_ "github.com/sivchari/awsim/internal/service/ecr"

--- a/internal/service/ds/handlers.go
+++ b/internal/service/ds/handlers.go
@@ -1,0 +1,268 @@
+package ds
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// CreateDirectory handles the CreateDirectory API.
+func (s *Service) CreateDirectory(w http.ResponseWriter, r *http.Request) {
+	var req CreateDirectoryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeDSError(w, ErrClientException, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Name == "" {
+		writeDSError(w, ErrInvalidParameter, "Name is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Password == "" {
+		writeDSError(w, ErrInvalidParameter, "Password is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Size == "" {
+		req.Size = DirectorySizeSmall
+	}
+
+	directory, err := s.storage.CreateDirectory(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	resp := &CreateDirectoryResponse{
+		DirectoryID: directory.DirectoryID,
+	}
+
+	writeJSONResponse(w, resp)
+}
+
+// DescribeDirectories handles the DescribeDirectories API.
+func (s *Service) DescribeDirectories(w http.ResponseWriter, r *http.Request) {
+	var req DescribeDirectoriesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeDSError(w, ErrClientException, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	directories, nextToken, err := s.storage.DescribeDirectories(r.Context(), req.DirectoryIDs, req.Limit, req.NextToken)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	descriptions := make([]*DirectoryDescription, len(directories))
+
+	for i, d := range directories {
+		desc := &DirectoryDescription{
+			DirectoryID:        d.DirectoryID,
+			Name:               d.Name,
+			ShortName:          d.ShortName,
+			Size:               d.Size,
+			Description:        d.Description,
+			DNSIPAddrs:         d.DNSIPAddrs,
+			Stage:              d.Stage,
+			LaunchTime:         float64(d.LaunchTime.Unix()),
+			StageLastUpdatedAt: float64(d.StageLastUpdatedAt.Unix()),
+			Type:               d.Type,
+			SSOEnabled:         d.SSOEnabled,
+			DesiredNumberOfDCs: d.DesiredNumberOfDCs,
+		}
+
+		if d.VPCSettings != nil {
+			desc.VPCSettings = &DirectoryVPCSettingsResp{
+				VPCID:             d.VPCSettings.VPCID,
+				SubnetIDs:         d.VPCSettings.SubnetIDs,
+				SecurityGroupID:   d.VPCSettings.SecurityGroupID,
+				AvailabilityZones: d.VPCSettings.AvailabilityZones,
+			}
+		}
+
+		descriptions[i] = desc
+	}
+
+	resp := &DescribeDirectoriesResponse{
+		DirectoryDescriptions: descriptions,
+		NextToken:             nextToken,
+	}
+
+	writeJSONResponse(w, resp)
+}
+
+// DeleteDirectory handles the DeleteDirectory API.
+func (s *Service) DeleteDirectory(w http.ResponseWriter, r *http.Request) {
+	var req DeleteDirectoryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeDSError(w, ErrClientException, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DirectoryID == "" {
+		writeDSError(w, ErrInvalidParameter, "DirectoryId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	err := s.storage.DeleteDirectory(r.Context(), req.DirectoryID)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	resp := &DeleteDirectoryResponse{
+		DirectoryID: req.DirectoryID,
+	}
+
+	writeJSONResponse(w, resp)
+}
+
+// CreateSnapshot handles the CreateSnapshot API.
+func (s *Service) CreateSnapshot(w http.ResponseWriter, r *http.Request) {
+	var req CreateSnapshotRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeDSError(w, ErrClientException, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DirectoryID == "" {
+		writeDSError(w, ErrInvalidParameter, "DirectoryId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	snapshot, err := s.storage.CreateSnapshot(r.Context(), req.DirectoryID, req.Name)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	resp := &CreateSnapshotResponse{
+		SnapshotID: snapshot.SnapshotID,
+	}
+
+	writeJSONResponse(w, resp)
+}
+
+// DescribeSnapshots handles the DescribeSnapshots API.
+func (s *Service) DescribeSnapshots(w http.ResponseWriter, r *http.Request) {
+	var req DescribeSnapshotsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeDSError(w, ErrClientException, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	snapshots, nextToken, err := s.storage.DescribeSnapshots(r.Context(), req.DirectoryID, req.SnapshotIDs, req.Limit, req.NextToken)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	descriptions := make([]*SnapshotDescription, len(snapshots))
+	for i, snap := range snapshots {
+		descriptions[i] = &SnapshotDescription{
+			SnapshotID:  snap.SnapshotID,
+			DirectoryID: snap.DirectoryID,
+			Name:        snap.Name,
+			Type:        snap.Type,
+			Status:      snap.Status,
+			StartTime:   float64(snap.StartTime.Unix()),
+		}
+	}
+
+	resp := &DescribeSnapshotsResponse{
+		Snapshots: descriptions,
+		NextToken: nextToken,
+	}
+
+	writeJSONResponse(w, resp)
+}
+
+// DeleteSnapshot handles the DeleteSnapshot API.
+func (s *Service) DeleteSnapshot(w http.ResponseWriter, r *http.Request) {
+	var req DeleteSnapshotRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeDSError(w, ErrClientException, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.SnapshotID == "" {
+		writeDSError(w, ErrInvalidParameter, "SnapshotId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	err := s.storage.DeleteSnapshot(r.Context(), req.SnapshotID)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	resp := &DeleteSnapshotResponse{
+		SnapshotID: req.SnapshotID,
+	}
+
+	writeJSONResponse(w, resp)
+}
+
+// handleError handles Error and writes appropriate response.
+func handleError(w http.ResponseWriter, err error) {
+	var dsErr *Error
+	if errors.As(err, &dsErr) {
+		status := http.StatusBadRequest
+
+		switch dsErr.Type {
+		case ErrEntityDoesNotExist:
+			status = http.StatusBadRequest
+		case ErrEntityAlreadyExists:
+			status = http.StatusConflict
+		case ErrServiceException:
+			status = http.StatusInternalServerError
+		}
+
+		writeDSError(w, dsErr.Type, dsErr.Message, status)
+
+		return
+	}
+
+	writeDSError(w, ErrServiceException, "Internal server error", http.StatusInternalServerError)
+}
+
+// writeJSONResponse writes a JSON response with status 200 OK.
+func writeJSONResponse(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.Header().Set("X-Amzn-Requestid", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeDSError writes a Directory Service error response.
+func writeDSError(w http.ResponseWriter, errType, message string, status int) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.Header().Set("X-Amzn-Requestid", uuid.New().String())
+	w.Header().Set("X-Amzn-Errortype", errType)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(&Error{
+		Type:    errType,
+		Message: message,
+	})
+}

--- a/internal/service/ds/service.go
+++ b/internal/service/ds/service.go
@@ -1,0 +1,71 @@
+package ds
+
+import (
+	"net/http"
+
+	"github.com/sivchari/awsim/internal/service"
+)
+
+func init() {
+	svc := NewService()
+	service.Register(svc)
+}
+
+// Service implements the Directory Service.
+type Service struct {
+	storage Storage
+}
+
+// NewService creates a new Directory Service.
+func NewService() *Service {
+	return &Service{
+		storage: NewMemoryStorage(),
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "ds"
+}
+
+// Prefix returns the URL prefix for this service.
+func (s *Service) Prefix() string {
+	return ""
+}
+
+// RegisterRoutes registers the Directory Service routes.
+// Directory Service uses AWS JSON 1.1 protocol with X-Amz-Target header.
+func (s *Service) RegisterRoutes(_ service.Router) {
+	// Directory Service uses POST / with X-Amz-Target header
+	// Routes are handled by the JSON protocol dispatcher.
+}
+
+// TargetPrefix returns the X-Amz-Target prefix for this service.
+func (s *Service) TargetPrefix() string {
+	return "DirectoryService_20150416"
+}
+
+// DispatchAction dispatches the action to the appropriate handler.
+func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
+	action := r.Header.Get("X-Amz-Target")
+
+	switch action {
+	case "DirectoryService_20150416.CreateDirectory":
+		s.CreateDirectory(w, r)
+	case "DirectoryService_20150416.DescribeDirectories":
+		s.DescribeDirectories(w, r)
+	case "DirectoryService_20150416.DeleteDirectory":
+		s.DeleteDirectory(w, r)
+	case "DirectoryService_20150416.CreateSnapshot":
+		s.CreateSnapshot(w, r)
+	case "DirectoryService_20150416.DescribeSnapshots":
+		s.DescribeSnapshots(w, r)
+	case "DirectoryService_20150416.DeleteSnapshot":
+		s.DeleteSnapshot(w, r)
+	default:
+		writeDSError(w, ErrUnsupportedOperation, "Unsupported operation: "+action, http.StatusBadRequest)
+	}
+}
+
+// JSONProtocol is a marker method for JSON protocol services.
+func (s *Service) JSONProtocol() {}

--- a/internal/service/ds/storage.go
+++ b/internal/service/ds/storage.go
@@ -1,0 +1,277 @@
+package ds
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Storage defines the Directory Service storage interface.
+type Storage interface {
+	CreateDirectory(ctx context.Context, req *CreateDirectoryRequest) (*Directory, error)
+	DescribeDirectories(ctx context.Context, directoryIDs []string, limit int, nextToken string) ([]*Directory, string, error)
+	DeleteDirectory(ctx context.Context, directoryID string) error
+	CreateSnapshot(ctx context.Context, directoryID, name string) (*Snapshot, error)
+	DescribeSnapshots(ctx context.Context, directoryID string, snapshotIDs []string, limit int, nextToken string) ([]*Snapshot, string, error)
+	DeleteSnapshot(ctx context.Context, snapshotID string) error
+}
+
+// MemoryStorage implements Storage with in-memory data.
+type MemoryStorage struct {
+	mu          sync.RWMutex
+	directories map[string]*Directory
+	snapshots   map[string]*Snapshot
+	region      string
+	accountID   string
+}
+
+// NewMemoryStorage creates a new in-memory storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		directories: make(map[string]*Directory),
+		snapshots:   make(map[string]*Snapshot),
+		region:      "us-east-1",
+		accountID:   "123456789012",
+	}
+}
+
+// CreateDirectory creates a new directory.
+func (s *MemoryStorage) CreateDirectory(_ context.Context, req *CreateDirectoryRequest) (*Directory, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check for duplicate directory name.
+	for _, d := range s.directories {
+		if d.Name == req.Name {
+			return nil, &Error{
+				Type:    ErrEntityAlreadyExists,
+				Message: fmt.Sprintf("Directory with name %s already exists", req.Name),
+			}
+		}
+	}
+
+	directoryID := "d-" + uuid.New().String()[:10]
+
+	var vpcSettings *DirectoryVPCSettings
+	if req.VPCSettings != nil {
+		vpcSettings = &DirectoryVPCSettings{
+			VPCID:             req.VPCSettings.VPCID,
+			SubnetIDs:         req.VPCSettings.SubnetIDs,
+			SecurityGroupID:   "sg-" + uuid.New().String()[:8],
+			AvailabilityZones: []string{"us-east-1a", "us-east-1b"},
+		}
+	}
+
+	shortName := req.ShortName
+	if shortName == "" {
+		shortName = req.Name
+	}
+
+	now := time.Now().UTC()
+	directory := &Directory{
+		DirectoryID:        directoryID,
+		Name:               req.Name,
+		ShortName:          shortName,
+		Password:           req.Password,
+		Description:        req.Description,
+		Size:               req.Size,
+		Type:               DirectoryTypeSimpleAD,
+		Stage:              DirectoryStateActive,
+		DNSIPAddrs:         []string{"10.0.0.1", "10.0.0.2"},
+		SSOEnabled:         false,
+		DesiredNumberOfDCs: 2,
+		VPCSettings:        vpcSettings,
+		LaunchTime:         now,
+		StageLastUpdatedAt: now,
+	}
+
+	s.directories[directoryID] = directory
+
+	return directory, nil
+}
+
+// DescribeDirectories returns directories matching the given IDs.
+func (s *MemoryStorage) DescribeDirectories(_ context.Context, directoryIDs []string, limit int, nextToken string) ([]*Directory, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if limit == 0 {
+		limit = 100
+	}
+
+	var directories []*Directory
+
+	if len(directoryIDs) > 0 {
+		// Return specific directories.
+		for _, id := range directoryIDs {
+			if d, exists := s.directories[id]; exists {
+				directories = append(directories, d)
+			}
+		}
+	} else {
+		// Return all directories.
+		for _, d := range s.directories {
+			directories = append(directories, d)
+		}
+	}
+
+	// Sort by directory ID for consistent pagination.
+	sort.Slice(directories, func(i, j int) bool {
+		return directories[i].DirectoryID < directories[j].DirectoryID
+	})
+
+	// Handle pagination.
+	start := 0
+
+	if nextToken != "" {
+		for i, d := range directories {
+			if d.DirectoryID == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := min(start+limit, len(directories))
+	result := directories[start:end]
+	newNextToken := ""
+
+	if end < len(directories) {
+		newNextToken = directories[end].DirectoryID
+	}
+
+	return result, newNextToken, nil
+}
+
+// DeleteDirectory deletes a directory.
+func (s *MemoryStorage) DeleteDirectory(_ context.Context, directoryID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.directories[directoryID]; !exists {
+		return &Error{
+			Type:    ErrEntityDoesNotExist,
+			Message: fmt.Sprintf("Directory %s does not exist", directoryID),
+		}
+	}
+
+	delete(s.directories, directoryID)
+
+	return nil
+}
+
+// CreateSnapshot creates a new snapshot for a directory.
+func (s *MemoryStorage) CreateSnapshot(_ context.Context, directoryID, name string) (*Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.directories[directoryID]; !exists {
+		return nil, &Error{
+			Type:    ErrEntityDoesNotExist,
+			Message: fmt.Sprintf("Directory %s does not exist", directoryID),
+		}
+	}
+
+	snapshotID := "s-" + uuid.New().String()[:10]
+	now := time.Now().UTC()
+
+	snapshot := &Snapshot{
+		SnapshotID:  snapshotID,
+		DirectoryID: directoryID,
+		Name:        name,
+		Type:        SnapshotTypeManual,
+		Status:      SnapshotStateCompleted,
+		StartTime:   now,
+	}
+
+	s.snapshots[snapshotID] = snapshot
+
+	return snapshot, nil
+}
+
+// DescribeSnapshots returns snapshots matching the given criteria.
+func (s *MemoryStorage) DescribeSnapshots(_ context.Context, directoryID string, snapshotIDs []string, limit int, nextToken string) ([]*Snapshot, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if limit == 0 {
+		limit = 100
+	}
+
+	var snapshots []*Snapshot
+
+	if len(snapshotIDs) > 0 {
+		// Return specific snapshots.
+		for _, id := range snapshotIDs {
+			snap, exists := s.snapshots[id]
+			if !exists {
+				continue
+			}
+
+			if directoryID != "" && snap.DirectoryID != directoryID {
+				continue
+			}
+
+			snapshots = append(snapshots, snap)
+		}
+	} else {
+		// Return all snapshots.
+		for _, snap := range s.snapshots {
+			if directoryID != "" && snap.DirectoryID != directoryID {
+				continue
+			}
+
+			snapshots = append(snapshots, snap)
+		}
+	}
+
+	// Sort by snapshot ID for consistent pagination.
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].SnapshotID < snapshots[j].SnapshotID
+	})
+
+	// Handle pagination.
+	start := 0
+
+	if nextToken != "" {
+		for i, snap := range snapshots {
+			if snap.SnapshotID == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := min(start+limit, len(snapshots))
+	result := snapshots[start:end]
+	newNextToken := ""
+
+	if end < len(snapshots) {
+		newNextToken = snapshots[end].SnapshotID
+	}
+
+	return result, newNextToken, nil
+}
+
+// DeleteSnapshot deletes a snapshot.
+func (s *MemoryStorage) DeleteSnapshot(_ context.Context, snapshotID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.snapshots[snapshotID]; !exists {
+		return &Error{
+			Type:    ErrEntityDoesNotExist,
+			Message: fmt.Sprintf("Snapshot %s does not exist", snapshotID),
+		}
+	}
+
+	delete(s.snapshots, snapshotID)
+
+	return nil
+}

--- a/internal/service/ds/types.go
+++ b/internal/service/ds/types.go
@@ -1,0 +1,283 @@
+//nolint:tagliatelle // AWS DS API uses PascalCase for JSON tags
+package ds
+
+import "time"
+
+// Directory states.
+const (
+	DirectoryStateCreating   = "Creating"
+	DirectoryStateCreated    = "Created"
+	DirectoryStateActive     = "Active"
+	DirectoryStateDeleting   = "Deleting"
+	DirectoryStateDeleted    = "Deleted"
+	DirectoryStateFailed     = "Failed"
+	DirectoryStateRestoring  = "Restoring"
+	DirectoryStateImpaired   = "Impaired"
+	DirectoryStateInoperable = "Inoperable"
+	DirectoryStateRequested  = "Requested"
+)
+
+// Directory sizes.
+const (
+	DirectorySizeSmall = "Small"
+	DirectorySizeLarge = "Large"
+)
+
+// Directory types.
+const (
+	DirectoryTypeSimpleAD    = "SimpleAD"
+	DirectoryTypeMicrosoftAD = "MicrosoftAD"
+	DirectoryTypeADConnector = "ADConnector"
+)
+
+// Snapshot states.
+const (
+	SnapshotStateCreating  = "Creating"
+	SnapshotStateCompleted = "Completed"
+	SnapshotStateFailed    = "Failed"
+)
+
+// Snapshot types.
+const (
+	SnapshotTypeAuto   = "Auto"
+	SnapshotTypeManual = "Manual"
+)
+
+// Directory represents a directory in the service.
+type Directory struct {
+	DirectoryID        string
+	Name               string
+	ShortName          string
+	Password           string
+	Description        string
+	Size               string
+	Type               string
+	Stage              string
+	StageReason        string
+	DNSIPAddrs         []string
+	AccessURL          string
+	Alias              string
+	SSOEnabled         bool
+	DesiredNumberOfDCs int
+	VPCSettings        *DirectoryVPCSettings
+	ConnectSettings    *DirectoryConnectSettings
+	RadiusSettings     *RadiusSettings
+	LaunchTime         time.Time
+	StageLastUpdatedAt time.Time
+	Edition            string
+	RegionsInfo        *RegionsInfo
+}
+
+// DirectoryVPCSettings represents VPC settings for a directory.
+type DirectoryVPCSettings struct {
+	VPCID             string
+	SubnetIDs         []string
+	SecurityGroupID   string
+	AvailabilityZones []string
+}
+
+// DirectoryConnectSettings represents connection settings for AD Connector.
+type DirectoryConnectSettings struct {
+	VPCID             string
+	SubnetIDs         []string
+	CustomerDNSIPs    []string
+	CustomerUserName  string
+	SecurityGroupID   string
+	AvailabilityZones []string
+	ConnectIPs        []string
+}
+
+// RadiusSettings represents RADIUS authentication settings.
+type RadiusSettings struct {
+	RadiusServers          []string
+	RadiusPort             int
+	RadiusTimeout          int
+	RadiusRetries          int
+	SharedSecret           string
+	AuthenticationProtocol string
+	DisplayLabel           string
+	UseSameUsername        bool
+}
+
+// RegionsInfo represents multi-region information.
+type RegionsInfo struct {
+	PrimaryRegion     string
+	AdditionalRegions []string
+}
+
+// Snapshot represents a directory snapshot.
+type Snapshot struct {
+	SnapshotID  string
+	DirectoryID string
+	Name        string
+	Type        string
+	Status      string
+	StartTime   time.Time
+}
+
+// CreateDirectoryRequest is the request for CreateDirectory.
+type CreateDirectoryRequest struct {
+	Name        string                   `json:"Name"`
+	ShortName   string                   `json:"ShortName,omitempty"`
+	Password    string                   `json:"Password"`
+	Description string                   `json:"Description,omitempty"`
+	Size        string                   `json:"Size"`
+	VPCSettings *DirectoryVPCSettingsReq `json:"VpcSettings,omitempty"`
+	Tags        []Tag                    `json:"Tags,omitempty"`
+}
+
+// DirectoryVPCSettingsReq is the VPC settings in request.
+type DirectoryVPCSettingsReq struct {
+	VPCID     string   `json:"VpcId"`
+	SubnetIDs []string `json:"SubnetIds"`
+}
+
+// Tag represents a resource tag.
+type Tag struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+// CreateDirectoryResponse is the response for CreateDirectory.
+type CreateDirectoryResponse struct {
+	DirectoryID string `json:"DirectoryId"`
+}
+
+// DescribeDirectoriesRequest is the request for DescribeDirectories.
+type DescribeDirectoriesRequest struct {
+	DirectoryIDs []string `json:"DirectoryIds,omitempty"`
+	NextToken    string   `json:"NextToken,omitempty"`
+	Limit        int      `json:"Limit,omitempty"`
+}
+
+// DescribeDirectoriesResponse is the response for DescribeDirectories.
+type DescribeDirectoriesResponse struct {
+	DirectoryDescriptions []*DirectoryDescription `json:"DirectoryDescriptions"`
+	NextToken             string                  `json:"NextToken,omitempty"`
+}
+
+// DirectoryDescription represents a directory description.
+type DirectoryDescription struct {
+	DirectoryID        string                    `json:"DirectoryId"`
+	Name               string                    `json:"Name"`
+	ShortName          string                    `json:"ShortName,omitempty"`
+	Size               string                    `json:"Size,omitempty"`
+	Edition            string                    `json:"Edition,omitempty"`
+	Alias              string                    `json:"Alias,omitempty"`
+	AccessURL          string                    `json:"AccessUrl,omitempty"`
+	Description        string                    `json:"Description,omitempty"`
+	DNSIPAddrs         []string                  `json:"DnsIpAddrs,omitempty"`
+	Stage              string                    `json:"Stage"`
+	StageReason        string                    `json:"StageReason,omitempty"`
+	LaunchTime         float64                   `json:"LaunchTime,omitempty"`
+	StageLastUpdatedAt float64                   `json:"StageLastUpdatedDateTime,omitempty"`
+	Type               string                    `json:"Type"`
+	VPCSettings        *DirectoryVPCSettingsResp `json:"VpcSettings,omitempty"`
+	ConnectSettings    *DirectoryConnectResp     `json:"ConnectSettings,omitempty"`
+	SSOEnabled         bool                      `json:"SsoEnabled"`
+	DesiredNumberOfDCs int                       `json:"DesiredNumberOfDomainControllers,omitempty"`
+	RegionsInfo        *RegionsInfoResp          `json:"RegionsInfo,omitempty"`
+}
+
+// DirectoryVPCSettingsResp is the VPC settings in response.
+type DirectoryVPCSettingsResp struct {
+	VPCID             string   `json:"VpcId"`
+	SubnetIDs         []string `json:"SubnetIds"`
+	SecurityGroupID   string   `json:"SecurityGroupId,omitempty"`
+	AvailabilityZones []string `json:"AvailabilityZones,omitempty"`
+}
+
+// DirectoryConnectResp is the connect settings in response.
+type DirectoryConnectResp struct {
+	VPCID             string   `json:"VpcId"`
+	SubnetIDs         []string `json:"SubnetIds"`
+	CustomerDNSIPs    []string `json:"CustomerDnsIps,omitempty"`
+	CustomerUserName  string   `json:"CustomerUserName,omitempty"`
+	SecurityGroupID   string   `json:"SecurityGroupId,omitempty"`
+	AvailabilityZones []string `json:"AvailabilityZones,omitempty"`
+	ConnectIPs        []string `json:"ConnectIps,omitempty"`
+}
+
+// RegionsInfoResp is the regions info in response.
+type RegionsInfoResp struct {
+	PrimaryRegion     string   `json:"PrimaryRegion,omitempty"`
+	AdditionalRegions []string `json:"AdditionalRegions,omitempty"`
+}
+
+// DeleteDirectoryRequest is the request for DeleteDirectory.
+type DeleteDirectoryRequest struct {
+	DirectoryID string `json:"DirectoryId"`
+}
+
+// DeleteDirectoryResponse is the response for DeleteDirectory.
+type DeleteDirectoryResponse struct {
+	DirectoryID string `json:"DirectoryId"`
+}
+
+// CreateSnapshotRequest is the request for CreateSnapshot.
+type CreateSnapshotRequest struct {
+	DirectoryID string `json:"DirectoryId"`
+	Name        string `json:"Name,omitempty"`
+}
+
+// CreateSnapshotResponse is the response for CreateSnapshot.
+type CreateSnapshotResponse struct {
+	SnapshotID string `json:"SnapshotId"`
+}
+
+// DescribeSnapshotsRequest is the request for DescribeSnapshots.
+type DescribeSnapshotsRequest struct {
+	DirectoryID string   `json:"DirectoryId,omitempty"`
+	SnapshotIDs []string `json:"SnapshotIds,omitempty"`
+	NextToken   string   `json:"NextToken,omitempty"`
+	Limit       int      `json:"Limit,omitempty"`
+}
+
+// DescribeSnapshotsResponse is the response for DescribeSnapshots.
+type DescribeSnapshotsResponse struct {
+	Snapshots []*SnapshotDescription `json:"Snapshots"`
+	NextToken string                 `json:"NextToken,omitempty"`
+}
+
+// SnapshotDescription represents a snapshot description.
+type SnapshotDescription struct {
+	SnapshotID  string  `json:"SnapshotId"`
+	DirectoryID string  `json:"DirectoryId"`
+	Name        string  `json:"Name,omitempty"`
+	Type        string  `json:"Type"`
+	Status      string  `json:"Status"`
+	StartTime   float64 `json:"StartTime,omitempty"`
+}
+
+// DeleteSnapshotRequest is the request for DeleteSnapshot.
+type DeleteSnapshotRequest struct {
+	SnapshotID string `json:"SnapshotId"`
+}
+
+// DeleteSnapshotResponse is the response for DeleteSnapshot.
+type DeleteSnapshotResponse struct {
+	SnapshotID string `json:"SnapshotId"`
+}
+
+// Error represents a Directory Service error.
+type Error struct {
+	Type    string `json:"__type"`
+	Message string `json:"message"`
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return e.Message
+}
+
+// Error codes for Directory Service.
+const (
+	ErrEntityDoesNotExist     = "EntityDoesNotExistException"
+	ErrEntityAlreadyExists    = "EntityAlreadyExistsException"
+	ErrInvalidParameter       = "InvalidParameterException"
+	ErrDirectoryLimitExceeded = "DirectoryLimitExceededException"
+	ErrSnapshotLimitExceeded  = "SnapshotLimitExceededException"
+	ErrServiceException       = "ServiceException"
+	ErrClientException        = "ClientException"
+	ErrUnsupportedOperation   = "UnsupportedOperationException"
+)

--- a/test/go.mod
+++ b/test/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codeconnections v1.10.16
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.58.0
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.61.1
+	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.35.13
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.285.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -44,6 +44,8 @@ github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.58.0 h1:FQQi7oGH
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.58.0/go.mod h1:bBgsO3htjygdyPTgT0Fou14A5VAQaLqiJ8YE2SW4NKw=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.61.1 h1:aho+qoT/ybRPv3EKee98Pc1hZcKRd5ECrv+KdCdj2I8=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.61.1/go.mod h1:jAsoyYj8HSPYo4ZMaoGtDG622Nz8VXtsYVA8jyPYyqI=
+github.com/aws/aws-sdk-go-v2/service/directoryservice v1.37.0 h1:5MthmITq3unZoB5EHlwYsoadubv0H/vi8/gnO0/UmF4=
+github.com/aws/aws-sdk-go-v2/service/directoryservice v1.37.0/go.mod h1:KkCYX9biRFzx8lAEgYyNSuQ3ljMK2ZOTnplMhHyCfhk=
 github.com/aws/aws-sdk-go-v2/service/dlm v1.35.13 h1:wyKOcqzzdbwz1UQtbFmmDw6YR6ux20yqmVaB4zONToE=
 github.com/aws/aws-sdk-go-v2/service/dlm v1.35.13/go.mod h1:H5FXmob8HAyO6t/Anh2UgK+SEYxGnNb/9H91npxUJgQ=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.55.0 h1:CyYoeHWjVSGimzMhlL0Z4l5gLCa++ccnRJKrsaNssxE=

--- a/test/integration/ds_test.go
+++ b/test/integration/ds_test.go
@@ -1,0 +1,198 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
+	"github.com/aws/aws-sdk-go-v2/service/directoryservice/types"
+	"github.com/sivchari/golden"
+)
+
+func newDSClient(t *testing.T) *directoryservice.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return directoryservice.NewFromConfig(cfg, func(o *directoryservice.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestDS_CreateAndDeleteDirectory(t *testing.T) {
+	client := newDSClient(t)
+	ctx := t.Context()
+	directoryName := "test.example.com"
+
+	// Create directory.
+	createOutput, err := client.CreateDirectory(ctx, &directoryservice.CreateDirectoryInput{
+		Name:     aws.String(directoryName),
+		Password: aws.String("Test1234!"),
+		Size:     types.DirectorySizeSmall,
+		VpcSettings: &types.DirectoryVpcSettings{
+			VpcId:     aws.String("vpc-12345678"),
+			SubnetIds: []string{"subnet-11111111", "subnet-22222222"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	directoryID := createOutput.DirectoryId
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteDirectory(context.Background(), &directoryservice.DeleteDirectoryInput{
+			DirectoryId: directoryID,
+		})
+	})
+
+	golden.New(t, golden.WithIgnoreFields("DirectoryId", "ResultMetadata")).Assert(t.Name()+"_create", createOutput)
+
+	// Delete directory.
+	deleteOutput, err := client.DeleteDirectory(ctx, &directoryservice.DeleteDirectoryInput{
+		DirectoryId: directoryID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("DirectoryId", "ResultMetadata")).Assert(t.Name()+"_delete", deleteOutput)
+}
+
+func TestDS_DescribeDirectories(t *testing.T) {
+	client := newDSClient(t)
+	ctx := t.Context()
+	directoryName := "describe-test.example.com"
+
+	// Create directory.
+	createOutput, err := client.CreateDirectory(ctx, &directoryservice.CreateDirectoryInput{
+		Name:        aws.String(directoryName),
+		Password:    aws.String("Test1234!"),
+		Size:        types.DirectorySizeSmall,
+		Description: aws.String("Test directory for describe"),
+		VpcSettings: &types.DirectoryVpcSettings{
+			VpcId:     aws.String("vpc-12345678"),
+			SubnetIds: []string{"subnet-11111111", "subnet-22222222"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	directoryID := createOutput.DirectoryId
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteDirectory(context.Background(), &directoryservice.DeleteDirectoryInput{
+			DirectoryId: directoryID,
+		})
+	})
+
+	// Describe directories.
+	describeOutput, err := client.DescribeDirectories(ctx, &directoryservice.DescribeDirectoriesInput{
+		DirectoryIds: []string{*directoryID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(describeOutput.DirectoryDescriptions) == 0 {
+		t.Fatal("expected at least one directory")
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"DirectoryId", "LaunchTime", "StageLastUpdatedDateTime", "DnsIpAddrs",
+		"VpcSettings", "ResultMetadata",
+	)).Assert(t.Name(), describeOutput)
+}
+
+func TestDS_CreateAndDeleteSnapshot(t *testing.T) {
+	client := newDSClient(t)
+	ctx := t.Context()
+	directoryName := "snapshot-test.example.com"
+
+	// Create directory first.
+	createDirOutput, err := client.CreateDirectory(ctx, &directoryservice.CreateDirectoryInput{
+		Name:     aws.String(directoryName),
+		Password: aws.String("Test1234!"),
+		Size:     types.DirectorySizeSmall,
+		VpcSettings: &types.DirectoryVpcSettings{
+			VpcId:     aws.String("vpc-12345678"),
+			SubnetIds: []string{"subnet-11111111", "subnet-22222222"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	directoryID := createDirOutput.DirectoryId
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteDirectory(context.Background(), &directoryservice.DeleteDirectoryInput{
+			DirectoryId: directoryID,
+		})
+	})
+
+	// Create snapshot.
+	createSnapOutput, err := client.CreateSnapshot(ctx, &directoryservice.CreateSnapshotInput{
+		DirectoryId: directoryID,
+		Name:        aws.String("test-snapshot"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshotID := createSnapOutput.SnapshotId
+
+	golden.New(t, golden.WithIgnoreFields("SnapshotId", "ResultMetadata")).Assert(t.Name()+"_create", createSnapOutput)
+
+	// Describe snapshots.
+	describeSnapOutput, err := client.DescribeSnapshots(ctx, &directoryservice.DescribeSnapshotsInput{
+		SnapshotIds: []string{*snapshotID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(describeSnapOutput.Snapshots) == 0 {
+		t.Fatal("expected at least one snapshot")
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"SnapshotId", "DirectoryId", "StartTime", "ResultMetadata",
+	)).Assert(t.Name()+"_describe", describeSnapOutput)
+
+	// Delete snapshot.
+	deleteSnapOutput, err := client.DeleteSnapshot(ctx, &directoryservice.DeleteSnapshotInput{
+		SnapshotId: snapshotID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("SnapshotId", "ResultMetadata")).Assert(t.Name()+"_delete", deleteSnapOutput)
+}
+
+func TestDS_DirectoryNotFound(t *testing.T) {
+	client := newDSClient(t)
+	ctx := t.Context()
+
+	_, err := client.DeleteDirectory(ctx, &directoryservice.DeleteDirectoryInput{
+		DirectoryId: aws.String("d-nonexistent"),
+	})
+	if err == nil {
+		t.Error("expected error for nonexistent directory")
+	}
+}

--- a/test/integration/testdata/ds_test_TestDS_CreateAndDeleteDirectory_TestDS_CreateAndDeleteDirectory_create.golden.go
+++ b/test/integration/testdata/ds_test_TestDS_CreateAndDeleteDirectory_TestDS_CreateAndDeleteDirectory_create.golden.go
@@ -1,0 +1,4 @@
+{
+  "DirectoryId": "d-e15a9736-e",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ds_test_TestDS_CreateAndDeleteDirectory_TestDS_CreateAndDeleteDirectory_delete.golden.go
+++ b/test/integration/testdata/ds_test_TestDS_CreateAndDeleteDirectory_TestDS_CreateAndDeleteDirectory_delete.golden.go
@@ -1,0 +1,4 @@
+{
+  "DirectoryId": "d-e15a9736-e",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ds_test_TestDS_CreateAndDeleteSnapshot_TestDS_CreateAndDeleteSnapshot_create.golden.go
+++ b/test/integration/testdata/ds_test_TestDS_CreateAndDeleteSnapshot_TestDS_CreateAndDeleteSnapshot_create.golden.go
@@ -1,0 +1,4 @@
+{
+  "SnapshotId": "s-05032592-e",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ds_test_TestDS_CreateAndDeleteSnapshot_TestDS_CreateAndDeleteSnapshot_delete.golden.go
+++ b/test/integration/testdata/ds_test_TestDS_CreateAndDeleteSnapshot_TestDS_CreateAndDeleteSnapshot_delete.golden.go
@@ -1,0 +1,4 @@
+{
+  "SnapshotId": "s-05032592-e",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ds_test_TestDS_CreateAndDeleteSnapshot_TestDS_CreateAndDeleteSnapshot_describe.golden.go
+++ b/test/integration/testdata/ds_test_TestDS_CreateAndDeleteSnapshot_TestDS_CreateAndDeleteSnapshot_describe.golden.go
@@ -1,0 +1,14 @@
+{
+  "NextToken": null,
+  "Snapshots": [
+    {
+      "DirectoryId": "d-bf7c121a-3",
+      "Name": "test-snapshot",
+      "SnapshotId": "s-05032592-e",
+      "StartTime": "2026-02-27T06:18:15Z",
+      "Status": "Completed",
+      "Type": "Manual"
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ds_test_TestDS_DescribeDirectories_TestDS_DescribeDirectories.golden.go
+++ b/test/integration/testdata/ds_test_TestDS_DescribeDirectories_TestDS_DescribeDirectories.golden.go
@@ -1,0 +1,49 @@
+{
+  "DirectoryDescriptions": [
+    {
+      "AccessUrl": null,
+      "Alias": null,
+      "ConnectSettings": null,
+      "Description": "Test directory for describe",
+      "DesiredNumberOfDomainControllers": 2,
+      "DirectoryId": "d-1801c22d-7",
+      "DnsIpAddrs": [
+        "10.0.0.1",
+        "10.0.0.2"
+      ],
+      "Edition": "",
+      "HybridSettings": null,
+      "LaunchTime": "2026-02-27T06:18:15Z",
+      "Name": "describe-test.example.com",
+      "OsVersion": "",
+      "OwnerDirectoryDescription": null,
+      "RadiusSettings": null,
+      "RadiusStatus": "",
+      "RegionsInfo": null,
+      "ShareMethod": "",
+      "ShareNotes": null,
+      "ShareStatus": "",
+      "ShortName": "describe-test.example.com",
+      "Size": "Small",
+      "SsoEnabled": false,
+      "Stage": "Active",
+      "StageLastUpdatedDateTime": "2026-02-27T06:18:15Z",
+      "StageReason": null,
+      "Type": "SimpleAD",
+      "VpcSettings": {
+        "AvailabilityZones": [
+          "us-east-1a",
+          "us-east-1b"
+        ],
+        "SecurityGroupId": "sg-d97100ad",
+        "SubnetIds": [
+          "subnet-11111111",
+          "subnet-22222222"
+        ],
+        "VpcId": "vpc-12345678"
+      }
+    }
+  ],
+  "NextToken": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
- Implement AWS Directory Service emulation for awsim
- Add CreateDirectory, DescribeDirectories, DeleteDirectory APIs
- Add CreateSnapshot, DescribeSnapshots, DeleteSnapshot APIs
- Include in-memory storage with pagination support
- Add integration tests with golden file validation

## Test plan
- [x] Run `make lint` - passes
- [x] Run `make test-integration` with docker compose - passes
- [x] Verify golden files are generated correctly

Closes #73