### PR TITLE
feat(route53resolver): implement AWS Route 53 Resolver service

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -222,6 +222,10 @@ linters:
       - path: internal/service/sagemaker/types\.go
         linters:
           - tagliatelle
+      # AWS Route 53 Resolver API requires PascalCase JSON field names.
+      - path: internal/service/route53resolver/types\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/pipes"
 	_ "github.com/sivchari/awsim/internal/service/rds"
 	_ "github.com/sivchari/awsim/internal/service/route53"
+	_ "github.com/sivchari/awsim/internal/service/route53resolver"
 	_ "github.com/sivchari/awsim/internal/service/s3"
 	_ "github.com/sivchari/awsim/internal/service/s3control"
 	_ "github.com/sivchari/awsim/internal/service/s3tables"

--- a/internal/service/route53resolver/handlers.go
+++ b/internal/service/route53resolver/handlers.go
@@ -1,0 +1,498 @@
+package route53resolver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	errInternalServiceError = "InternalServiceError"
+	errInvalidAction        = "InvalidAction"
+)
+
+// CreateResolverEndpoint handles the CreateResolverEndpoint action.
+func (s *Service) CreateResolverEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req CreateResolverEndpointRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.CreatorRequestID == "" {
+		writeResolverError(w, errInvalidParameter, "CreatorRequestId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Direction == "" {
+		writeResolverError(w, errInvalidParameter, "Direction is required", http.StatusBadRequest)
+
+		return
+	}
+
+	endpoint, err := s.storage.CreateResolverEndpoint(r.Context(), &req)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, CreateResolverEndpointResponse{
+		ResolverEndpoint: toResolverEndpointOutput(endpoint),
+	})
+}
+
+// GetResolverEndpoint handles the GetResolverEndpoint action.
+func (s *Service) GetResolverEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req GetResolverEndpointRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResolverEndpointID == "" {
+		writeResolverError(w, errInvalidParameter, "ResolverEndpointId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	endpoint, err := s.storage.GetResolverEndpoint(r.Context(), req.ResolverEndpointID)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, GetResolverEndpointResponse{
+		ResolverEndpoint: toResolverEndpointOutput(endpoint),
+	})
+}
+
+// DeleteResolverEndpoint handles the DeleteResolverEndpoint action.
+func (s *Service) DeleteResolverEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req DeleteResolverEndpointRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResolverEndpointID == "" {
+		writeResolverError(w, errInvalidParameter, "ResolverEndpointId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	endpoint, err := s.storage.DeleteResolverEndpoint(r.Context(), req.ResolverEndpointID)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, DeleteResolverEndpointResponse{
+		ResolverEndpoint: toResolverEndpointOutput(endpoint),
+	})
+}
+
+// ListResolverEndpoints handles the ListResolverEndpoints action.
+func (s *Service) ListResolverEndpoints(w http.ResponseWriter, r *http.Request) {
+	var req ListResolverEndpointsRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	endpoints, nextToken, err := s.storage.ListResolverEndpoints(r.Context(), req.MaxResults, req.NextToken)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	outputs := make([]*ResolverEndpointOutput, 0, len(endpoints))
+	for _, e := range endpoints {
+		outputs = append(outputs, toResolverEndpointOutput(e))
+	}
+
+	writeJSONResponse(w, ListResolverEndpointsResponse{
+		ResolverEndpoints: outputs,
+		MaxResults:        req.MaxResults,
+		NextToken:         nextToken,
+	})
+}
+
+// CreateResolverRule handles the CreateResolverRule action.
+func (s *Service) CreateResolverRule(w http.ResponseWriter, r *http.Request) {
+	var req CreateResolverRuleRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.CreatorRequestID == "" {
+		writeResolverError(w, errInvalidParameter, "CreatorRequestId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DomainName == "" {
+		writeResolverError(w, errInvalidParameter, "DomainName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RuleType == "" {
+		writeResolverError(w, errInvalidParameter, "RuleType is required", http.StatusBadRequest)
+
+		return
+	}
+
+	rule, err := s.storage.CreateResolverRule(r.Context(), &req)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, CreateResolverRuleResponse{
+		ResolverRule: toResolverRuleOutput(rule),
+	})
+}
+
+// GetResolverRule handles the GetResolverRule action.
+func (s *Service) GetResolverRule(w http.ResponseWriter, r *http.Request) {
+	var req GetResolverRuleRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResolverRuleID == "" {
+		writeResolverError(w, errInvalidParameter, "ResolverRuleId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	rule, err := s.storage.GetResolverRule(r.Context(), req.ResolverRuleID)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, GetResolverRuleResponse{
+		ResolverRule: toResolverRuleOutput(rule),
+	})
+}
+
+// DeleteResolverRule handles the DeleteResolverRule action.
+func (s *Service) DeleteResolverRule(w http.ResponseWriter, r *http.Request) {
+	var req DeleteResolverRuleRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResolverRuleID == "" {
+		writeResolverError(w, errInvalidParameter, "ResolverRuleId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	rule, err := s.storage.DeleteResolverRule(r.Context(), req.ResolverRuleID)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, DeleteResolverRuleResponse{
+		ResolverRule: toResolverRuleOutput(rule),
+	})
+}
+
+// ListResolverRules handles the ListResolverRules action.
+func (s *Service) ListResolverRules(w http.ResponseWriter, r *http.Request) {
+	var req ListResolverRulesRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	rules, nextToken, err := s.storage.ListResolverRules(r.Context(), req.MaxResults, req.NextToken)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	outputs := make([]*ResolverRuleOutput, 0, len(rules))
+	for _, rule := range rules {
+		outputs = append(outputs, toResolverRuleOutput(rule))
+	}
+
+	writeJSONResponse(w, ListResolverRulesResponse{
+		ResolverRules: outputs,
+		MaxResults:    req.MaxResults,
+		NextToken:     nextToken,
+	})
+}
+
+// AssociateResolverRule handles the AssociateResolverRule action.
+func (s *Service) AssociateResolverRule(w http.ResponseWriter, r *http.Request) {
+	var req AssociateResolverRuleRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResolverRuleID == "" {
+		writeResolverError(w, errInvalidParameter, "ResolverRuleId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.VPCID == "" {
+		writeResolverError(w, errInvalidParameter, "VPCId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	assoc, err := s.storage.AssociateResolverRule(r.Context(), &req)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, AssociateResolverRuleResponse{
+		ResolverRuleAssociation: toResolverRuleAssociationOutput(assoc),
+	})
+}
+
+// DisassociateResolverRule handles the DisassociateResolverRule action.
+func (s *Service) DisassociateResolverRule(w http.ResponseWriter, r *http.Request) {
+	var req DisassociateResolverRuleRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResolverRuleID == "" {
+		writeResolverError(w, errInvalidParameter, "ResolverRuleId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.VPCID == "" {
+		writeResolverError(w, errInvalidParameter, "VPCId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	assoc, err := s.storage.DisassociateResolverRule(r.Context(), req.ResolverRuleID, req.VPCID)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, DisassociateResolverRuleResponse{
+		ResolverRuleAssociation: toResolverRuleAssociationOutput(assoc),
+	})
+}
+
+// ListResolverRuleAssociations handles the ListResolverRuleAssociations action.
+func (s *Service) ListResolverRuleAssociations(w http.ResponseWriter, r *http.Request) {
+	var req ListResolverRuleAssociationsRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	associations, nextToken, err := s.storage.ListResolverRuleAssociations(r.Context(), req.MaxResults, req.NextToken)
+	if err != nil {
+		handleResolverError(w, err)
+
+		return
+	}
+
+	outputs := make([]*ResolverRuleAssociationOutput, 0, len(associations))
+	for _, assoc := range associations {
+		outputs = append(outputs, toResolverRuleAssociationOutput(assoc))
+	}
+
+	writeJSONResponse(w, ListResolverRuleAssociationsResponse{
+		ResolverRuleAssociations: outputs,
+		MaxResults:               req.MaxResults,
+		NextToken:                nextToken,
+	})
+}
+
+// DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.
+func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
+	target := r.Header.Get("X-Amz-Target")
+	action := strings.TrimPrefix(target, "Route53Resolver.")
+
+	switch action {
+	case "CreateResolverEndpoint":
+		s.CreateResolverEndpoint(w, r)
+	case "GetResolverEndpoint":
+		s.GetResolverEndpoint(w, r)
+	case "DeleteResolverEndpoint":
+		s.DeleteResolverEndpoint(w, r)
+	case "ListResolverEndpoints":
+		s.ListResolverEndpoints(w, r)
+	case "CreateResolverRule":
+		s.CreateResolverRule(w, r)
+	case "GetResolverRule":
+		s.GetResolverRule(w, r)
+	case "DeleteResolverRule":
+		s.DeleteResolverRule(w, r)
+	case "ListResolverRules":
+		s.ListResolverRules(w, r)
+	case "AssociateResolverRule":
+		s.AssociateResolverRule(w, r)
+	case "DisassociateResolverRule":
+		s.DisassociateResolverRule(w, r)
+	case "ListResolverRuleAssociations":
+		s.ListResolverRuleAssociations(w, r)
+	default:
+		writeResolverError(w, errInvalidAction, "The action "+action+" is not valid", http.StatusBadRequest)
+	}
+}
+
+// toResolverEndpointOutput converts a ResolverEndpoint to ResolverEndpointOutput.
+func toResolverEndpointOutput(e *ResolverEndpoint) *ResolverEndpointOutput {
+	return &ResolverEndpointOutput{
+		ID:                    e.ID,
+		CreatorRequestID:      e.CreatorRequestID,
+		ARN:                   e.ARN,
+		Name:                  e.Name,
+		SecurityGroupIDs:      e.SecurityGroupIDs,
+		Direction:             e.Direction,
+		IPAddressCount:        e.IPAddressCount,
+		HostVPCID:             e.HostVPCID,
+		Status:                e.Status,
+		StatusMessage:         e.StatusMessage,
+		CreationTime:          e.CreationTime,
+		ModificationTime:      e.ModificationTime,
+		OutpostArn:            e.OutpostArn,
+		PreferredInstanceType: e.PreferredInstanceType,
+		ResolverEndpointType:  e.ResolverEndpointType,
+		Protocols:             e.Protocols,
+	}
+}
+
+// toResolverRuleOutput converts a ResolverRule to ResolverRuleOutput.
+func toResolverRuleOutput(r *ResolverRule) *ResolverRuleOutput {
+	targetIPs := make([]TargetAddress, 0, len(r.TargetIPs))
+	for _, t := range r.TargetIPs {
+		targetIPs = append(targetIPs, TargetAddress{
+			IP:       t.IP,
+			Port:     t.Port,
+			IPv6:     t.IPv6,
+			Protocol: t.Protocol,
+		})
+	}
+
+	return &ResolverRuleOutput{
+		ID:                 r.ID,
+		CreatorRequestID:   r.CreatorRequestID,
+		ARN:                r.ARN,
+		DomainName:         r.DomainName,
+		Status:             r.Status,
+		StatusMessage:      r.StatusMessage,
+		RuleType:           r.RuleType,
+		Name:               r.Name,
+		TargetIPs:          targetIPs,
+		ResolverEndpointID: r.ResolverEndpointID,
+		OwnerID:            r.OwnerID,
+		ShareStatus:        r.ShareStatus,
+		CreationTime:       r.CreationTime,
+		ModificationTime:   r.ModificationTime,
+	}
+}
+
+// toResolverRuleAssociationOutput converts a ResolverRuleAssociation to ResolverRuleAssociationOutput.
+func toResolverRuleAssociationOutput(a *ResolverRuleAssociation) *ResolverRuleAssociationOutput {
+	return &ResolverRuleAssociationOutput{
+		ID:             a.ID,
+		ResolverRuleID: a.ResolverRuleID,
+		Name:           a.Name,
+		VPCID:          a.VPCID,
+		Status:         a.Status,
+		StatusMessage:  a.StatusMessage,
+	}
+}
+
+// handleResolverError handles errors and writes appropriate response.
+func handleResolverError(w http.ResponseWriter, err error) {
+	var resolverErr *ResolverError
+	if errors.As(err, &resolverErr) {
+		status := http.StatusBadRequest
+		if resolverErr.Code == errResourceNotFound {
+			status = http.StatusNotFound
+		}
+
+		writeResolverError(w, resolverErr.Code, resolverErr.Message, status)
+
+		return
+	}
+
+	writeResolverError(w, errInternalServiceError, "Internal server error", http.StatusInternalServerError)
+}
+
+// readJSONRequest reads and decodes JSON request body.
+func readJSONRequest(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return nil
+}
+
+// writeJSONResponse writes a JSON response with HTTP 200 OK.
+func writeJSONResponse(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeResolverError writes a Route 53 Resolver error response in JSON format.
+func writeResolverError(w http.ResponseWriter, code, message string, status int) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{
+		Type:    code,
+		Message: message,
+	})
+}

--- a/internal/service/route53resolver/service.go
+++ b/internal/service/route53resolver/service.go
@@ -1,0 +1,41 @@
+package route53resolver
+
+import "github.com/sivchari/awsim/internal/service"
+
+// Compile-time check to ensure Service implements JSONProtocolService.
+var _ service.JSONProtocolService = (*Service)(nil)
+
+func init() {
+	service.Register(New(NewMemoryStorage()))
+}
+
+// Service implements the Route 53 Resolver service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new Route 53 Resolver service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "route53resolver"
+}
+
+// RegisterRoutes registers the Route 53 Resolver routes.
+// Route 53 Resolver uses AWS JSON 1.1 protocol via the JSONProtocolService interface.
+func (s *Service) RegisterRoutes(_ service.Router) {
+	// No routes to register - Route 53 Resolver uses JSON protocol dispatcher
+}
+
+// TargetPrefix returns the X-Amz-Target header prefix for Route 53 Resolver.
+func (s *Service) TargetPrefix() string {
+	return "Route53Resolver"
+}
+
+// JSONProtocol is a marker method that indicates Route 53 Resolver uses AWS JSON 1.1 protocol.
+func (s *Service) JSONProtocol() {}

