### PR TITLE
feat(rekognition): implement AWS Rekognition service

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -246,6 +246,10 @@ linters:
       - path: internal/service/ce/types\.go
         linters:
           - tagliatelle
+      # AWS Rekognition API requires PascalCase JSON field names.
+      - path: internal/service/rekognition/types\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/organizations"
 	_ "github.com/sivchari/awsim/internal/service/pipes"
 	_ "github.com/sivchari/awsim/internal/service/rds"
+	_ "github.com/sivchari/awsim/internal/service/rekognition"
 	_ "github.com/sivchari/awsim/internal/service/resiliencehub"
 	_ "github.com/sivchari/awsim/internal/service/route53"
 	_ "github.com/sivchari/awsim/internal/service/route53resolver"

--- a/internal/service/rekognition/handlers.go
+++ b/internal/service/rekognition/handlers.go
@@ -1,0 +1,364 @@
+package rekognition
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// handlerFunc is a type alias for handler functions.
+type handlerFunc func(http.ResponseWriter, *http.Request)
+
+// getActionHandlers returns a map of action names to handler functions.
+func (s *Service) getActionHandlers() map[string]handlerFunc {
+	return map[string]handlerFunc{
+		// Collection management
+		"CreateCollection":   s.CreateCollection,
+		"DeleteCollection":   s.DeleteCollection,
+		"ListCollections":    s.ListCollections,
+		"DescribeCollection": s.DescribeCollection,
+
+		// Face operations
+		"IndexFaces":  s.IndexFaces,
+		"ListFaces":   s.ListFaces,
+		"SearchFaces": s.SearchFaces,
+		"DeleteFaces": s.DeleteFaces,
+
+		// Detection operations
+		"DetectFaces":            s.DetectFaces,
+		"DetectLabels":           s.DetectLabels,
+		"DetectText":             s.DetectText,
+		"RecognizeCelebrities":   s.RecognizeCelebrities,
+		"DetectModerationLabels": s.DetectModerationLabels,
+	}
+}
+
+// DispatchAction dispatches the request to the appropriate handler.
+func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
+	target := r.Header.Get("X-Amz-Target")
+	action := strings.TrimPrefix(target, "RekognitionService.")
+
+	handlers := s.getActionHandlers()
+	if handler, ok := handlers[action]; ok {
+		handler(w, r)
+
+		return
+	}
+
+	writeError(w, "InvalidAction", "The action "+action+" is not valid for this endpoint.", http.StatusBadRequest)
+}
+
+// CreateCollection handles the CreateCollection API.
+func (s *Service) CreateCollection(w http.ResponseWriter, r *http.Request) {
+	var req CreateCollectionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.CreateCollection(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// DeleteCollection handles the DeleteCollection API.
+func (s *Service) DeleteCollection(w http.ResponseWriter, r *http.Request) {
+	var req DeleteCollectionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.CollectionID == "" {
+		writeError(w, errInvalidParameter, "CollectionId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.DeleteCollection(r.Context(), req.CollectionID)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// ListCollections handles the ListCollections API.
+func (s *Service) ListCollections(w http.ResponseWriter, r *http.Request) {
+	var req ListCollectionsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// Empty body is acceptable for list operations
+		req = ListCollectionsRequest{}
+	}
+
+	resp, err := s.storage.ListCollections(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// DescribeCollection handles the DescribeCollection API.
+func (s *Service) DescribeCollection(w http.ResponseWriter, r *http.Request) {
+	var req DescribeCollectionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.CollectionID == "" {
+		writeError(w, errInvalidParameter, "CollectionId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.DescribeCollection(r.Context(), req.CollectionID)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// IndexFaces handles the IndexFaces API.
+func (s *Service) IndexFaces(w http.ResponseWriter, r *http.Request) {
+	var req IndexFacesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.IndexFaces(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// ListFaces handles the ListFaces API.
+func (s *Service) ListFaces(w http.ResponseWriter, r *http.Request) {
+	var req ListFacesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.ListFaces(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// SearchFaces handles the SearchFaces API.
+func (s *Service) SearchFaces(w http.ResponseWriter, r *http.Request) {
+	var req SearchFacesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.SearchFaces(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// DeleteFaces handles the DeleteFaces API.
+func (s *Service) DeleteFaces(w http.ResponseWriter, r *http.Request) {
+	var req DeleteFacesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.DeleteFaces(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// DetectFaces handles the DetectFaces API.
+func (s *Service) DetectFaces(w http.ResponseWriter, r *http.Request) {
+	var req DetectFacesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.DetectFaces(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// DetectLabels handles the DetectLabels API.
+func (s *Service) DetectLabels(w http.ResponseWriter, r *http.Request) {
+	var req DetectLabelsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.DetectLabels(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// DetectText handles the DetectText API.
+func (s *Service) DetectText(w http.ResponseWriter, r *http.Request) {
+	var req DetectTextRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.DetectText(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// RecognizeCelebrities handles the RecognizeCelebrities API.
+func (s *Service) RecognizeCelebrities(w http.ResponseWriter, r *http.Request) {
+	var req RecognizeCelebritiesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.RecognizeCelebrities(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// DetectModerationLabels handles the DetectModerationLabels API.
+func (s *Service) DetectModerationLabels(w http.ResponseWriter, r *http.Request) {
+	var req DetectModerationLabelsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.DetectModerationLabels(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, resp)
+}
+
+// writeResponse writes a JSON response.
+func writeResponse(w http.ResponseWriter, resp any) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// writeError writes an error response.
+func writeError(w http.ResponseWriter, code, message string, status int) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(&ErrorResponse{
+		Type:    code,
+		Message: message,
+	})
+}
+
+// handleError handles Rekognition errors.
+func handleError(w http.ResponseWriter, err error) {
+	var svcErr *ServiceError
+	if errors.As(err, &svcErr) {
+		status := getErrorStatus(svcErr.Code)
+		writeError(w, svcErr.Code, svcErr.Message, status)
+
+		return
+	}
+
+	writeError(w, errInternalServer, err.Error(), http.StatusInternalServerError)
+}
+
+// getErrorStatus returns the HTTP status code for a given error code.
+func getErrorStatus(code string) int {
+	switch code {
+	case errResourceNotFound:
+		return http.StatusBadRequest
+	case errResourceExists:
+		return http.StatusBadRequest
+	case errInvalidParameter:
+		return http.StatusBadRequest
+	case errAccessDenied:
+		return http.StatusForbidden
+	case errImageTooLarge:
+		return http.StatusBadRequest
+	case errInvalidImageFormat:
+		return http.StatusBadRequest
+	case errProvisionedThroughput, errThrottling:
+		return http.StatusTooManyRequests
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/internal/service/rekognition/service.go
+++ b/internal/service/rekognition/service.go
@@ -1,0 +1,42 @@
+package rekognition
+
+import (
+	"github.com/sivchari/awsim/internal/service"
+)
+
+// Compile-time check to ensure Service implements service.Service.
+var _ service.Service = (*Service)(nil)
+
+func init() {
+	service.Register(New(NewMemoryStorage()))
+}
+
+// Service implements the AWS Rekognition service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new Rekognition service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "rekognition"
+}
+
+// TargetPrefix returns the X-Amz-Target prefix for JSON protocol dispatch.
+func (s *Service) TargetPrefix() string {
+	return "RekognitionService"
+}
+
+// JSONProtocol marks this service as using JSON protocol.
+func (s *Service) JSONProtocol() {}
+
+// RegisterRoutes registers the routes for this service.
+func (s *Service) RegisterRoutes(_ service.Router) {
+	// JSON protocol services use DispatchAction for routing
+}

--- a/internal/service/rekognition/storage.go
+++ b/internal/service/rekognition/storage.go
@@ -1,0 +1,547 @@
+package rekognition
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	defaultRegion                 = "us-east-1"
+	defaultAccountID              = "123456789012"
+	defaultFaceModelVersion       = "6.0"
+	defaultLabelModelVersion      = "3.0"
+	defaultTextModelVersion       = "3.0"
+	defaultModerationModelVersion = "6.0"
+)
+
+// Collection represents a Rekognition collection.
+type Collection struct {
+	CollectionID      string
+	CollectionArn     string
+	FaceModelVersion  string
+	CreationTimestamp float64
+	FaceCount         int64
+	UserCount         int64
+	Tags              map[string]string
+	Faces             map[string]*Face
+}
+
+// Storage defines the interface for Rekognition storage.
+type Storage interface {
+	// Collection management
+	CreateCollection(ctx context.Context, req *CreateCollectionRequest) (*CreateCollectionResponse, error)
+	DeleteCollection(ctx context.Context, collectionID string) (*DeleteCollectionResponse, error)
+	ListCollections(ctx context.Context, req *ListCollectionsRequest) (*ListCollectionsResponse, error)
+	DescribeCollection(ctx context.Context, collectionID string) (*DescribeCollectionResponse, error)
+
+	// Face operations
+	IndexFaces(ctx context.Context, req *IndexFacesRequest) (*IndexFacesResponse, error)
+	ListFaces(ctx context.Context, req *ListFacesRequest) (*ListFacesResponse, error)
+	SearchFaces(ctx context.Context, req *SearchFacesRequest) (*SearchFacesResponse, error)
+	DeleteFaces(ctx context.Context, req *DeleteFacesRequest) (*DeleteFacesResponse, error)
+
+	// Detection operations (stateless - return mock data)
+	DetectFaces(ctx context.Context, req *DetectFacesRequest) (*DetectFacesResponse, error)
+	DetectLabels(ctx context.Context, req *DetectLabelsRequest) (*DetectLabelsResponse, error)
+	DetectText(ctx context.Context, req *DetectTextRequest) (*DetectTextResponse, error)
+	RecognizeCelebrities(ctx context.Context, req *RecognizeCelebritiesRequest) (*RecognizeCelebritiesResponse, error)
+	DetectModerationLabels(ctx context.Context, req *DetectModerationLabelsRequest) (*DetectModerationLabelsResponse, error)
+}
+
+// MemoryStorage implements in-memory storage for Rekognition.
+type MemoryStorage struct {
+	mu          sync.RWMutex
+	collections map[string]*Collection
+}
+
+// NewMemoryStorage creates a new in-memory storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		collections: make(map[string]*Collection),
+	}
+}
+
+// CreateCollection creates a new collection.
+func (s *MemoryStorage) CreateCollection(_ context.Context, req *CreateCollectionRequest) (*CreateCollectionResponse, error) {
+	if req.CollectionID == "" {
+		return nil, &ServiceError{
+			Code:    errInvalidParameter,
+			Message: "CollectionId is required",
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.collections[req.CollectionID]; exists {
+		return nil, &ServiceError{
+			Code:    errResourceExists,
+			Message: fmt.Sprintf("Collection with id %s already exists", req.CollectionID),
+		}
+	}
+
+	arn := fmt.Sprintf("arn:aws:rekognition:%s:%s:collection/%s", defaultRegion, defaultAccountID, req.CollectionID)
+
+	collection := &Collection{
+		CollectionID:      req.CollectionID,
+		CollectionArn:     arn,
+		FaceModelVersion:  defaultFaceModelVersion,
+		CreationTimestamp: float64(time.Now().Unix()),
+		FaceCount:         0,
+		UserCount:         0,
+		Tags:              req.Tags,
+		Faces:             make(map[string]*Face),
+	}
+
+	s.collections[req.CollectionID] = collection
+
+	return &CreateCollectionResponse{
+		CollectionArn:    arn,
+		FaceModelVersion: defaultFaceModelVersion,
+		StatusCode:       200,
+	}, nil
+}
+
+// DeleteCollection deletes a collection.
+func (s *MemoryStorage) DeleteCollection(_ context.Context, collectionID string) (*DeleteCollectionResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.collections[collectionID]; !exists {
+		return nil, &ServiceError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Collection with id %s not found", collectionID),
+		}
+	}
+
+	delete(s.collections, collectionID)
+
+	return &DeleteCollectionResponse{
+		StatusCode: 200,
+	}, nil
+}
+
+// ListCollections lists all collections.
+func (s *MemoryStorage) ListCollections(_ context.Context, _ *ListCollectionsRequest) (*ListCollectionsResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	collectionIDs := make([]string, 0, len(s.collections))
+	faceModelVersions := make([]string, 0, len(s.collections))
+
+	for _, c := range s.collections {
+		collectionIDs = append(collectionIDs, c.CollectionID)
+		faceModelVersions = append(faceModelVersions, c.FaceModelVersion)
+	}
+
+	return &ListCollectionsResponse{
+		CollectionIDs:     collectionIDs,
+		FaceModelVersions: faceModelVersions,
+	}, nil
+}
+
+// DescribeCollection describes a collection.
+func (s *MemoryStorage) DescribeCollection(_ context.Context, collectionID string) (*DescribeCollectionResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	collection, exists := s.collections[collectionID]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Collection with id %s not found", collectionID),
+		}
+	}
+
+	return &DescribeCollectionResponse{
+		CollectionARN:     collection.CollectionArn,
+		CreationTimestamp: collection.CreationTimestamp,
+		FaceCount:         collection.FaceCount,
+		FaceModelVersion:  collection.FaceModelVersion,
+		UserCount:         collection.UserCount,
+	}, nil
+}
+
+// IndexFaces indexes faces in a collection.
+func (s *MemoryStorage) IndexFaces(_ context.Context, req *IndexFacesRequest) (*IndexFacesResponse, error) {
+	if req.CollectionID == "" {
+		return nil, &ServiceError{
+			Code:    errInvalidParameter,
+			Message: "CollectionId is required",
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	collection, exists := s.collections[req.CollectionID]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Collection with id %s not found", req.CollectionID),
+		}
+	}
+
+	// Generate mock face data
+	faceID := uuid.New().String()
+	imageID := uuid.New().String()
+
+	face := &Face{
+		FaceID:                 faceID,
+		ImageID:                imageID,
+		ExternalImageID:        req.ExternalImageID,
+		Confidence:             99.99,
+		IndexFacesModelVersion: defaultFaceModelVersion,
+		BoundingBox: &BoundingBox{
+			Height: 0.3,
+			Left:   0.2,
+			Top:    0.1,
+			Width:  0.25,
+		},
+	}
+
+	collection.Faces[faceID] = face
+	collection.FaceCount++
+
+	faceDetail := &FaceDetail{
+		BoundingBox: face.BoundingBox,
+		Confidence:  face.Confidence,
+		Landmarks:   generateMockLandmarks(),
+		Pose:        &Pose{Pitch: 0.5, Roll: 1.2, Yaw: -0.3},
+		Quality:     &ImageQuality{Brightness: 80.0, Sharpness: 95.0},
+	}
+
+	return &IndexFacesResponse{
+		FaceModelVersion: defaultFaceModelVersion,
+		FaceRecords: []FaceRecord{
+			{
+				Face:       face,
+				FaceDetail: faceDetail,
+			},
+		},
+		UnindexedFaces: []UnindexedFace{},
+	}, nil
+}
+
+// ListFaces lists faces in a collection.
+func (s *MemoryStorage) ListFaces(_ context.Context, req *ListFacesRequest) (*ListFacesResponse, error) {
+	if req.CollectionID == "" {
+		return nil, &ServiceError{
+			Code:    errInvalidParameter,
+			Message: "CollectionId is required",
+		}
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	collection, exists := s.collections[req.CollectionID]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Collection with id %s not found", req.CollectionID),
+		}
+	}
+
+	faces := make([]Face, 0, len(collection.Faces))
+
+	for _, f := range collection.Faces {
+		faces = append(faces, *f)
+	}
+
+	return &ListFacesResponse{
+		FaceModelVersion: defaultFaceModelVersion,
+		Faces:            faces,
+	}, nil
+}
+
+// SearchFaces searches for faces in a collection.
+func (s *MemoryStorage) SearchFaces(_ context.Context, req *SearchFacesRequest) (*SearchFacesResponse, error) {
+	if req.CollectionID == "" {
+		return nil, &ServiceError{
+			Code:    errInvalidParameter,
+			Message: "CollectionId is required",
+		}
+	}
+
+	if req.FaceID == "" {
+		return nil, &ServiceError{
+			Code:    errInvalidParameter,
+			Message: "FaceId is required",
+		}
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	collection, exists := s.collections[req.CollectionID]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Collection with id %s not found", req.CollectionID),
+		}
+	}
+
+	if _, faceExists := collection.Faces[req.FaceID]; !faceExists {
+		return nil, &ServiceError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Face with id %s not found in collection", req.FaceID),
+		}
+	}
+
+	// Return mock matches (excluding the searched face)
+	matches := make([]FaceMatch, 0)
+
+	for faceID, face := range collection.Faces {
+		if faceID != req.FaceID {
+			matches = append(matches, FaceMatch{
+				Face:       face,
+				Similarity: 95.5,
+			})
+		}
+	}
+
+	return &SearchFacesResponse{
+		FaceModelVersion: defaultFaceModelVersion,
+		FaceMatches:      matches,
+		SearchedFaceID:   req.FaceID,
+	}, nil
+}
+
+// DeleteFaces deletes faces from a collection.
+func (s *MemoryStorage) DeleteFaces(_ context.Context, req *DeleteFacesRequest) (*DeleteFacesResponse, error) {
+	if req.CollectionID == "" {
+		return nil, &ServiceError{
+			Code:    errInvalidParameter,
+			Message: "CollectionId is required",
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	collection, exists := s.collections[req.CollectionID]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Collection with id %s not found", req.CollectionID),
+		}
+	}
+
+	deletedFaces := make([]string, 0)
+
+	for _, faceID := range req.FaceIDs {
+		if _, faceExists := collection.Faces[faceID]; faceExists {
+			delete(collection.Faces, faceID)
+
+			collection.FaceCount--
+
+			deletedFaces = append(deletedFaces, faceID)
+		}
+	}
+
+	return &DeleteFacesResponse{
+		DeletedFaces: deletedFaces,
+	}, nil
+}
+
+// DetectFaces detects faces in an image.
+func (s *MemoryStorage) DetectFaces(_ context.Context, _ *DetectFacesRequest) (*DetectFacesResponse, error) {
+	// Return mock face detection results
+	return &DetectFacesResponse{
+		FaceDetails: []FaceDetail{
+			{
+				BoundingBox: &BoundingBox{
+					Height: 0.35,
+					Left:   0.25,
+					Top:    0.15,
+					Width:  0.28,
+				},
+				Confidence: 99.95,
+				AgeRange:   &AgeRange{Low: 25, High: 35},
+				Smile:      &Attribute{Confidence: 98.5, Value: true},
+				Eyeglasses: &Attribute{Confidence: 99.2, Value: false},
+				Sunglasses: &Attribute{Confidence: 99.8, Value: false},
+				Gender:     &Gender{Confidence: 99.5, Value: "Female"},
+				Beard:      &Attribute{Confidence: 99.9, Value: false},
+				Mustache:   &Attribute{Confidence: 99.9, Value: false},
+				EyesOpen:   &Attribute{Confidence: 99.3, Value: true},
+				MouthOpen:  &Attribute{Confidence: 98.7, Value: false},
+				Emotions: []Emotion{
+					{Type: "HAPPY", Confidence: 95.5},
+					{Type: "CALM", Confidence: 4.2},
+					{Type: "SURPRISED", Confidence: 0.3},
+				},
+				Landmarks: generateMockLandmarks(),
+				Pose:      &Pose{Pitch: 2.5, Roll: -1.3, Yaw: 4.2},
+				Quality:   &ImageQuality{Brightness: 82.5, Sharpness: 91.3},
+			},
+		},
+	}, nil
+}
+
+// DetectLabels detects labels in an image.
+func (s *MemoryStorage) DetectLabels(_ context.Context, _ *DetectLabelsRequest) (*DetectLabelsResponse, error) {
+	// Return mock label detection results
+	return &DetectLabelsResponse{
+		LabelModelVersion: defaultLabelModelVersion,
+		Labels: []Label{
+			{
+				Name:       "Person",
+				Confidence: 99.5,
+				Parents:    []Parent{},
+				Categories: []LabelCategory{{Name: "Person Description"}},
+				Instances: []Instance{
+					{
+						BoundingBox: &BoundingBox{Height: 0.8, Left: 0.1, Top: 0.1, Width: 0.4},
+						Confidence:  98.5,
+					},
+				},
+			},
+			{
+				Name:       "Human",
+				Confidence: 99.5,
+				Parents:    []Parent{},
+				Categories: []LabelCategory{{Name: "Person Description"}},
+			},
+			{
+				Name:       "Face",
+				Confidence: 98.8,
+				Parents:    []Parent{{Name: "Person"}, {Name: "Human"}},
+				Categories: []LabelCategory{{Name: "Person Description"}},
+			},
+			{
+				Name:       "Outdoors",
+				Confidence: 85.3,
+				Parents:    []Parent{},
+				Categories: []LabelCategory{{Name: "Places and Locations"}},
+			},
+			{
+				Name:       "Nature",
+				Confidence: 82.1,
+				Parents:    []Parent{{Name: "Outdoors"}},
+				Categories: []LabelCategory{{Name: "Places and Locations"}},
+			},
+		},
+	}, nil
+}
+
+// DetectText detects text in an image.
+func (s *MemoryStorage) DetectText(_ context.Context, _ *DetectTextRequest) (*DetectTextResponse, error) {
+	// Return mock text detection results
+	parentID := 0
+
+	return &DetectTextResponse{
+		TextModelVersion: defaultTextModelVersion,
+		TextDetections: []TextDetection{
+			{
+				ID:           0,
+				DetectedText: "HELLO WORLD",
+				Type:         "LINE",
+				Confidence:   99.5,
+				Geometry: &Geometry{
+					BoundingBox: &BoundingBox{Height: 0.08, Left: 0.1, Top: 0.2, Width: 0.3},
+					Polygon: []Point{
+						{X: 0.1, Y: 0.2},
+						{X: 0.4, Y: 0.2},
+						{X: 0.4, Y: 0.28},
+						{X: 0.1, Y: 0.28},
+					},
+				},
+			},
+			{
+				ID:           1,
+				ParentID:     &parentID,
+				DetectedText: "HELLO",
+				Type:         "WORD",
+				Confidence:   99.8,
+				Geometry: &Geometry{
+					BoundingBox: &BoundingBox{Height: 0.08, Left: 0.1, Top: 0.2, Width: 0.12},
+					Polygon: []Point{
+						{X: 0.1, Y: 0.2},
+						{X: 0.22, Y: 0.2},
+						{X: 0.22, Y: 0.28},
+						{X: 0.1, Y: 0.28},
+					},
+				},
+			},
+			{
+				ID:           2,
+				ParentID:     &parentID,
+				DetectedText: "WORLD",
+				Type:         "WORD",
+				Confidence:   99.6,
+				Geometry: &Geometry{
+					BoundingBox: &BoundingBox{Height: 0.08, Left: 0.25, Top: 0.2, Width: 0.15},
+					Polygon: []Point{
+						{X: 0.25, Y: 0.2},
+						{X: 0.4, Y: 0.2},
+						{X: 0.4, Y: 0.28},
+						{X: 0.25, Y: 0.28},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// RecognizeCelebrities recognizes celebrities in an image.
+func (s *MemoryStorage) RecognizeCelebrities(_ context.Context, _ *RecognizeCelebritiesRequest) (*RecognizeCelebritiesResponse, error) {
+	// Return mock celebrity recognition results (no celebrities found for mock)
+	return &RecognizeCelebritiesResponse{
+		CelebrityFaces:    []Celebrity{},
+		UnrecognizedFaces: []FaceDetail{},
+	}, nil
+}
+
+// DetectModerationLabels detects moderation labels in an image.
+func (s *MemoryStorage) DetectModerationLabels(_ context.Context, _ *DetectModerationLabelsRequest) (*DetectModerationLabelsResponse, error) {
+	// Return mock moderation results (safe content)
+	return &DetectModerationLabelsResponse{
+		ModerationModelVersion: defaultModerationModelVersion,
+		ModerationLabels:       []ModerationLabel{},
+		ContentTypes: []ContentType{
+			{Name: "Illustrated", Confidence: 75.5},
+		},
+	}, nil
+}
+
+// generateMockLandmarks generates mock facial landmarks.
+func generateMockLandmarks() []Landmark {
+	return []Landmark{
+		{Type: "eyeLeft", X: 0.35, Y: 0.35},
+		{Type: "eyeRight", X: 0.65, Y: 0.35},
+		{Type: "mouthLeft", X: 0.35, Y: 0.7},
+		{Type: "mouthRight", X: 0.65, Y: 0.7},
+		{Type: "nose", X: 0.5, Y: 0.55},
+		{Type: "leftEyeBrowLeft", X: 0.28, Y: 0.3},
+		{Type: "leftEyeBrowRight", X: 0.38, Y: 0.28},
+		{Type: "leftEyeBrowUp", X: 0.33, Y: 0.27},
+		{Type: "rightEyeBrowLeft", X: 0.62, Y: 0.28},
+		{Type: "rightEyeBrowRight", X: 0.72, Y: 0.3},
+		{Type: "rightEyeBrowUp", X: 0.67, Y: 0.27},
+		{Type: "leftEyeLeft", X: 0.32, Y: 0.35},
+		{Type: "leftEyeRight", X: 0.38, Y: 0.35},
+		{Type: "leftEyeUp", X: 0.35, Y: 0.33},
+		{Type: "leftEyeDown", X: 0.35, Y: 0.37},
+		{Type: "rightEyeLeft", X: 0.62, Y: 0.35},
+		{Type: "rightEyeRight", X: 0.68, Y: 0.35},
+		{Type: "rightEyeUp", X: 0.65, Y: 0.33},
+		{Type: "rightEyeDown", X: 0.65, Y: 0.37},
+		{Type: "noseLeft", X: 0.45, Y: 0.6},
+		{Type: "noseRight", X: 0.55, Y: 0.6},
+		{Type: "mouthUp", X: 0.5, Y: 0.68},
+		{Type: "mouthDown", X: 0.5, Y: 0.75},
+		{Type: "leftPupil", X: 0.35, Y: 0.35},
+		{Type: "rightPupil", X: 0.65, Y: 0.35},
+		{Type: "upperJawlineLeft", X: 0.2, Y: 0.4},
+		{Type: "midJawlineLeft", X: 0.22, Y: 0.55},
+		{Type: "chinBottom", X: 0.5, Y: 0.85},
+		{Type: "midJawlineRight", X: 0.78, Y: 0.55},
+		{Type: "upperJawlineRight", X: 0.8, Y: 0.4},
+	}
+}

--- a/internal/service/rekognition/types.go
+++ b/internal/service/rekognition/types.go
@@ -1,0 +1,501 @@
+// Package rekognition provides AWS Rekognition service emulation.
+package rekognition
+
+// Image represents an image for Rekognition operations.
+type Image struct {
+	Bytes    []byte    `json:"Bytes,omitempty"`
+	S3Object *S3Object `json:"S3Object,omitempty"`
+}
+
+// S3Object represents an S3 object reference.
+type S3Object struct {
+	Bucket  string `json:"Bucket,omitempty"`
+	Name    string `json:"Name,omitempty"`
+	Version string `json:"Version,omitempty"`
+}
+
+// BoundingBox represents a bounding box around a detected object.
+type BoundingBox struct {
+	Height float64 `json:"Height"`
+	Left   float64 `json:"Left"`
+	Top    float64 `json:"Top"`
+	Width  float64 `json:"Width"`
+}
+
+// Landmark represents a facial landmark.
+type Landmark struct {
+	Type string  `json:"Type"`
+	X    float64 `json:"X"`
+	Y    float64 `json:"Y"`
+}
+
+// Pose represents the pose of a face.
+type Pose struct {
+	Pitch float64 `json:"Pitch"`
+	Roll  float64 `json:"Roll"`
+	Yaw   float64 `json:"Yaw"`
+}
+
+// ImageQuality represents the quality of an image.
+type ImageQuality struct {
+	Brightness float64 `json:"Brightness"`
+	Sharpness  float64 `json:"Sharpness"`
+}
+
+// AgeRange represents an estimated age range.
+type AgeRange struct {
+	High int `json:"High"`
+	Low  int `json:"Low"`
+}
+
+// Attribute represents a boolean attribute with confidence.
+type Attribute struct {
+	Confidence float64 `json:"Confidence"`
+	Value      bool    `json:"Value"`
+}
+
+// Gender represents detected gender.
+type Gender struct {
+	Confidence float64 `json:"Confidence"`
+	Value      string  `json:"Value"`
+}
+
+// Emotion represents a detected emotion.
+type Emotion struct {
+	Confidence float64 `json:"Confidence"`
+	Type       string  `json:"Type"`
+}
+
+// FaceDetail represents detailed face information.
+type FaceDetail struct {
+	AgeRange    *AgeRange     `json:"AgeRange,omitempty"`
+	Beard       *Attribute    `json:"Beard,omitempty"`
+	BoundingBox *BoundingBox  `json:"BoundingBox,omitempty"`
+	Confidence  float64       `json:"Confidence,omitempty"`
+	Emotions    []Emotion     `json:"Emotions,omitempty"`
+	Eyeglasses  *Attribute    `json:"Eyeglasses,omitempty"`
+	EyesOpen    *Attribute    `json:"EyesOpen,omitempty"`
+	Gender      *Gender       `json:"Gender,omitempty"`
+	Landmarks   []Landmark    `json:"Landmarks,omitempty"`
+	MouthOpen   *Attribute    `json:"MouthOpen,omitempty"`
+	Mustache    *Attribute    `json:"Mustache,omitempty"`
+	Pose        *Pose         `json:"Pose,omitempty"`
+	Quality     *ImageQuality `json:"Quality,omitempty"`
+	Smile       *Attribute    `json:"Smile,omitempty"`
+	Sunglasses  *Attribute    `json:"Sunglasses,omitempty"`
+}
+
+// Face represents a face in a collection.
+type Face struct {
+	BoundingBox            *BoundingBox `json:"BoundingBox,omitempty"`
+	Confidence             float64      `json:"Confidence,omitempty"`
+	ExternalImageID        string       `json:"ExternalImageId,omitempty"`
+	FaceID                 string       `json:"FaceId,omitempty"`
+	ImageID                string       `json:"ImageId,omitempty"`
+	IndexFacesModelVersion string       `json:"IndexFacesModelVersion,omitempty"`
+	UserID                 string       `json:"UserId,omitempty"`
+}
+
+// FaceMatch represents a face match result.
+type FaceMatch struct {
+	Face       *Face   `json:"Face,omitempty"`
+	Similarity float64 `json:"Similarity,omitempty"`
+}
+
+// FaceRecord represents an indexed face record.
+type FaceRecord struct {
+	Face       *Face       `json:"Face,omitempty"`
+	FaceDetail *FaceDetail `json:"FaceDetail,omitempty"`
+}
+
+// UnindexedFace represents a face that could not be indexed.
+type UnindexedFace struct {
+	FaceDetail *FaceDetail `json:"FaceDetail,omitempty"`
+	Reasons    []string    `json:"Reasons,omitempty"`
+}
+
+// Label represents a detected label.
+type Label struct {
+	Aliases    []LabelAlias    `json:"Aliases,omitempty"`
+	Categories []LabelCategory `json:"Categories,omitempty"`
+	Confidence float64         `json:"Confidence,omitempty"`
+	Instances  []Instance      `json:"Instances,omitempty"`
+	Name       string          `json:"Name,omitempty"`
+	Parents    []Parent        `json:"Parents,omitempty"`
+}
+
+// LabelAlias represents a label alias.
+type LabelAlias struct {
+	Name string `json:"Name,omitempty"`
+}
+
+// LabelCategory represents a label category.
+type LabelCategory struct {
+	Name string `json:"Name,omitempty"`
+}
+
+// Instance represents an instance of a label.
+type Instance struct {
+	BoundingBox    *BoundingBox    `json:"BoundingBox,omitempty"`
+	Confidence     float64         `json:"Confidence,omitempty"`
+	DominantColors []DominantColor `json:"DominantColors,omitempty"`
+}
+
+// DominantColor represents a dominant color.
+type DominantColor struct {
+	Blue            int     `json:"Blue,omitempty"`
+	CSSColor        string  `json:"CSSColor,omitempty"`
+	Green           int     `json:"Green,omitempty"`
+	HexCode         string  `json:"HexCode,omitempty"`
+	PixelPercent    float64 `json:"PixelPercent,omitempty"`
+	Red             int     `json:"Red,omitempty"`
+	SimplifiedColor string  `json:"SimplifiedColor,omitempty"`
+}
+
+// Parent represents a parent label.
+type Parent struct {
+	Name string `json:"Name,omitempty"`
+}
+
+// TextDetection represents detected text.
+type TextDetection struct {
+	Confidence   float64   `json:"Confidence,omitempty"`
+	DetectedText string    `json:"DetectedText,omitempty"`
+	Geometry     *Geometry `json:"Geometry,omitempty"`
+	ID           int       `json:"Id,omitempty"`
+	ParentID     *int      `json:"ParentId,omitempty"`
+	Type         string    `json:"Type,omitempty"`
+}
+
+// Geometry represents text geometry.
+type Geometry struct {
+	BoundingBox *BoundingBox `json:"BoundingBox,omitempty"`
+	Polygon     []Point      `json:"Polygon,omitempty"`
+}
+
+// Point represents a point in a polygon.
+type Point struct {
+	X float64 `json:"X"`
+	Y float64 `json:"Y"`
+}
+
+// Celebrity represents a recognized celebrity.
+type Celebrity struct {
+	Face            *FaceDetail  `json:"Face,omitempty"`
+	ID              string       `json:"Id,omitempty"`
+	KnownGender     *KnownGender `json:"KnownGender,omitempty"`
+	MatchConfidence float64      `json:"MatchConfidence,omitempty"`
+	Name            string       `json:"Name,omitempty"`
+	Urls            []string     `json:"Urls,omitempty"`
+}
+
+// KnownGender represents known gender information.
+type KnownGender struct {
+	Type string `json:"Type,omitempty"`
+}
+
+// ModerationLabel represents a moderation label.
+type ModerationLabel struct {
+	Confidence    float64 `json:"Confidence,omitempty"`
+	Name          string  `json:"Name,omitempty"`
+	ParentName    string  `json:"ParentName,omitempty"`
+	TaxonomyLevel int     `json:"TaxonomyLevel,omitempty"`
+}
+
+// ContentType represents content type information.
+type ContentType struct {
+	Confidence float64 `json:"Confidence,omitempty"`
+	Name       string  `json:"Name,omitempty"`
+}
+
+// CreateCollectionRequest represents a CreateCollection request.
+type CreateCollectionRequest struct {
+	CollectionID string            `json:"CollectionId"`
+	Tags         map[string]string `json:"Tags,omitempty"`
+}
+
+// CreateCollectionResponse represents a CreateCollection response.
+type CreateCollectionResponse struct {
+	CollectionArn    string `json:"CollectionArn,omitempty"`
+	FaceModelVersion string `json:"FaceModelVersion,omitempty"`
+	StatusCode       int    `json:"StatusCode,omitempty"`
+}
+
+// DeleteCollectionRequest represents a DeleteCollection request.
+type DeleteCollectionRequest struct {
+	CollectionID string `json:"CollectionId"`
+}
+
+// DeleteCollectionResponse represents a DeleteCollection response.
+type DeleteCollectionResponse struct {
+	StatusCode int `json:"StatusCode,omitempty"`
+}
+
+// ListCollectionsRequest represents a ListCollections request.
+type ListCollectionsRequest struct {
+	MaxResults int    `json:"MaxResults,omitempty"`
+	NextToken  string `json:"NextToken,omitempty"`
+}
+
+// ListCollectionsResponse represents a ListCollections response.
+type ListCollectionsResponse struct {
+	CollectionIDs     []string `json:"CollectionIds,omitempty"`
+	FaceModelVersions []string `json:"FaceModelVersions,omitempty"`
+	NextToken         string   `json:"NextToken,omitempty"`
+}
+
+// DetectFacesRequest represents a DetectFaces request.
+type DetectFacesRequest struct {
+	Attributes []string `json:"Attributes,omitempty"`
+	Image      Image    `json:"Image"`
+}
+
+// DetectFacesResponse represents a DetectFaces response.
+type DetectFacesResponse struct {
+	FaceDetails           []FaceDetail `json:"FaceDetails,omitempty"`
+	OrientationCorrection string       `json:"OrientationCorrection,omitempty"`
+}
+
+// IndexFacesRequest represents an IndexFaces request.
+type IndexFacesRequest struct {
+	CollectionID        string   `json:"CollectionId"`
+	DetectionAttributes []string `json:"DetectionAttributes,omitempty"`
+	ExternalImageID     string   `json:"ExternalImageId,omitempty"`
+	Image               Image    `json:"Image"`
+	MaxFaces            int      `json:"MaxFaces,omitempty"`
+	QualityFilter       string   `json:"QualityFilter,omitempty"`
+}
+
+// IndexFacesResponse represents an IndexFaces response.
+type IndexFacesResponse struct {
+	FaceModelVersion      string          `json:"FaceModelVersion,omitempty"`
+	FaceRecords           []FaceRecord    `json:"FaceRecords,omitempty"`
+	OrientationCorrection string          `json:"OrientationCorrection,omitempty"`
+	UnindexedFaces        []UnindexedFace `json:"UnindexedFaces,omitempty"`
+}
+
+// SearchFacesRequest represents a SearchFaces request.
+type SearchFacesRequest struct {
+	CollectionID       string  `json:"CollectionId"`
+	FaceID             string  `json:"FaceId"`
+	FaceMatchThreshold float64 `json:"FaceMatchThreshold,omitempty"`
+	MaxFaces           int     `json:"MaxFaces,omitempty"`
+}
+
+// SearchFacesResponse represents a SearchFaces response.
+type SearchFacesResponse struct {
+	FaceMatches      []FaceMatch `json:"FaceMatches,omitempty"`
+	FaceModelVersion string      `json:"FaceModelVersion,omitempty"`
+	SearchedFaceID   string      `json:"SearchedFaceId,omitempty"`
+}
+
+// ListFacesRequest represents a ListFaces request.
+type ListFacesRequest struct {
+	CollectionID string   `json:"CollectionId"`
+	FaceIDs      []string `json:"FaceIds,omitempty"`
+	MaxResults   int      `json:"MaxResults,omitempty"`
+	NextToken    string   `json:"NextToken,omitempty"`
+	UserID       string   `json:"UserId,omitempty"`
+}
+
+// ListFacesResponse represents a ListFaces response.
+type ListFacesResponse struct {
+	FaceModelVersion string `json:"FaceModelVersion,omitempty"`
+	Faces            []Face `json:"Faces,omitempty"`
+	NextToken        string `json:"NextToken,omitempty"`
+}
+
+// DeleteFacesRequest represents a DeleteFaces request.
+type DeleteFacesRequest struct {
+	CollectionID string   `json:"CollectionId"`
+	FaceIDs      []string `json:"FaceIds"`
+}
+
+// DeleteFacesResponse represents a DeleteFaces response.
+type DeleteFacesResponse struct {
+	DeletedFaces              []string                   `json:"DeletedFaces,omitempty"`
+	UnsuccessfulFaceDeletions []UnsuccessfulFaceDeletion `json:"UnsuccessfulFaceDeletions,omitempty"`
+}
+
+// UnsuccessfulFaceDeletion represents an unsuccessful face deletion.
+type UnsuccessfulFaceDeletion struct {
+	FaceID  string   `json:"FaceId,omitempty"`
+	Reasons []string `json:"Reasons,omitempty"`
+	UserID  string   `json:"UserId,omitempty"`
+}
+
+// DetectLabelsRequest represents a DetectLabels request.
+type DetectLabelsRequest struct {
+	Features      []string              `json:"Features,omitempty"`
+	Image         Image                 `json:"Image"`
+	MaxLabels     int                   `json:"MaxLabels,omitempty"`
+	MinConfidence float64               `json:"MinConfidence,omitempty"`
+	Settings      *DetectLabelsSettings `json:"Settings,omitempty"`
+}
+
+// DetectLabelsSettings represents settings for DetectLabels.
+type DetectLabelsSettings struct {
+	GeneralLabels   *GeneralLabelsSettings   `json:"GeneralLabels,omitempty"`
+	ImageProperties *ImagePropertiesSettings `json:"ImageProperties,omitempty"`
+}
+
+// GeneralLabelsSettings represents general labels settings.
+type GeneralLabelsSettings struct {
+	LabelCategoryExclusionFilters []string `json:"LabelCategoryExclusionFilters,omitempty"`
+	LabelCategoryInclusionFilters []string `json:"LabelCategoryInclusionFilters,omitempty"`
+	LabelExclusionFilters         []string `json:"LabelExclusionFilters,omitempty"`
+	LabelInclusionFilters         []string `json:"LabelInclusionFilters,omitempty"`
+}
+
+// ImagePropertiesSettings represents image properties settings.
+type ImagePropertiesSettings struct {
+	MaxDominantColors int `json:"MaxDominantColors,omitempty"`
+}
+
+// DetectLabelsResponse represents a DetectLabels response.
+type DetectLabelsResponse struct {
+	ImageProperties       *ImageProperties `json:"ImageProperties,omitempty"`
+	LabelModelVersion     string           `json:"LabelModelVersion,omitempty"`
+	Labels                []Label          `json:"Labels,omitempty"`
+	OrientationCorrection string           `json:"OrientationCorrection,omitempty"`
+}
+
+// ImageProperties represents image properties.
+type ImageProperties struct {
+	Background     *BackgroundColors `json:"Background,omitempty"`
+	DominantColors []DominantColor   `json:"DominantColors,omitempty"`
+	Foreground     *ForegroundColors `json:"Foreground,omitempty"`
+	Quality        *ImageQuality     `json:"Quality,omitempty"`
+}
+
+// BackgroundColors represents background colors.
+type BackgroundColors struct {
+	DominantColors []DominantColor `json:"DominantColors,omitempty"`
+}
+
+// ForegroundColors represents foreground colors.
+type ForegroundColors struct {
+	DominantColors []DominantColor `json:"DominantColors,omitempty"`
+}
+
+// DetectTextRequest represents a DetectText request.
+type DetectTextRequest struct {
+	Filters *DetectTextFilters `json:"Filters,omitempty"`
+	Image   Image              `json:"Image"`
+}
+
+// DetectTextFilters represents filters for DetectText.
+type DetectTextFilters struct {
+	RegionsOfInterest []RegionOfInterest `json:"RegionsOfInterest,omitempty"`
+	WordFilter        *WordFilter        `json:"WordFilter,omitempty"`
+}
+
+// RegionOfInterest represents a region of interest.
+type RegionOfInterest struct {
+	BoundingBox *BoundingBox `json:"BoundingBox,omitempty"`
+	Polygon     []Point      `json:"Polygon,omitempty"`
+}
+
+// WordFilter represents a word filter.
+type WordFilter struct {
+	MinBoundingBoxHeight float64 `json:"MinBoundingBoxHeight,omitempty"`
+	MinBoundingBoxWidth  float64 `json:"MinBoundingBoxWidth,omitempty"`
+	MinConfidence        float64 `json:"MinConfidence,omitempty"`
+}
+
+// DetectTextResponse represents a DetectText response.
+type DetectTextResponse struct {
+	TextDetections   []TextDetection `json:"TextDetections,omitempty"`
+	TextModelVersion string          `json:"TextModelVersion,omitempty"`
+}
+
+// RecognizeCelebritiesRequest represents a RecognizeCelebrities request.
+type RecognizeCelebritiesRequest struct {
+	Image Image `json:"Image"`
+}
+
+// RecognizeCelebritiesResponse represents a RecognizeCelebrities response.
+type RecognizeCelebritiesResponse struct {
+	CelebrityFaces        []Celebrity  `json:"CelebrityFaces,omitempty"`
+	OrientationCorrection string       `json:"OrientationCorrection,omitempty"`
+	UnrecognizedFaces     []FaceDetail `json:"UnrecognizedFaces,omitempty"`
+}
+
+// DetectModerationLabelsRequest represents a DetectModerationLabels request.
+type DetectModerationLabelsRequest struct {
+	HumanLoopConfig *HumanLoopConfig `json:"HumanLoopConfig,omitempty"`
+	Image           Image            `json:"Image"`
+	MinConfidence   float64          `json:"MinConfidence,omitempty"`
+	ProjectVersion  string           `json:"ProjectVersion,omitempty"`
+}
+
+// HumanLoopConfig represents human loop configuration.
+type HumanLoopConfig struct {
+	DataAttributes    *HumanLoopDataAttributes `json:"DataAttributes,omitempty"`
+	FlowDefinitionArn string                   `json:"FlowDefinitionArn,omitempty"`
+	HumanLoopName     string                   `json:"HumanLoopName,omitempty"`
+}
+
+// HumanLoopDataAttributes represents human loop data attributes.
+type HumanLoopDataAttributes struct {
+	ContentClassifiers []string `json:"ContentClassifiers,omitempty"`
+}
+
+// DetectModerationLabelsResponse represents a DetectModerationLabels response.
+type DetectModerationLabelsResponse struct {
+	ContentTypes              []ContentType              `json:"ContentTypes,omitempty"`
+	HumanLoopActivationOutput *HumanLoopActivationOutput `json:"HumanLoopActivationOutput,omitempty"`
+	ModerationLabels          []ModerationLabel          `json:"ModerationLabels,omitempty"`
+	ModerationModelVersion    string                     `json:"ModerationModelVersion,omitempty"`
+}
+
+// HumanLoopActivationOutput represents human loop activation output.
+type HumanLoopActivationOutput struct {
+	HumanLoopActivationConditionsEvaluationResults string   `json:"HumanLoopActivationConditionsEvaluationResults,omitempty"`
+	HumanLoopActivationReasons                     []string `json:"HumanLoopActivationReasons,omitempty"`
+	HumanLoopArn                                   string   `json:"HumanLoopArn,omitempty"`
+}
+
+// DescribeCollectionRequest represents a DescribeCollection request.
+type DescribeCollectionRequest struct {
+	CollectionID string `json:"CollectionId"`
+}
+
+// DescribeCollectionResponse represents a DescribeCollection response.
+type DescribeCollectionResponse struct {
+	CollectionARN     string  `json:"CollectionARN,omitempty"`
+	CreationTimestamp float64 `json:"CreationTimestamp,omitempty"`
+	FaceCount         int64   `json:"FaceCount,omitempty"`
+	FaceModelVersion  string  `json:"FaceModelVersion,omitempty"`
+	UserCount         int64   `json:"UserCount,omitempty"`
+}
+
+// ErrorResponse represents an error response.
+type ErrorResponse struct {
+	Type    string `json:"__type"`
+	Message string `json:"message"`
+}
+
+// ServiceError represents a service error.
+type ServiceError struct {
+	Code    string
+	Message string
+}
+
+// Error returns the error message.
+func (e *ServiceError) Error() string {
+	return e.Message
+}
+
+// Error codes.
+const (
+	errResourceNotFound      = "ResourceNotFoundException"
+	errResourceExists        = "ResourceAlreadyExistsException"
+	errInvalidParameter      = "InvalidParameterException"
+	errAccessDenied          = "AccessDeniedException"
+	errInternalServer        = "InternalServerError"
+	errImageTooLarge         = "ImageTooLargeException"
+	errInvalidImageFormat    = "InvalidImageFormatException"
+	errProvisionedThroughput = "ProvisionedThroughputExceededException"
+	errThrottling            = "ThrottlingException"
+)

--- a/test/go.mod
+++ b/test/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.50.3
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.17
 	github.com/aws/aws-sdk-go-v2/service/rds v1.115.0
+	github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.17
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.35.10
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.2
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.42.2

--- a/test/go.sum
+++ b/test/go.sum
@@ -46,6 +46,8 @@ github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.18 h1:Nq5a1NHA7V26jCwajbSf
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.18/go.mod h1:RAyYQafoEJR/v5MhsSzl7h15SZP7l+YcPjUZTRRuE+0=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.61.1 h1:aho+qoT/ybRPv3EKee98Pc1hZcKRd5ECrv+KdCdj2I8=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.61.1/go.mod h1:jAsoyYj8HSPYo4ZMaoGtDG622Nz8VXtsYVA8jyPYyqI=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.3 h1:4/SsyLjRsD+mub/wEt9xjo/SVPzl1idgwvDtklvp8tw=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.3/go.mod h1:GMraVPHg0sV7jaLWiOpIcpo6wA2OyXgJmgPh/GREv9w=
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.37.0 h1:5MthmITq3unZoB5EHlwYsoadubv0H/vi8/gnO0/UmF4=
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.37.0/go.mod h1:KkCYX9biRFzx8lAEgYyNSuQ3ljMK2ZOTnplMhHyCfhk=
 github.com/aws/aws-sdk-go-v2/service/dlm v1.35.13 h1:wyKOcqzzdbwz1UQtbFmmDw6YR6ux20yqmVaB4zONToE=
@@ -106,6 +108,8 @@ github.com/aws/aws-sdk-go-v2/service/pipes v1.23.17 h1:mVj6qM8m1vacLPRvpYsrhqIop
 github.com/aws/aws-sdk-go-v2/service/pipes v1.23.17/go.mod h1:eLlxQF7rzISHqpiOqcW/IdjS7kwO+t1NdEpfLFIapAA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.115.0 h1:oNl6YghOtxu3MiFk1tQ86QlrYMIEJazGUDbBCg9nxLA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.115.0/go.mod h1:JBRYWpz5oXQtHgQC+X8LX9lh0FBCwRHJlWEIT+TTLaE=
+github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.17 h1:6j6Oyx94NqHnnakbwTEwl2C/Q5vsKuzVlKl0ruPQZCo=
+github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.17/go.mod h1:K3SrqERm8hniMSa1nYUI4zOhh/2gGKWAEv3XWcFxUrU=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.35.10 h1:3QfrRqxoAf3cOeYjXCs2NLp24JOSg+/hkrBZF5ib5gw=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.35.10/go.mod h1:HSwhMNwfAsZNfPHStNaDC9Cai/2uu2o89S7hJTEhg3g=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.2 h1:zoD/SoiVQi8l8tuQn//VexrXS2yorg/+717JNA4Ble8=
@@ -152,5 +156,3 @@ github.com/aws/smithy-go v1.24.1 h1:VbyeNfmYkWoxMVpGUAbQumkODcYmfMRfZ8yQiH30SK0=
 github.com/aws/smithy-go v1.24.1/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
 github.com/sivchari/golden v0.3.0 h1:WUtMlhvqeH8mXcX4hsZwyfrA5jeNz5F9IL1w+u7Ew7w=
 github.com/sivchari/golden v0.3.0/go.mod h1:gddwjsjxPtLYRCq0M471x9WD9khQWty82Yn/PZ/2I8E=
-github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.3 h1:4/SsyLjRsD+mub/wEt9xjo/SVPzl1idgwvDtklvp8tw=
-github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.3/go.mod h1:GMraVPHg0sV7jaLWiOpIcpo6wA2OyXgJmgPh/GREv9w=

--- a/test/integration/rekognition_test.go
+++ b/test/integration/rekognition_test.go
@@ -1,0 +1,280 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/rekognition"
+	"github.com/aws/aws-sdk-go-v2/service/rekognition/types"
+	"github.com/sivchari/golden"
+)
+
+func newRekognitionClient(t *testing.T) *rekognition.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return rekognition.NewFromConfig(cfg, func(o *rekognition.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestRekognition_CreateAndDeleteCollection(t *testing.T) {
+	client := newRekognitionClient(t)
+	ctx := t.Context()
+
+	// Create collection
+	collectionId := "test-collection"
+
+	createOutput, err := client.CreateCollection(ctx, &rekognition.CreateCollectionInput{
+		CollectionId: aws.String(collectionId),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "CollectionArn"),
+	)
+	g.Assert(t.Name()+"_create", createOutput)
+
+	// Delete collection
+	deleteOutput, err := client.DeleteCollection(ctx, &rekognition.DeleteCollectionInput{
+		CollectionId: aws.String(collectionId),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata"),
+	)
+	g2.Assert(t.Name()+"_delete", deleteOutput)
+}
+
+func TestRekognition_ListCollections(t *testing.T) {
+	client := newRekognitionClient(t)
+	ctx := t.Context()
+
+	// Create a collection first
+	_, err := client.CreateCollection(ctx, &rekognition.CreateCollectionInput{
+		CollectionId: aws.String("test-list-collection"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteCollection(ctx, &rekognition.DeleteCollectionInput{
+			CollectionId: aws.String("test-list-collection"),
+		})
+	})
+
+	// List collections
+	output, err := client.ListCollections(ctx, &rekognition.ListCollectionsInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "CollectionIds", "FaceModelVersions"),
+	)
+	g.Assert(t.Name(), output)
+}
+
+func TestRekognition_DescribeCollection(t *testing.T) {
+	client := newRekognitionClient(t)
+	ctx := t.Context()
+
+	collectionId := "test-describe-collection"
+
+	// Create collection
+	_, err := client.CreateCollection(ctx, &rekognition.CreateCollectionInput{
+		CollectionId: aws.String(collectionId),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteCollection(ctx, &rekognition.DeleteCollectionInput{
+			CollectionId: aws.String(collectionId),
+		})
+	})
+
+	// Describe collection
+	output, err := client.DescribeCollection(ctx, &rekognition.DescribeCollectionInput{
+		CollectionId: aws.String(collectionId),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "CollectionARN", "CreationTimestamp"),
+	)
+	g.Assert(t.Name(), output)
+}
+
+func TestRekognition_DetectFaces(t *testing.T) {
+	client := newRekognitionClient(t)
+	ctx := t.Context()
+
+	// Detect faces with a minimal image (mock returns predefined data)
+	output, err := client.DetectFaces(ctx, &rekognition.DetectFacesInput{
+		Image: &types.Image{
+			Bytes: []byte{0x89, 0x50, 0x4E, 0x47}, // PNG header bytes (mock)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata"),
+	)
+	g.Assert(t.Name(), output)
+}
+
+func TestRekognition_DetectLabels(t *testing.T) {
+	client := newRekognitionClient(t)
+	ctx := t.Context()
+
+	// Detect labels with a minimal image
+	output, err := client.DetectLabels(ctx, &rekognition.DetectLabelsInput{
+		Image: &types.Image{
+			Bytes: []byte{0x89, 0x50, 0x4E, 0x47},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata"),
+	)
+	g.Assert(t.Name(), output)
+}
+
+func TestRekognition_DetectText(t *testing.T) {
+	client := newRekognitionClient(t)
+	ctx := t.Context()
+
+	// Detect text with a minimal image
+	output, err := client.DetectText(ctx, &rekognition.DetectTextInput{
+		Image: &types.Image{
+			Bytes: []byte{0x89, 0x50, 0x4E, 0x47},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata"),
+	)
+	g.Assert(t.Name(), output)
+}
+
+func TestRekognition_RecognizeCelebrities(t *testing.T) {
+	client := newRekognitionClient(t)
+	ctx := t.Context()
+
+	// Recognize celebrities with a minimal image
+	output, err := client.RecognizeCelebrities(ctx, &rekognition.RecognizeCelebritiesInput{
+		Image: &types.Image{
+			Bytes: []byte{0x89, 0x50, 0x4E, 0x47},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata"),
+	)
+	g.Assert(t.Name(), output)
+}
+
+func TestRekognition_DetectModerationLabels(t *testing.T) {
+	client := newRekognitionClient(t)
+	ctx := t.Context()
+
+	// Detect moderation labels with a minimal image
+	output, err := client.DetectModerationLabels(ctx, &rekognition.DetectModerationLabelsInput{
+		Image: &types.Image{
+			Bytes: []byte{0x89, 0x50, 0x4E, 0x47},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata"),
+	)
+	g.Assert(t.Name(), output)
+}
+
+func TestRekognition_IndexAndSearchFaces(t *testing.T) {
+	client := newRekognitionClient(t)
+	ctx := t.Context()
+
+	collectionId := "test-face-collection"
+
+	// Create collection
+	_, err := client.CreateCollection(ctx, &rekognition.CreateCollectionInput{
+		CollectionId: aws.String(collectionId),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteCollection(ctx, &rekognition.DeleteCollectionInput{
+			CollectionId: aws.String(collectionId),
+		})
+	})
+
+	// Index a face
+	indexOutput, err := client.IndexFaces(ctx, &rekognition.IndexFacesInput{
+		CollectionId:    aws.String(collectionId),
+		ExternalImageId: aws.String("test-person-1"),
+		Image: &types.Image{
+			Bytes: []byte{0x89, 0x50, 0x4E, 0x47},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "FaceRecords", "FaceModelVersion"),
+	)
+	g.Assert(t.Name()+"_index", indexOutput)
+
+	// List faces
+	listOutput, err := client.ListFaces(ctx, &rekognition.ListFacesInput{
+		CollectionId: aws.String(collectionId),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g2 := golden.New(t,
+		golden.WithIgnoreFields("ResultMetadata", "Faces", "FaceModelVersion"),
+	)
+	g2.Assert(t.Name()+"_list", listOutput)
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_CreateAndDeleteCollection_TestRekognition_CreateAndDeleteCollection_create.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_CreateAndDeleteCollection_TestRekognition_CreateAndDeleteCollection_create.golden.go
@@ -1,0 +1,6 @@
+{
+  "CollectionArn": "arn:aws:rekognition:us-east-1:123456789012:collection/test-collection",
+  "FaceModelVersion": "6.0",
+  "StatusCode": 200,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_CreateAndDeleteCollection_TestRekognition_CreateAndDeleteCollection_delete.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_CreateAndDeleteCollection_TestRekognition_CreateAndDeleteCollection_delete.golden.go
@@ -1,0 +1,4 @@
+{
+  "StatusCode": 200,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_DescribeCollection_TestRekognition_DescribeCollection.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_DescribeCollection_TestRekognition_DescribeCollection.golden.go
@@ -1,0 +1,8 @@
+{
+  "CollectionARN": "arn:aws:rekognition:us-east-1:123456789012:collection/test-describe-collection",
+  "CreationTimestamp": "2026-03-03T02:35:18Z",
+  "FaceCount": null,
+  "FaceModelVersion": "6.0",
+  "UserCount": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_DetectFaces_TestRekognition_DetectFaces.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_DetectFaces_TestRekognition_DetectFaces.golden.go
@@ -1,0 +1,228 @@
+{
+  "FaceDetails": [
+    {
+      "AgeRange": {
+        "High": 35,
+        "Low": 25
+      },
+      "Beard": {
+        "Confidence": 99.9,
+        "Value": false
+      },
+      "BoundingBox": {
+        "Height": 0.35,
+        "Left": 0.25,
+        "Top": 0.15,
+        "Width": 0.28
+      },
+      "Confidence": 99.95,
+      "Emotions": [
+        {
+          "Confidence": 95.5,
+          "Type": "HAPPY"
+        },
+        {
+          "Confidence": 4.2,
+          "Type": "CALM"
+        },
+        {
+          "Confidence": 0.3,
+          "Type": "SURPRISED"
+        }
+      ],
+      "EyeDirection": null,
+      "Eyeglasses": {
+        "Confidence": 99.2,
+        "Value": false
+      },
+      "EyesOpen": {
+        "Confidence": 99.3,
+        "Value": true
+      },
+      "FaceOccluded": null,
+      "Gender": {
+        "Confidence": 99.5,
+        "Value": "Female"
+      },
+      "Landmarks": [
+        {
+          "Type": "eyeLeft",
+          "X": 0.35,
+          "Y": 0.35
+        },
+        {
+          "Type": "eyeRight",
+          "X": 0.65,
+          "Y": 0.35
+        },
+        {
+          "Type": "mouthLeft",
+          "X": 0.35,
+          "Y": 0.7
+        },
+        {
+          "Type": "mouthRight",
+          "X": 0.65,
+          "Y": 0.7
+        },
+        {
+          "Type": "nose",
+          "X": 0.5,
+          "Y": 0.55
+        },
+        {
+          "Type": "leftEyeBrowLeft",
+          "X": 0.28,
+          "Y": 0.3
+        },
+        {
+          "Type": "leftEyeBrowRight",
+          "X": 0.38,
+          "Y": 0.28
+        },
+        {
+          "Type": "leftEyeBrowUp",
+          "X": 0.33,
+          "Y": 0.27
+        },
+        {
+          "Type": "rightEyeBrowLeft",
+          "X": 0.62,
+          "Y": 0.28
+        },
+        {
+          "Type": "rightEyeBrowRight",
+          "X": 0.72,
+          "Y": 0.3
+        },
+        {
+          "Type": "rightEyeBrowUp",
+          "X": 0.67,
+          "Y": 0.27
+        },
+        {
+          "Type": "leftEyeLeft",
+          "X": 0.32,
+          "Y": 0.35
+        },
+        {
+          "Type": "leftEyeRight",
+          "X": 0.38,
+          "Y": 0.35
+        },
+        {
+          "Type": "leftEyeUp",
+          "X": 0.35,
+          "Y": 0.33
+        },
+        {
+          "Type": "leftEyeDown",
+          "X": 0.35,
+          "Y": 0.37
+        },
+        {
+          "Type": "rightEyeLeft",
+          "X": 0.62,
+          "Y": 0.35
+        },
+        {
+          "Type": "rightEyeRight",
+          "X": 0.68,
+          "Y": 0.35
+        },
+        {
+          "Type": "rightEyeUp",
+          "X": 0.65,
+          "Y": 0.33
+        },
+        {
+          "Type": "rightEyeDown",
+          "X": 0.65,
+          "Y": 0.37
+        },
+        {
+          "Type": "noseLeft",
+          "X": 0.45,
+          "Y": 0.6
+        },
+        {
+          "Type": "noseRight",
+          "X": 0.55,
+          "Y": 0.6
+        },
+        {
+          "Type": "mouthUp",
+          "X": 0.5,
+          "Y": 0.68
+        },
+        {
+          "Type": "mouthDown",
+          "X": 0.5,
+          "Y": 0.75
+        },
+        {
+          "Type": "leftPupil",
+          "X": 0.35,
+          "Y": 0.35
+        },
+        {
+          "Type": "rightPupil",
+          "X": 0.65,
+          "Y": 0.35
+        },
+        {
+          "Type": "upperJawlineLeft",
+          "X": 0.2,
+          "Y": 0.4
+        },
+        {
+          "Type": "midJawlineLeft",
+          "X": 0.22,
+          "Y": 0.55
+        },
+        {
+          "Type": "chinBottom",
+          "X": 0.5,
+          "Y": 0.85
+        },
+        {
+          "Type": "midJawlineRight",
+          "X": 0.78,
+          "Y": 0.55
+        },
+        {
+          "Type": "upperJawlineRight",
+          "X": 0.8,
+          "Y": 0.4
+        }
+      ],
+      "MouthOpen": {
+        "Confidence": 98.7,
+        "Value": false
+      },
+      "Mustache": {
+        "Confidence": 99.9,
+        "Value": false
+      },
+      "Pose": {
+        "Pitch": 2.5,
+        "Roll": -1.3,
+        "Yaw": 4.2
+      },
+      "Quality": {
+        "Brightness": 82.5,
+        "Sharpness": 91.3
+      },
+      "Smile": {
+        "Confidence": 98.5,
+        "Value": true
+      },
+      "Sunglasses": {
+        "Confidence": 99.8,
+        "Value": false
+      }
+    }
+  ],
+  "OrientationCorrection": "",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_DetectLabels_TestRekognition_DetectLabels.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_DetectLabels_TestRekognition_DetectLabels.golden.go
@@ -1,0 +1,90 @@
+{
+  "ImageProperties": null,
+  "LabelModelVersion": "3.0",
+  "Labels": [
+    {
+      "Aliases": null,
+      "Categories": [
+        {
+          "Name": "Person Description"
+        }
+      ],
+      "Confidence": 99.5,
+      "Instances": [
+        {
+          "BoundingBox": {
+            "Height": 0.8,
+            "Left": 0.1,
+            "Top": 0.1,
+            "Width": 0.4
+          },
+          "Confidence": 98.5,
+          "DominantColors": null
+        }
+      ],
+      "Name": "Person",
+      "Parents": null
+    },
+    {
+      "Aliases": null,
+      "Categories": [
+        {
+          "Name": "Person Description"
+        }
+      ],
+      "Confidence": 99.5,
+      "Instances": null,
+      "Name": "Human",
+      "Parents": null
+    },
+    {
+      "Aliases": null,
+      "Categories": [
+        {
+          "Name": "Person Description"
+        }
+      ],
+      "Confidence": 98.8,
+      "Instances": null,
+      "Name": "Face",
+      "Parents": [
+        {
+          "Name": "Person"
+        },
+        {
+          "Name": "Human"
+        }
+      ]
+    },
+    {
+      "Aliases": null,
+      "Categories": [
+        {
+          "Name": "Places and Locations"
+        }
+      ],
+      "Confidence": 85.3,
+      "Instances": null,
+      "Name": "Outdoors",
+      "Parents": null
+    },
+    {
+      "Aliases": null,
+      "Categories": [
+        {
+          "Name": "Places and Locations"
+        }
+      ],
+      "Confidence": 82.1,
+      "Instances": null,
+      "Name": "Nature",
+      "Parents": [
+        {
+          "Name": "Outdoors"
+        }
+      ]
+    }
+  ],
+  "OrientationCorrection": "",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_DetectModerationLabels_TestRekognition_DetectModerationLabels.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_DetectModerationLabels_TestRekognition_DetectModerationLabels.golden.go
@@ -1,0 +1,13 @@
+{
+  "ContentTypes": [
+    {
+      "Confidence": 75.5,
+      "Name": "Illustrated"
+    }
+  ],
+  "HumanLoopActivationOutput": null,
+  "ModerationLabels": null,
+  "ModerationModelVersion": "6.0",
+  "ProjectVersion": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_DetectText_TestRekognition_DetectText.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_DetectText_TestRekognition_DetectText.golden.go
@@ -1,0 +1,105 @@
+{
+  "TextDetections": [
+    {
+      "Confidence": 99.5,
+      "DetectedText": "HELLO WORLD",
+      "Geometry": {
+        "BoundingBox": {
+          "Height": 0.08,
+          "Left": 0.1,
+          "Top": 0.2,
+          "Width": 0.3
+        },
+        "Polygon": [
+          {
+            "X": 0.1,
+            "Y": 0.2
+          },
+          {
+            "X": 0.4,
+            "Y": 0.2
+          },
+          {
+            "X": 0.4,
+            "Y": 0.28
+          },
+          {
+            "X": 0.1,
+            "Y": 0.28
+          }
+        ]
+      },
+      "Id": null,
+      "ParentId": null,
+      "Type": "LINE"
+    },
+    {
+      "Confidence": 99.8,
+      "DetectedText": "HELLO",
+      "Geometry": {
+        "BoundingBox": {
+          "Height": 0.08,
+          "Left": 0.1,
+          "Top": 0.2,
+          "Width": 0.12
+        },
+        "Polygon": [
+          {
+            "X": 0.1,
+            "Y": 0.2
+          },
+          {
+            "X": 0.22,
+            "Y": 0.2
+          },
+          {
+            "X": 0.22,
+            "Y": 0.28
+          },
+          {
+            "X": 0.1,
+            "Y": 0.28
+          }
+        ]
+      },
+      "Id": 1,
+      "ParentId": 0,
+      "Type": "WORD"
+    },
+    {
+      "Confidence": 99.6,
+      "DetectedText": "WORLD",
+      "Geometry": {
+        "BoundingBox": {
+          "Height": 0.08,
+          "Left": 0.25,
+          "Top": 0.2,
+          "Width": 0.15
+        },
+        "Polygon": [
+          {
+            "X": 0.25,
+            "Y": 0.2
+          },
+          {
+            "X": 0.4,
+            "Y": 0.2
+          },
+          {
+            "X": 0.4,
+            "Y": 0.28
+          },
+          {
+            "X": 0.25,
+            "Y": 0.28
+          }
+        ]
+      },
+      "Id": 2,
+      "ParentId": 0,
+      "Type": "WORD"
+    }
+  ],
+  "TextModelVersion": "3.0",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_IndexAndSearchFaces_TestRekognition_IndexAndSearchFaces_index.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_IndexAndSearchFaces_TestRekognition_IndexAndSearchFaces_index.golden.go
@@ -1,0 +1,206 @@
+{
+  "FaceModelVersion": "6.0",
+  "FaceRecords": [
+    {
+      "Face": {
+        "BoundingBox": {
+          "Height": 0.3,
+          "Left": 0.2,
+          "Top": 0.1,
+          "Width": 0.25
+        },
+        "Confidence": 99.99,
+        "ExternalImageId": "test-person-1",
+        "FaceId": "0a7fdd08-c9ea-4105-9a66-5488e93acc4c",
+        "ImageId": "0bb46040-5223-4b05-8197-bf9dc557c41b",
+        "IndexFacesModelVersion": "6.0",
+        "UserId": null
+      },
+      "FaceDetail": {
+        "AgeRange": null,
+        "Beard": null,
+        "BoundingBox": {
+          "Height": 0.3,
+          "Left": 0.2,
+          "Top": 0.1,
+          "Width": 0.25
+        },
+        "Confidence": 99.99,
+        "Emotions": null,
+        "EyeDirection": null,
+        "Eyeglasses": null,
+        "EyesOpen": null,
+        "FaceOccluded": null,
+        "Gender": null,
+        "Landmarks": [
+          {
+            "Type": "eyeLeft",
+            "X": 0.35,
+            "Y": 0.35
+          },
+          {
+            "Type": "eyeRight",
+            "X": 0.65,
+            "Y": 0.35
+          },
+          {
+            "Type": "mouthLeft",
+            "X": 0.35,
+            "Y": 0.7
+          },
+          {
+            "Type": "mouthRight",
+            "X": 0.65,
+            "Y": 0.7
+          },
+          {
+            "Type": "nose",
+            "X": 0.5,
+            "Y": 0.55
+          },
+          {
+            "Type": "leftEyeBrowLeft",
+            "X": 0.28,
+            "Y": 0.3
+          },
+          {
+            "Type": "leftEyeBrowRight",
+            "X": 0.38,
+            "Y": 0.28
+          },
+          {
+            "Type": "leftEyeBrowUp",
+            "X": 0.33,
+            "Y": 0.27
+          },
+          {
+            "Type": "rightEyeBrowLeft",
+            "X": 0.62,
+            "Y": 0.28
+          },
+          {
+            "Type": "rightEyeBrowRight",
+            "X": 0.72,
+            "Y": 0.3
+          },
+          {
+            "Type": "rightEyeBrowUp",
+            "X": 0.67,
+            "Y": 0.27
+          },
+          {
+            "Type": "leftEyeLeft",
+            "X": 0.32,
+            "Y": 0.35
+          },
+          {
+            "Type": "leftEyeRight",
+            "X": 0.38,
+            "Y": 0.35
+          },
+          {
+            "Type": "leftEyeUp",
+            "X": 0.35,
+            "Y": 0.33
+          },
+          {
+            "Type": "leftEyeDown",
+            "X": 0.35,
+            "Y": 0.37
+          },
+          {
+            "Type": "rightEyeLeft",
+            "X": 0.62,
+            "Y": 0.35
+          },
+          {
+            "Type": "rightEyeRight",
+            "X": 0.68,
+            "Y": 0.35
+          },
+          {
+            "Type": "rightEyeUp",
+            "X": 0.65,
+            "Y": 0.33
+          },
+          {
+            "Type": "rightEyeDown",
+            "X": 0.65,
+            "Y": 0.37
+          },
+          {
+            "Type": "noseLeft",
+            "X": 0.45,
+            "Y": 0.6
+          },
+          {
+            "Type": "noseRight",
+            "X": 0.55,
+            "Y": 0.6
+          },
+          {
+            "Type": "mouthUp",
+            "X": 0.5,
+            "Y": 0.68
+          },
+          {
+            "Type": "mouthDown",
+            "X": 0.5,
+            "Y": 0.75
+          },
+          {
+            "Type": "leftPupil",
+            "X": 0.35,
+            "Y": 0.35
+          },
+          {
+            "Type": "rightPupil",
+            "X": 0.65,
+            "Y": 0.35
+          },
+          {
+            "Type": "upperJawlineLeft",
+            "X": 0.2,
+            "Y": 0.4
+          },
+          {
+            "Type": "midJawlineLeft",
+            "X": 0.22,
+            "Y": 0.55
+          },
+          {
+            "Type": "chinBottom",
+            "X": 0.5,
+            "Y": 0.85
+          },
+          {
+            "Type": "midJawlineRight",
+            "X": 0.78,
+            "Y": 0.55
+          },
+          {
+            "Type": "upperJawlineRight",
+            "X": 0.8,
+            "Y": 0.4
+          }
+        ],
+        "MouthOpen": null,
+        "Mustache": null,
+        "Pose": {
+          "Pitch": 0.5,
+          "Roll": 1.2,
+          "Yaw": -0.3
+        },
+        "Quality": {
+          "Brightness": 80,
+          "Sharpness": 95
+        },
+        "Smile": null,
+        "Sunglasses": null
+      }
+    }
+  ],
+  "OrientationCorrection": "",
+  "UnindexedFaces": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_IndexAndSearchFaces_TestRekognition_IndexAndSearchFaces_list.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_IndexAndSearchFaces_TestRekognition_IndexAndSearchFaces_list.golden.go
@@ -1,0 +1,21 @@
+{
+  "FaceModelVersion": "6.0",
+  "Faces": [
+    {
+      "BoundingBox": {
+        "Height": 0.3,
+        "Left": 0.2,
+        "Top": 0.1,
+        "Width": 0.25
+      },
+      "Confidence": 99.99,
+      "ExternalImageId": "test-person-1",
+      "FaceId": "0a7fdd08-c9ea-4105-9a66-5488e93acc4c",
+      "ImageId": "0bb46040-5223-4b05-8197-bf9dc557c41b",
+      "IndexFacesModelVersion": "6.0",
+      "UserId": null
+    }
+  ],
+  "NextToken": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_ListCollections_TestRekognition_ListCollections.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_ListCollections_TestRekognition_ListCollections.golden.go
@@ -1,0 +1,10 @@
+{
+  "CollectionIds": [
+    "test-list-collection"
+  ],
+  "FaceModelVersions": [
+    "6.0"
+  ],
+  "NextToken": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/rekognition_test_TestRekognition_RecognizeCelebrities_TestRekognition_RecognizeCelebrities.golden.go
+++ b/test/integration/testdata/rekognition_test_TestRekognition_RecognizeCelebrities_TestRekognition_RecognizeCelebrities.golden.go
@@ -1,0 +1,6 @@
+{
+  "CelebrityFaces": null,
+  "OrientationCorrection": "",
+  "UnrecognizedFaces": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
- Implement AWS Rekognition service with AWS JSON 1.1 protocol
- Add collection management operations (CreateCollection, DeleteCollection, ListCollections, DescribeCollection)
- Add face operations (IndexFaces, ListFaces, SearchFaces, DeleteFaces)
- Add detection operations (DetectFaces, DetectLabels, DetectText, RecognizeCelebrities, DetectModerationLabels)
- Add integration tests with golden file snapshots

## Test plan
- [x] All integration tests pass
- [x] Lint passes (except gosec warnings for existing services)
- [x] Golden files generated and verified

Closes #123