### PR TITLE
feat(securitylake): implement AWS Security Lake service

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -226,6 +226,10 @@ linters:
       - path: internal/service/route53resolver/types\.go
         linters:
           - tagliatelle
+      # AWS Security Lake API requires specific JSON field names.
+      - path: internal/service/securitylake/types\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -52,6 +52,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/sagemaker"
 	_ "github.com/sivchari/awsim/internal/service/scheduler"
 	_ "github.com/sivchari/awsim/internal/service/secretsmanager"
+	_ "github.com/sivchari/awsim/internal/service/securitylake"
 	_ "github.com/sivchari/awsim/internal/service/servicequotas"
 	_ "github.com/sivchari/awsim/internal/service/sesv2"
 	_ "github.com/sivchari/awsim/internal/service/sfn"

--- a/internal/service/securitylake/handlers.go
+++ b/internal/service/securitylake/handlers.go
@@ -1,0 +1,329 @@
+package securitylake
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+)
+
+// CreateDataLake handles the CreateDataLake action.
+func (s *Service) CreateDataLake(w http.ResponseWriter, r *http.Request) {
+	var req CreateDataLakeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	dataLakes, err := s.storage.CreateDataLake(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &CreateDataLakeResponse{DataLakes: dataLakes})
+}
+
+// DeleteDataLake handles the DeleteDataLake action.
+func (s *Service) DeleteDataLake(w http.ResponseWriter, r *http.Request) {
+	var req DeleteDataLakeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	if err := s.storage.DeleteDataLake(r.Context(), req.Regions); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &DeleteDataLakeResponse{})
+}
+
+// ListDataLakes handles the ListDataLakes action.
+func (s *Service) ListDataLakes(w http.ResponseWriter, r *http.Request) {
+	regions := r.URL.Query()["regions"]
+
+	dataLakes, err := s.storage.ListDataLakes(r.Context(), regions)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &ListDataLakesResponse{DataLakes: dataLakes})
+}
+
+// UpdateDataLake handles the UpdateDataLake action.
+func (s *Service) UpdateDataLake(w http.ResponseWriter, r *http.Request) {
+	var req UpdateDataLakeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	dataLakes, err := s.storage.UpdateDataLake(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &UpdateDataLakeResponse{DataLakes: dataLakes})
+}
+
+// CreateSubscriber handles the CreateSubscriber action.
+func (s *Service) CreateSubscriber(w http.ResponseWriter, r *http.Request) {
+	var req CreateSubscriberRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	subscriber, err := s.storage.CreateSubscriber(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &CreateSubscriberResponse{Subscriber: subscriber})
+}
+
+// GetSubscriber handles the GetSubscriber action.
+func (s *Service) GetSubscriber(w http.ResponseWriter, r *http.Request) {
+	subscriberID := r.PathValue("subscriberId")
+
+	subscriber, err := s.storage.GetSubscriber(r.Context(), subscriberID)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &GetSubscriberResponse{Subscriber: subscriber})
+}
+
+// DeleteSubscriber handles the DeleteSubscriber action.
+func (s *Service) DeleteSubscriber(w http.ResponseWriter, r *http.Request) {
+	subscriberID := r.PathValue("subscriberId")
+
+	if err := s.storage.DeleteSubscriber(r.Context(), subscriberID); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &DeleteSubscriberResponse{})
+}
+
+// UpdateSubscriber handles the UpdateSubscriber action.
+func (s *Service) UpdateSubscriber(w http.ResponseWriter, r *http.Request) {
+	subscriberID := r.PathValue("subscriberId")
+
+	var req UpdateSubscriberRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	req.SubscriberID = subscriberID
+
+	subscriber, err := s.storage.UpdateSubscriber(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &UpdateSubscriberResponse{Subscriber: subscriber})
+}
+
+// ListSubscribers handles the ListSubscribers action.
+func (s *Service) ListSubscribers(w http.ResponseWriter, r *http.Request) {
+	maxResults := 0
+
+	if maxResultsStr := r.URL.Query().Get("maxResults"); maxResultsStr != "" {
+		var err error
+
+		maxResults, err = strconv.Atoi(maxResultsStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, errValidation, "Invalid maxResults")
+
+			return
+		}
+	}
+
+	nextToken := r.URL.Query().Get("nextToken")
+
+	subscribers, resultNextToken, err := s.storage.ListSubscribers(r.Context(), maxResults, nextToken)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &ListSubscribersResponse{
+		Subscribers: subscribers,
+		NextToken:   resultNextToken,
+	})
+}
+
+// CreateAwsLogSource handles the CreateAwsLogSource action.
+func (s *Service) CreateAwsLogSource(w http.ResponseWriter, r *http.Request) {
+	var req CreateAwsLogSourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	failed, err := s.storage.CreateAwsLogSource(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &CreateAwsLogSourceResponse{Failed: failed})
+}
+
+// DeleteAwsLogSource handles the DeleteAwsLogSource action.
+func (s *Service) DeleteAwsLogSource(w http.ResponseWriter, r *http.Request) {
+	var req DeleteAwsLogSourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	failed, err := s.storage.DeleteAwsLogSource(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &DeleteAwsLogSourceResponse{Failed: failed})
+}
+
+// ListLogSources handles the ListLogSources action.
+func (s *Service) ListLogSources(w http.ResponseWriter, r *http.Request) {
+	var req ListLogSourcesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	sources, nextToken, err := s.storage.ListLogSources(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &ListLogSourcesResponse{
+		Sources:   sources,
+		NextToken: nextToken,
+	})
+}
+
+// TagResource handles the TagResource action.
+func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
+	resourceARN := r.PathValue("resourceArn")
+
+	var req TagResourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	if err := s.storage.TagResource(r.Context(), resourceARN, req.Tags); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &TagResourceResponse{})
+}
+
+// UntagResource handles the UntagResource action.
+func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
+	resourceARN := r.PathValue("resourceArn")
+	tagKeys := r.URL.Query()["tagKeys"]
+
+	if err := s.storage.UntagResource(r.Context(), resourceARN, tagKeys); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &UntagResourceResponse{})
+}
+
+// ListTagsForResource handles the ListTagsForResource action.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
+	resourceARN := r.PathValue("resourceArn")
+
+	tags, err := s.storage.ListTagsForResource(r.Context(), resourceARN)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &ListTagsForResourceResponse{Tags: tags})
+}
+
+func writeJSON(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func writeError(w http.ResponseWriter, statusCode int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+
+	errResp := &Error{
+		Code:    code,
+		Message: message,
+	}
+
+	if err := json.NewEncoder(w).Encode(errResp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func handleStorageError(w http.ResponseWriter, err error) {
+	var slErr *Error
+
+	if errors.As(err, &slErr) {
+		statusCode := http.StatusBadRequest
+
+		switch slErr.Code {
+		case errResourceNotFound:
+			statusCode = http.StatusNotFound
+		case errConflict:
+			statusCode = http.StatusConflict
+		}
+
+		writeError(w, statusCode, slErr.Code, slErr.Message)
+
+		return
+	}
+
+	writeError(w, http.StatusInternalServerError, "InternalException", err.Error())
+}

--- a/internal/service/securitylake/service.go
+++ b/internal/service/securitylake/service.go
@@ -1,0 +1,58 @@
+package securitylake
+
+import "github.com/sivchari/awsim/internal/service"
+
+// Compile-time check to ensure Service implements service.Service.
+var _ service.Service = (*Service)(nil)
+
+func init() {
+	service.Register(New(NewMemoryStorage()))
+}
+
+// Service implements the Security Lake service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new Security Lake service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "securitylake"
+}
+
+// RegisterRoutes registers the Security Lake routes.
+func (s *Service) RegisterRoutes(r service.Router) {
+	// Data Lake operations
+	r.Handle("POST", "/v1/datalake", s.CreateDataLake)
+	r.Handle("POST", "/v1/datalake/delete", s.DeleteDataLake)
+	r.Handle("GET", "/v1/datalakes", s.ListDataLakes)
+	r.Handle("PUT", "/v1/datalake", s.UpdateDataLake)
+
+	// Subscriber operations
+	r.Handle("POST", "/v1/subscribers", s.CreateSubscriber)
+	r.Handle("GET", "/v1/subscribers/{subscriberId}", s.GetSubscriber)
+	r.Handle("DELETE", "/v1/subscribers/{subscriberId}", s.DeleteSubscriber)
+	r.Handle("PUT", "/v1/subscribers/{subscriberId}", s.UpdateSubscriber)
+	r.Handle("GET", "/v1/subscribers", s.ListSubscribers)
+
+	// Log Source operations
+	r.Handle("POST", "/v1/datalake/logsources/aws", s.CreateAwsLogSource)
+	r.Handle("POST", "/v1/datalake/logsources/aws/delete", s.DeleteAwsLogSource)
+	r.Handle("POST", "/v1/datalake/logsources/list", s.ListLogSources)
+
+	// Tag operations
+	r.Handle("POST", "/v1/tags/{resourceArn}", s.TagResource)
+	r.Handle("DELETE", "/v1/tags/{resourceArn}", s.UntagResource)
+	r.Handle("GET", "/v1/tags/{resourceArn}", s.ListTagsForResource)
+}
+
+// Prefix returns the URL prefix for Security Lake.
+func (s *Service) Prefix() string {
+	return "/securitylake"
+}

--- a/internal/service/securitylake/storage.go
+++ b/internal/service/securitylake/storage.go
@@ -1,0 +1,476 @@
+package securitylake
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	errResourceNotFound = "ResourceNotFoundException"
+	errConflict         = "ConflictException"
+	errValidation       = "ValidationException"
+
+	statusCompleted = "COMPLETED"
+	statusActive    = "ACTIVE"
+)
+
+// Storage is the interface for Security Lake storage operations.
+type Storage interface {
+	// Data Lake operations
+	CreateDataLake(ctx context.Context, req *CreateDataLakeRequest) ([]*DataLake, error)
+	DeleteDataLake(ctx context.Context, regions []string) error
+	ListDataLakes(ctx context.Context, regions []string) ([]*DataLake, error)
+	UpdateDataLake(ctx context.Context, req *UpdateDataLakeRequest) ([]*DataLake, error)
+
+	// Subscriber operations
+	CreateSubscriber(ctx context.Context, req *CreateSubscriberRequest) (*Subscriber, error)
+	GetSubscriber(ctx context.Context, subscriberID string) (*Subscriber, error)
+	DeleteSubscriber(ctx context.Context, subscriberID string) error
+	UpdateSubscriber(ctx context.Context, req *UpdateSubscriberRequest) (*Subscriber, error)
+	ListSubscribers(ctx context.Context, maxResults int, nextToken string) ([]*Subscriber, string, error)
+
+	// Log Source operations
+	CreateAwsLogSource(ctx context.Context, req *CreateAwsLogSourceRequest) ([]string, error)
+	DeleteAwsLogSource(ctx context.Context, req *DeleteAwsLogSourceRequest) ([]string, error)
+	ListLogSources(ctx context.Context, req *ListLogSourcesRequest) ([]*LogSource, string, error)
+
+	// Tag operations
+	TagResource(ctx context.Context, resourceARN string, tags []*Tag) error
+	UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error
+	ListTagsForResource(ctx context.Context, resourceARN string) ([]*Tag, error)
+}
+
+// MemoryStorage implements in-memory storage for Security Lake.
+type MemoryStorage struct {
+	mu          sync.RWMutex
+	dataLakes   map[string]*DataLake
+	subscribers map[string]*Subscriber
+	logSources  map[string]*LogSource
+	tags        map[string][]*Tag
+	accountID   string
+	region      string
+}
+
+// NewMemoryStorage creates a new in-memory storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		dataLakes:   make(map[string]*DataLake),
+		subscribers: make(map[string]*Subscriber),
+		logSources:  make(map[string]*LogSource),
+		tags:        make(map[string][]*Tag),
+		accountID:   "123456789012",
+		region:      "us-east-1",
+	}
+}
+
+// CreateDataLake creates new data lakes.
+func (s *MemoryStorage) CreateDataLake(_ context.Context, req *CreateDataLakeRequest) ([]*DataLake, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dataLakes := make([]*DataLake, 0, len(req.Configurations))
+
+	for _, config := range req.Configurations {
+		region := config.Region
+		if region == "" {
+			region = s.region
+		}
+
+		// Check if data lake already exists for this region
+		if _, exists := s.dataLakes[region]; exists {
+			return nil, &Error{
+				Code:    errConflict,
+				Message: fmt.Sprintf("Data lake already exists in region %s", region),
+			}
+		}
+
+		bucketName := fmt.Sprintf("aws-security-data-lake-%s-%s-%s", s.region, s.accountID, uuid.New().String()[:8])
+		arn := fmt.Sprintf("arn:aws:securitylake:%s:%s:data-lake/default", region, s.accountID)
+
+		dataLake := &DataLake{
+			ARN:                      arn,
+			CreateStatus:             statusCompleted,
+			EncryptionConfiguration:  config.EncryptionConfiguration,
+			LifecycleConfiguration:   config.LifecycleConfiguration,
+			Region:                   region,
+			ReplicationConfiguration: config.ReplicationConfiguration,
+			S3BucketARN:              fmt.Sprintf("arn:aws:s3:::%s", bucketName),
+		}
+
+		s.dataLakes[region] = dataLake
+
+		if len(req.Tags) > 0 {
+			s.tags[arn] = req.Tags
+		}
+
+		dataLakes = append(dataLakes, dataLake)
+	}
+
+	return dataLakes, nil
+}
+
+// DeleteDataLake deletes data lakes.
+func (s *MemoryStorage) DeleteDataLake(_ context.Context, regions []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, region := range regions {
+		dataLake, exists := s.dataLakes[region]
+		if !exists {
+			return &Error{
+				Code:    errResourceNotFound,
+				Message: fmt.Sprintf("Data lake not found in region %s", region),
+			}
+		}
+
+		delete(s.tags, dataLake.ARN)
+		delete(s.dataLakes, region)
+	}
+
+	return nil
+}
+
+// ListDataLakes lists data lakes.
+func (s *MemoryStorage) ListDataLakes(_ context.Context, regions []string) ([]*DataLake, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dataLakes := make([]*DataLake, 0)
+
+	if len(regions) == 0 {
+		for _, dataLake := range s.dataLakes {
+			dataLakes = append(dataLakes, dataLake)
+		}
+	} else {
+		for _, region := range regions {
+			if dataLake, exists := s.dataLakes[region]; exists {
+				dataLakes = append(dataLakes, dataLake)
+			}
+		}
+	}
+
+	return dataLakes, nil
+}
+
+// UpdateDataLake updates data lakes.
+func (s *MemoryStorage) UpdateDataLake(_ context.Context, req *UpdateDataLakeRequest) ([]*DataLake, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dataLakes := make([]*DataLake, 0, len(req.Configurations))
+
+	for _, config := range req.Configurations {
+		region := config.Region
+		if region == "" {
+			region = s.region
+		}
+
+		dataLake, exists := s.dataLakes[region]
+		if !exists {
+			return nil, &Error{
+				Code:    errResourceNotFound,
+				Message: fmt.Sprintf("Data lake not found in region %s", region),
+			}
+		}
+
+		if config.EncryptionConfiguration != nil {
+			dataLake.EncryptionConfiguration = config.EncryptionConfiguration
+		}
+
+		if config.LifecycleConfiguration != nil {
+			dataLake.LifecycleConfiguration = config.LifecycleConfiguration
+		}
+
+		if config.ReplicationConfiguration != nil {
+			dataLake.ReplicationConfiguration = config.ReplicationConfiguration
+		}
+
+		dataLakes = append(dataLakes, dataLake)
+	}
+
+	return dataLakes, nil
+}
+
+// CreateSubscriber creates a new subscriber.
+func (s *MemoryStorage) CreateSubscriber(_ context.Context, req *CreateSubscriberRequest) (*Subscriber, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check for duplicate subscriber name
+	for _, sub := range s.subscribers {
+		if sub.SubscriberName == req.SubscriberName {
+			return nil, &Error{
+				Code:    errConflict,
+				Message: fmt.Sprintf("Subscriber with name %s already exists", req.SubscriberName),
+			}
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	subscriberID := uuid.New().String()
+	arn := fmt.Sprintf("arn:aws:securitylake:%s:%s:subscriber/%s", s.region, s.accountID, subscriberID)
+
+	subscriber := &Subscriber{
+		AccessTypes:           req.AccessTypes,
+		CreatedAt:             now,
+		Sources:               req.Sources,
+		SubscriberARN:         arn,
+		SubscriberDescription: req.SubscriberDescription,
+		SubscriberID:          subscriberID,
+		SubscriberIdentity:    req.SubscriberIdentity,
+		SubscriberName:        req.SubscriberName,
+		SubscriberStatus:      statusActive,
+		UpdatedAt:             now,
+	}
+
+	s.subscribers[subscriberID] = subscriber
+
+	if len(req.Tags) > 0 {
+		s.tags[arn] = req.Tags
+	}
+
+	return subscriber, nil
+}
+
+// GetSubscriber retrieves a subscriber by ID.
+func (s *MemoryStorage) GetSubscriber(_ context.Context, subscriberID string) (*Subscriber, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	subscriber, exists := s.subscribers[subscriberID]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Subscriber with ID %s not found", subscriberID),
+		}
+	}
+
+	return subscriber, nil
+}
+
+// DeleteSubscriber deletes a subscriber.
+func (s *MemoryStorage) DeleteSubscriber(_ context.Context, subscriberID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	subscriber, exists := s.subscribers[subscriberID]
+	if !exists {
+		return &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Subscriber with ID %s not found", subscriberID),
+		}
+	}
+
+	delete(s.tags, subscriber.SubscriberARN)
+	delete(s.subscribers, subscriberID)
+
+	return nil
+}
+
+// UpdateSubscriber updates a subscriber.
+func (s *MemoryStorage) UpdateSubscriber(_ context.Context, req *UpdateSubscriberRequest) (*Subscriber, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	subscriber, exists := s.subscribers[req.SubscriberID]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Subscriber with ID %s not found", req.SubscriberID),
+		}
+	}
+
+	if req.SubscriberName != "" {
+		subscriber.SubscriberName = req.SubscriberName
+	}
+
+	if req.SubscriberDescription != "" {
+		subscriber.SubscriberDescription = req.SubscriberDescription
+	}
+
+	if req.SubscriberIdentity != nil {
+		subscriber.SubscriberIdentity = req.SubscriberIdentity
+	}
+
+	if len(req.Sources) > 0 {
+		subscriber.Sources = req.Sources
+	}
+
+	subscriber.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+
+	return subscriber, nil
+}
+
+// ListSubscribers lists subscribers.
+func (s *MemoryStorage) ListSubscribers(_ context.Context, maxResults int, _ string) ([]*Subscriber, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults == 0 {
+		maxResults = 10
+	}
+
+	subscribers := make([]*Subscriber, 0, len(s.subscribers))
+
+	for _, subscriber := range s.subscribers {
+		subscribers = append(subscribers, subscriber)
+
+		if len(subscribers) >= maxResults {
+			break
+		}
+	}
+
+	return subscribers, "", nil
+}
+
+// CreateAwsLogSource creates AWS log sources.
+func (s *MemoryStorage) CreateAwsLogSource(_ context.Context, req *CreateAwsLogSourceRequest) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	failed := make([]string, 0)
+
+	for _, source := range req.Sources {
+		for _, region := range source.Regions {
+			key := fmt.Sprintf("%s-%s-%s", source.SourceName, region, s.accountID)
+
+			logSource := &LogSource{
+				Account: s.accountID,
+				Region:  region,
+				Sources: []*LogSourceResource{
+					{
+						AwsLogSource: &AwsLogSourceResource{
+							SourceName:    source.SourceName,
+							SourceVersion: source.SourceVersion,
+						},
+					},
+				},
+			}
+
+			s.logSources[key] = logSource
+		}
+	}
+
+	return failed, nil
+}
+
+// DeleteAwsLogSource deletes AWS log sources.
+func (s *MemoryStorage) DeleteAwsLogSource(_ context.Context, req *DeleteAwsLogSourceRequest) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	failed := make([]string, 0)
+
+	for _, source := range req.Sources {
+		for _, region := range source.Regions {
+			key := fmt.Sprintf("%s-%s-%s", source.SourceName, region, s.accountID)
+
+			delete(s.logSources, key)
+		}
+	}
+
+	return failed, nil
+}
+
+// ListLogSources lists log sources.
+func (s *MemoryStorage) ListLogSources(_ context.Context, req *ListLogSourcesRequest) ([]*LogSource, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	maxResults := req.MaxResults
+	if maxResults == 0 {
+		maxResults = 10
+	}
+
+	sources := make([]*LogSource, 0, len(s.logSources))
+
+	for _, source := range s.logSources {
+		// Filter by regions if specified
+		if len(req.Regions) > 0 && !slices.Contains(req.Regions, source.Region) {
+			continue
+		}
+
+		// Filter by accounts if specified
+		if len(req.Accounts) > 0 && !slices.Contains(req.Accounts, source.Account) {
+			continue
+		}
+
+		sources = append(sources, source)
+
+		if len(sources) >= maxResults {
+			break
+		}
+	}
+
+	return sources, "", nil
+}
+
+// TagResource adds tags to a resource.
+func (s *MemoryStorage) TagResource(_ context.Context, resourceARN string, tags []*Tag) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existingTags := s.tags[resourceARN]
+	tagMap := make(map[string]string)
+
+	for _, tag := range existingTags {
+		tagMap[tag.Key] = tag.Value
+	}
+
+	for _, tag := range tags {
+		tagMap[tag.Key] = tag.Value
+	}
+
+	newTags := make([]*Tag, 0, len(tagMap))
+
+	for k, v := range tagMap {
+		newTags = append(newTags, &Tag{Key: k, Value: v})
+	}
+
+	s.tags[resourceARN] = newTags
+
+	return nil
+}
+
+// UntagResource removes tags from a resource.
+func (s *MemoryStorage) UntagResource(_ context.Context, resourceARN string, tagKeys []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existingTags := s.tags[resourceARN]
+	keySet := make(map[string]bool)
+
+	for _, key := range tagKeys {
+		keySet[key] = true
+	}
+
+	newTags := make([]*Tag, 0)
+
+	for _, tag := range existingTags {
+		if !keySet[tag.Key] {
+			newTags = append(newTags, tag)
+		}
+	}
+
+	s.tags[resourceARN] = newTags
+
+	return nil
+}
+
+// ListTagsForResource lists tags for a resource.
+func (s *MemoryStorage) ListTagsForResource(_ context.Context, resourceARN string) ([]*Tag, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tags := s.tags[resourceARN]
+	if tags == nil {
+		tags = make([]*Tag, 0)
+	}
+
+	return tags, nil
+}