--- a/internal/service/route53resolver/storage.go
+++ b/internal/service/route53resolver/storage.go
@@ -1,0 +1,363 @@
+package route53resolver
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	errResourceNotFound = "ResourceNotFoundException"
+	errResourceExists   = "ResourceExistsException"
+	errResourceInUse    = "ResourceInUseException"
+	errInvalidParameter = "InvalidParameterException"
+
+	statusDeleting = "DELETING"
+)
+
+// Storage is the interface for Route 53 Resolver storage operations.
+type Storage interface {
+	// Resolver Endpoints
+	CreateResolverEndpoint(ctx context.Context, req *CreateResolverEndpointRequest) (*ResolverEndpoint, error)
+	GetResolverEndpoint(ctx context.Context, id string) (*ResolverEndpoint, error)
+	DeleteResolverEndpoint(ctx context.Context, id string) (*ResolverEndpoint, error)
+	ListResolverEndpoints(ctx context.Context, maxResults int, nextToken string) ([]*ResolverEndpoint, string, error)
+
+	// Resolver Rules
+	CreateResolverRule(ctx context.Context, req *CreateResolverRuleRequest) (*ResolverRule, error)
+	GetResolverRule(ctx context.Context, id string) (*ResolverRule, error)
+	DeleteResolverRule(ctx context.Context, id string) (*ResolverRule, error)
+	ListResolverRules(ctx context.Context, maxResults int, nextToken string) ([]*ResolverRule, string, error)
+
+	// Resolver Rule Associations
+	AssociateResolverRule(ctx context.Context, req *AssociateResolverRuleRequest) (*ResolverRuleAssociation, error)
+	DisassociateResolverRule(ctx context.Context, ruleID, vpcID string) (*ResolverRuleAssociation, error)
+	ListResolverRuleAssociations(ctx context.Context, maxResults int, nextToken string) ([]*ResolverRuleAssociation, string, error)
+}
+
+// MemoryStorage implements in-memory storage for Route 53 Resolver.
+type MemoryStorage struct {
+	mu           sync.RWMutex
+	endpoints    map[string]*ResolverEndpoint
+	rules        map[string]*ResolverRule
+	associations map[string]*ResolverRuleAssociation
+	accountID    string
+	region       string
+}
+
+// NewMemoryStorage creates a new in-memory storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		endpoints:    make(map[string]*ResolverEndpoint),
+		rules:        make(map[string]*ResolverRule),
+		associations: make(map[string]*ResolverRuleAssociation),
+		accountID:    "123456789012",
+		region:       "us-east-1",
+	}
+}
+
+// CreateResolverEndpoint creates a new resolver endpoint.
+func (s *MemoryStorage) CreateResolverEndpoint(_ context.Context, req *CreateResolverEndpointRequest) (*ResolverEndpoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id := "rslvr-" + req.Direction[:2] + "-" + uuid.New().String()[:8]
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Extract VPC ID from first subnet (simplified)
+	vpcID := "vpc-" + uuid.New().String()[:8]
+
+	ipAddresses := make([]*IPAddressResponse, 0, len(req.IPAddresses))
+
+	for _, ipReq := range req.IPAddresses {
+		ipAddr := &IPAddressResponse{
+			IPAddressID:      "rslvr-ip-" + uuid.New().String()[:8],
+			SubnetID:         ipReq.SubnetID,
+			IP:               ipReq.IP,
+			IPv6:             ipReq.IPv6,
+			Status:           "ATTACHED",
+			CreationTime:     now,
+			ModificationTime: now,
+		}
+
+		if ipAddr.IP == "" {
+			ipAddr.IP = fmt.Sprintf("10.0.%d.%d", len(ipAddresses), len(ipAddresses)+1)
+		}
+
+		ipAddresses = append(ipAddresses, ipAddr)
+	}
+
+	endpoint := &ResolverEndpoint{
+		ID:                    id,
+		CreatorRequestID:      req.CreatorRequestID,
+		ARN:                   fmt.Sprintf("arn:aws:route53resolver:%s:%s:resolver-endpoint/%s", s.region, s.accountID, id),
+		Name:                  req.Name,
+		SecurityGroupIDs:      req.SecurityGroupIDs,
+		Direction:             req.Direction,
+		IPAddressCount:        len(ipAddresses),
+		HostVPCID:             vpcID,
+		Status:                "OPERATIONAL",
+		CreationTime:          now,
+		ModificationTime:      now,
+		OutpostArn:            req.OutpostArn,
+		PreferredInstanceType: req.PreferredInstanceType,
+		ResolverEndpointType:  req.ResolverEndpointType,
+		Protocols:             req.Protocols,
+		IPAddresses:           ipAddresses,
+	}
+
+	if endpoint.ResolverEndpointType == "" {
+		endpoint.ResolverEndpointType = "IPV4"
+	}
+
+	if len(endpoint.Protocols) == 0 {
+		endpoint.Protocols = []string{"Do53"}
+	}
+
+	s.endpoints[id] = endpoint
+
+	return endpoint, nil
+}
+
+// GetResolverEndpoint retrieves a resolver endpoint by ID.
+func (s *MemoryStorage) GetResolverEndpoint(_ context.Context, id string) (*ResolverEndpoint, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	endpoint, exists := s.endpoints[id]
+	if !exists {
+		return nil, &ResolverError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Resolver endpoint with ID '%s' does not exist", id),
+		}
+	}
+
+	return endpoint, nil
+}
+
+// DeleteResolverEndpoint deletes a resolver endpoint.
+func (s *MemoryStorage) DeleteResolverEndpoint(_ context.Context, id string) (*ResolverEndpoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	endpoint, exists := s.endpoints[id]
+	if !exists {
+		return nil, &ResolverError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Resolver endpoint with ID '%s' does not exist", id),
+		}
+	}
+
+	endpoint.Status = statusDeleting
+
+	delete(s.endpoints, id)
+
+	return endpoint, nil
+}
+
+// ListResolverEndpoints lists resolver endpoints.
+func (s *MemoryStorage) ListResolverEndpoints(_ context.Context, maxResults int, _ string) ([]*ResolverEndpoint, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults == 0 {
+		maxResults = 10
+	}
+
+	endpoints := make([]*ResolverEndpoint, 0, len(s.endpoints))
+	for _, endpoint := range s.endpoints {
+		endpoints = append(endpoints, endpoint)
+		if len(endpoints) >= maxResults {
+			break
+		}
+	}
+
+	return endpoints, "", nil
+}
+
+// CreateResolverRule creates a new resolver rule.
+func (s *MemoryStorage) CreateResolverRule(_ context.Context, req *CreateResolverRuleRequest) (*ResolverRule, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id := "rslvr-rr-" + uuid.New().String()[:8]
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	targetIPs := make([]*TargetAddress, 0, len(req.TargetIPs))
+	for _, t := range req.TargetIPs {
+		targetIPs = append(targetIPs, &TargetAddress{
+			IP:       t.IP,
+			Port:     t.Port,
+			IPv6:     t.IPv6,
+			Protocol: t.Protocol,
+		})
+	}
+
+	rule := &ResolverRule{
+		ID:                 id,
+		CreatorRequestID:   req.CreatorRequestID,
+		ARN:                fmt.Sprintf("arn:aws:route53resolver:%s:%s:resolver-rule/%s", s.region, s.accountID, id),
+		DomainName:         req.DomainName,
+		Status:             "COMPLETE",
+		RuleType:           req.RuleType,
+		Name:               req.Name,
+		TargetIPs:          targetIPs,
+		ResolverEndpointID: req.ResolverEndpointID,
+		OwnerID:            s.accountID,
+		ShareStatus:        "NOT_SHARED",
+		CreationTime:       now,
+		ModificationTime:   now,
+	}
+
+	s.rules[id] = rule
+
+	return rule, nil
+}
+
+// GetResolverRule retrieves a resolver rule by ID.
+func (s *MemoryStorage) GetResolverRule(_ context.Context, id string) (*ResolverRule, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rule, exists := s.rules[id]
+	if !exists {
+		return nil, &ResolverError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Resolver rule with ID '%s' does not exist", id),
+		}
+	}
+
+	return rule, nil
+}
+
+// DeleteResolverRule deletes a resolver rule.
+func (s *MemoryStorage) DeleteResolverRule(_ context.Context, id string) (*ResolverRule, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rule, exists := s.rules[id]
+	if !exists {
+		return nil, &ResolverError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Resolver rule with ID '%s' does not exist", id),
+		}
+	}
+
+	// Check if rule is associated with any VPC
+	for _, assoc := range s.associations {
+		if assoc.ResolverRuleID == id {
+			return nil, &ResolverError{
+				Code:    errResourceInUse,
+				Message: fmt.Sprintf("Resolver rule '%s' is still associated with VPCs", id),
+			}
+		}
+	}
+
+	rule.Status = statusDeleting
+
+	delete(s.rules, id)
+
+	return rule, nil
+}
+
+// ListResolverRules lists resolver rules.
+func (s *MemoryStorage) ListResolverRules(_ context.Context, maxResults int, _ string) ([]*ResolverRule, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults == 0 {
+		maxResults = 10
+	}
+
+	rules := make([]*ResolverRule, 0, len(s.rules))
+	for _, rule := range s.rules {
+		rules = append(rules, rule)
+		if len(rules) >= maxResults {
+			break
+		}
+	}
+
+	return rules, "", nil
+}
+
+// AssociateResolverRule associates a resolver rule with a VPC.
+func (s *MemoryStorage) AssociateResolverRule(_ context.Context, req *AssociateResolverRuleRequest) (*ResolverRuleAssociation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if rule exists
+	if _, exists := s.rules[req.ResolverRuleID]; !exists {
+		return nil, &ResolverError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Resolver rule with ID '%s' does not exist", req.ResolverRuleID),
+		}
+	}
+
+	// Check if association already exists
+	for _, assoc := range s.associations {
+		if assoc.ResolverRuleID == req.ResolverRuleID && assoc.VPCID == req.VPCID {
+			return nil, &ResolverError{
+				Code:    errResourceExists,
+				Message: fmt.Sprintf("Resolver rule '%s' is already associated with VPC '%s'", req.ResolverRuleID, req.VPCID),
+			}
+		}
+	}
+
+	id := "rslvr-rrassoc-" + uuid.New().String()[:8]
+
+	assoc := &ResolverRuleAssociation{
+		ID:             id,
+		ResolverRuleID: req.ResolverRuleID,
+		Name:           req.Name,
+		VPCID:          req.VPCID,
+		Status:         "COMPLETE",
+	}
+
+	s.associations[id] = assoc
+
+	return assoc, nil
+}
+
+// DisassociateResolverRule disassociates a resolver rule from a VPC.
+func (s *MemoryStorage) DisassociateResolverRule(_ context.Context, ruleID, vpcID string) (*ResolverRuleAssociation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id, assoc := range s.associations {
+		if assoc.ResolverRuleID == ruleID && assoc.VPCID == vpcID {
+			assoc.Status = statusDeleting
+
+			delete(s.associations, id)
+
+			return assoc, nil
+		}
+	}
+
+	return nil, &ResolverError{
+		Code:    errResourceNotFound,
+		Message: fmt.Sprintf("Association between resolver rule '%s' and VPC '%s' does not exist", ruleID, vpcID),
+	}
+}
+
+// ListResolverRuleAssociations lists resolver rule associations.
+func (s *MemoryStorage) ListResolverRuleAssociations(_ context.Context, maxResults int, _ string) ([]*ResolverRuleAssociation, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults == 0 {
+		maxResults = 10
+	}
+
+	associations := make([]*ResolverRuleAssociation, 0, len(s.associations))
+	for _, assoc := range s.associations {
+		associations = append(associations, assoc)
+		if len(associations) >= maxResults {
+			break
+		}
+	}
+
+	return associations, "", nil
+}

