### PR TITLE
feat(finspace): implement AWS FinSpace service

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -230,6 +230,10 @@ linters:
       - path: internal/service/securitylake/types\.go
         linters:
           - tagliatelle
+      # AWS FinSpace API requires specific JSON field names.
+      - path: internal/service/finspace/types\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/elbv2"
 	_ "github.com/sivchari/awsim/internal/service/emrserverless"
 	_ "github.com/sivchari/awsim/internal/service/eventbridge"
+	_ "github.com/sivchari/awsim/internal/service/finspace"
 	_ "github.com/sivchari/awsim/internal/service/firehose"
 	_ "github.com/sivchari/awsim/internal/service/forecast"
 	_ "github.com/sivchari/awsim/internal/service/gamelift"

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -74,7 +74,7 @@ func extractRoutePrefix(pattern string) string {
 	// /service is for RPC v2 CBOR protocol
 	// EventBridge Pipes uses /v1/pipes and /tags paths
 	// EMR Serverless uses /applications paths
-	prefixes := []string{"/lambda", "/eks", "/iam", "/buckets", "/namespaces", "/tables", "/get-table", "/apigateway", "/ses", "/2020-05-31", "/2013-04-01", "/service", "/appsync", "/v1", "/tags", "/applications", "/v20190125", "/scheduler", "/dlm", "/mq", "/v20180820"}
+	prefixes := []string{"/lambda", "/eks", "/iam", "/buckets", "/namespaces", "/tables", "/get-table", "/apigateway", "/ses", "/2020-05-31", "/2013-04-01", "/service", "/appsync", "/v1", "/tags", "/applications", "/v20190125", "/scheduler", "/dlm", "/mq", "/v20180820", "/kx"}
 
 	for _, prefix := range prefixes {
 		if len(pattern) >= len(prefix) && pattern[:len(prefix)] == prefix {

--- a/internal/service/finspace/handlers.go
+++ b/internal/service/finspace/handlers.go
@@ -1,0 +1,406 @@
+package finspace
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+)
+
+// CreateKxEnvironment handles the CreateKxEnvironment action.
+func (s *Service) CreateKxEnvironment(w http.ResponseWriter, r *http.Request) {
+	var req CreateKxEnvironmentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	resp, err := s.storage.CreateKxEnvironment(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// GetKxEnvironment handles the GetKxEnvironment action.
+func (s *Service) GetKxEnvironment(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+
+	resp, err := s.storage.GetKxEnvironment(r.Context(), environmentID)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// DeleteKxEnvironment handles the DeleteKxEnvironment action.
+func (s *Service) DeleteKxEnvironment(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+
+	if err := s.storage.DeleteKxEnvironment(r.Context(), environmentID); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &DeleteKxEnvironmentResponse{})
+}
+
+// ListKxEnvironments handles the ListKxEnvironments action.
+func (s *Service) ListKxEnvironments(w http.ResponseWriter, r *http.Request) {
+	maxResults := 0
+
+	if maxResultsStr := r.URL.Query().Get("maxResults"); maxResultsStr != "" {
+		var err error
+
+		maxResults, err = strconv.Atoi(maxResultsStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, errValidation, "Invalid maxResults")
+
+			return
+		}
+	}
+
+	nextToken := r.URL.Query().Get("nextToken")
+
+	resp, err := s.storage.ListKxEnvironments(r.Context(), maxResults, nextToken)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// UpdateKxEnvironment handles the UpdateKxEnvironment action.
+func (s *Service) UpdateKxEnvironment(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+
+	var req UpdateKxEnvironmentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	req.EnvironmentID = environmentID
+
+	resp, err := s.storage.UpdateKxEnvironment(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// CreateKxDatabase handles the CreateKxDatabase action.
+func (s *Service) CreateKxDatabase(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+
+	var req CreateKxDatabaseRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	req.EnvironmentID = environmentID
+
+	resp, err := s.storage.CreateKxDatabase(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// GetKxDatabase handles the GetKxDatabase action.
+func (s *Service) GetKxDatabase(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+	databaseName := r.PathValue("databaseName")
+
+	resp, err := s.storage.GetKxDatabase(r.Context(), environmentID, databaseName)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// DeleteKxDatabase handles the DeleteKxDatabase action.
+func (s *Service) DeleteKxDatabase(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+	databaseName := r.PathValue("databaseName")
+
+	if err := s.storage.DeleteKxDatabase(r.Context(), environmentID, databaseName); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &DeleteKxDatabaseResponse{})
+}
+
+// ListKxDatabases handles the ListKxDatabases action.
+func (s *Service) ListKxDatabases(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+	maxResults := 0
+
+	if maxResultsStr := r.URL.Query().Get("maxResults"); maxResultsStr != "" {
+		var err error
+
+		maxResults, err = strconv.Atoi(maxResultsStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, errValidation, "Invalid maxResults")
+
+			return
+		}
+	}
+
+	nextToken := r.URL.Query().Get("nextToken")
+
+	resp, err := s.storage.ListKxDatabases(r.Context(), environmentID, maxResults, nextToken)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// UpdateKxDatabase handles the UpdateKxDatabase action.
+func (s *Service) UpdateKxDatabase(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+	databaseName := r.PathValue("databaseName")
+
+	var req UpdateKxDatabaseRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	req.EnvironmentID = environmentID
+	req.DatabaseName = databaseName
+
+	resp, err := s.storage.UpdateKxDatabase(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// CreateKxUser handles the CreateKxUser action.
+func (s *Service) CreateKxUser(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+
+	var req CreateKxUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	req.EnvironmentID = environmentID
+
+	resp, err := s.storage.CreateKxUser(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// GetKxUser handles the GetKxUser action.
+func (s *Service) GetKxUser(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+	userName := r.PathValue("userName")
+
+	resp, err := s.storage.GetKxUser(r.Context(), environmentID, userName)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// DeleteKxUser handles the DeleteKxUser action.
+func (s *Service) DeleteKxUser(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+	userName := r.PathValue("userName")
+
+	if err := s.storage.DeleteKxUser(r.Context(), environmentID, userName); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &DeleteKxUserResponse{})
+}
+
+// ListKxUsers handles the ListKxUsers action.
+func (s *Service) ListKxUsers(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+	maxResults := 0
+
+	if maxResultsStr := r.URL.Query().Get("maxResults"); maxResultsStr != "" {
+		var err error
+
+		maxResults, err = strconv.Atoi(maxResultsStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, errValidation, "Invalid maxResults")
+
+			return
+		}
+	}
+
+	nextToken := r.URL.Query().Get("nextToken")
+
+	resp, err := s.storage.ListKxUsers(r.Context(), environmentID, maxResults, nextToken)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// UpdateKxUser handles the UpdateKxUser action.
+func (s *Service) UpdateKxUser(w http.ResponseWriter, r *http.Request) {
+	environmentID := r.PathValue("environmentId")
+	userName := r.PathValue("userName")
+
+	var req UpdateKxUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	req.EnvironmentID = environmentID
+	req.UserName = userName
+
+	resp, err := s.storage.UpdateKxUser(r.Context(), &req)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+// TagResource handles the TagResource action.
+func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
+	resourceARN := r.URL.Query().Get("resourceArn")
+
+	var req TagResourceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+
+		return
+	}
+
+	if err := s.storage.TagResource(r.Context(), resourceARN, req.Tags); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &TagResourceResponse{})
+}
+
+// UntagResource handles the UntagResource action.
+func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
+	resourceARN := r.URL.Query().Get("resourceArn")
+	tagKeys := r.URL.Query()["tagKeys"]
+
+	if err := s.storage.UntagResource(r.Context(), resourceARN, tagKeys); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &UntagResourceResponse{})
+}
+
+// ListTagsForResource handles the ListTagsForResource action.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
+	resourceARN := r.URL.Query().Get("resourceArn")
+
+	tags, err := s.storage.ListTagsForResource(r.Context(), resourceARN)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeJSON(w, &ListTagsForResourceResponse{Tags: tags})
+}
+
+func writeJSON(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func writeError(w http.ResponseWriter, statusCode int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+
+	errResp := &Error{
+		Code:    code,
+		Message: message,
+	}
+
+	if err := json.NewEncoder(w).Encode(errResp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func handleStorageError(w http.ResponseWriter, err error) {
+	var fsErr *Error
+
+	if errors.As(err, &fsErr) {
+		statusCode := http.StatusBadRequest
+
+		switch fsErr.Code {
+		case errResourceNotFound:
+			statusCode = http.StatusNotFound
+		case errConflict:
+			statusCode = http.StatusConflict
+		}
+
+		writeError(w, statusCode, fsErr.Code, fsErr.Message)
+
+		return
+	}
+
+	writeError(w, http.StatusInternalServerError, "InternalException", err.Error())
+}

--- a/internal/service/finspace/service.go
+++ b/internal/service/finspace/service.go
@@ -1,0 +1,61 @@
+package finspace
+
+import "github.com/sivchari/awsim/internal/service"
+
+// Compile-time check to ensure Service implements service.Service.
+var _ service.Service = (*Service)(nil)
+
+func init() {
+	service.Register(New(NewMemoryStorage()))
+}
+
+// Service implements the FinSpace service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new FinSpace service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "finspace"
+}
+
+// RegisterRoutes registers the FinSpace routes.
+func (s *Service) RegisterRoutes(r service.Router) {
+	// KxEnvironment operations
+	r.Handle("POST", "/kx/environments", s.CreateKxEnvironment)
+	r.Handle("GET", "/kx/environments/{environmentId}", s.GetKxEnvironment)
+	r.Handle("DELETE", "/kx/environments/{environmentId}", s.DeleteKxEnvironment)
+	r.Handle("GET", "/kx/environments", s.ListKxEnvironments)
+	r.Handle("PUT", "/kx/environments/{environmentId}", s.UpdateKxEnvironment)
+
+	// KxDatabase operations
+	r.Handle("POST", "/kx/environments/{environmentId}/databases", s.CreateKxDatabase)
+	r.Handle("GET", "/kx/environments/{environmentId}/databases/{databaseName}", s.GetKxDatabase)
+	r.Handle("DELETE", "/kx/environments/{environmentId}/databases/{databaseName}", s.DeleteKxDatabase)
+	r.Handle("GET", "/kx/environments/{environmentId}/databases", s.ListKxDatabases)
+	r.Handle("PUT", "/kx/environments/{environmentId}/databases/{databaseName}", s.UpdateKxDatabase)
+
+	// KxUser operations
+	r.Handle("POST", "/kx/environments/{environmentId}/users", s.CreateKxUser)
+	r.Handle("GET", "/kx/environments/{environmentId}/users/{userName}", s.GetKxUser)
+	r.Handle("DELETE", "/kx/environments/{environmentId}/users/{userName}", s.DeleteKxUser)
+	r.Handle("GET", "/kx/environments/{environmentId}/users", s.ListKxUsers)
+	r.Handle("PUT", "/kx/environments/{environmentId}/users/{userName}", s.UpdateKxUser)
+
+	// Tag operations
+	r.Handle("POST", "/tags", s.TagResource)
+	r.Handle("DELETE", "/tags", s.UntagResource)
+	r.Handle("GET", "/tags", s.ListTagsForResource)
+}
+
+// Prefix returns the URL prefix for FinSpace.
+func (s *Service) Prefix() string {
+	return "/finspace"
+}

--- a/internal/service/finspace/storage.go
+++ b/internal/service/finspace/storage.go
@@ -1,0 +1,584 @@
+package finspace
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	errResourceNotFound = "ResourceNotFoundException"
+	errConflict         = "ConflictException"
+	errValidation       = "ValidationException"
+
+	statusCreated = "CREATED"
+)
+
+// Storage is the interface for FinSpace storage operations.
+type Storage interface {
+	// KxEnvironment operations
+	CreateKxEnvironment(ctx context.Context, req *CreateKxEnvironmentRequest) (*CreateKxEnvironmentResponse, error)
+	GetKxEnvironment(ctx context.Context, environmentID string) (*GetKxEnvironmentResponse, error)
+	DeleteKxEnvironment(ctx context.Context, environmentID string) error
+	ListKxEnvironments(ctx context.Context, maxResults int, nextToken string) (*ListKxEnvironmentsResponse, error)
+	UpdateKxEnvironment(ctx context.Context, req *UpdateKxEnvironmentRequest) (*UpdateKxEnvironmentResponse, error)
+
+	// KxDatabase operations
+	CreateKxDatabase(ctx context.Context, req *CreateKxDatabaseRequest) (*CreateKxDatabaseResponse, error)
+	GetKxDatabase(ctx context.Context, environmentID, databaseName string) (*GetKxDatabaseResponse, error)
+	DeleteKxDatabase(ctx context.Context, environmentID, databaseName string) error
+	ListKxDatabases(ctx context.Context, environmentID string, maxResults int, nextToken string) (*ListKxDatabasesResponse, error)
+	UpdateKxDatabase(ctx context.Context, req *UpdateKxDatabaseRequest) (*UpdateKxDatabaseResponse, error)
+
+	// KxUser operations
+	CreateKxUser(ctx context.Context, req *CreateKxUserRequest) (*CreateKxUserResponse, error)
+	GetKxUser(ctx context.Context, environmentID, userName string) (*GetKxUserResponse, error)
+	DeleteKxUser(ctx context.Context, environmentID, userName string) error
+	ListKxUsers(ctx context.Context, environmentID string, maxResults int, nextToken string) (*ListKxUsersResponse, error)
+	UpdateKxUser(ctx context.Context, req *UpdateKxUserRequest) (*UpdateKxUserResponse, error)
+
+	// Tag operations
+	TagResource(ctx context.Context, resourceARN string, tags map[string]string) error
+	UntagResource(ctx context.Context, resourceARN string, tagKeys []string) error
+	ListTagsForResource(ctx context.Context, resourceARN string) (map[string]string, error)
+}
+
+// MemoryStorage implements in-memory storage for FinSpace.
+type MemoryStorage struct {
+	mu           sync.RWMutex
+	environments map[string]*KxEnvironment
+	databases    map[string]*KxDatabase // key: environmentID/databaseName
+	users        map[string]*KxUser     // key: environmentID/userName
+	tags         map[string]map[string]string
+	accountID    string
+	region       string
+}
+
+// NewMemoryStorage creates a new in-memory storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		environments: make(map[string]*KxEnvironment),
+		databases:    make(map[string]*KxDatabase),
+		users:        make(map[string]*KxUser),
+		tags:         make(map[string]map[string]string),
+		accountID:    "123456789012",
+		region:       "us-east-1",
+	}
+}
+
+// CreateKxEnvironment creates a new kdb environment.
+func (s *MemoryStorage) CreateKxEnvironment(_ context.Context, req *CreateKxEnvironmentRequest) (*CreateKxEnvironmentResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check for duplicate name
+	for _, env := range s.environments {
+		if env.Name == req.Name {
+			return nil, &Error{
+				Code:    errConflict,
+				Message: fmt.Sprintf("Environment with name %s already exists", req.Name),
+			}
+		}
+	}
+
+	now := float64(time.Now().Unix())
+	environmentID := uuid.New().String()
+	arn := fmt.Sprintf("arn:aws:finspace:%s:%s:kxEnvironment/%s", s.region, s.accountID, environmentID)
+
+	env := &KxEnvironment{
+		AwsAccountID:      s.accountID,
+		CreationTimestamp: now,
+		Description:       req.Description,
+		EnvironmentARN:    arn,
+		EnvironmentID:     environmentID,
+		KmsKeyID:          req.KmsKeyID,
+		Name:              req.Name,
+		Status:            statusCreated,
+		UpdateTimestamp:   now,
+	}
+
+	s.environments[environmentID] = env
+
+	if len(req.Tags) > 0 {
+		s.tags[arn] = req.Tags
+	}
+
+	return &CreateKxEnvironmentResponse{
+		CreationTimestamp: env.CreationTimestamp,
+		Description:       env.Description,
+		EnvironmentARN:    env.EnvironmentARN,
+		EnvironmentID:     env.EnvironmentID,
+		KmsKeyID:          env.KmsKeyID,
+		Name:              env.Name,
+		Status:            env.Status,
+	}, nil
+}
+
+// GetKxEnvironment retrieves a kdb environment by ID.
+func (s *MemoryStorage) GetKxEnvironment(_ context.Context, environmentID string) (*GetKxEnvironmentResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	env, exists := s.environments[environmentID]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Environment with ID %s not found", environmentID),
+		}
+	}
+
+	return &GetKxEnvironmentResponse{
+		AvailabilityZoneIDs:       env.AvailabilityZoneIDs,
+		AwsAccountID:              env.AwsAccountID,
+		CertificateARN:            env.CertificateARN,
+		CreationTimestamp:         env.CreationTimestamp,
+		CustomDNSConfiguration:    env.CustomDNSConfiguration,
+		DedicatedServiceAccountID: env.DedicatedServiceAccountID,
+		Description:               env.Description,
+		DNSStatus:                 env.DNSStatus,
+		EnvironmentARN:            env.EnvironmentARN,
+		EnvironmentID:             env.EnvironmentID,
+		ErrorMessage:              env.ErrorMessage,
+		KmsKeyID:                  env.KmsKeyID,
+		Name:                      env.Name,
+		Status:                    env.Status,
+		TgwStatus:                 env.TgwStatus,
+		UpdateTimestamp:           env.UpdateTimestamp,
+	}, nil
+}
+
+// DeleteKxEnvironment deletes a kdb environment.
+func (s *MemoryStorage) DeleteKxEnvironment(_ context.Context, environmentID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	env, exists := s.environments[environmentID]
+	if !exists {
+		return &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Environment with ID %s not found", environmentID),
+		}
+	}
+
+	delete(s.tags, env.EnvironmentARN)
+	delete(s.environments, environmentID)
+
+	return nil
+}
+
+// ListKxEnvironments lists kdb environments.
+func (s *MemoryStorage) ListKxEnvironments(_ context.Context, maxResults int, _ string) (*ListKxEnvironmentsResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults == 0 {
+		maxResults = 10
+	}
+
+	environments := make([]*KxEnvironment, 0, len(s.environments))
+
+	for _, env := range s.environments {
+		environments = append(environments, env)
+
+		if len(environments) >= maxResults {
+			break
+		}
+	}
+
+	return &ListKxEnvironmentsResponse{
+		Environments: environments,
+	}, nil
+}
+
+// UpdateKxEnvironment updates a kdb environment.
+func (s *MemoryStorage) UpdateKxEnvironment(_ context.Context, req *UpdateKxEnvironmentRequest) (*UpdateKxEnvironmentResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	env, exists := s.environments[req.EnvironmentID]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Environment with ID %s not found", req.EnvironmentID),
+		}
+	}
+
+	if req.Name != "" {
+		env.Name = req.Name
+	}
+
+	if req.Description != "" {
+		env.Description = req.Description
+	}
+
+	env.UpdateTimestamp = float64(time.Now().Unix())
+
+	return &UpdateKxEnvironmentResponse{
+		AvailabilityZoneIDs:       env.AvailabilityZoneIDs,
+		AwsAccountID:              env.AwsAccountID,
+		CreationTimestamp:         env.CreationTimestamp,
+		DedicatedServiceAccountID: env.DedicatedServiceAccountID,
+		Description:               env.Description,
+		DNSStatus:                 env.DNSStatus,
+		EnvironmentARN:            env.EnvironmentARN,
+		EnvironmentID:             env.EnvironmentID,
+		KmsKeyID:                  env.KmsKeyID,
+		Name:                      env.Name,
+		Status:                    env.Status,
+		TgwStatus:                 env.TgwStatus,
+		UpdateTimestamp:           env.UpdateTimestamp,
+	}, nil
+}
+
+// CreateKxDatabase creates a new kdb database.
+func (s *MemoryStorage) CreateKxDatabase(_ context.Context, req *CreateKxDatabaseRequest) (*CreateKxDatabaseResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if environment exists
+	if _, exists := s.environments[req.EnvironmentID]; !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Environment with ID %s not found", req.EnvironmentID),
+		}
+	}
+
+	key := fmt.Sprintf("%s/%s", req.EnvironmentID, req.DatabaseName)
+
+	// Check for duplicate
+	if _, exists := s.databases[key]; exists {
+		return nil, &Error{
+			Code:    errConflict,
+			Message: fmt.Sprintf("Database with name %s already exists in environment %s", req.DatabaseName, req.EnvironmentID),
+		}
+	}
+
+	now := float64(time.Now().Unix())
+	arn := fmt.Sprintf("arn:aws:finspace:%s:%s:kxEnvironment/%s/kxDatabase/%s", s.region, s.accountID, req.EnvironmentID, req.DatabaseName)
+
+	db := &KxDatabase{
+		CreatedTimestamp:      now,
+		DatabaseARN:           arn,
+		DatabaseName:          req.DatabaseName,
+		Description:           req.Description,
+		EnvironmentID:         req.EnvironmentID,
+		LastModifiedTimestamp: now,
+	}
+
+	s.databases[key] = db
+
+	if len(req.Tags) > 0 {
+		s.tags[arn] = req.Tags
+	}
+
+	return &CreateKxDatabaseResponse{
+		CreatedTimestamp: db.CreatedTimestamp,
+		DatabaseARN:      db.DatabaseARN,
+		DatabaseName:     db.DatabaseName,
+		Description:      db.Description,
+		EnvironmentID:    db.EnvironmentID,
+	}, nil
+}
+
+// GetKxDatabase retrieves a kdb database.
+func (s *MemoryStorage) GetKxDatabase(_ context.Context, environmentID, databaseName string) (*GetKxDatabaseResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := fmt.Sprintf("%s/%s", environmentID, databaseName)
+
+	db, exists := s.databases[key]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Database with name %s not found in environment %s", databaseName, environmentID),
+		}
+	}
+
+	return &GetKxDatabaseResponse{
+		CreatedTimestamp:         db.CreatedTimestamp,
+		DatabaseARN:              db.DatabaseARN,
+		DatabaseName:             db.DatabaseName,
+		Description:              db.Description,
+		EnvironmentID:            db.EnvironmentID,
+		LastCompletedChangesetID: db.LastCompletedChangesetID,
+		LastModifiedTimestamp:    db.LastModifiedTimestamp,
+		NumBytes:                 db.NumBytes,
+		NumChangesets:            db.NumChangesets,
+		NumFiles:                 db.NumFiles,
+	}, nil
+}
+
+// DeleteKxDatabase deletes a kdb database.
+func (s *MemoryStorage) DeleteKxDatabase(_ context.Context, environmentID, databaseName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := fmt.Sprintf("%s/%s", environmentID, databaseName)
+
+	db, exists := s.databases[key]
+	if !exists {
+		return &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Database with name %s not found in environment %s", databaseName, environmentID),
+		}
+	}
+
+	delete(s.tags, db.DatabaseARN)
+	delete(s.databases, key)
+
+	return nil
+}
+
+// ListKxDatabases lists kdb databases.
+func (s *MemoryStorage) ListKxDatabases(_ context.Context, environmentID string, maxResults int, _ string) (*ListKxDatabasesResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults == 0 {
+		maxResults = 10
+	}
+
+	databases := make([]*KxDatabase, 0)
+
+	for key, db := range s.databases {
+		if db.EnvironmentID == environmentID {
+			databases = append(databases, db)
+
+			if len(databases) >= maxResults {
+				break
+			}
+		}
+
+		_ = key
+	}
+
+	return &ListKxDatabasesResponse{
+		KxDatabases: databases,
+	}, nil
+}
+
+// UpdateKxDatabase updates a kdb database.
+func (s *MemoryStorage) UpdateKxDatabase(_ context.Context, req *UpdateKxDatabaseRequest) (*UpdateKxDatabaseResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := fmt.Sprintf("%s/%s", req.EnvironmentID, req.DatabaseName)
+
+	db, exists := s.databases[key]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Database with name %s not found in environment %s", req.DatabaseName, req.EnvironmentID),
+		}
+	}
+
+	if req.Description != "" {
+		db.Description = req.Description
+	}
+
+	db.LastModifiedTimestamp = float64(time.Now().Unix())
+
+	return &UpdateKxDatabaseResponse{
+		DatabaseARN:           db.DatabaseARN,
+		DatabaseName:          db.DatabaseName,
+		Description:           db.Description,
+		EnvironmentID:         db.EnvironmentID,
+		LastModifiedTimestamp: db.LastModifiedTimestamp,
+	}, nil
+}
+
+// CreateKxUser creates a new kdb user.
+func (s *MemoryStorage) CreateKxUser(_ context.Context, req *CreateKxUserRequest) (*CreateKxUserResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if environment exists
+	if _, exists := s.environments[req.EnvironmentID]; !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Environment with ID %s not found", req.EnvironmentID),
+		}
+	}
+
+	key := fmt.Sprintf("%s/%s", req.EnvironmentID, req.UserName)
+
+	// Check for duplicate
+	if _, exists := s.users[key]; exists {
+		return nil, &Error{
+			Code:    errConflict,
+			Message: fmt.Sprintf("User with name %s already exists in environment %s", req.UserName, req.EnvironmentID),
+		}
+	}
+
+	now := float64(time.Now().Unix())
+	arn := fmt.Sprintf("arn:aws:finspace:%s:%s:kxEnvironment/%s/kxUser/%s", s.region, s.accountID, req.EnvironmentID, req.UserName)
+
+	user := &KxUser{
+		CreateTimestamp: now,
+		IamRole:         req.IamRole,
+		UpdateTimestamp: now,
+		UserARN:         arn,
+		UserName:        req.UserName,
+	}
+
+	s.users[key] = user
+
+	if len(req.Tags) > 0 {
+		s.tags[arn] = req.Tags
+	}
+
+	return &CreateKxUserResponse{
+		EnvironmentID: req.EnvironmentID,
+		IamRole:       user.IamRole,
+		UserARN:       user.UserARN,
+		UserName:      user.UserName,
+	}, nil
+}
+
+// GetKxUser retrieves a kdb user.
+func (s *MemoryStorage) GetKxUser(_ context.Context, environmentID, userName string) (*GetKxUserResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := fmt.Sprintf("%s/%s", environmentID, userName)
+
+	user, exists := s.users[key]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("User with name %s not found in environment %s", userName, environmentID),
+		}
+	}
+
+	return &GetKxUserResponse{
+		EnvironmentID: environmentID,
+		IamRole:       user.IamRole,
+		UserARN:       user.UserARN,
+		UserName:      user.UserName,
+	}, nil
+}
+
+// DeleteKxUser deletes a kdb user.
+func (s *MemoryStorage) DeleteKxUser(_ context.Context, environmentID, userName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := fmt.Sprintf("%s/%s", environmentID, userName)
+
+	user, exists := s.users[key]
+	if !exists {
+		return &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("User with name %s not found in environment %s", userName, environmentID),
+		}
+	}
+
+	delete(s.tags, user.UserARN)
+	delete(s.users, key)
+
+	return nil
+}
+
+// ListKxUsers lists kdb users.
+func (s *MemoryStorage) ListKxUsers(_ context.Context, environmentID string, maxResults int, _ string) (*ListKxUsersResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults == 0 {
+		maxResults = 10
+	}
+
+	users := make([]*KxUser, 0)
+
+	for key, user := range s.users {
+		// Check if the key starts with the environmentID
+		if len(key) > len(environmentID) && key[:len(environmentID)] == environmentID && key[len(environmentID)] == '/' {
+			users = append(users, user)
+
+			if len(users) >= maxResults {
+				break
+			}
+		}
+	}
+
+	return &ListKxUsersResponse{
+		Users: users,
+	}, nil
+}
+
+// UpdateKxUser updates a kdb user.
+func (s *MemoryStorage) UpdateKxUser(_ context.Context, req *UpdateKxUserRequest) (*UpdateKxUserResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := fmt.Sprintf("%s/%s", req.EnvironmentID, req.UserName)
+
+	user, exists := s.users[key]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("User with name %s not found in environment %s", req.UserName, req.EnvironmentID),
+		}
+	}
+
+	if req.IamRole != "" {
+		user.IamRole = req.IamRole
+	}
+
+	user.UpdateTimestamp = float64(time.Now().Unix())
+
+	return &UpdateKxUserResponse{
+		EnvironmentID: req.EnvironmentID,
+		IamRole:       user.IamRole,
+		UserARN:       user.UserARN,
+		UserName:      user.UserName,
+	}, nil
+}
+
+// TagResource adds tags to a resource.
+func (s *MemoryStorage) TagResource(_ context.Context, resourceARN string, tags map[string]string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.tags[resourceARN] == nil {
+		s.tags[resourceARN] = make(map[string]string)
+	}
+
+	maps.Copy(s.tags[resourceARN], tags)
+
+	return nil
+}
+
+// UntagResource removes tags from a resource.
+func (s *MemoryStorage) UntagResource(_ context.Context, resourceARN string, tagKeys []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.tags[resourceARN] == nil {
+		return nil
+	}
+
+	for _, key := range tagKeys {
+		delete(s.tags[resourceARN], key)
+	}
+
+	return nil
+}
+
+// ListTagsForResource lists tags for a resource.
+func (s *MemoryStorage) ListTagsForResource(_ context.Context, resourceARN string) (map[string]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tags := s.tags[resourceARN]
+	if tags == nil {
+		tags = make(map[string]string)
+	}
+
+	return tags, nil
+}

