### PR TITLE
feat(s3control): implement AWS S3 Control service

### DIFF
--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/rds"
 	_ "github.com/sivchari/awsim/internal/service/route53"
 	_ "github.com/sivchari/awsim/internal/service/s3"
+	_ "github.com/sivchari/awsim/internal/service/s3control"
 	_ "github.com/sivchari/awsim/internal/service/s3tables"
 	_ "github.com/sivchari/awsim/internal/service/sagemaker"
 	_ "github.com/sivchari/awsim/internal/service/scheduler"

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -74,7 +74,7 @@ func extractRoutePrefix(pattern string) string {
 	// /service is for RPC v2 CBOR protocol
 	// EventBridge Pipes uses /v1/pipes and /tags paths
 	// EMR Serverless uses /applications paths
-	prefixes := []string{"/lambda", "/eks", "/iam", "/buckets", "/namespaces", "/tables", "/get-table", "/apigateway", "/ses", "/2020-05-31", "/2013-04-01", "/service", "/appsync", "/v1", "/tags", "/applications", "/v20190125", "/scheduler", "/dlm", "/mq"}
+	prefixes := []string{"/lambda", "/eks", "/iam", "/buckets", "/namespaces", "/tables", "/get-table", "/apigateway", "/ses", "/2020-05-31", "/2013-04-01", "/service", "/appsync", "/v1", "/tags", "/applications", "/v20190125", "/scheduler", "/dlm", "/mq", "/v20180820"}
 
 	for _, prefix := range prefixes {
 		if len(pattern) >= len(prefix) && pattern[:len(prefix)] == prefix {

--- a/internal/service/s3control/handlers.go
+++ b/internal/service/s3control/handlers.go
@@ -1,0 +1,289 @@
+// Package s3control implements the AWS S3 Control service.
+package s3control
+
+import (
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+const (
+	headerAccountID = "X-Amz-Account-Id"
+)
+
+// GetPublicAccessBlock handles the GetPublicAccessBlock API.
+func (s *Service) GetPublicAccessBlock(w http.ResponseWriter, r *http.Request) {
+	accountID := r.Header.Get(headerAccountID)
+	if accountID == "" {
+		writeError(w, ErrInvalidRequest, "Missing x-amz-account-id header", http.StatusBadRequest)
+
+		return
+	}
+
+	config, err := s.storage.GetPublicAccessBlock(r.Context(), accountID)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	resp := &GetPublicAccessBlockOutput{
+		PublicAccessBlockConfiguration: config,
+	}
+
+	writeXMLResponse(w, resp)
+}
+
+// PutPublicAccessBlock handles the PutPublicAccessBlock API.
+func (s *Service) PutPublicAccessBlock(w http.ResponseWriter, r *http.Request) {
+	accountID := r.Header.Get(headerAccountID)
+	if accountID == "" {
+		writeError(w, ErrInvalidRequest, "Missing x-amz-account-id header", http.StatusBadRequest)
+
+		return
+	}
+
+	var config PublicAccessBlockConfiguration
+	if err := xml.NewDecoder(r.Body).Decode(&config); err != nil {
+		writeError(w, ErrInvalidRequest, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.PutPublicAccessBlock(r.Context(), accountID, &config); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// DeletePublicAccessBlock handles the DeletePublicAccessBlock API.
+func (s *Service) DeletePublicAccessBlock(w http.ResponseWriter, r *http.Request) {
+	accountID := r.Header.Get(headerAccountID)
+	if accountID == "" {
+		writeError(w, ErrInvalidRequest, "Missing x-amz-account-id header", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeletePublicAccessBlock(r.Context(), accountID); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// CreateAccessPoint handles the CreateAccessPoint API.
+func (s *Service) CreateAccessPoint(w http.ResponseWriter, r *http.Request) {
+	accountID := r.Header.Get(headerAccountID)
+	if accountID == "" {
+		writeError(w, ErrInvalidRequest, "Missing x-amz-account-id header", http.StatusBadRequest)
+
+		return
+	}
+
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, ErrInvalidRequest, "Missing access point name", http.StatusBadRequest)
+
+		return
+	}
+
+	var input CreateAccessPointInput
+	if err := xml.NewDecoder(r.Body).Decode(&input); err != nil {
+		writeError(w, ErrInvalidRequest, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	ap := &AccessPoint{
+		Name:              name,
+		Bucket:            input.Bucket,
+		VpcConfiguration:  input.VpcConfiguration,
+		PublicAccessBlock: input.PublicAccessBlockConfiguration,
+		BucketAccountID:   input.BucketAccountID,
+	}
+
+	result, err := s.storage.CreateAccessPoint(r.Context(), accountID, ap)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	resp := &CreateAccessPointResult{
+		AccessPointArn: result.AccessPointArn,
+		Alias:          result.Alias,
+	}
+
+	writeXMLResponse(w, resp)
+}
+
+// GetAccessPoint handles the GetAccessPoint API.
+func (s *Service) GetAccessPoint(w http.ResponseWriter, r *http.Request) {
+	accountID := r.Header.Get(headerAccountID)
+	if accountID == "" {
+		writeError(w, ErrInvalidRequest, "Missing x-amz-account-id header", http.StatusBadRequest)
+
+		return
+	}
+
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, ErrInvalidRequest, "Missing access point name", http.StatusBadRequest)
+
+		return
+	}
+
+	ap, err := s.storage.GetAccessPoint(r.Context(), accountID, name)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	resp := &GetAccessPointResult{
+		Name:                           ap.Name,
+		Bucket:                         ap.Bucket,
+		NetworkOrigin:                  ap.NetworkOrigin,
+		VpcConfiguration:               ap.VpcConfiguration,
+		PublicAccessBlockConfiguration: ap.PublicAccessBlock,
+		AccessPointArn:                 ap.AccessPointArn,
+		Alias:                          ap.Alias,
+		BucketAccountID:                ap.BucketAccountID,
+	}
+
+	if len(ap.Endpoints) > 0 {
+		resp.Endpoints = &Endpoints{}
+
+		for k, v := range ap.Endpoints {
+			resp.Endpoints.Entry = append(resp.Endpoints.Entry, EndpointEntry{
+				Key:   k,
+				Value: v,
+			})
+		}
+	}
+
+	writeXMLResponse(w, resp)
+}
+
+// DeleteAccessPoint handles the DeleteAccessPoint API.
+func (s *Service) DeleteAccessPoint(w http.ResponseWriter, r *http.Request) {
+	accountID := r.Header.Get(headerAccountID)
+	if accountID == "" {
+		writeError(w, ErrInvalidRequest, "Missing x-amz-account-id header", http.StatusBadRequest)
+
+		return
+	}
+
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, ErrInvalidRequest, "Missing access point name", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteAccessPoint(r.Context(), accountID, name); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListAccessPoints handles the ListAccessPoints API.
+func (s *Service) ListAccessPoints(w http.ResponseWriter, r *http.Request) {
+	accountID := r.Header.Get(headerAccountID)
+	if accountID == "" {
+		writeError(w, ErrInvalidRequest, "Missing x-amz-account-id header", http.StatusBadRequest)
+
+		return
+	}
+
+	bucket := r.URL.Query().Get("bucket")
+	nextToken := r.URL.Query().Get("nextToken")
+	maxResults := 1000
+
+	if maxResultsStr := r.URL.Query().Get("maxResults"); maxResultsStr != "" {
+		if val, err := strconv.Atoi(maxResultsStr); err == nil {
+			maxResults = val
+		}
+	}
+
+	accessPoints, newNextToken, err := s.storage.ListAccessPoints(r.Context(), accountID, bucket, maxResults, nextToken)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	resp := &ListAccessPointsResult{}
+
+	for _, ap := range accessPoints {
+		item := AccessPointListItem{
+			Name:             ap.Name,
+			NetworkOrigin:    ap.NetworkOrigin,
+			VpcConfiguration: ap.VpcConfiguration,
+			Bucket:           ap.Bucket,
+			AccessPointArn:   ap.AccessPointArn,
+			Alias:            ap.Alias,
+			BucketAccountID:  ap.BucketAccountID,
+		}
+		resp.AccessPointList = append(resp.AccessPointList, item)
+	}
+
+	resp.NextToken = newNextToken
+
+	writeXMLResponse(w, resp)
+}
+
+// handleError handles errors and writes appropriate response.
+func handleError(w http.ResponseWriter, err error) {
+	var s3Err *Error
+	if errors.As(err, &s3Err) {
+		status := http.StatusBadRequest
+
+		switch s3Err.Code {
+		case ErrNoSuchAccessPoint, ErrNoSuchPublicAccessBlockConfiguration:
+			status = http.StatusNotFound
+		case ErrAccessPointAlreadyOwnedByYou:
+			status = http.StatusConflict
+		case ErrInternalError:
+			status = http.StatusInternalServerError
+		}
+
+		writeError(w, s3Err.Code, s3Err.Message, status)
+
+		return
+	}
+
+	writeError(w, ErrInternalError, "Internal server error", http.StatusInternalServerError)
+}
+
+// writeXMLResponse writes an XML response with status 200 OK.
+func writeXMLResponse(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/xml")
+	w.Header().Set("X-Amz-Request-Id", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_ = xml.NewEncoder(w).Encode(v)
+}
+
+// writeError writes an error response.
+func writeError(w http.ResponseWriter, code, message string, status int) {
+	w.Header().Set("Content-Type", "application/xml")
+	w.Header().Set("X-Amz-Request-Id", uuid.New().String())
+	w.WriteHeader(status)
+	_ = xml.NewEncoder(w).Encode(&Error{
+		Code:      code,
+		Message:   message,
+		RequestID: uuid.New().String(),
+	})
+}

--- a/internal/service/s3control/service.go
+++ b/internal/service/s3control/service.go
@@ -1,0 +1,40 @@
+package s3control
+
+import (
+	"github.com/sivchari/awsim/internal/service"
+)
+
+func init() {
+	service.Register(New(NewMemoryStorage()))
+}
+
+// Service implements the S3 Control service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new S3 Control service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "s3control"
+}
+
+// RegisterRoutes registers the S3 Control routes.
+func (s *Service) RegisterRoutes(r service.Router) {
+	// Public Access Block operations
+	r.Handle("GET", "/v20180820/configuration/publicAccessBlock", s.GetPublicAccessBlock)
+	r.Handle("PUT", "/v20180820/configuration/publicAccessBlock", s.PutPublicAccessBlock)
+	r.Handle("DELETE", "/v20180820/configuration/publicAccessBlock", s.DeletePublicAccessBlock)
+
+	// Access Point operations
+	r.Handle("PUT", "/v20180820/accesspoint/{name}", s.CreateAccessPoint)
+	r.Handle("GET", "/v20180820/accesspoint/{name}", s.GetAccessPoint)
+	r.Handle("DELETE", "/v20180820/accesspoint/{name}", s.DeleteAccessPoint)
+	r.Handle("GET", "/v20180820/accesspoint", s.ListAccessPoints)
+}

--- a/internal/service/s3control/storage.go
+++ b/internal/service/s3control/storage.go
@@ -1,0 +1,211 @@
+package s3control
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Storage is the interface for S3 Control storage operations.
+type Storage interface {
+	// Public Access Block operations
+	GetPublicAccessBlock(ctx context.Context, accountID string) (*PublicAccessBlockConfiguration, error)
+	PutPublicAccessBlock(ctx context.Context, accountID string, config *PublicAccessBlockConfiguration) error
+	DeletePublicAccessBlock(ctx context.Context, accountID string) error
+
+	// Access Point operations
+	CreateAccessPoint(ctx context.Context, accountID string, ap *AccessPoint) (*AccessPoint, error)
+	GetAccessPoint(ctx context.Context, accountID, name string) (*AccessPoint, error)
+	DeleteAccessPoint(ctx context.Context, accountID, name string) error
+	ListAccessPoints(ctx context.Context, accountID, bucket string, maxResults int, nextToken string) ([]*AccessPoint, string, error)
+}
+
+// MemoryStorage implements in-memory storage for S3 Control.
+type MemoryStorage struct {
+	mu                 sync.RWMutex
+	publicAccessBlocks map[string]*PublicAccessBlockConfiguration // key: accountID
+	accessPoints       map[string]map[string]*AccessPoint         // key: accountID -> name -> AccessPoint
+}
+
+// NewMemoryStorage creates a new in-memory storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		publicAccessBlocks: make(map[string]*PublicAccessBlockConfiguration),
+		accessPoints:       make(map[string]map[string]*AccessPoint),
+	}
+}
+
+// GetPublicAccessBlock retrieves the public access block configuration for an account.
+func (s *MemoryStorage) GetPublicAccessBlock(_ context.Context, accountID string) (*PublicAccessBlockConfiguration, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	config, exists := s.publicAccessBlocks[accountID]
+	if !exists {
+		return nil, &Error{
+			Code:    ErrNoSuchPublicAccessBlockConfiguration,
+			Message: "The public access block configuration was not found",
+		}
+	}
+
+	return config, nil
+}
+
+// PutPublicAccessBlock sets the public access block configuration for an account.
+func (s *MemoryStorage) PutPublicAccessBlock(_ context.Context, accountID string, config *PublicAccessBlockConfiguration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.publicAccessBlocks[accountID] = config
+
+	return nil
+}
+
+// DeletePublicAccessBlock removes the public access block configuration for an account.
+func (s *MemoryStorage) DeletePublicAccessBlock(_ context.Context, accountID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.publicAccessBlocks, accountID)
+
+	return nil
+}
+
+// CreateAccessPoint creates a new access point.
+func (s *MemoryStorage) CreateAccessPoint(_ context.Context, accountID string, ap *AccessPoint) (*AccessPoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.accessPoints[accountID]; !exists {
+		s.accessPoints[accountID] = make(map[string]*AccessPoint)
+	}
+
+	if _, exists := s.accessPoints[accountID][ap.Name]; exists {
+		return nil, &Error{
+			Code:    ErrAccessPointAlreadyOwnedByYou,
+			Message: fmt.Sprintf("Access point %s already exists", ap.Name),
+		}
+	}
+
+	// Generate ARN and alias
+	ap.AccountID = accountID
+	ap.AccessPointArn = fmt.Sprintf("arn:aws:s3:%s:%s:accesspoint/%s", "us-east-1", accountID, ap.Name)
+	ap.Alias = fmt.Sprintf("%s-%s-s3alias", ap.Name, accountID[:12])
+
+	if ap.VpcConfiguration != nil {
+		ap.NetworkOrigin = "VPC"
+	} else {
+		ap.NetworkOrigin = "Internet"
+	}
+
+	ap.Endpoints = map[string]string{
+		"https": fmt.Sprintf("https://%s-%s.s3-accesspoint.us-east-1.amazonaws.com", ap.Name, accountID),
+	}
+
+	s.accessPoints[accountID][ap.Name] = ap
+
+	return ap, nil
+}
+
+// GetAccessPoint retrieves an access point.
+func (s *MemoryStorage) GetAccessPoint(_ context.Context, accountID, name string) (*AccessPoint, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	accountAPs, exists := s.accessPoints[accountID]
+	if !exists {
+		return nil, &Error{
+			Code:    ErrNoSuchAccessPoint,
+			Message: fmt.Sprintf("Access point %s does not exist", name),
+		}
+	}
+
+	ap, exists := accountAPs[name]
+	if !exists {
+		return nil, &Error{
+			Code:    ErrNoSuchAccessPoint,
+			Message: fmt.Sprintf("Access point %s does not exist", name),
+		}
+	}
+
+	return ap, nil
+}
+
+// DeleteAccessPoint deletes an access point.
+func (s *MemoryStorage) DeleteAccessPoint(_ context.Context, accountID, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	accountAPs, exists := s.accessPoints[accountID]
+	if !exists {
+		return &Error{
+			Code:    ErrNoSuchAccessPoint,
+			Message: fmt.Sprintf("Access point %s does not exist", name),
+		}
+	}
+
+	if _, exists := accountAPs[name]; !exists {
+		return &Error{
+			Code:    ErrNoSuchAccessPoint,
+			Message: fmt.Sprintf("Access point %s does not exist", name),
+		}
+	}
+
+	delete(accountAPs, name)
+
+	return nil
+}
+
+// ListAccessPoints lists access points for an account.
+func (s *MemoryStorage) ListAccessPoints(_ context.Context, accountID, bucket string, maxResults int, nextToken string) ([]*AccessPoint, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults == 0 {
+		maxResults = 1000
+	}
+
+	accountAPs, exists := s.accessPoints[accountID]
+	if !exists {
+		return []*AccessPoint{}, "", nil
+	}
+
+	var accessPoints []*AccessPoint
+
+	for _, ap := range accountAPs {
+		if bucket != "" && ap.Bucket != bucket {
+			continue
+		}
+
+		accessPoints = append(accessPoints, ap)
+	}
+
+	// Simple pagination (no sorting for simplicity)
+	start := 0
+
+	if nextToken != "" {
+		for i, ap := range accessPoints {
+			if ap.Name == nextToken {
+				start = i
+
+				break
+			}
+		}
+	}
+
+	end := min(start+maxResults, len(accessPoints))
+
+	result := accessPoints[start:end]
+	newNextToken := ""
+
+	if end < len(accessPoints) {
+		newNextToken = accessPoints[end].Name
+	}
+
+	return result, newNextToken, nil
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return e.Message
+}

--- a/internal/service/s3control/types.go
+++ b/internal/service/s3control/types.go
@@ -1,0 +1,115 @@
+package s3control
+
+import "encoding/xml"
+
+// PublicAccessBlockConfiguration represents public access block settings.
+type PublicAccessBlockConfiguration struct {
+	XMLName               xml.Name `xml:"PublicAccessBlockConfiguration"`
+	BlockPublicAcls       bool     `xml:"BlockPublicAcls"`
+	IgnorePublicAcls      bool     `xml:"IgnorePublicAcls"`
+	BlockPublicPolicy     bool     `xml:"BlockPublicPolicy"`
+	RestrictPublicBuckets bool     `xml:"RestrictPublicBuckets"`
+}
+
+// GetPublicAccessBlockOutput is the response for GetPublicAccessBlock.
+type GetPublicAccessBlockOutput struct {
+	XMLName                        xml.Name                        `xml:"GetPublicAccessBlockOutput"`
+	PublicAccessBlockConfiguration *PublicAccessBlockConfiguration `xml:"PublicAccessBlockConfiguration"`
+}
+
+// AccessPoint represents an S3 access point.
+type AccessPoint struct {
+	Name              string
+	Bucket            string
+	AccountID         string
+	NetworkOrigin     string
+	VpcConfiguration  *VpcConfiguration
+	PublicAccessBlock *PublicAccessBlockConfiguration
+	Alias             string
+	AccessPointArn    string
+	Endpoints         map[string]string
+	BucketAccountID   string
+}
+
+// VpcConfiguration represents VPC settings for an access point.
+type VpcConfiguration struct {
+	VpcID string `xml:"VpcId"`
+}
+
+// CreateAccessPointInput is the input for CreateAccessPoint.
+type CreateAccessPointInput struct {
+	XMLName                        xml.Name                        `xml:"CreateAccessPointRequest"`
+	Bucket                         string                          `xml:"Bucket"`
+	Name                           string                          `xml:"-"`
+	VpcConfiguration               *VpcConfiguration               `xml:"VpcConfiguration,omitempty"`
+	PublicAccessBlockConfiguration *PublicAccessBlockConfiguration `xml:"PublicAccessBlockConfiguration,omitempty"`
+	BucketAccountID                string                          `xml:"BucketAccountId,omitempty"`
+}
+
+// CreateAccessPointResult is the response for CreateAccessPoint.
+type CreateAccessPointResult struct {
+	XMLName        xml.Name `xml:"CreateAccessPointResult"`
+	AccessPointArn string   `xml:"AccessPointArn"`
+	Alias          string   `xml:"Alias"`
+}
+
+// GetAccessPointResult is the response for GetAccessPoint.
+type GetAccessPointResult struct {
+	XMLName                        xml.Name                        `xml:"GetAccessPointResult"`
+	Name                           string                          `xml:"Name"`
+	Bucket                         string                          `xml:"Bucket"`
+	NetworkOrigin                  string                          `xml:"NetworkOrigin"`
+	VpcConfiguration               *VpcConfiguration               `xml:"VpcConfiguration,omitempty"`
+	PublicAccessBlockConfiguration *PublicAccessBlockConfiguration `xml:"PublicAccessBlockConfiguration,omitempty"`
+	AccessPointArn                 string                          `xml:"AccessPointArn"`
+	Alias                          string                          `xml:"Alias"`
+	Endpoints                      *Endpoints                      `xml:"Endpoints,omitempty"`
+	BucketAccountID                string                          `xml:"BucketAccountId,omitempty"`
+}
+
+// Endpoints represents access point endpoints.
+type Endpoints struct {
+	Entry []EndpointEntry `xml:"entry"`
+}
+
+// EndpointEntry represents a single endpoint entry.
+type EndpointEntry struct {
+	Key   string `xml:"key"`
+	Value string `xml:"value"`
+}
+
+// ListAccessPointsResult is the response for ListAccessPoints.
+type ListAccessPointsResult struct {
+	XMLName         xml.Name              `xml:"ListAccessPointsResult"`
+	AccessPointList []AccessPointListItem `xml:"AccessPointList>AccessPoint"`
+	NextToken       string                `xml:"NextToken,omitempty"`
+}
+
+// AccessPointListItem represents an access point in a list.
+type AccessPointListItem struct {
+	Name             string            `xml:"Name"`
+	NetworkOrigin    string            `xml:"NetworkOrigin"`
+	VpcConfiguration *VpcConfiguration `xml:"VpcConfiguration,omitempty"`
+	Bucket           string            `xml:"Bucket"`
+	AccessPointArn   string            `xml:"AccessPointArn"`
+	Alias            string            `xml:"Alias"`
+	BucketAccountID  string            `xml:"BucketAccountId,omitempty"`
+}
+
+// Error represents an S3 Control error response.
+type Error struct {
+	XMLName   xml.Name `xml:"Error"`
+	Code      string   `xml:"Code"`
+	Message   string   `xml:"Message"`
+	Resource  string   `xml:"Resource,omitempty"`
+	RequestID string   `xml:"RequestId"`
+}
+
+// Error codes for S3 Control.
+const (
+	ErrNoSuchAccessPoint                    = "NoSuchAccessPoint"
+	ErrAccessPointAlreadyOwnedByYou         = "AccessPointAlreadyOwnedByYou"
+	ErrNoSuchPublicAccessBlockConfiguration = "NoSuchPublicAccessBlockConfiguration"
+	ErrInvalidRequest                       = "InvalidRequest"
+	ErrInternalError                        = "InternalError"
+)

--- a/test/go.mod
+++ b/test/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.115.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
+	github.com/aws/aws-sdk-go-v2/service/s3control v1.68.1
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.233.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.19
@@ -58,6 +59,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8
 	github.com/aws/aws-sdk-go-v2/service/xray v1.36.17
 	github.com/sivchari/golden v0.3.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
@@ -71,12 +73,15 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.18 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect
 	github.com/aws/smithy-go v1.24.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/sivchari/awsim => ../

--- a/test/go.sum
+++ b/test/go.sum
@@ -86,8 +86,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.17 h1:Nhx
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.17/go.mod h1:AjmK8JWnlAevq1b1NBtv5oQVG4iqnYXUufdgol+q9wg=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 h1:RuNSMoozM8oXlgLG/n6WLaFGoea7/CddrCfIiSA+xdY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17/go.mod h1:F2xxQ9TZz5gDWsclCtPQscGpP0VUOc8RqgFM3vDENmU=
-github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 h1:bGeHBsGZx0Dvu/eJC0Lh9adJa3M1xREcndxLNZlve2U=
-github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17/go.mod h1:dcW24lbU0CzHusTE8LLHhRLI42ejmINN8Lcr22bwh/g=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.18 h1:/A/xDuZAVD2BpsS2fftFRo/NoEKQJ8YTnJDEHBy2Gtg=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.18/go.mod h1:hWe9b4f+djUQGmyiGEeOnZv69dtMSgpDRIvNMvuvzvY=
 github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.0 h1:xqUZZ3mQHLCsrmZXmhI3UaP0KeCPKqBOMCkJVepY+HA=
 github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.0/go.mod h1:Fpex7CunMujL2O9qaKTDYG0xnl1ZP3pBZ68XyQCmhtA=
 github.com/aws/aws-sdk-go-v2/service/kms v1.49.5 h1:DKibav4XF66XSeaXcrn9GlWGHos6D/vJ4r7jsK7z5CE=
@@ -106,6 +106,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.62.2 h1:zoD/SoiVQi8l8tuQn//VexrX
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.2/go.mod h1:Ll1DCasPTBFtHK5t/U5WIwGIyRuY3xY+x8/LmqIlqpM=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 h1:oeu8VPlOre74lBA/PMhxa5vewaMIMmILM+RraSyB8KA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0/go.mod h1:5jggDlZ2CLQhwJBiZJb4vfk4f0GxWdEDruWKEJ1xOdo=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.68.1 h1:4QG80z0U97W4dQrZRgZlnMgLq/QC/eZegQct0aIjDso=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.68.1/go.mod h1:wtMhE5a4RHx4aXoQLJvOIPFs15LcEEov0jWwoFRX71c=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.14.0 h1:PrT+91Zc0K7w7v71PkvhxrblCSpl92kuiIveQ6Dnz8U=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.14.0/go.mod h1:1nxPz+DecxdsuL/ykEU9EN3WoaMhpX8K6S9CHbms6Eg=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.233.1 h1:Wx9PBanAjQoaTic4/syMZkvDhwYQ35uHHFiHANHR4vA=
@@ -138,5 +140,15 @@ github.com/aws/aws-sdk-go-v2/service/xray v1.36.17 h1:b480fLepDHf9B7FXgcgB7XVDN3
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.17/go.mod h1:ASKVut5pRPVm4bF9/P01ClCthnIopv1PjxWsLOTjKPU=
 github.com/aws/smithy-go v1.24.1 h1:VbyeNfmYkWoxMVpGUAbQumkODcYmfMRfZ8yQiH30SK0=
 github.com/aws/smithy-go v1.24.1/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sivchari/golden v0.3.0 h1:WUtMlhvqeH8mXcX4hsZwyfrA5jeNz5F9IL1w+u7Ew7w=
 github.com/sivchari/golden v0.3.0/go.mod h1:gddwjsjxPtLYRCq0M471x9WD9khQWty82Yn/PZ/2I8E=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/integration/s3control_test.go
+++ b/test/integration/s3control_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3control"
+	"github.com/aws/aws-sdk-go-v2/service/s3control/types"
+	smithyendpoints "github.com/aws/smithy-go/endpoints"
+	"github.com/sivchari/golden"
+)
+
+// s3ControlEndpointResolver is a custom endpoint resolver for S3 Control that
+// disables the account ID subdomain behavior.
+type s3ControlEndpointResolver struct{}
+
+func (r *s3ControlEndpointResolver) ResolveEndpoint(_ context.Context, params s3control.EndpointParameters) (smithyendpoints.Endpoint, error) {
+	u, _ := url.Parse("http://localhost:4566")
+
+	return smithyendpoints.Endpoint{URI: *u}, nil
+}
+
+func newS3ControlClient(t *testing.T) *s3control.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return s3control.NewFromConfig(cfg, func(o *s3control.Options) {
+		o.EndpointResolverV2 = &s3ControlEndpointResolver{}
+	})
+}
+
+func TestS3Control_PublicAccessBlock(t *testing.T) {
+	client := newS3ControlClient(t)
+	ctx := t.Context()
+	accountID := "123456789012"
+
+	// Put public access block.
+	_, err := client.PutPublicAccessBlock(ctx, &s3control.PutPublicAccessBlockInput{
+		AccountId: aws.String(accountID),
+		PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{
+			BlockPublicAcls:       aws.Bool(true),
+			IgnorePublicAcls:      aws.Bool(true),
+			BlockPublicPolicy:     aws.Bool(true),
+			RestrictPublicBuckets: aws.Bool(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get public access block.
+	getOutput, err := client.GetPublicAccessBlock(ctx, &s3control.GetPublicAccessBlockInput{
+		AccountId: aws.String(accountID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata"),
+	)
+	g.Assert("get", getOutput)
+
+	// Delete public access block.
+	_, err = client.DeletePublicAccessBlock(ctx, &s3control.DeletePublicAccessBlockInput{
+		AccountId: aws.String(accountID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify it's deleted - should return error.
+	_, err = client.GetPublicAccessBlock(ctx, &s3control.GetPublicAccessBlockInput{
+		AccountId: aws.String(accountID),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestS3Control_AccessPoint(t *testing.T) {
+	client := newS3ControlClient(t)
+	ctx := t.Context()
+	accountID := "123456789012"
+	apName := "test-access-point"
+	bucketName := "test-bucket"
+
+	// Create access point.
+	createOutput, err := client.CreateAccessPoint(ctx, &s3control.CreateAccessPointInput{
+		AccountId: aws.String(accountID),
+		Name:      aws.String(apName),
+		Bucket:    aws.String(bucketName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "AccessPointArn", "Alias"),
+	)
+	g.Assert("create", createOutput)
+
+	// Get access point.
+	getOutput, err := client.GetAccessPoint(ctx, &s3control.GetAccessPointInput{
+		AccountId: aws.String(accountID),
+		Name:      aws.String(apName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "AccessPointArn", "Alias", "Endpoints"),
+	)
+	g2.Assert("get", getOutput)
+
+	// List access points.
+	listOutput, err := client.ListAccessPoints(ctx, &s3control.ListAccessPointsInput{
+		AccountId: aws.String(accountID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g3 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "AccessPointArn", "Alias"),
+	)
+	g3.Assert("list", listOutput)
+
+	// Delete access point.
+	_, err = client.DeleteAccessPoint(ctx, &s3control.DeleteAccessPointInput{
+		AccountId: aws.String(accountID),
+		Name:      aws.String(apName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify it's deleted.
+	_, err = client.GetAccessPoint(ctx, &s3control.GetAccessPointInput{
+		AccountId: aws.String(accountID),
+		Name:      aws.String(apName),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/test/integration/testdata/s3control_test_TestS3Control_AccessPoint_create.golden.go
+++ b/test/integration/testdata/s3control_test_TestS3Control_AccessPoint_create.golden.go
@@ -1,0 +1,5 @@
+{
+  "AccessPointArn": "arn:aws:s3:us-east-1:123456789012:accesspoint/test-access-point",
+  "Alias": "test-access-point-123456789012-s3alias",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/s3control_test_TestS3Control_AccessPoint_get.golden.go
+++ b/test/integration/testdata/s3control_test_TestS3Control_AccessPoint_get.golden.go
@@ -1,0 +1,17 @@
+{
+  "AccessPointArn": "arn:aws:s3:us-east-1:123456789012:accesspoint/test-access-point",
+  "Alias": "test-access-point-123456789012-s3alias",
+  "Bucket": "test-bucket",
+  "BucketAccountId": null,
+  "CreationDate": null,
+  "DataSourceId": null,
+  "DataSourceType": null,
+  "Endpoints": {
+    "https": "https://test-access-point-123456789012.s3-accesspoint.us-east-1.amazonaws.com"
+  },
+  "Name": "test-access-point",
+  "NetworkOrigin": "Internet",
+  "PublicAccessBlockConfiguration": null,
+  "VpcConfiguration": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/s3control_test_TestS3Control_AccessPoint_list.golden.go
+++ b/test/integration/testdata/s3control_test_TestS3Control_AccessPoint_list.golden.go
@@ -1,0 +1,17 @@
+{
+  "AccessPointList": [
+    {
+      "Bucket": "test-bucket",
+      "Name": "test-access-point",
+      "NetworkOrigin": "Internet",
+      "AccessPointArn": "arn:aws:s3:us-east-1:123456789012:accesspoint/test-access-point",
+      "Alias": "test-access-point-123456789012-s3alias",
+      "BucketAccountId": null,
+      "DataSourceId": null,
+      "DataSourceType": null,
+      "VpcConfiguration": null
+    }
+  ],
+  "NextToken": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/s3control_test_TestS3Control_PublicAccessBlock_get.golden.go
+++ b/test/integration/testdata/s3control_test_TestS3Control_PublicAccessBlock_get.golden.go
@@ -1,0 +1,9 @@
+{
+  "PublicAccessBlockConfiguration": {
+    "BlockPublicAcls": null,
+    "BlockPublicPolicy": null,
+    "IgnorePublicAcls": null,
+    "RestrictPublicBuckets": null
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
- Implement S3 Control service with Public Access Block and Access Point operations
- Add custom EndpointResolverV2 in tests to handle S3 Control SDK's account ID subdomain behavior
- Add /v20180820 prefix to router to isolate routes from S3's wildcard patterns

## Operations Implemented
### Public Access Block
- GetPublicAccessBlock
- PutPublicAccessBlock
- DeletePublicAccessBlock

### Access Points
- CreateAccessPoint
- GetAccessPoint
- DeleteAccessPoint
- ListAccessPoints

## Test plan
- [x] Integration tests with AWS SDK v2
- [x] Golden file validation for all operations
- [x] Verified create/get/delete workflow

Closes #128