--- a/internal/service/route53resolver/types.go
+++ b/internal/service/route53resolver/types.go
@@ -1,0 +1,295 @@
+// Package route53resolver provides Route 53 Resolver service emulation for awsim.
+package route53resolver
+
+// ResolverEndpoint represents a Route 53 Resolver endpoint.
+type ResolverEndpoint struct {
+	ID                    string
+	CreatorRequestID      string
+	ARN                   string
+	Name                  string
+	SecurityGroupIDs      []string
+	Direction             string // INBOUND or OUTBOUND
+	IPAddressCount        int
+	HostVPCID             string
+	Status                string
+	StatusMessage         string
+	CreationTime          string
+	ModificationTime      string
+	OutpostArn            string
+	PreferredInstanceType string
+	ResolverEndpointType  string
+	Protocols             []string
+	IPAddresses           []*IPAddressResponse
+}
+
+// IPAddressRequest represents an IP address request.
+type IPAddressRequest struct {
+	SubnetID string `json:"SubnetId"`
+	IP       string `json:"Ip,omitempty"`
+	IPv6     string `json:"Ipv6,omitempty"`
+}
+
+// IPAddressResponse represents an IP address response.
+type IPAddressResponse struct {
+	IPAddressID      string `json:"IpId"`
+	SubnetID         string `json:"SubnetId"`
+	IP               string `json:"Ip,omitempty"`
+	IPv6             string `json:"Ipv6,omitempty"`
+	Status           string `json:"Status"`
+	StatusMessage    string `json:"StatusMessage,omitempty"`
+	CreationTime     string `json:"CreationTime"`
+	ModificationTime string `json:"ModificationTime"`
+}
+
+// ResolverRule represents a Route 53 Resolver rule.
+type ResolverRule struct {
+	ID                 string
+	CreatorRequestID   string
+	ARN                string
+	DomainName         string
+	Status             string
+	StatusMessage      string
+	RuleType           string // FORWARD, SYSTEM, or RECURSIVE
+	Name               string
+	TargetIPs          []*TargetAddress
+	ResolverEndpointID string
+	OwnerID            string
+	ShareStatus        string
+	CreationTime       string
+	ModificationTime   string
+}
+
+// TargetAddress represents a target IP address for forwarding.
+type TargetAddress struct {
+	IP       string `json:"Ip,omitempty"`
+	Port     int    `json:"Port,omitempty"`
+	IPv6     string `json:"Ipv6,omitempty"`
+	Protocol string `json:"Protocol,omitempty"`
+}
+
+// ResolverRuleAssociation represents an association between a resolver rule and a VPC.
+type ResolverRuleAssociation struct {
+	ID             string
+	ResolverRuleID string
+	Name           string
+	VPCID          string
+	Status         string
+	StatusMessage  string
+}
+
+// Tag represents a resource tag.
+type Tag struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+// CreateResolverEndpointRequest is the request for CreateResolverEndpoint.
+type CreateResolverEndpointRequest struct {
+	CreatorRequestID      string             `json:"CreatorRequestId"`
+	Name                  string             `json:"Name,omitempty"`
+	SecurityGroupIDs      []string           `json:"SecurityGroupIds"`
+	Direction             string             `json:"Direction"`
+	IPAddresses           []IPAddressRequest `json:"IpAddresses"`
+	OutpostArn            string             `json:"OutpostArn,omitempty"`
+	PreferredInstanceType string             `json:"PreferredInstanceType,omitempty"`
+	ResolverEndpointType  string             `json:"ResolverEndpointType,omitempty"`
+	Protocols             []string           `json:"Protocols,omitempty"`
+	Tags                  []Tag              `json:"Tags,omitempty"`
+}
+
+// CreateResolverEndpointResponse is the response for CreateResolverEndpoint.
+type CreateResolverEndpointResponse struct {
+	ResolverEndpoint *ResolverEndpointOutput `json:"ResolverEndpoint"`
+}
+
+// ResolverEndpointOutput represents a resolver endpoint in API responses.
+type ResolverEndpointOutput struct {
+	ID                    string   `json:"Id"`
+	CreatorRequestID      string   `json:"CreatorRequestId"`
+	ARN                   string   `json:"Arn"`
+	Name                  string   `json:"Name,omitempty"`
+	SecurityGroupIDs      []string `json:"SecurityGroupIds"`
+	Direction             string   `json:"Direction"`
+	IPAddressCount        int      `json:"IpAddressCount"`
+	HostVPCID             string   `json:"HostVPCId"`
+	Status                string   `json:"Status"`
+	StatusMessage         string   `json:"StatusMessage,omitempty"`
+	CreationTime          string   `json:"CreationTime"`
+	ModificationTime      string   `json:"ModificationTime"`
+	OutpostArn            string   `json:"OutpostArn,omitempty"`
+	PreferredInstanceType string   `json:"PreferredInstanceType,omitempty"`
+	ResolverEndpointType  string   `json:"ResolverEndpointType,omitempty"`
+	Protocols             []string `json:"Protocols,omitempty"`
+}
+
+// GetResolverEndpointRequest is the request for GetResolverEndpoint.
+type GetResolverEndpointRequest struct {
+	ResolverEndpointID string `json:"ResolverEndpointId"`
+}
+
+// GetResolverEndpointResponse is the response for GetResolverEndpoint.
+type GetResolverEndpointResponse struct {
+	ResolverEndpoint *ResolverEndpointOutput `json:"ResolverEndpoint"`
+}
+
+// DeleteResolverEndpointRequest is the request for DeleteResolverEndpoint.
+type DeleteResolverEndpointRequest struct {
+	ResolverEndpointID string `json:"ResolverEndpointId"`
+}
+
+// DeleteResolverEndpointResponse is the response for DeleteResolverEndpoint.
+type DeleteResolverEndpointResponse struct {
+	ResolverEndpoint *ResolverEndpointOutput `json:"ResolverEndpoint"`
+}
+
+// ListResolverEndpointsRequest is the request for ListResolverEndpoints.
+type ListResolverEndpointsRequest struct {
+	MaxResults int      `json:"MaxResults,omitempty"`
+	NextToken  string   `json:"NextToken,omitempty"`
+	Filters    []Filter `json:"Filters,omitempty"`
+}
+
+// Filter represents a filter for list operations.
+type Filter struct {
+	Name   string   `json:"Name"`
+	Values []string `json:"Values"`
+}
+
+// ListResolverEndpointsResponse is the response for ListResolverEndpoints.
+type ListResolverEndpointsResponse struct {
+	NextToken         string                    `json:"NextToken,omitempty"`
+	MaxResults        int                       `json:"MaxResults"`
+	ResolverEndpoints []*ResolverEndpointOutput `json:"ResolverEndpoints"`
+}
+
+// CreateResolverRuleRequest is the request for CreateResolverRule.
+type CreateResolverRuleRequest struct {
+	CreatorRequestID   string          `json:"CreatorRequestId"`
+	Name               string          `json:"Name,omitempty"`
+	RuleType           string          `json:"RuleType"`
+	DomainName         string          `json:"DomainName"`
+	TargetIPs          []TargetAddress `json:"TargetIps,omitempty"`
+	ResolverEndpointID string          `json:"ResolverEndpointId,omitempty"`
+	Tags               []Tag           `json:"Tags,omitempty"`
+}
+
+// CreateResolverRuleResponse is the response for CreateResolverRule.
+type CreateResolverRuleResponse struct {
+	ResolverRule *ResolverRuleOutput `json:"ResolverRule"`
+}
+
+// ResolverRuleOutput represents a resolver rule in API responses.
+type ResolverRuleOutput struct {
+	ID                 string          `json:"Id"`
+	CreatorRequestID   string          `json:"CreatorRequestId"`
+	ARN                string          `json:"Arn"`
+	DomainName         string          `json:"DomainName"`
+	Status             string          `json:"Status"`
+	StatusMessage      string          `json:"StatusMessage,omitempty"`
+	RuleType           string          `json:"RuleType"`
+	Name               string          `json:"Name,omitempty"`
+	TargetIPs          []TargetAddress `json:"TargetIps,omitempty"`
+	ResolverEndpointID string          `json:"ResolverEndpointId,omitempty"`
+	OwnerID            string          `json:"OwnerId"`
+	ShareStatus        string          `json:"ShareStatus"`
+	CreationTime       string          `json:"CreationTime"`
+	ModificationTime   string          `json:"ModificationTime"`
+}
+
+// GetResolverRuleRequest is the request for GetResolverRule.
+type GetResolverRuleRequest struct {
+	ResolverRuleID string `json:"ResolverRuleId"`
+}
+
+// GetResolverRuleResponse is the response for GetResolverRule.
+type GetResolverRuleResponse struct {
+	ResolverRule *ResolverRuleOutput `json:"ResolverRule"`
+}
+
+// DeleteResolverRuleRequest is the request for DeleteResolverRule.
+type DeleteResolverRuleRequest struct {
+	ResolverRuleID string `json:"ResolverRuleId"`
+}
+
+// DeleteResolverRuleResponse is the response for DeleteResolverRule.
+type DeleteResolverRuleResponse struct {
+	ResolverRule *ResolverRuleOutput `json:"ResolverRule"`
+}
+
+// ListResolverRulesRequest is the request for ListResolverRules.
+type ListResolverRulesRequest struct {
+	MaxResults int      `json:"MaxResults,omitempty"`
+	NextToken  string   `json:"NextToken,omitempty"`
+	Filters    []Filter `json:"Filters,omitempty"`
+}
+
+// ListResolverRulesResponse is the response for ListResolverRules.
+type ListResolverRulesResponse struct {
+	NextToken     string                `json:"NextToken,omitempty"`
+	MaxResults    int                   `json:"MaxResults"`
+	ResolverRules []*ResolverRuleOutput `json:"ResolverRules"`
+}
+
+// AssociateResolverRuleRequest is the request for AssociateResolverRule.
+type AssociateResolverRuleRequest struct {
+	ResolverRuleID string `json:"ResolverRuleId"`
+	Name           string `json:"Name,omitempty"`
+	VPCID          string `json:"VPCId"`
+}
+
+// AssociateResolverRuleResponse is the response for AssociateResolverRule.
+type AssociateResolverRuleResponse struct {
+	ResolverRuleAssociation *ResolverRuleAssociationOutput `json:"ResolverRuleAssociation"`
+}
+
+// ResolverRuleAssociationOutput represents a resolver rule association in API responses.
+type ResolverRuleAssociationOutput struct {
+	ID             string `json:"Id"`
+	ResolverRuleID string `json:"ResolverRuleId"`
+	Name           string `json:"Name,omitempty"`
+	VPCID          string `json:"VPCId"`
+	Status         string `json:"Status"`
+	StatusMessage  string `json:"StatusMessage,omitempty"`
+}
+
+// DisassociateResolverRuleRequest is the request for DisassociateResolverRule.
+type DisassociateResolverRuleRequest struct {
+	ResolverRuleID string `json:"ResolverRuleId"`
+	VPCID          string `json:"VPCId"`
+}
+
+// DisassociateResolverRuleResponse is the response for DisassociateResolverRule.
+type DisassociateResolverRuleResponse struct {
+	ResolverRuleAssociation *ResolverRuleAssociationOutput `json:"ResolverRuleAssociation"`
+}
+
+// ListResolverRuleAssociationsRequest is the request for ListResolverRuleAssociations.
+type ListResolverRuleAssociationsRequest struct {
+	MaxResults int      `json:"MaxResults,omitempty"`
+	NextToken  string   `json:"NextToken,omitempty"`
+	Filters    []Filter `json:"Filters,omitempty"`
+}
+
+// ListResolverRuleAssociationsResponse is the response for ListResolverRuleAssociations.
+type ListResolverRuleAssociationsResponse struct {
+	NextToken                string                           `json:"NextToken,omitempty"`
+	MaxResults               int                              `json:"MaxResults"`
+	ResolverRuleAssociations []*ResolverRuleAssociationOutput `json:"ResolverRuleAssociations"`
+}
+
+// ErrorResponse represents a Route 53 Resolver error response.
+type ErrorResponse struct {
+	Type    string `json:"__type"`
+	Message string `json:"Message"`
+}
+
+// ResolverError represents a Route 53 Resolver error.
+type ResolverError struct {
+	Code    string
+	Message string
+}
+
+// Error implements the error interface.
+func (e *ResolverError) Error() string {
+	return e.Message
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.17
 	github.com/aws/aws-sdk-go-v2/service/rds v1.115.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.2
+	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.42.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.68.1
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.14.0
@@ -58,8 +59,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.21
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8
 	github.com/aws/aws-sdk-go-v2/service/xray v1.36.17
+	github.com/aws/smithy-go v1.24.1
 	github.com/sivchari/golden v0.3.0
-	github.com/stretchr/testify v1.11.1
 )
 
 require (
@@ -78,10 +79,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect
-	github.com/aws/smithy-go v1.24.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/sivchari/awsim => ../

--- a/test/go.sum
+++ b/test/go.sum
@@ -104,6 +104,8 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.115.0 h1:oNl6YghOtxu3MiFk1tQ86QlrYMI
 github.com/aws/aws-sdk-go-v2/service/rds v1.115.0/go.mod h1:JBRYWpz5oXQtHgQC+X8LX9lh0FBCwRHJlWEIT+TTLaE=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.2 h1:zoD/SoiVQi8l8tuQn//VexrXS2yorg/+717JNA4Ble8=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.2/go.mod h1:Ll1DCasPTBFtHK5t/U5WIwGIyRuY3xY+x8/LmqIlqpM=
+github.com/aws/aws-sdk-go-v2/service/route53resolver v1.42.2 h1:D54xyxi00fXBCTEzg/2HAZr4YeZS/aoif6FfRsCAFx8=
+github.com/aws/aws-sdk-go-v2/service/route53resolver v1.42.2/go.mod h1:kOKvnZVJ5Lwc0Cv7fDQb0gdKOJC+oRqZYXN5MbdWx54=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 h1:oeu8VPlOre74lBA/PMhxa5vewaMIMmILM+RraSyB8KA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0/go.mod h1:5jggDlZ2CLQhwJBiZJb4vfk4f0GxWdEDruWKEJ1xOdo=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.68.1 h1:4QG80z0U97W4dQrZRgZlnMgLq/QC/eZegQct0aIjDso=
@@ -140,15 +142,5 @@ github.com/aws/aws-sdk-go-v2/service/xray v1.36.17 h1:b480fLepDHf9B7FXgcgB7XVDN3
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.17/go.mod h1:ASKVut5pRPVm4bF9/P01ClCthnIopv1PjxWsLOTjKPU=
 github.com/aws/smithy-go v1.24.1 h1:VbyeNfmYkWoxMVpGUAbQumkODcYmfMRfZ8yQiH30SK0=
 github.com/aws/smithy-go v1.24.1/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sivchari/golden v0.3.0 h1:WUtMlhvqeH8mXcX4hsZwyfrA5jeNz5F9IL1w+u7Ew7w=
 github.com/sivchari/golden v0.3.0/go.mod h1:gddwjsjxPtLYRCq0M471x9WD9khQWty82Yn/PZ/2I8E=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/integration/route53resolver_test.go
+++ b/test/integration/route53resolver_test.go
@@ -1,0 +1,193 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/route53resolver"
+	"github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
+	"github.com/sivchari/golden"
+)
+
+func newRoute53ResolverClient(t *testing.T) *route53resolver.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return route53resolver.NewFromConfig(cfg, func(o *route53resolver.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestRoute53Resolver_ResolverEndpoint(t *testing.T) {
+	client := newRoute53ResolverClient(t)
+	ctx := t.Context()
+
+	// Create resolver endpoint.
+	createOutput, err := client.CreateResolverEndpoint(ctx, &route53resolver.CreateResolverEndpointInput{
+		CreatorRequestId: aws.String("test-request-id-1"),
+		Name:             aws.String("test-endpoint"),
+		SecurityGroupIds: []string{"sg-12345678"},
+		Direction:        types.ResolverEndpointDirectionInbound,
+		IpAddresses: []types.IpAddressRequest{
+			{
+				SubnetId: aws.String("subnet-12345678"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	endpointID := *createOutput.ResolverEndpoint.Id
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "Id", "Arn", "CreationTime", "ModificationTime", "HostVPCId"),
+	)
+	g.Assert("create", createOutput)
+
+	// Get resolver endpoint.
+	getOutput, err := client.GetResolverEndpoint(ctx, &route53resolver.GetResolverEndpointInput{
+		ResolverEndpointId: aws.String(endpointID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "Id", "Arn", "CreationTime", "ModificationTime", "HostVPCId"),
+	)
+	g2.Assert("get", getOutput)
+
+	// List resolver endpoints.
+	listOutput, err := client.ListResolverEndpoints(ctx, &route53resolver.ListResolverEndpointsInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g3 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "Id", "Arn", "CreationTime", "ModificationTime", "HostVPCId"),
+	)
+	g3.Assert("list", listOutput)
+
+	// Delete resolver endpoint.
+	_, err = client.DeleteResolverEndpoint(ctx, &route53resolver.DeleteResolverEndpointInput{
+		ResolverEndpointId: aws.String(endpointID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify it's deleted - should return error.
+	_, err = client.GetResolverEndpoint(ctx, &route53resolver.GetResolverEndpointInput{
+		ResolverEndpointId: aws.String(endpointID),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRoute53Resolver_ResolverRule(t *testing.T) {
+	client := newRoute53ResolverClient(t)
+	ctx := t.Context()
+
+	// Create resolver rule.
+	createOutput, err := client.CreateResolverRule(ctx, &route53resolver.CreateResolverRuleInput{
+		CreatorRequestId: aws.String("test-rule-request-id"),
+		Name:             aws.String("test-rule"),
+		RuleType:         types.RuleTypeOptionForward,
+		DomainName:       aws.String("example.com."),
+		TargetIps: []types.TargetAddress{
+			{
+				Ip:   aws.String("10.0.0.1"),
+				Port: aws.Int32(53),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ruleID := *createOutput.ResolverRule.Id
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "Id", "Arn", "CreationTime", "ModificationTime", "OwnerId"),
+	)
+	g.Assert("create", createOutput)
+
+	// Get resolver rule.
+	getOutput, err := client.GetResolverRule(ctx, &route53resolver.GetResolverRuleInput{
+		ResolverRuleId: aws.String(ruleID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "Id", "Arn", "CreationTime", "ModificationTime", "OwnerId"),
+	)
+	g2.Assert("get", getOutput)
+
+	// Associate resolver rule with VPC.
+	assocOutput, err := client.AssociateResolverRule(ctx, &route53resolver.AssociateResolverRuleInput{
+		ResolverRuleId: aws.String(ruleID),
+		VPCId:          aws.String("vpc-12345678"),
+		Name:           aws.String("test-association"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g3 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "Id", "ResolverRuleId"),
+	)
+	g3.Assert("associate", assocOutput)
+
+	// List resolver rule associations.
+	listAssocOutput, err := client.ListResolverRuleAssociations(ctx, &route53resolver.ListResolverRuleAssociationsInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g4 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "Id", "ResolverRuleId"),
+	)
+	g4.Assert("list_associations", listAssocOutput)
+
+	// Disassociate resolver rule.
+	_, err = client.DisassociateResolverRule(ctx, &route53resolver.DisassociateResolverRuleInput{
+		ResolverRuleId: aws.String(ruleID),
+		VPCId:          aws.String("vpc-12345678"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete resolver rule.
+	_, err = client.DeleteResolverRule(ctx, &route53resolver.DeleteResolverRuleInput{
+		ResolverRuleId: aws.String(ruleID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify it's deleted - should return error.
+	_, err = client.GetResolverRule(ctx, &route53resolver.GetResolverRuleInput{
+		ResolverRuleId: aws.String(ruleID),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverEndpoint_create.golden.go
+++ b/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverEndpoint_create.golden.go
@@ -1,0 +1,27 @@
+{
+  "ResolverEndpoint": {
+    "Arn": "arn:aws:route53resolver:us-east-1:123456789012:resolver-endpoint/rslvr-IN-80f26297",
+    "CreationTime": "2026-02-27T08:35:03Z",
+    "CreatorRequestId": "test-request-id-1",
+    "Direction": "INBOUND",
+    "HostVPCId": "vpc-0a2b87f6",
+    "Id": "rslvr-IN-80f26297",
+    "IpAddressCount": 1,
+    "ModificationTime": "2026-02-27T08:35:03Z",
+    "Name": "test-endpoint",
+    "OutpostArn": null,
+    "PreferredInstanceType": null,
+    "Protocols": [
+      "Do53"
+    ],
+    "ResolverEndpointType": "IPV4",
+    "RniEnhancedMetricsEnabled": null,
+    "SecurityGroupIds": [
+      "sg-12345678"
+    ],
+    "Status": "OPERATIONAL",
+    "StatusMessage": null,
+    "TargetNameServerMetricsEnabled": null
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverEndpoint_get.golden.go
+++ b/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverEndpoint_get.golden.go
@@ -1,0 +1,27 @@
+{
+  "ResolverEndpoint": {
+    "Arn": "arn:aws:route53resolver:us-east-1:123456789012:resolver-endpoint/rslvr-IN-80f26297",
+    "CreationTime": "2026-02-27T08:35:03Z",
+    "CreatorRequestId": "test-request-id-1",
+    "Direction": "INBOUND",
+    "HostVPCId": "vpc-0a2b87f6",
+    "Id": "rslvr-IN-80f26297",
+    "IpAddressCount": 1,
+    "ModificationTime": "2026-02-27T08:35:03Z",
+    "Name": "test-endpoint",
+    "OutpostArn": null,
+    "PreferredInstanceType": null,
+    "Protocols": [
+      "Do53"
+    ],
+    "ResolverEndpointType": "IPV4",
+    "RniEnhancedMetricsEnabled": null,
+    "SecurityGroupIds": [
+      "sg-12345678"
+    ],
+    "Status": "OPERATIONAL",
+    "StatusMessage": null,
+    "TargetNameServerMetricsEnabled": null
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverEndpoint_list.golden.go
+++ b/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverEndpoint_list.golden.go
@@ -1,0 +1,31 @@
+{
+  "MaxResults": 0,
+  "NextToken": null,
+  "ResolverEndpoints": [
+    {
+      "Arn": "arn:aws:route53resolver:us-east-1:123456789012:resolver-endpoint/rslvr-IN-80f26297",
+      "CreationTime": "2026-02-27T08:35:03Z",
+      "CreatorRequestId": "test-request-id-1",
+      "Direction": "INBOUND",
+      "HostVPCId": "vpc-0a2b87f6",
+      "Id": "rslvr-IN-80f26297",
+      "IpAddressCount": 1,
+      "ModificationTime": "2026-02-27T08:35:03Z",
+      "Name": "test-endpoint",
+      "OutpostArn": null,
+      "PreferredInstanceType": null,
+      "Protocols": [
+        "Do53"
+      ],
+      "ResolverEndpointType": "IPV4",
+      "RniEnhancedMetricsEnabled": null,
+      "SecurityGroupIds": [
+        "sg-12345678"
+      ],
+      "Status": "OPERATIONAL",
+      "StatusMessage": null,
+      "TargetNameServerMetricsEnabled": null
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverRule_associate.golden.go
+++ b/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverRule_associate.golden.go
@@ -1,0 +1,11 @@
+{
+  "ResolverRuleAssociation": {
+    "Id": "rslvr-rrassoc-8c673706",
+    "Name": "test-association",
+    "ResolverRuleId": "rslvr-rr-555be086",
+    "Status": "COMPLETE",
+    "StatusMessage": null,
+    "VPCId": "vpc-12345678"
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverRule_create.golden.go
+++ b/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverRule_create.golden.go
@@ -1,0 +1,28 @@
+{
+  "ResolverRule": {
+    "Arn": "arn:aws:route53resolver:us-east-1:123456789012:resolver-rule/rslvr-rr-555be086",
+    "CreationTime": "2026-02-27T08:35:03Z",
+    "CreatorRequestId": "test-rule-request-id",
+    "DelegationRecord": null,
+    "DomainName": "example.com.",
+    "Id": "rslvr-rr-555be086",
+    "ModificationTime": "2026-02-27T08:35:03Z",
+    "Name": "test-rule",
+    "OwnerId": "123456789012",
+    "ResolverEndpointId": null,
+    "RuleType": "FORWARD",
+    "ShareStatus": "NOT_SHARED",
+    "Status": "COMPLETE",
+    "StatusMessage": null,
+    "TargetIps": [
+      {
+        "Ip": "10.0.0.1",
+        "Ipv6": null,
+        "Port": 53,
+        "Protocol": "",
+        "ServerNameIndication": null
+      }
+    ]
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverRule_get.golden.go
+++ b/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverRule_get.golden.go
@@ -1,0 +1,28 @@
+{
+  "ResolverRule": {
+    "Arn": "arn:aws:route53resolver:us-east-1:123456789012:resolver-rule/rslvr-rr-555be086",
+    "CreationTime": "2026-02-27T08:35:03Z",
+    "CreatorRequestId": "test-rule-request-id",
+    "DelegationRecord": null,
+    "DomainName": "example.com.",
+    "Id": "rslvr-rr-555be086",
+    "ModificationTime": "2026-02-27T08:35:03Z",
+    "Name": "test-rule",
+    "OwnerId": "123456789012",
+    "ResolverEndpointId": null,
+    "RuleType": "FORWARD",
+    "ShareStatus": "NOT_SHARED",
+    "Status": "COMPLETE",
+    "StatusMessage": null,
+    "TargetIps": [
+      {
+        "Ip": "10.0.0.1",
+        "Ipv6": null,
+        "Port": 53,
+        "Protocol": "",
+        "ServerNameIndication": null
+      }
+    ]
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverRule_list_associations.golden.go
+++ b/test/integration/testdata/route53resolver_test_TestRoute53Resolver_ResolverRule_list_associations.golden.go
@@ -1,0 +1,15 @@
+{
+  "MaxResults": 0,
+  "NextToken": null,
+  "ResolverRuleAssociations": [
+    {
+      "Id": "rslvr-rrassoc-8c673706",
+      "Name": "test-association",
+      "ResolverRuleId": "rslvr-rr-555be086",
+      "Status": "COMPLETE",
+      "StatusMessage": null,
+      "VPCId": "vpc-12345678"
+    }
+  ],
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
- Implement Route 53 Resolver service with Resolver Endpoints, Rules, and Rule Associations
- Uses AWS JSON 1.1 protocol via JSONProtocolService interface
- Add compile-time interface verification

## Operations Implemented
### Resolver Endpoints
- CreateResolverEndpoint
- GetResolverEndpoint
- DeleteResolverEndpoint
- ListResolverEndpoints

### Resolver Rules
- CreateResolverRule
- GetResolverRule
- DeleteResolverRule
- ListResolverRules

### Resolver Rule Associations
- AssociateResolverRule
- DisassociateResolverRule
- ListResolverRuleAssociations

## Test plan
- [ ] Integration tests with AWS SDK v2
- [ ] Golden file validation (pending CI run)

Closes #127