--- a/internal/service/finspace/types.go
+++ b/internal/service/finspace/types.go
@@ -1,0 +1,366 @@
+// Package finspace provides an in-memory implementation of AWS FinSpace.
+package finspace
+
+// Error represents an error response.
+type Error struct {
+	Code    string `json:"__type"`
+	Message string `json:"message"`
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return e.Message
+}
+
+// KxEnvironment represents a managed kdb environment.
+type KxEnvironment struct {
+	AvailabilityZoneIDs       []string           `json:"availabilityZoneIds,omitempty"`
+	AwsAccountID              string             `json:"awsAccountId,omitempty"`
+	CertificateARN            string             `json:"certificateArn,omitempty"`
+	CreationTimestamp         float64            `json:"creationTimestamp,omitempty"`
+	CustomDNSConfiguration    []*CustomDNSServer `json:"customDNSConfiguration,omitempty"`
+	DedicatedServiceAccountID string             `json:"dedicatedServiceAccountId,omitempty"`
+	Description               string             `json:"description,omitempty"`
+	DNSStatus                 string             `json:"dnsStatus,omitempty"`
+	EnvironmentARN            string             `json:"environmentArn,omitempty"`
+	EnvironmentID             string             `json:"environmentId,omitempty"`
+	ErrorMessage              string             `json:"errorMessage,omitempty"`
+	KmsKeyID                  string             `json:"kmsKeyId,omitempty"`
+	Name                      string             `json:"name,omitempty"`
+	Status                    string             `json:"status,omitempty"`
+	TgwStatus                 string             `json:"tgwStatus,omitempty"`
+	UpdateTimestamp           float64            `json:"updateTimestamp,omitempty"`
+}
+
+// CustomDNSServer represents a custom DNS server configuration.
+type CustomDNSServer struct {
+	CustomDNSServerIP   string `json:"customDNSServerIP,omitempty"`
+	CustomDNSServerName string `json:"customDNSServerName,omitempty"`
+}
+
+// TransitGatewayConfiguration represents transit gateway configuration.
+type TransitGatewayConfiguration struct {
+	AttachmentNetworkACLConfiguration []*NetworkACLEntry `json:"attachmentNetworkAclConfiguration,omitempty"`
+	RoutableCIDRSpace                 string             `json:"routableCIDRSpace,omitempty"`
+	TransitGatewayID                  string             `json:"transitGatewayID,omitempty"`
+}
+
+// NetworkACLEntry represents a network ACL entry.
+type NetworkACLEntry struct {
+	CidrBlock  string        `json:"cidrBlock,omitempty"`
+	ICMPType   *ICMPTypeCode `json:"icmpTypeCode,omitempty"`
+	PortRange  *PortRange    `json:"portRange,omitempty"`
+	Protocol   string        `json:"protocol,omitempty"`
+	RuleAction string        `json:"ruleAction,omitempty"`
+	RuleNumber int           `json:"ruleNumber,omitempty"`
+}
+
+// ICMPTypeCode represents ICMP type and code.
+type ICMPTypeCode struct {
+	Code int `json:"code,omitempty"`
+	Type int `json:"type,omitempty"`
+}
+
+// PortRange represents a port range.
+type PortRange struct {
+	From int `json:"from,omitempty"`
+	To   int `json:"to,omitempty"`
+}
+
+// KxDatabase represents a kdb database.
+type KxDatabase struct {
+	CreatedTimestamp         float64 `json:"createdTimestamp,omitempty"`
+	DatabaseARN              string  `json:"databaseArn,omitempty"`
+	DatabaseName             string  `json:"databaseName,omitempty"`
+	Description              string  `json:"description,omitempty"`
+	EnvironmentID            string  `json:"environmentId,omitempty"`
+	LastCompletedChangesetID string  `json:"lastCompletedChangesetId,omitempty"`
+	LastModifiedTimestamp    float64 `json:"lastModifiedTimestamp,omitempty"`
+	NumBytes                 int64   `json:"numBytes,omitempty"`
+	NumChangesets            int     `json:"numChangesets,omitempty"`
+	NumFiles                 int     `json:"numFiles,omitempty"`
+}
+
+// KxUser represents a kdb user.
+type KxUser struct {
+	CreateTimestamp float64 `json:"createTimestamp,omitempty"`
+	IamRole         string  `json:"iamRole,omitempty"`
+	UpdateTimestamp float64 `json:"updateTimestamp,omitempty"`
+	UserARN         string  `json:"userArn,omitempty"`
+	UserName        string  `json:"userName,omitempty"`
+}
+
+// Tag represents a resource tag.
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// CreateKxEnvironmentRequest represents a CreateKxEnvironment request.
+type CreateKxEnvironmentRequest struct {
+	ClientToken string            `json:"clientToken,omitempty"`
+	Description string            `json:"description,omitempty"`
+	KmsKeyID    string            `json:"kmsKeyId,omitempty"`
+	Name        string            `json:"name"`
+	Tags        map[string]string `json:"tags,omitempty"`
+}
+
+// CreateKxEnvironmentResponse represents a CreateKxEnvironment response.
+type CreateKxEnvironmentResponse struct {
+	CreationTimestamp float64 `json:"creationTimestamp,omitempty"`
+	Description       string  `json:"description,omitempty"`
+	EnvironmentARN    string  `json:"environmentArn,omitempty"`
+	EnvironmentID     string  `json:"environmentId,omitempty"`
+	KmsKeyID          string  `json:"kmsKeyId,omitempty"`
+	Name              string  `json:"name,omitempty"`
+	Status            string  `json:"status,omitempty"`
+}
+
+// GetKxEnvironmentRequest represents a GetKxEnvironment request.
+type GetKxEnvironmentRequest struct {
+	EnvironmentID string `json:"environmentId"`
+}
+
+// GetKxEnvironmentResponse represents a GetKxEnvironment response.
+type GetKxEnvironmentResponse struct {
+	AvailabilityZoneIDs         []string                     `json:"availabilityZoneIds,omitempty"`
+	AwsAccountID                string                       `json:"awsAccountId,omitempty"`
+	CertificateARN              string                       `json:"certificateArn,omitempty"`
+	CreationTimestamp           float64                      `json:"creationTimestamp,omitempty"`
+	CustomDNSConfiguration      []*CustomDNSServer           `json:"customDNSConfiguration,omitempty"`
+	DedicatedServiceAccountID   string                       `json:"dedicatedServiceAccountId,omitempty"`
+	Description                 string                       `json:"description,omitempty"`
+	DNSStatus                   string                       `json:"dnsStatus,omitempty"`
+	EnvironmentARN              string                       `json:"environmentArn,omitempty"`
+	EnvironmentID               string                       `json:"environmentId,omitempty"`
+	ErrorMessage                string                       `json:"errorMessage,omitempty"`
+	KmsKeyID                    string                       `json:"kmsKeyId,omitempty"`
+	Name                        string                       `json:"name,omitempty"`
+	Status                      string                       `json:"status,omitempty"`
+	TgwStatus                   string                       `json:"tgwStatus,omitempty"`
+	TransitGatewayConfiguration *TransitGatewayConfiguration `json:"transitGatewayConfiguration,omitempty"`
+	UpdateTimestamp             float64                      `json:"updateTimestamp,omitempty"`
+}
+
+// DeleteKxEnvironmentRequest represents a DeleteKxEnvironment request.
+type DeleteKxEnvironmentRequest struct {
+	ClientToken   string `json:"clientToken,omitempty"`
+	EnvironmentID string `json:"environmentId"`
+}
+
+// DeleteKxEnvironmentResponse represents a DeleteKxEnvironment response.
+type DeleteKxEnvironmentResponse struct{}
+
+// ListKxEnvironmentsRequest represents a ListKxEnvironments request.
+type ListKxEnvironmentsRequest struct {
+	MaxResults int    `json:"maxResults,omitempty"`
+	NextToken  string `json:"nextToken,omitempty"`
+}
+
+// ListKxEnvironmentsResponse represents a ListKxEnvironments response.
+type ListKxEnvironmentsResponse struct {
+	Environments []*KxEnvironment `json:"environments,omitempty"`
+	NextToken    string           `json:"nextToken,omitempty"`
+}
+
+// UpdateKxEnvironmentRequest represents an UpdateKxEnvironment request.
+type UpdateKxEnvironmentRequest struct {
+	ClientToken   string `json:"clientToken,omitempty"`
+	Description   string `json:"description,omitempty"`
+	EnvironmentID string `json:"environmentId"`
+	Name          string `json:"name,omitempty"`
+}
+
+// UpdateKxEnvironmentResponse represents an UpdateKxEnvironment response.
+type UpdateKxEnvironmentResponse struct {
+	AvailabilityZoneIDs         []string                     `json:"availabilityZoneIds,omitempty"`
+	AwsAccountID                string                       `json:"awsAccountId,omitempty"`
+	CreationTimestamp           float64                      `json:"creationTimestamp,omitempty"`
+	DedicatedServiceAccountID   string                       `json:"dedicatedServiceAccountId,omitempty"`
+	Description                 string                       `json:"description,omitempty"`
+	DNSStatus                   string                       `json:"dnsStatus,omitempty"`
+	EnvironmentARN              string                       `json:"environmentArn,omitempty"`
+	EnvironmentID               string                       `json:"environmentId,omitempty"`
+	KmsKeyID                    string                       `json:"kmsKeyId,omitempty"`
+	Name                        string                       `json:"name,omitempty"`
+	Status                      string                       `json:"status,omitempty"`
+	TgwStatus                   string                       `json:"tgwStatus,omitempty"`
+	TransitGatewayConfiguration *TransitGatewayConfiguration `json:"transitGatewayConfiguration,omitempty"`
+	UpdateTimestamp             float64                      `json:"updateTimestamp,omitempty"`
+}
+
+// CreateKxDatabaseRequest represents a CreateKxDatabase request.
+type CreateKxDatabaseRequest struct {
+	ClientToken   string            `json:"clientToken,omitempty"`
+	DatabaseName  string            `json:"databaseName"`
+	Description   string            `json:"description,omitempty"`
+	EnvironmentID string            `json:"environmentId"`
+	Tags          map[string]string `json:"tags,omitempty"`
+}
+
+// CreateKxDatabaseResponse represents a CreateKxDatabase response.
+type CreateKxDatabaseResponse struct {
+	CreatedTimestamp float64 `json:"createdTimestamp,omitempty"`
+	DatabaseARN      string  `json:"databaseArn,omitempty"`
+	DatabaseName     string  `json:"databaseName,omitempty"`
+	Description      string  `json:"description,omitempty"`
+	EnvironmentID    string  `json:"environmentId,omitempty"`
+}
+
+// GetKxDatabaseRequest represents a GetKxDatabase request.
+type GetKxDatabaseRequest struct {
+	DatabaseName  string `json:"databaseName"`
+	EnvironmentID string `json:"environmentId"`
+}
+
+// GetKxDatabaseResponse represents a GetKxDatabase response.
+type GetKxDatabaseResponse struct {
+	CreatedTimestamp         float64 `json:"createdTimestamp,omitempty"`
+	DatabaseARN              string  `json:"databaseArn,omitempty"`
+	DatabaseName             string  `json:"databaseName,omitempty"`
+	Description              string  `json:"description,omitempty"`
+	EnvironmentID            string  `json:"environmentId,omitempty"`
+	LastCompletedChangesetID string  `json:"lastCompletedChangesetId,omitempty"`
+	LastModifiedTimestamp    float64 `json:"lastModifiedTimestamp,omitempty"`
+	NumBytes                 int64   `json:"numBytes,omitempty"`
+	NumChangesets            int     `json:"numChangesets,omitempty"`
+	NumFiles                 int     `json:"numFiles,omitempty"`
+}
+
+// DeleteKxDatabaseRequest represents a DeleteKxDatabase request.
+type DeleteKxDatabaseRequest struct {
+	ClientToken   string `json:"clientToken,omitempty"`
+	DatabaseName  string `json:"databaseName"`
+	EnvironmentID string `json:"environmentId"`
+}
+
+// DeleteKxDatabaseResponse represents a DeleteKxDatabase response.
+type DeleteKxDatabaseResponse struct{}
+
+// ListKxDatabasesRequest represents a ListKxDatabases request.
+type ListKxDatabasesRequest struct {
+	EnvironmentID string `json:"environmentId"`
+	MaxResults    int    `json:"maxResults,omitempty"`
+	NextToken     string `json:"nextToken,omitempty"`
+}
+
+// ListKxDatabasesResponse represents a ListKxDatabases response.
+type ListKxDatabasesResponse struct {
+	KxDatabases []*KxDatabase `json:"kxDatabases,omitempty"`
+	NextToken   string        `json:"nextToken,omitempty"`
+}
+
+// UpdateKxDatabaseRequest represents an UpdateKxDatabase request.
+type UpdateKxDatabaseRequest struct {
+	ClientToken   string `json:"clientToken,omitempty"`
+	DatabaseName  string `json:"databaseName"`
+	Description   string `json:"description,omitempty"`
+	EnvironmentID string `json:"environmentId"`
+}
+
+// UpdateKxDatabaseResponse represents an UpdateKxDatabase response.
+type UpdateKxDatabaseResponse struct {
+	DatabaseARN           string  `json:"databaseArn,omitempty"`
+	DatabaseName          string  `json:"databaseName,omitempty"`
+	Description           string  `json:"description,omitempty"`
+	EnvironmentID         string  `json:"environmentId,omitempty"`
+	LastModifiedTimestamp float64 `json:"lastModifiedTimestamp,omitempty"`
+}
+
+// CreateKxUserRequest represents a CreateKxUser request.
+type CreateKxUserRequest struct {
+	ClientToken   string            `json:"clientToken,omitempty"`
+	EnvironmentID string            `json:"environmentId"`
+	IamRole       string            `json:"iamRole"`
+	Tags          map[string]string `json:"tags,omitempty"`
+	UserName      string            `json:"userName"`
+}
+
+// CreateKxUserResponse represents a CreateKxUser response.
+type CreateKxUserResponse struct {
+	EnvironmentID string `json:"environmentId,omitempty"`
+	IamRole       string `json:"iamRole,omitempty"`
+	UserARN       string `json:"userArn,omitempty"`
+	UserName      string `json:"userName,omitempty"`
+}
+
+// GetKxUserRequest represents a GetKxUser request.
+type GetKxUserRequest struct {
+	EnvironmentID string `json:"environmentId"`
+	UserName      string `json:"userName"`
+}
+
+// GetKxUserResponse represents a GetKxUser response.
+type GetKxUserResponse struct {
+	EnvironmentID string `json:"environmentId,omitempty"`
+	IamRole       string `json:"iamRole,omitempty"`
+	UserARN       string `json:"userArn,omitempty"`
+	UserName      string `json:"userName,omitempty"`
+}
+
+// DeleteKxUserRequest represents a DeleteKxUser request.
+type DeleteKxUserRequest struct {
+	ClientToken   string `json:"clientToken,omitempty"`
+	EnvironmentID string `json:"environmentId"`
+	UserName      string `json:"userName"`
+}
+
+// DeleteKxUserResponse represents a DeleteKxUser response.
+type DeleteKxUserResponse struct{}
+
+// ListKxUsersRequest represents a ListKxUsers request.
+type ListKxUsersRequest struct {
+	EnvironmentID string `json:"environmentId"`
+	MaxResults    int    `json:"maxResults,omitempty"`
+	NextToken     string `json:"nextToken,omitempty"`
+}
+
+// ListKxUsersResponse represents a ListKxUsers response.
+type ListKxUsersResponse struct {
+	NextToken string    `json:"nextToken,omitempty"`
+	Users     []*KxUser `json:"users,omitempty"`
+}
+
+// UpdateKxUserRequest represents an UpdateKxUser request.
+type UpdateKxUserRequest struct {
+	ClientToken   string `json:"clientToken,omitempty"`
+	EnvironmentID string `json:"environmentId"`
+	IamRole       string `json:"iamRole"`
+	UserName      string `json:"userName"`
+}
+
+// UpdateKxUserResponse represents an UpdateKxUser response.
+type UpdateKxUserResponse struct {
+	EnvironmentID string `json:"environmentId,omitempty"`
+	IamRole       string `json:"iamRole,omitempty"`
+	UserARN       string `json:"userArn,omitempty"`
+	UserName      string `json:"userName,omitempty"`
+}
+
+// TagResourceRequest represents a TagResource request.
+type TagResourceRequest struct {
+	ResourceARN string            `json:"resourceArn"`
+	Tags        map[string]string `json:"tags"`
+}
+
+// TagResourceResponse represents a TagResource response.
+type TagResourceResponse struct{}
+
+// UntagResourceRequest represents an UntagResource request.
+type UntagResourceRequest struct {
+	ResourceARN string   `json:"resourceArn"`
+	TagKeys     []string `json:"tagKeys"`
+}
+
+// UntagResourceResponse represents an UntagResource response.
+type UntagResourceResponse struct{}
+
+// ListTagsForResourceRequest represents a ListTagsForResource request.
+type ListTagsForResourceRequest struct {
+	ResourceARN string `json:"resourceArn"`
+}
+
+// ListTagsForResourceResponse represents a ListTagsForResource response.
+type ListTagsForResourceResponse struct {
+	Tags map[string]string `json:"tags,omitempty"`
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.7
 	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.39.3
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.18
+	github.com/aws/aws-sdk-go-v2/service/finspace v1.33.18
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.9
 	github.com/aws/aws-sdk-go-v2/service/forecast v1.41.18
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.50.1
@@ -52,6 +53,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.233.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.17.19
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
+	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.10
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.34.2
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.59.1
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.40.6
@@ -75,7 +77,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.18 // indirect
-	github.com/aws/aws-sdk-go-v2/service/securitylake v1.25.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -66,6 +66,8 @@ github.com/aws/aws-sdk-go-v2/service/emrserverless v1.39.3 h1:VyyYx+0dPDLFPPTvUl
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.39.3/go.mod h1:JPM46oURtuLCuXENONKSnWfjOtJ8vzkHcoPlloi+eGI=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.18 h1:Zqe/Mbpjy3Vk0IKreW4cdxz2PBb0JNCeMwYAKbuBnvg=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.18/go.mod h1:oGNgLQOntNCt7Tl3d1NQu5QKFxdufg4huUAmyNECPDU=
+github.com/aws/aws-sdk-go-v2/service/finspace v1.33.18 h1:/O9FaWPzNe2KUClT0zcbfctDqt/byKmt9NZAKmuW0x4=
+github.com/aws/aws-sdk-go-v2/service/finspace v1.33.18/go.mod h1:If7C9aBO0LjTzEMOEp+Qh6RUdaJUXE1u2LRWf20yIwA=
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.9 h1:nFzEdq+y0lvgnSbYtRkgsSDFI7awmCrihWHFxWg8OQ0=
 github.com/aws/aws-sdk-go-v2/service/firehose v1.42.9/go.mod h1:rWQA39HYDLIx/K0Kdk5YXynPju527z3rXHrllkY1uTs=
 github.com/aws/aws-sdk-go-v2/service/forecast v1.41.18 h1:qnTIzASDu7VEzPhA8mH7CnbESv/pnYiIXL8bk3iNwOQ=

--- a/test/integration/finspace_test.go
+++ b/test/integration/finspace_test.go
@@ -1,0 +1,238 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/finspace"
+	"github.com/sivchari/golden"
+)
+
+func newFinSpaceClient(t *testing.T) *finspace.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return finspace.NewFromConfig(cfg, func(o *finspace.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestFinSpace_CreateAndDeleteKxEnvironment(t *testing.T) {
+	client := newFinSpaceClient(t)
+	ctx := t.Context()
+
+	// Create environment.
+	createOutput, err := client.CreateKxEnvironment(ctx, &finspace.CreateKxEnvironmentInput{
+		Name:     aws.String("test-environment"),
+		KmsKeyId: aws.String("arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	environmentID := *createOutput.EnvironmentId
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "EnvironmentId", "EnvironmentArn", "CreationTimestamp"),
+	)
+	g.Assert("create", createOutput)
+
+	// Get environment.
+	getOutput, err := client.GetKxEnvironment(ctx, &finspace.GetKxEnvironmentInput{
+		EnvironmentId: aws.String(environmentID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "EnvironmentId", "EnvironmentArn", "CreationTimestamp", "UpdateTimestamp"),
+	)
+	g2.Assert("get", getOutput)
+
+	// List environments.
+	listOutput, err := client.ListKxEnvironments(ctx, &finspace.ListKxEnvironmentsInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g3 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "EnvironmentId", "EnvironmentArn", "CreationTimestamp", "UpdateTimestamp"),
+	)
+	g3.Assert("list", listOutput)
+
+	// Delete environment.
+	_, err = client.DeleteKxEnvironment(ctx, &finspace.DeleteKxEnvironmentInput{
+		EnvironmentId: aws.String(environmentID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify it's deleted - should return error.
+	_, err = client.GetKxEnvironment(ctx, &finspace.GetKxEnvironmentInput{
+		EnvironmentId: aws.String(environmentID),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestFinSpace_CreateAndDeleteKxDatabase(t *testing.T) {
+	client := newFinSpaceClient(t)
+	ctx := t.Context()
+
+	// First create an environment.
+	createEnvOutput, err := client.CreateKxEnvironment(ctx, &finspace.CreateKxEnvironmentInput{
+		Name:     aws.String("test-env-for-db"),
+		KmsKeyId: aws.String("arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	environmentID := *createEnvOutput.EnvironmentId
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteKxEnvironment(t.Context(), &finspace.DeleteKxEnvironmentInput{
+			EnvironmentId: aws.String(environmentID),
+		})
+	})
+
+	// Create database.
+	createOutput, err := client.CreateKxDatabase(ctx, &finspace.CreateKxDatabaseInput{
+		EnvironmentId: aws.String(environmentID),
+		DatabaseName:  aws.String("test-database"),
+		Description:   aws.String("Test database"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "EnvironmentId", "DatabaseArn", "CreatedTimestamp"),
+	)
+	g.Assert("create", createOutput)
+
+	// Get database.
+	getOutput, err := client.GetKxDatabase(ctx, &finspace.GetKxDatabaseInput{
+		EnvironmentId: aws.String(environmentID),
+		DatabaseName:  aws.String("test-database"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "EnvironmentId", "DatabaseArn", "CreatedTimestamp", "LastModifiedTimestamp"),
+	)
+	g2.Assert("get", getOutput)
+
+	// List databases.
+	listOutput, err := client.ListKxDatabases(ctx, &finspace.ListKxDatabasesInput{
+		EnvironmentId: aws.String(environmentID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g3 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "EnvironmentId", "DatabaseArn", "CreatedTimestamp", "LastModifiedTimestamp"),
+	)
+	g3.Assert("list", listOutput)
+
+	// Delete database.
+	_, err = client.DeleteKxDatabase(ctx, &finspace.DeleteKxDatabaseInput{
+		EnvironmentId: aws.String(environmentID),
+		DatabaseName:  aws.String("test-database"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFinSpace_CreateAndDeleteKxUser(t *testing.T) {
+	client := newFinSpaceClient(t)
+	ctx := t.Context()
+
+	// First create an environment.
+	createEnvOutput, err := client.CreateKxEnvironment(ctx, &finspace.CreateKxEnvironmentInput{
+		Name:     aws.String("test-env-for-user"),
+		KmsKeyId: aws.String("arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	environmentID := *createEnvOutput.EnvironmentId
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteKxEnvironment(t.Context(), &finspace.DeleteKxEnvironmentInput{
+			EnvironmentId: aws.String(environmentID),
+		})
+	})
+
+	// Create user.
+	createOutput, err := client.CreateKxUser(ctx, &finspace.CreateKxUserInput{
+		EnvironmentId: aws.String(environmentID),
+		UserName:      aws.String("test-user"),
+		IamRole:       aws.String("arn:aws:iam::123456789012:role/TestRole"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "EnvironmentId", "UserArn"),
+	)
+	g.Assert("create", createOutput)
+
+	// Get user.
+	getOutput, err := client.GetKxUser(ctx, &finspace.GetKxUserInput{
+		EnvironmentId: aws.String(environmentID),
+		UserName:      aws.String("test-user"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "EnvironmentId", "UserArn"),
+	)
+	g2.Assert("get", getOutput)
+
+	// List users.
+	listOutput, err := client.ListKxUsers(ctx, &finspace.ListKxUsersInput{
+		EnvironmentId: aws.String(environmentID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g3 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "UserArn", "CreateTimestamp", "UpdateTimestamp"),
+	)
+	g3.Assert("list", listOutput)
+
+	// Delete user.
+	_, err = client.DeleteKxUser(ctx, &finspace.DeleteKxUserInput{
+		EnvironmentId: aws.String(environmentID),
+		UserName:      aws.String("test-user"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxDatabase_create.golden.go
+++ b/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxDatabase_create.golden.go
@@ -1,0 +1,9 @@
+{
+  "CreatedTimestamp": "2026-02-27T16:08:41Z",
+  "DatabaseArn": "arn:aws:finspace:us-east-1:123456789012:kxEnvironment/789c5b4e-3fe6-4580-b696-0258a6d69964/kxDatabase/test-database",
+  "DatabaseName": "test-database",
+  "Description": "Test database",
+  "EnvironmentId": "789c5b4e-3fe6-4580-b696-0258a6d69964",
+  "LastModifiedTimestamp": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxDatabase_get.golden.go
+++ b/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxDatabase_get.golden.go
@@ -1,0 +1,13 @@
+{
+  "CreatedTimestamp": "2026-02-27T16:08:41Z",
+  "DatabaseArn": "arn:aws:finspace:us-east-1:123456789012:kxEnvironment/789c5b4e-3fe6-4580-b696-0258a6d69964/kxDatabase/test-database",
+  "DatabaseName": "test-database",
+  "Description": "Test database",
+  "EnvironmentId": "789c5b4e-3fe6-4580-b696-0258a6d69964",
+  "LastCompletedChangesetId": null,
+  "LastModifiedTimestamp": "2026-02-27T16:08:41Z",
+  "NumBytes": 0,
+  "NumChangesets": 0,
+  "NumFiles": 0,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxDatabase_list.golden.go
+++ b/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxDatabase_list.golden.go
@@ -1,0 +1,11 @@
+{
+  "KxDatabases": [
+    {
+      "CreatedTimestamp": "2026-02-27T16:08:41Z",
+      "DatabaseName": "test-database",
+      "LastModifiedTimestamp": "2026-02-27T16:08:41Z"
+    }
+  ],
+  "NextToken": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxEnvironment_create.golden.go
+++ b/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxEnvironment_create.golden.go
@@ -1,0 +1,10 @@
+{
+  "CreationTimestamp": "2026-02-27T16:08:41Z",
+  "Description": null,
+  "EnvironmentArn": "arn:aws:finspace:us-east-1:123456789012:kxEnvironment/83b4cc6d-6ea9-4b52-8a78-5fb94ca9aefd",
+  "EnvironmentId": "83b4cc6d-6ea9-4b52-8a78-5fb94ca9aefd",
+  "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+  "Name": "test-environment",
+  "Status": "CREATED",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxEnvironment_get.golden.go
+++ b/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxEnvironment_get.golden.go
@@ -1,0 +1,20 @@
+{
+  "AvailabilityZoneIds": null,
+  "AwsAccountId": "123456789012",
+  "CertificateAuthorityArn": null,
+  "CreationTimestamp": "2026-02-27T16:08:41Z",
+  "CustomDNSConfiguration": null,
+  "DedicatedServiceAccountId": null,
+  "Description": null,
+  "DnsStatus": "",
+  "EnvironmentArn": "arn:aws:finspace:us-east-1:123456789012:kxEnvironment/83b4cc6d-6ea9-4b52-8a78-5fb94ca9aefd",
+  "EnvironmentId": "83b4cc6d-6ea9-4b52-8a78-5fb94ca9aefd",
+  "ErrorMessage": null,
+  "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+  "Name": "test-environment",
+  "Status": "CREATED",
+  "TgwStatus": "",
+  "TransitGatewayConfiguration": null,
+  "UpdateTimestamp": "2026-02-27T16:08:41Z",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxEnvironment_list.golden.go
+++ b/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxEnvironment_list.golden.go
@@ -1,0 +1,25 @@
+{
+  "Environments": [
+    {
+      "AvailabilityZoneIds": null,
+      "AwsAccountId": "123456789012",
+      "CertificateAuthorityArn": null,
+      "CreationTimestamp": "2026-02-27T16:08:41Z",
+      "CustomDNSConfiguration": null,
+      "DedicatedServiceAccountId": null,
+      "Description": null,
+      "DnsStatus": "",
+      "EnvironmentArn": "arn:aws:finspace:us-east-1:123456789012:kxEnvironment/83b4cc6d-6ea9-4b52-8a78-5fb94ca9aefd",
+      "EnvironmentId": "83b4cc6d-6ea9-4b52-8a78-5fb94ca9aefd",
+      "ErrorMessage": null,
+      "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+      "Name": "test-environment",
+      "Status": "CREATED",
+      "TgwStatus": "",
+      "TransitGatewayConfiguration": null,
+      "UpdateTimestamp": "2026-02-27T16:08:41Z"
+    }
+  ],
+  "NextToken": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxUser_create.golden.go
+++ b/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxUser_create.golden.go
@@ -1,0 +1,7 @@
+{
+  "EnvironmentId": "464a8eeb-40b2-48e6-a5fd-cb05c1c3e696",
+  "IamRole": "arn:aws:iam::123456789012:role/TestRole",
+  "UserArn": "arn:aws:finspace:us-east-1:123456789012:kxEnvironment/464a8eeb-40b2-48e6-a5fd-cb05c1c3e696/kxUser/test-user",
+  "UserName": "test-user",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxUser_get.golden.go
+++ b/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxUser_get.golden.go
@@ -1,0 +1,7 @@
+{
+  "EnvironmentId": "464a8eeb-40b2-48e6-a5fd-cb05c1c3e696",
+  "IamRole": "arn:aws:iam::123456789012:role/TestRole",
+  "UserArn": "arn:aws:finspace:us-east-1:123456789012:kxEnvironment/464a8eeb-40b2-48e6-a5fd-cb05c1c3e696/kxUser/test-user",
+  "UserName": "test-user",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxUser_list.golden.go
+++ b/test/integration/testdata/finspace_test_TestFinSpace_CreateAndDeleteKxUser_list.golden.go
@@ -1,0 +1,13 @@
+{
+  "NextToken": null,
+  "Users": [
+    {
+      "CreateTimestamp": "2026-02-27T16:08:41Z",
+      "IamRole": "arn:aws:iam::123456789012:role/TestRole",
+      "UpdateTimestamp": "2026-02-27T16:08:41Z",
+      "UserArn": "arn:aws:finspace:us-east-1:123456789012:kxEnvironment/464a8eeb-40b2-48e6-a5fd-cb05c1c3e696/kxUser/test-user",
+      "UserName": "test-user"
+    }
+  ],
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
- Implement in-memory AWS FinSpace service with managed kdb Insights (Kx) APIs
- Support KxEnvironment, KxDatabase, and KxUser operations (Create, Get, Delete, List, Update)
- Support Tag operations (TagResource, UntagResource, ListTagsForResource)
- Add integration tests with golden file assertions

## Test plan
- [x] Run integration tests: `GOLDEN_UPDATE=true go test -tags=integration -run TestFinSpace ./integration/...`
- [x] Run linter: `make lint`
- [x] Verify all FinSpace operations work correctly with AWS SDK v2

Closes #173