### PR TITLE
refactor: remove unused Prefix() method from Service interface

### DIFF
--- a/internal/service/acm/service.go
+++ b/internal/service/acm/service.go
@@ -25,11 +25,6 @@ func (s *Service) Name() string {
 	return "acm"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the ACM routes.
 // Note: ACM uses AWS JSON 1.1 protocol via the JSONProtocolService interface,
 // so no direct routes are registered here.

--- a/internal/service/apigateway/service.go
+++ b/internal/service/apigateway/service.go
@@ -26,11 +26,6 @@ func (s *Service) Name() string {
 	return "apigateway"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return "/apigateway"
-}
-
 // RegisterRoutes registers the API Gateway routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// REST API routes.

--- a/internal/service/appmesh/service.go
+++ b/internal/service/appmesh/service.go
@@ -23,11 +23,6 @@ func (s *Service) Name() string {
 	return "appmesh"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return "/v20190125"
-}
-
 // RegisterRoutes registers the service routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// Mesh operations.

--- a/internal/service/appsync/service.go
+++ b/internal/service/appsync/service.go
@@ -25,11 +25,6 @@ func (s *Service) Name() string {
 	return "appsync"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return "/appsync"
-}
-
 // RegisterRoutes registers the AppSync routes.
 // AppSync uses REST API protocol with /v1 prefix.
 // Note: Routes use /appsync prefix for internal routing to avoid S3 conflicts.

--- a/internal/service/athena/service.go
+++ b/internal/service/athena/service.go
@@ -26,11 +26,6 @@ func (s *Service) Name() string {
 	return "athena"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the Athena routes.
 // Note: Athena uses AWS JSON 1.1 protocol via the JSONProtocolService interface,
 // so no direct routes are registered here.

--- a/internal/service/batch/service.go
+++ b/internal/service/batch/service.go
@@ -25,11 +25,6 @@ func (s *Service) Name() string {
 	return "batch"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the Batch routes.
 // Batch uses REST JSON protocol with paths like /v1/createcomputeenvironment.
 func (s *Service) RegisterRoutes(r service.Router) {

--- a/internal/service/cloudformation/service.go
+++ b/internal/service/cloudformation/service.go
@@ -27,11 +27,6 @@ func (s *Service) Name() string {
 	return "cloudformation"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix for the service.
 func (s *Service) TargetPrefix() string {
 	return "CloudFormation"

--- a/internal/service/cloudfront/service.go
+++ b/internal/service/cloudfront/service.go
@@ -25,11 +25,6 @@ func (s *Service) Name() string {
 	return "cloudfront"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the CloudFront routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// Distribution operations.

--- a/internal/service/cloudtrail/service.go
+++ b/internal/service/cloudtrail/service.go
@@ -22,11 +22,6 @@ func (s *Service) Name() string {
 	return "cloudtrail"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix.
 func (s *Service) TargetPrefix() string {
 	return "CloudTrail_20131101"

--- a/internal/service/cloudwatch/service.go
+++ b/internal/service/cloudwatch/service.go
@@ -29,11 +29,6 @@ func (s *Service) Name() string {
 	return "monitoring"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers routes with the router.
 // CloudWatch uses CBOR protocol, so routes are registered via DispatchCBORAction.
 func (s *Service) RegisterRoutes(_ service.Router) {

--- a/internal/service/cloudwatchlogs/service.go
+++ b/internal/service/cloudwatchlogs/service.go
@@ -29,11 +29,6 @@ func (s *Service) Name() string {
 	return "logs"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the CloudWatch Logs routes.
 // Note: CloudWatch Logs uses AWS JSON 1.1 protocol via the JSONProtocolService interface,
 // so no direct routes are registered here.

--- a/internal/service/codeconnections/service.go
+++ b/internal/service/codeconnections/service.go
@@ -21,11 +21,6 @@ func (s *Service) Name() string {
 	return "codeconnections"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix for JSON protocol dispatch.
 func (s *Service) TargetPrefix() string {
 	return "CodeConnections_20231201"

--- a/internal/service/cognito/service.go
+++ b/internal/service/cognito/service.go
@@ -20,11 +20,6 @@ func (s *Service) Name() string {
 	return "cognito-idp"
 }
 
-// Prefix returns the URL prefix for routing.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the AWS JSON target prefix.
 func (s *Service) TargetPrefix() string {
 	return "AWSCognitoIdentityProviderService"

--- a/internal/service/configservice/service.go
+++ b/internal/service/configservice/service.go
@@ -22,11 +22,6 @@ func (s *Service) Name() string {
 	return "configservice"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix.
 func (s *Service) TargetPrefix() string {
 	return "StarlingDoveService"

--- a/internal/service/dlm/service.go
+++ b/internal/service/dlm/service.go
@@ -24,12 +24,6 @@ func (s *Service) Name() string {
 	return "dlm"
 }
 
-// Prefix returns the URL prefix for the service.
-// Note: DLM uses /dlm prefix to avoid conflicts with S3 wildcard routes.
-func (s *Service) Prefix() string {
-	return "/dlm"
-}
-
 // RegisterRoutes registers the service routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	r.HandleFunc("POST", "/dlm/policies", s.CreateLifecyclePolicy)

--- a/internal/service/ds/service.go
+++ b/internal/service/ds/service.go
@@ -28,11 +28,6 @@ func (s *Service) Name() string {
 	return "ds"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the Directory Service routes.
 // Directory Service uses AWS JSON 1.1 protocol with X-Amz-Target header.
 func (s *Service) RegisterRoutes(_ service.Router) {

--- a/internal/service/dynamodb/service.go
+++ b/internal/service/dynamodb/service.go
@@ -27,11 +27,6 @@ func (s *Service) Name() string {
 	return "dynamodb"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the DynamoDB routes.
 // Note: DynamoDB uses AWS JSON 1.0 protocol via the JSONProtocolService interface,
 // so no direct routes are registered here.

--- a/internal/service/ec2/service.go
+++ b/internal/service/ec2/service.go
@@ -27,9 +27,6 @@ func (s *Service) Name() string {
 }
 
 // Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
 
 // RegisterRoutes registers routes with the router.
 // EC2 uses Query protocol, so routes are registered via DispatchAction.

--- a/internal/service/ecr/service.go
+++ b/internal/service/ecr/service.go
@@ -22,11 +22,6 @@ func (s *Service) Name() string {
 	return "ecr"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix.
 func (s *Service) TargetPrefix() string {
 	return "AmazonEC2ContainerRegistry_V20150921"

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -25,11 +25,6 @@ func (s *Service) Name() string {
 	return "ecs"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the ECS routes.
 // Note: ECS uses AWS JSON 1.1 protocol via the JSONProtocolService interface,
 // so no direct routes are registered here.

--- a/internal/service/eks/service.go
+++ b/internal/service/eks/service.go
@@ -26,12 +26,6 @@ func (s *Service) Name() string {
 	return "eks"
 }
 
-// Prefix returns the URL prefix for the service.
-// Note: EKS uses /eks prefix to avoid conflicts with S3 wildcard routes.
-func (s *Service) Prefix() string {
-	return "/eks"
-}
-
 // RegisterRoutes registers the service routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// Cluster operations

--- a/internal/service/elasticache/service.go
+++ b/internal/service/elasticache/service.go
@@ -26,11 +26,6 @@ func (s *Service) Name() string {
 	return "elasticache"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers routes with the router.
 // ElastiCache uses Query protocol, so routes are registered via DispatchAction.
 func (s *Service) RegisterRoutes(_ service.Router) {

--- a/internal/service/elbv2/service.go
+++ b/internal/service/elbv2/service.go
@@ -26,11 +26,6 @@ func (s *Service) Name() string {
 	return "elasticloadbalancingv2"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers routes with the router.
 // ELB uses Query protocol, so routes are registered via DispatchAction.
 func (s *Service) RegisterRoutes(_ service.Router) {

--- a/internal/service/emrserverless/service.go
+++ b/internal/service/emrserverless/service.go
@@ -25,12 +25,6 @@ func (s *Service) Name() string {
 	return "emrserverless"
 }
 
-// Prefix returns the URL prefix for the service.
-// EMR Serverless uses /applications path without a service-specific prefix.
-func (s *Service) Prefix() string {
-	return "/applications"
-}
-
 // RegisterRoutes registers the service routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// Application operations.

--- a/internal/service/eventbridge/service.go
+++ b/internal/service/eventbridge/service.go
@@ -20,11 +20,6 @@ func (s *Service) Name() string {
 	return "events"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix.
 func (s *Service) TargetPrefix() string {
 	return "AWSEvents"

--- a/internal/service/firehose/service.go
+++ b/internal/service/firehose/service.go
@@ -22,11 +22,6 @@ func (s *Service) Name() string {
 	return "firehose"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix.
 func (s *Service) TargetPrefix() string {
 	return "Firehose_20150804"

--- a/internal/service/forecast/service.go
+++ b/internal/service/forecast/service.go
@@ -18,11 +18,6 @@ func (s *Service) Name() string {
 	return "forecast"
 }
 
-// Prefix returns the URL prefix.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the target prefix for AWS JSON protocol.
 func (s *Service) TargetPrefix() string {
 	return "AmazonForecast"

--- a/internal/service/gamelift/service.go
+++ b/internal/service/gamelift/service.go
@@ -22,11 +22,6 @@ func (s *Service) Name() string {
 	return "gamelift"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix.
 func (s *Service) TargetPrefix() string {
 	return "GameLift"

--- a/internal/service/globalaccelerator/service.go
+++ b/internal/service/globalaccelerator/service.go
@@ -20,11 +20,6 @@ func (s *Service) Name() string {
 	return "globalaccelerator"
 }
 
-// Prefix returns the URL prefix for routing.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the AWS JSON target prefix.
 func (s *Service) TargetPrefix() string {
 	return "GlobalAccelerator_V20180706"

--- a/internal/service/glue/service.go
+++ b/internal/service/glue/service.go
@@ -25,11 +25,6 @@ func (s *Service) Name() string {
 	return "glue"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the Glue routes.
 // Note: Glue uses AWS JSON 1.1 protocol via the JSONProtocolService interface,
 // so no direct routes are registered here.

--- a/internal/service/iam/service.go
+++ b/internal/service/iam/service.go
@@ -62,11 +62,6 @@ func (s *Service) Name() string {
 	return "iam"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return "/iam"
-}
-
 // RegisterRoutes registers the IAM routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// IAM uses a single endpoint with Action parameter.

--- a/internal/service/interface.go
+++ b/internal/service/interface.go
@@ -10,10 +10,6 @@ type Service interface {
 	// Name returns the service name (e.g., "s3", "sqs", "dynamodb").
 	Name() string
 
-	// Prefix returns the URL prefix for path-based routing (e.g., "/s3").
-	// Returns empty string for host-based routing.
-	Prefix() string
-
 	// RegisterRoutes registers the service's routes with the router.
 	RegisterRoutes(r Router)
 }

--- a/internal/service/kinesis/service.go
+++ b/internal/service/kinesis/service.go
@@ -22,11 +22,6 @@ func (s *Service) Name() string {
 	return "kinesis"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix.
 func (s *Service) TargetPrefix() string {
 	return "Kinesis_20131202"

--- a/internal/service/kms/service.go
+++ b/internal/service/kms/service.go
@@ -21,11 +21,6 @@ func (s *Service) Name() string {
 	return "kms"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix for JSON protocol dispatch.
 func (s *Service) TargetPrefix() string {
 	return "TrentService"

--- a/internal/service/lambda/service.go
+++ b/internal/service/lambda/service.go
@@ -29,11 +29,6 @@ func (s *Service) Name() string {
 	return "lambda"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return "/lambda"
-}
-
 // RegisterRoutes registers the Lambda routes.
 // Note: Routes use /lambda prefix to avoid conflicts with S3 wildcard routes.
 func (s *Service) RegisterRoutes(r service.Router) {

--- a/internal/service/mq/service.go
+++ b/internal/service/mq/service.go
@@ -27,11 +27,6 @@ func (s *Service) Name() string {
 	return "mq"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the MQ routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// Broker operations

--- a/internal/service/organizations/service.go
+++ b/internal/service/organizations/service.go
@@ -18,11 +18,6 @@ func (s *Service) Name() string {
 	return "organizations"
 }
 
-// Prefix returns the URL prefix.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the target prefix for AWS JSON protocol.
 func (s *Service) TargetPrefix() string {
 	return "AWSOrganizationsV20161128"

--- a/internal/service/pipes/service.go
+++ b/internal/service/pipes/service.go
@@ -25,11 +25,6 @@ func (s *Service) Name() string {
 	return "pipes"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the Pipes routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// Pipe CRUD operations.

--- a/internal/service/rds/service.go
+++ b/internal/service/rds/service.go
@@ -26,11 +26,6 @@ func (s *Service) Name() string {
 	return "rds"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers routes with the router.
 // RDS uses Query protocol, so routes are registered via DispatchAction.
 func (s *Service) RegisterRoutes(_ service.Router) {

--- a/internal/service/route53/service.go
+++ b/internal/service/route53/service.go
@@ -22,11 +22,6 @@ func (s *Service) Name() string {
 	return "route53"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the service routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// Hosted Zones

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -25,12 +25,6 @@ func (s *Service) Name() string {
 	return "s3"
 }
 
-// Prefix returns the URL prefix for the service.
-// S3 uses path-style URLs, so no prefix is needed.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the S3 routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// Bucket operations

--- a/internal/service/s3tables/service.go
+++ b/internal/service/s3tables/service.go
@@ -24,13 +24,6 @@ func (s *Service) Name() string {
 	return "s3tables"
 }
 
-// Prefix returns the URL prefix for the service.
-// S3 Tables routes don't have a common prefix, so we return empty.
-// The router handles S3 Tables paths (/buckets, /namespaces, /tables, /get-table) explicitly.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the service routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// Table bucket operations

--- a/internal/service/sagemaker/service.go
+++ b/internal/service/sagemaker/service.go
@@ -26,11 +26,6 @@ func (s *Service) Name() string {
 	return "sagemaker"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the SageMaker routes.
 // Note: SageMaker uses AWS JSON 1.1 protocol via the JSONProtocolService interface,
 // so no direct routes are registered here.

--- a/internal/service/scheduler/service.go
+++ b/internal/service/scheduler/service.go
@@ -24,12 +24,6 @@ func (s *Service) Name() string {
 	return "scheduler"
 }
 
-// Prefix returns the URL prefix for the service.
-// Note: Scheduler uses /scheduler prefix to avoid conflicts with S3 wildcard routes.
-func (s *Service) Prefix() string {
-	return "/scheduler"
-}
-
 // RegisterRoutes registers the service routes.
 func (s *Service) RegisterRoutes(r service.Router) {
 	// Schedule operations

--- a/internal/service/secretsmanager/service.go
+++ b/internal/service/secretsmanager/service.go
@@ -29,11 +29,6 @@ func (s *Service) Name() string {
 	return "secretsmanager"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the Secrets Manager routes.
 // Note: Secrets Manager uses AWS JSON 1.1 protocol via the JSONProtocolService interface,
 // so no direct routes are registered here.

--- a/internal/service/servicequotas/service.go
+++ b/internal/service/servicequotas/service.go
@@ -18,11 +18,6 @@ func (s *Service) Name() string {
 	return "service-quotas"
 }
 
-// Prefix returns the URL prefix.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the target prefix for AWS JSON protocol.
 func (s *Service) TargetPrefix() string {
 	return "ServiceQuotasV20190624"

--- a/internal/service/sesv2/service.go
+++ b/internal/service/sesv2/service.go
@@ -25,11 +25,6 @@ func (s *Service) Name() string {
 	return "sesv2"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return "/ses"
-}
-
 // RegisterRoutes registers the SES v2 routes.
 // SES v2 uses REST API with path-based routing.
 func (s *Service) RegisterRoutes(r service.Router) {

--- a/internal/service/sfn/service.go
+++ b/internal/service/sfn/service.go
@@ -22,11 +22,6 @@ func (s *Service) Name() string {
 	return "states"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // TargetPrefix returns the X-Amz-Target prefix.
 func (s *Service) TargetPrefix() string {
 	return "AWSStepFunctions"

--- a/internal/service/sns/service.go
+++ b/internal/service/sns/service.go
@@ -26,11 +26,6 @@ func (s *Service) Name() string {
 	return "sns"
 }
 
-// Prefix returns the URL prefix for the service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers routes with the router.
 // SNS uses Query protocol, so routes are registered via DispatchAction.
 func (s *Service) RegisterRoutes(_ service.Router) {

--- a/internal/service/sqs/service.go
+++ b/internal/service/sqs/service.go
@@ -29,11 +29,6 @@ func (s *Service) Name() string {
 	return "sqs"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the SQS routes.
 // Note: SQS uses AWS JSON 1.0 protocol via the JSONProtocolService interface,
 // so no direct routes are registered here.

--- a/internal/service/ssm/service.go
+++ b/internal/service/ssm/service.go
@@ -28,11 +28,6 @@ func (s *Service) Name() string {
 	return "ssm"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return ""
-}
-
 // RegisterRoutes registers the SSM routes.
 // Note: SSM uses AWS JSON 1.1 protocol via the JSONProtocolService interface,
 // so no direct routes are registered here.

--- a/internal/service/xray/service.go
+++ b/internal/service/xray/service.go
@@ -25,11 +25,6 @@ func (s *Service) Name() string {
 	return "xray"
 }
 
-// Prefix returns the URL prefix for this service.
-func (s *Service) Prefix() string {
-	return "/xray"
-}
-
 // RegisterRoutes registers the X-Ray routes.
 // X-Ray uses REST JSON protocol.
 func (s *Service) RegisterRoutes(r service.Router) {


### PR DESCRIPTION
## Summary
- Remove unused `Prefix()` method from `Service` interface
- Remove `Prefix()` implementation from all 51 service files
- The method was defined but never called anywhere in the codebase

## Test plan
- [x] Run `make lint` - passes
- [x] Run `make build` - passes

Closes #293