--- a/internal/service/securitylake/types.go
+++ b/internal/service/securitylake/types.go
@@ -1,0 +1,318 @@
+// Package securitylake provides an in-memory implementation of AWS Security Lake.
+package securitylake
+
+// Error represents an error response.
+type Error struct {
+	Code    string `json:"__type"`
+	Message string `json:"message"`
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return e.Message
+}
+
+// DataLake represents a Security Lake data lake.
+type DataLake struct {
+	ARN                      string                    `json:"dataLakeArn,omitempty"`
+	CreateStatus             string                    `json:"createStatus,omitempty"`
+	EncryptionConfiguration  *EncryptionConfiguration  `json:"encryptionConfiguration,omitempty"`
+	LifecycleConfiguration   *LifecycleConfiguration   `json:"lifecycleConfiguration,omitempty"`
+	Region                   string                    `json:"region,omitempty"`
+	ReplicationConfiguration *ReplicationConfiguration `json:"replicationConfiguration,omitempty"`
+	S3BucketARN              string                    `json:"s3BucketArn,omitempty"`
+	UpdateStatus             *DataLakeUpdateStatus     `json:"updateStatus,omitempty"`
+}
+
+// EncryptionConfiguration represents the encryption configuration for a data lake.
+type EncryptionConfiguration struct {
+	KmsKeyID string `json:"kmsKeyId,omitempty"`
+}
+
+// LifecycleConfiguration represents the lifecycle configuration for a data lake.
+type LifecycleConfiguration struct {
+	Expiration  *Expiration   `json:"expiration,omitempty"`
+	Transitions []*Transition `json:"transitions,omitempty"`
+}
+
+// Expiration represents the expiration settings.
+type Expiration struct {
+	Days int `json:"days,omitempty"`
+}
+
+// Transition represents a storage class transition.
+type Transition struct {
+	Days         int    `json:"days,omitempty"`
+	StorageClass string `json:"storageClass,omitempty"`
+}
+
+// ReplicationConfiguration represents the replication configuration.
+type ReplicationConfiguration struct {
+	Regions []string `json:"regions,omitempty"`
+	RoleARN string   `json:"roleArn,omitempty"`
+}
+
+// DataLakeUpdateStatus represents the update status of a data lake.
+type DataLakeUpdateStatus struct {
+	Exception *DataLakeException `json:"exception,omitempty"`
+	RequestID string             `json:"requestId,omitempty"`
+	Status    string             `json:"status,omitempty"`
+}
+
+// DataLakeException represents an exception that occurred.
+type DataLakeException struct {
+	Exception   string `json:"exception,omitempty"`
+	Region      string `json:"region,omitempty"`
+	Remediation string `json:"remediation,omitempty"`
+	Timestamp   string `json:"timestamp,omitempty"`
+}
+
+// DataLakeConfiguration represents the configuration for creating a data lake.
+type DataLakeConfiguration struct {
+	EncryptionConfiguration  *EncryptionConfiguration  `json:"encryptionConfiguration,omitempty"`
+	LifecycleConfiguration   *LifecycleConfiguration   `json:"lifecycleConfiguration,omitempty"`
+	Region                   string                    `json:"region,omitempty"`
+	ReplicationConfiguration *ReplicationConfiguration `json:"replicationConfiguration,omitempty"`
+}
+
+// Subscriber represents a Security Lake subscriber.
+type Subscriber struct {
+	AccessTypes           []string             `json:"accessTypes,omitempty"`
+	CreatedAt             string               `json:"createdAt,omitempty"`
+	ResourceShareARN      string               `json:"resourceShareArn,omitempty"`
+	ResourceShareName     string               `json:"resourceShareName,omitempty"`
+	RoleARN               string               `json:"roleArn,omitempty"`
+	S3BucketARN           string               `json:"s3BucketArn,omitempty"`
+	Sources               []*LogSourceResource `json:"sources,omitempty"`
+	SubscriberARN         string               `json:"subscriberArn,omitempty"`
+	SubscriberDescription string               `json:"subscriberDescription,omitempty"`
+	SubscriberEndpoint    string               `json:"subscriberEndpoint,omitempty"`
+	SubscriberID          string               `json:"subscriberId,omitempty"`
+	SubscriberIdentity    *SubscriberIdentity  `json:"subscriberIdentity,omitempty"`
+	SubscriberName        string               `json:"subscriberName,omitempty"`
+	SubscriberStatus      string               `json:"subscriberStatus,omitempty"`
+	UpdatedAt             string               `json:"updatedAt,omitempty"`
+}
+
+// SubscriberIdentity represents the identity of a subscriber.
+type SubscriberIdentity struct {
+	ExternalID string `json:"externalId,omitempty"`
+	Principal  string `json:"principal,omitempty"`
+}
+
+// LogSourceResource represents a log source resource.
+type LogSourceResource struct {
+	AwsLogSource    *AwsLogSourceResource    `json:"awsLogSource,omitempty"`
+	CustomLogSource *CustomLogSourceResource `json:"customLogSource,omitempty"`
+}
+
+// AwsLogSourceResource represents an AWS log source resource.
+type AwsLogSourceResource struct {
+	SourceName    string `json:"sourceName,omitempty"`
+	SourceVersion string `json:"sourceVersion,omitempty"`
+}
+
+// CustomLogSourceResource represents a custom log source resource.
+type CustomLogSourceResource struct {
+	Attributes    *CustomLogSourceAttributes `json:"attributes,omitempty"`
+	Provider      *CustomLogSourceProvider   `json:"provider,omitempty"`
+	SourceName    string                     `json:"sourceName,omitempty"`
+	SourceVersion string                     `json:"sourceVersion,omitempty"`
+}
+
+// CustomLogSourceAttributes represents custom log source attributes.
+type CustomLogSourceAttributes struct {
+	CrawlerARN  string `json:"crawlerArn,omitempty"`
+	DatabaseARN string `json:"databaseArn,omitempty"`
+	TableARN    string `json:"tableArn,omitempty"`
+}
+
+// CustomLogSourceProvider represents a custom log source provider.
+type CustomLogSourceProvider struct {
+	Location string `json:"location,omitempty"`
+	RoleARN  string `json:"roleArn,omitempty"`
+}
+
+// Tag represents a resource tag.
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// CreateDataLakeRequest represents a CreateDataLake request.
+type CreateDataLakeRequest struct {
+	Configurations          []*DataLakeConfiguration `json:"configurations"`
+	MetaStoreManagerRoleARN string                   `json:"metaStoreManagerRoleArn,omitempty"`
+	Tags                    []*Tag                   `json:"tags,omitempty"`
+}
+
+// CreateDataLakeResponse represents a CreateDataLake response.
+type CreateDataLakeResponse struct {
+	DataLakes []*DataLake `json:"dataLakes,omitempty"`
+}
+
+// DeleteDataLakeRequest represents a DeleteDataLake request.
+type DeleteDataLakeRequest struct {
+	Regions []string `json:"regions"`
+}
+
+// DeleteDataLakeResponse represents a DeleteDataLake response.
+type DeleteDataLakeResponse struct{}
+
+// ListDataLakesRequest represents a ListDataLakes request.
+type ListDataLakesRequest struct {
+	Regions []string `json:"regions,omitempty"`
+}
+
+// ListDataLakesResponse represents a ListDataLakes response.
+type ListDataLakesResponse struct {
+	DataLakes []*DataLake `json:"dataLakes,omitempty"`
+}
+
+// UpdateDataLakeRequest represents an UpdateDataLake request.
+type UpdateDataLakeRequest struct {
+	Configurations          []*DataLakeConfiguration `json:"configurations"`
+	MetaStoreManagerRoleARN string                   `json:"metaStoreManagerRoleArn,omitempty"`
+}
+
+// UpdateDataLakeResponse represents an UpdateDataLake response.
+type UpdateDataLakeResponse struct {
+	DataLakes []*DataLake `json:"dataLakes,omitempty"`
+}
+
+// CreateSubscriberRequest represents a CreateSubscriber request.
+type CreateSubscriberRequest struct {
+	AccessTypes           []string             `json:"accessTypes,omitempty"`
+	Sources               []*LogSourceResource `json:"sources"`
+	SubscriberDescription string               `json:"subscriberDescription,omitempty"`
+	SubscriberIdentity    *SubscriberIdentity  `json:"subscriberIdentity"`
+	SubscriberName        string               `json:"subscriberName"`
+	Tags                  []*Tag               `json:"tags,omitempty"`
+}
+
+// CreateSubscriberResponse represents a CreateSubscriber response.
+type CreateSubscriberResponse struct {
+	Subscriber *Subscriber `json:"subscriber,omitempty"`
+}
+
+// GetSubscriberRequest represents a GetSubscriber request.
+type GetSubscriberRequest struct {
+	SubscriberID string `json:"subscriberId"`
+}
+
+// GetSubscriberResponse represents a GetSubscriber response.
+type GetSubscriberResponse struct {
+	Subscriber *Subscriber `json:"subscriber,omitempty"`
+}
+
+// DeleteSubscriberRequest represents a DeleteSubscriber request.
+type DeleteSubscriberRequest struct {
+	SubscriberID string `json:"subscriberId"`
+}
+
+// DeleteSubscriberResponse represents a DeleteSubscriber response.
+type DeleteSubscriberResponse struct{}
+
+// UpdateSubscriberRequest represents an UpdateSubscriber request.
+type UpdateSubscriberRequest struct {
+	Sources               []*LogSourceResource `json:"sources,omitempty"`
+	SubscriberDescription string               `json:"subscriberDescription,omitempty"`
+	SubscriberID          string               `json:"subscriberId"`
+	SubscriberIdentity    *SubscriberIdentity  `json:"subscriberIdentity,omitempty"`
+	SubscriberName        string               `json:"subscriberName,omitempty"`
+}
+
+// UpdateSubscriberResponse represents an UpdateSubscriber response.
+type UpdateSubscriberResponse struct {
+	Subscriber *Subscriber `json:"subscriber,omitempty"`
+}
+
+// ListSubscribersRequest represents a ListSubscribers request.
+type ListSubscribersRequest struct {
+	MaxResults int    `json:"maxResults,omitempty"`
+	NextToken  string `json:"nextToken,omitempty"`
+}
+
+// ListSubscribersResponse represents a ListSubscribers response.
+type ListSubscribersResponse struct {
+	NextToken   string        `json:"nextToken,omitempty"`
+	Subscribers []*Subscriber `json:"subscribers,omitempty"`
+}
+
+// CreateAwsLogSourceRequest represents a CreateAwsLogSource request.
+type CreateAwsLogSourceRequest struct {
+	Sources []*AwsLogSourceConfiguration `json:"sources"`
+}
+
+// AwsLogSourceConfiguration represents an AWS log source configuration.
+type AwsLogSourceConfiguration struct {
+	Accounts      []string `json:"accounts,omitempty"`
+	Regions       []string `json:"regions"`
+	SourceName    string   `json:"sourceName"`
+	SourceVersion string   `json:"sourceVersion,omitempty"`
+}
+
+// CreateAwsLogSourceResponse represents a CreateAwsLogSource response.
+type CreateAwsLogSourceResponse struct {
+	Failed []string `json:"failed,omitempty"`
+}
+
+// DeleteAwsLogSourceRequest represents a DeleteAwsLogSource request.
+type DeleteAwsLogSourceRequest struct {
+	Sources []*AwsLogSourceConfiguration `json:"sources"`
+}
+
+// DeleteAwsLogSourceResponse represents a DeleteAwsLogSource response.
+type DeleteAwsLogSourceResponse struct {
+	Failed []string `json:"failed,omitempty"`
+}
+
+// ListLogSourcesRequest represents a ListLogSources request.
+type ListLogSourcesRequest struct {
+	Accounts   []string             `json:"accounts,omitempty"`
+	MaxResults int                  `json:"maxResults,omitempty"`
+	NextToken  string               `json:"nextToken,omitempty"`
+	Regions    []string             `json:"regions,omitempty"`
+	Sources    []*LogSourceResource `json:"sources,omitempty"`
+}
+
+// LogSource represents a log source.
+type LogSource struct {
+	Account string               `json:"account,omitempty"`
+	Region  string               `json:"region,omitempty"`
+	Sources []*LogSourceResource `json:"sources,omitempty"`
+}
+
+// ListLogSourcesResponse represents a ListLogSources response.
+type ListLogSourcesResponse struct {
+	NextToken string       `json:"nextToken,omitempty"`
+	Sources   []*LogSource `json:"sources,omitempty"`
+}
+
+// TagResourceRequest represents a TagResource request.
+type TagResourceRequest struct {
+	ResourceARN string `json:"resourceArn"`
+	Tags        []*Tag `json:"tags"`
+}
+
+// TagResourceResponse represents a TagResource response.
+type TagResourceResponse struct{}
+
+// UntagResourceRequest represents an UntagResource request.
+type UntagResourceRequest struct {
+	ResourceARN string   `json:"resourceArn"`
+	TagKeys     []string `json:"tagKeys"`
+}
+
+// UntagResourceResponse represents an UntagResource response.
+type UntagResourceResponse struct{}
+
+// ListTagsForResourceRequest represents a ListTagsForResource request.
+type ListTagsForResourceRequest struct {
+	ResourceARN string `json:"resourceArn"`
+}
+
+// ListTagsForResourceResponse represents a ListTagsForResource response.
+type ListTagsForResourceResponse struct {
+	Tags []*Tag `json:"tags,omitempty"`
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.18 // indirect
+	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -118,6 +118,8 @@ github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.19 h1:Jsz0LdqfucS8YM1E6pbcu
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.19/go.mod h1:LbJJ7RHzglcg4ogjIOMsyuw+GSAYXipEaikJGDkKAxY=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1 h1:72DBkm/CCuWx2LMHAXvLDkZfzopT3psfAeyZDIt1/yE=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1/go.mod h1:A+oSJxFvzgjZWkpM0mXs3RxB5O1SD6473w3qafOC9eU=
+github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.10 h1:6xbHSTjP6Zqs6N2qX8eBaLxcFk4vP6Mqjsx/TPh/Whc=
+github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.10/go.mod h1:h1PveMN8Tj7U8cVnpCJyzs3MmqTRtYOHaQUoyaYlje4=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.34.2 h1:sm6NBL6B4zM9NwDukeXb9j6/aYRrBWtMjEwmSpc+Bss=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.34.2/go.mod h1:5X/vFNucNV7Ab1dqsncCnenSs/AbZH8cv8I30feCpdg=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.59.1 h1:0Pitfk3kTCUeJp+7xvTYhdgwVQhszqw1i4s8U93Z/ds=

--- a/test/integration/securitylake_test.go
+++ b/test/integration/securitylake_test.go
@@ -1,0 +1,240 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/securitylake"
+	"github.com/aws/aws-sdk-go-v2/service/securitylake/types"
+	"github.com/sivchari/golden"
+)
+
+func newSecurityLakeClient(t *testing.T) *securitylake.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return securitylake.NewFromConfig(cfg, func(o *securitylake.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestSecurityLake_CreateAndDeleteDataLake(t *testing.T) {
+	client := newSecurityLakeClient(t)
+	ctx := t.Context()
+
+	// Create data lake.
+	createOutput, err := client.CreateDataLake(ctx, &securitylake.CreateDataLakeInput{
+		MetaStoreManagerRoleArn: aws.String("arn:aws:iam::123456789012:role/AmazonSecurityLakeMetaStoreManager"),
+		Configurations: []types.DataLakeConfiguration{
+			{
+				Region: aws.String("us-east-1"),
+				EncryptionConfiguration: &types.DataLakeEncryptionConfiguration{
+					KmsKeyId: aws.String("alias/aws/securitylake"),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "DataLakeArn", "S3BucketArn"),
+	)
+	g.Assert("create", createOutput)
+
+	// List data lakes.
+	listOutput, err := client.ListDataLakes(ctx, &securitylake.ListDataLakesInput{
+		Regions: []string{"us-east-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "DataLakeArn", "S3BucketArn"),
+	)
+	g2.Assert("list", listOutput)
+
+	// Delete data lake.
+	_, err = client.DeleteDataLake(ctx, &securitylake.DeleteDataLakeInput{
+		Regions: []string{"us-east-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSecurityLake_CreateAndDeleteSubscriber(t *testing.T) {
+	client := newSecurityLakeClient(t)
+	ctx := t.Context()
+
+	// First create a data lake.
+	_, err := client.CreateDataLake(ctx, &securitylake.CreateDataLakeInput{
+		MetaStoreManagerRoleArn: aws.String("arn:aws:iam::123456789012:role/AmazonSecurityLakeMetaStoreManager"),
+		Configurations: []types.DataLakeConfiguration{
+			{
+				Region: aws.String("us-west-1"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteDataLake(t.Context(), &securitylake.DeleteDataLakeInput{
+			Regions: []string{"us-west-1"},
+		})
+	})
+
+	// Create subscriber.
+	createOutput, err := client.CreateSubscriber(ctx, &securitylake.CreateSubscriberInput{
+		SubscriberName: aws.String("test-subscriber"),
+		SubscriberIdentity: &types.AwsIdentity{
+			ExternalId: aws.String("test-external-id"),
+			Principal:  aws.String("123456789012"),
+		},
+		Sources: []types.LogSourceResource{
+			&types.LogSourceResourceMemberAwsLogSource{
+				Value: types.AwsLogSourceResource{
+					SourceName:    types.AwsLogSourceNameCloudTrailMgmt,
+					SourceVersion: aws.String("1.0"),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subscriberID := *createOutput.Subscriber.SubscriberId
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "SubscriberId", "SubscriberArn", "CreatedAt", "UpdatedAt"),
+	)
+	g.Assert("create", createOutput)
+
+	// Get subscriber.
+	getOutput, err := client.GetSubscriber(ctx, &securitylake.GetSubscriberInput{
+		SubscriberId: aws.String(subscriberID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "SubscriberId", "SubscriberArn", "CreatedAt", "UpdatedAt"),
+	)
+	g2.Assert("get", getOutput)
+
+	// List subscribers.
+	listOutput, err := client.ListSubscribers(ctx, &securitylake.ListSubscribersInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g3 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "SubscriberId", "SubscriberArn", "CreatedAt", "UpdatedAt"),
+	)
+	g3.Assert("list", listOutput)
+
+	// Delete subscriber.
+	_, err = client.DeleteSubscriber(ctx, &securitylake.DeleteSubscriberInput{
+		SubscriberId: aws.String(subscriberID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify it's deleted - should return error.
+	_, err = client.GetSubscriber(ctx, &securitylake.GetSubscriberInput{
+		SubscriberId: aws.String(subscriberID),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestSecurityLake_CreateAndDeleteAwsLogSource(t *testing.T) {
+	client := newSecurityLakeClient(t)
+	ctx := t.Context()
+
+	// First create a data lake.
+	_, err := client.CreateDataLake(ctx, &securitylake.CreateDataLakeInput{
+		MetaStoreManagerRoleArn: aws.String("arn:aws:iam::123456789012:role/AmazonSecurityLakeMetaStoreManager"),
+		Configurations: []types.DataLakeConfiguration{
+			{
+				Region: aws.String("eu-west-1"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteDataLake(t.Context(), &securitylake.DeleteDataLakeInput{
+			Regions: []string{"eu-west-1"},
+		})
+	})
+
+	// Create AWS log source.
+	createOutput, err := client.CreateAwsLogSource(ctx, &securitylake.CreateAwsLogSourceInput{
+		Sources: []types.AwsLogSourceConfiguration{
+			{
+				SourceName:    types.AwsLogSourceNameCloudTrailMgmt,
+				SourceVersion: aws.String("1.0"),
+				Regions:       []string{"eu-west-1"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata"),
+	)
+	g.Assert("create", createOutput)
+
+	// List log sources.
+	listOutput, err := client.ListLogSources(ctx, &securitylake.ListLogSourcesInput{
+		Regions: []string{"eu-west-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata"),
+	)
+	g2.Assert("list", listOutput)
+
+	// Delete AWS log source.
+	_, err = client.DeleteAwsLogSource(ctx, &securitylake.DeleteAwsLogSourceInput{
+		Sources: []types.AwsLogSourceConfiguration{
+			{
+				SourceName:    types.AwsLogSourceNameCloudTrailMgmt,
+				SourceVersion: aws.String("1.0"),
+				Regions:       []string{"eu-west-1"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteAwsLogSource_create.golden.go
+++ b/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteAwsLogSource_create.golden.go
@@ -1,0 +1,4 @@
+{
+  "Failed": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteAwsLogSource_list.golden.go
+++ b/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteAwsLogSource_list.golden.go
@@ -1,0 +1,18 @@
+{
+  "NextToken": null,
+  "Sources": [
+    {
+      "Account": "123456789012",
+      "Region": "eu-west-1",
+      "Sources": [
+        {
+          "Value": {
+            "SourceName": "CLOUD_TRAIL_MGMT",
+            "SourceVersion": "1.0"
+          }
+        }
+      ]
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteDataLake_create.golden.go
+++ b/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteDataLake_create.golden.go
@@ -1,0 +1,17 @@
+{
+  "DataLakes": [
+    {
+      "DataLakeArn": "arn:aws:securitylake:us-east-1:123456789012:data-lake/default",
+      "Region": "us-east-1",
+      "CreateStatus": "COMPLETED",
+      "EncryptionConfiguration": {
+        "KmsKeyId": "alias/aws/securitylake"
+      },
+      "LifecycleConfiguration": null,
+      "ReplicationConfiguration": null,
+      "S3BucketArn": "arn:aws:s3:::aws-security-data-lake-us-east-1-123456789012-3e283d26",
+      "UpdateStatus": null
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteDataLake_list.golden.go
+++ b/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteDataLake_list.golden.go
@@ -1,0 +1,17 @@
+{
+  "DataLakes": [
+    {
+      "DataLakeArn": "arn:aws:securitylake:us-east-1:123456789012:data-lake/default",
+      "Region": "us-east-1",
+      "CreateStatus": "COMPLETED",
+      "EncryptionConfiguration": {
+        "KmsKeyId": "alias/aws/securitylake"
+      },
+      "LifecycleConfiguration": null,
+      "ReplicationConfiguration": null,
+      "S3BucketArn": "arn:aws:s3:::aws-security-data-lake-us-east-1-123456789012-3e283d26",
+      "UpdateStatus": null
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteSubscriber_create.golden.go
+++ b/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteSubscriber_create.golden.go
@@ -1,0 +1,30 @@
+{
+  "Subscriber": {
+    "Sources": [
+      {
+        "Value": {
+          "SourceName": "CLOUD_TRAIL_MGMT",
+          "SourceVersion": "1.0"
+        }
+      }
+    ],
+    "SubscriberArn": "arn:aws:securitylake:us-east-1:123456789012:subscriber/fa363911-374b-45ab-b840-ee81778ddef5",
+    "SubscriberId": "fa363911-374b-45ab-b840-ee81778ddef5",
+    "SubscriberIdentity": {
+      "ExternalId": "test-external-id",
+      "Principal": "123456789012"
+    },
+    "SubscriberName": "test-subscriber",
+    "AccessTypes": null,
+    "CreatedAt": "2026-02-27T15:18:19Z",
+    "ResourceShareArn": null,
+    "ResourceShareName": null,
+    "RoleArn": null,
+    "S3BucketArn": null,
+    "SubscriberDescription": null,
+    "SubscriberEndpoint": null,
+    "SubscriberStatus": "ACTIVE",
+    "UpdatedAt": "2026-02-27T15:18:19Z"
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteSubscriber_get.golden.go
+++ b/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteSubscriber_get.golden.go
@@ -1,0 +1,30 @@
+{
+  "Subscriber": {
+    "Sources": [
+      {
+        "Value": {
+          "SourceName": "CLOUD_TRAIL_MGMT",
+          "SourceVersion": "1.0"
+        }
+      }
+    ],
+    "SubscriberArn": "arn:aws:securitylake:us-east-1:123456789012:subscriber/fa363911-374b-45ab-b840-ee81778ddef5",
+    "SubscriberId": "fa363911-374b-45ab-b840-ee81778ddef5",
+    "SubscriberIdentity": {
+      "ExternalId": "test-external-id",
+      "Principal": "123456789012"
+    },
+    "SubscriberName": "test-subscriber",
+    "AccessTypes": null,
+    "CreatedAt": "2026-02-27T15:18:19Z",
+    "ResourceShareArn": null,
+    "ResourceShareName": null,
+    "RoleArn": null,
+    "S3BucketArn": null,
+    "SubscriberDescription": null,
+    "SubscriberEndpoint": null,
+    "SubscriberStatus": "ACTIVE",
+    "UpdatedAt": "2026-02-27T15:18:19Z"
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteSubscriber_list.golden.go
+++ b/test/integration/testdata/securitylake_test_TestSecurityLake_CreateAndDeleteSubscriber_list.golden.go
@@ -1,0 +1,33 @@
+{
+  "NextToken": null,
+  "Subscribers": [
+    {
+      "Sources": [
+        {
+          "Value": {
+            "SourceName": "CLOUD_TRAIL_MGMT",
+            "SourceVersion": "1.0"
+          }
+        }
+      ],
+      "SubscriberArn": "arn:aws:securitylake:us-east-1:123456789012:subscriber/fa363911-374b-45ab-b840-ee81778ddef5",
+      "SubscriberId": "fa363911-374b-45ab-b840-ee81778ddef5",
+      "SubscriberIdentity": {
+        "ExternalId": "test-external-id",
+        "Principal": "123456789012"
+      },
+      "SubscriberName": "test-subscriber",
+      "AccessTypes": null,
+      "CreatedAt": "2026-02-27T15:18:19Z",
+      "ResourceShareArn": null,
+      "ResourceShareName": null,
+      "RoleArn": null,
+      "S3BucketArn": null,
+      "SubscriberDescription": null,
+      "SubscriberEndpoint": null,
+      "SubscriberStatus": "ACTIVE",
+      "UpdatedAt": "2026-02-27T15:18:19Z"
+    }
+  ],
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
- Add AWS Security Lake service implementation with in-memory storage
- Implement Data Lake, Subscriber, AWS Log Source, and Tag operations
- Add integration tests with golden file assertions

## Test plan
- [x] Run `make lint` - all checks pass
- [x] Run integration tests via `docker compose up -d --build` then `cd test && GOLDEN_UPDATE=true go test -tags=integration -run TestSecurityLake ./integration/... -v`
- [x] Verify golden files are generated correctly

Closes #174