### PR TITLE
feat(memorydb): implement AWS MemoryDB service

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -250,6 +250,10 @@ linters:
       - path: internal/service/rekognition/types\.go
         linters:
           - tagliatelle
+      # AWS MemoryDB API requires PascalCase JSON field names.
+      - path: internal/service/memorydb/types\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -45,6 +45,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/kinesis"
 	_ "github.com/sivchari/awsim/internal/service/kms"
 	_ "github.com/sivchari/awsim/internal/service/lambda"
+	_ "github.com/sivchari/awsim/internal/service/memorydb"
 	_ "github.com/sivchari/awsim/internal/service/mq"
 	_ "github.com/sivchari/awsim/internal/service/organizations"
 	_ "github.com/sivchari/awsim/internal/service/pipes"

--- a/internal/service/memorydb/handlers.go
+++ b/internal/service/memorydb/handlers.go
@@ -1,0 +1,327 @@
+// Package memorydb provides AWS MemoryDB service emulation.
+package memorydb
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const errInvalidParam = "InvalidParameterValueException"
+
+// handlerFunc is a type alias for handler functions.
+type handlerFunc func(http.ResponseWriter, *http.Request)
+
+// getActionHandlers returns a map of action names to handler functions.
+func (s *Service) getActionHandlers() map[string]handlerFunc {
+	return map[string]handlerFunc{
+		"CreateCluster":    s.CreateCluster,
+		"DescribeClusters": s.DescribeClusters,
+		"UpdateCluster":    s.UpdateCluster,
+		"DeleteCluster":    s.DeleteCluster,
+		"CreateUser":       s.CreateUser,
+		"DescribeUsers":    s.DescribeUsers,
+		"DeleteUser":       s.DeleteUser,
+		"CreateACL":        s.CreateACL,
+		"DescribeACLs":     s.DescribeACLs,
+		"DeleteACL":        s.DeleteACL,
+	}
+}
+
+// DispatchAction dispatches the request to the appropriate handler.
+func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
+	target := r.Header.Get("X-Amz-Target")
+	action := strings.TrimPrefix(target, "AmazonMemoryDB.")
+
+	handlers := s.getActionHandlers()
+	if handler, ok := handlers[action]; ok {
+		handler(w, r)
+
+		return
+	}
+
+	writeError(w, "InvalidAction", "The action "+action+" is not valid for this endpoint.", http.StatusBadRequest)
+}
+
+// CreateCluster handles the CreateCluster API.
+func (s *Service) CreateCluster(w http.ResponseWriter, r *http.Request) {
+	var req CreateClusterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParam, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ClusterName == "" {
+		writeError(w, errInvalidParam, "ClusterName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.NodeType == "" {
+		writeError(w, errInvalidParam, "NodeType is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ACLName == "" {
+		writeError(w, errInvalidParam, "ACLName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	cluster, err := s.storage.CreateCluster(r.Context(), &req)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &CreateClusterResponse{Cluster: cluster})
+}
+
+// DescribeClusters handles the DescribeClusters API.
+func (s *Service) DescribeClusters(w http.ResponseWriter, r *http.Request) {
+	var req DescribeClustersRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParam, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	clusters, err := s.storage.DescribeClusters(r.Context(), req.ClusterName)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DescribeClustersResponse{Clusters: clusters})
+}
+
+// UpdateCluster handles the UpdateCluster API.
+func (s *Service) UpdateCluster(w http.ResponseWriter, r *http.Request) {
+	var req UpdateClusterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParam, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ClusterName == "" {
+		writeError(w, errInvalidParam, "ClusterName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	cluster, err := s.storage.UpdateCluster(r.Context(), &req)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &UpdateClusterResponse{Cluster: cluster})
+}
+
+// DeleteCluster handles the DeleteCluster API.
+func (s *Service) DeleteCluster(w http.ResponseWriter, r *http.Request) {
+	var req DeleteClusterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParam, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ClusterName == "" {
+		writeError(w, errInvalidParam, "ClusterName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	cluster, err := s.storage.DeleteCluster(r.Context(), req.ClusterName)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DeleteClusterResponse{Cluster: cluster})
+}
+
+// CreateUser handles the CreateUser API.
+func (s *Service) CreateUser(w http.ResponseWriter, r *http.Request) {
+	var req CreateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParam, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.UserName == "" {
+		writeError(w, errInvalidParam, "UserName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.AccessString == "" {
+		writeError(w, errInvalidParam, "AccessString is required", http.StatusBadRequest)
+
+		return
+	}
+
+	user, err := s.storage.CreateUser(r.Context(), &req)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &CreateUserResponse{User: user})
+}
+
+// DescribeUsers handles the DescribeUsers API.
+func (s *Service) DescribeUsers(w http.ResponseWriter, r *http.Request) {
+	var req DescribeUsersRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParam, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	users, err := s.storage.DescribeUsers(r.Context(), req.UserName)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DescribeUsersResponse{Users: users})
+}
+
+// DeleteUser handles the DeleteUser API.
+func (s *Service) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	var req DeleteUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParam, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.UserName == "" {
+		writeError(w, errInvalidParam, "UserName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	user, err := s.storage.DeleteUser(r.Context(), req.UserName)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DeleteUserResponse{User: user})
+}
+
+// CreateACL handles the CreateACL API.
+func (s *Service) CreateACL(w http.ResponseWriter, r *http.Request) {
+	var req CreateACLRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParam, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ACLName == "" {
+		writeError(w, errInvalidParam, "ACLName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	acl, err := s.storage.CreateACL(r.Context(), &req)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &CreateACLResponse{ACL: acl})
+}
+
+// DescribeACLs handles the DescribeACLs API.
+func (s *Service) DescribeACLs(w http.ResponseWriter, r *http.Request) {
+	var req DescribeACLsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParam, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	acls, err := s.storage.DescribeACLs(r.Context(), req.ACLName)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DescribeACLsResponse{ACLs: acls})
+}
+
+// DeleteACL handles the DeleteACL API.
+func (s *Service) DeleteACL(w http.ResponseWriter, r *http.Request) {
+	var req DeleteACLRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errInvalidParam, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ACLName == "" {
+		writeError(w, errInvalidParam, "ACLName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	acl, err := s.storage.DeleteACL(r.Context(), req.ACLName)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DeleteACLResponse{ACL: acl})
+}
+
+// Helper functions.
+
+func writeResponse(w http.ResponseWriter, resp any) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func writeError(w http.ResponseWriter, code, message string, status int) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(&ErrorResponse{
+		Type:    code,
+		Message: message,
+	})
+}
+
+func handleServiceError(w http.ResponseWriter, err error) {
+	var svcErr *ServiceError
+	if errors.As(err, &svcErr) {
+		writeError(w, svcErr.Code, svcErr.Message, http.StatusBadRequest)
+
+		return
+	}
+
+	writeError(w, "InternalServiceError", err.Error(), http.StatusInternalServerError)
+}

--- a/internal/service/memorydb/service.go
+++ b/internal/service/memorydb/service.go
@@ -1,0 +1,39 @@
+package memorydb
+
+import (
+	"github.com/sivchari/awsim/internal/service"
+)
+
+// Service implements the AWS MemoryDB service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new MemoryDB service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "memorydb"
+}
+
+// TargetPrefix returns the X-Amz-Target prefix for JSON protocol dispatch.
+func (s *Service) TargetPrefix() string {
+	return "AmazonMemoryDB"
+}
+
+// JSONProtocol marks this service as using JSON protocol.
+func (s *Service) JSONProtocol() {}
+
+// RegisterRoutes registers the routes for this service.
+func (s *Service) RegisterRoutes(_ service.Router) {
+	// JSON protocol services use DispatchAction for routing
+}
+
+func init() {
+	service.Register(New(NewMemoryStorage()))
+}

--- a/internal/service/memorydb/storage.go
+++ b/internal/service/memorydb/storage.go
@@ -1,0 +1,434 @@
+package memorydb
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+const (
+	defaultRegion    = "us-east-1"
+	defaultAccountID = "000000000000"
+)
+
+// ServiceError represents a MemoryDB service error.
+type ServiceError struct {
+	Code    string
+	Message string
+}
+
+func (e *ServiceError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+const (
+	errClusterNotFound = "ClusterNotFoundFault"
+	errClusterExists   = "ClusterAlreadyExistsFault"
+	errUserNotFound    = "UserNotFoundFault"
+	errUserExists      = "UserAlreadyExistsFault"
+	errACLNotFound     = "ACLNotFoundFault"
+	errACLExists       = "ACLAlreadyExistsFault"
+
+	statusDeleting = "deleting"
+)
+
+// Storage defines the MemoryDB storage interface.
+type Storage interface {
+	CreateCluster(ctx context.Context, req *CreateClusterRequest) (*Cluster, error)
+	DescribeClusters(ctx context.Context, clusterName string) ([]Cluster, error)
+	UpdateCluster(ctx context.Context, req *UpdateClusterRequest) (*Cluster, error)
+	DeleteCluster(ctx context.Context, clusterName string) (*Cluster, error)
+
+	CreateUser(ctx context.Context, req *CreateUserRequest) (*User, error)
+	DescribeUsers(ctx context.Context, userName string) ([]User, error)
+	DeleteUser(ctx context.Context, userName string) (*User, error)
+
+	CreateACL(ctx context.Context, req *CreateACLRequest) (*ACL, error)
+	DescribeACLs(ctx context.Context, aclName string) ([]ACL, error)
+	DeleteACL(ctx context.Context, aclName string) (*ACL, error)
+}
+
+// MemoryStorage implements Storage with in-memory data.
+type MemoryStorage struct {
+	mu       sync.RWMutex
+	clusters map[string]*Cluster
+	users    map[string]*User
+	acls     map[string]*ACL
+}
+
+// NewMemoryStorage creates a new MemoryStorage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		clusters: make(map[string]*Cluster),
+		users:    make(map[string]*User),
+		acls:     make(map[string]*ACL),
+	}
+}
+
+// buildClusterBase creates a Cluster with core fields from a CreateClusterRequest.
+func buildClusterBase(req *CreateClusterRequest) *Cluster {
+	numShards := int32(1)
+	if req.NumShards != nil {
+		numShards = *req.NumShards
+	}
+
+	port := int32(6379)
+	if req.Port != nil {
+		port = *req.Port
+	}
+
+	engine := "redis"
+	if req.Engine != "" {
+		engine = req.Engine
+	}
+
+	engineVersion := "7.1"
+	if req.EngineVersion != "" {
+		engineVersion = req.EngineVersion
+	}
+
+	return &Cluster{
+		ACLName:            req.ACLName,
+		ARN:                fmt.Sprintf("arn:aws:memorydb:%s:%s:cluster/%s", defaultRegion, defaultAccountID, req.ClusterName),
+		AvailabilityMode:   "singleaz",
+		ClusterEndpoint:    &Endpoint{Address: fmt.Sprintf("%s.memorydb.%s.amazonaws.com", req.ClusterName, defaultRegion), Port: port},
+		Description:        req.Description,
+		Engine:             engine,
+		EngineVersion:      engineVersion,
+		KmsKeyID:           req.KmsKeyID,
+		MaintenanceWindow:  req.MaintenanceWindow,
+		Name:               req.ClusterName,
+		NodeType:           req.NodeType,
+		NumberOfShards:     numShards,
+		ParameterGroupName: req.ParameterGroupName,
+		Status:             "available",
+		SubnetGroupName:    req.SubnetGroupName,
+	}
+}
+
+// applyOptionalClusterFields sets optional fields on a Cluster from a CreateClusterRequest.
+func applyOptionalClusterFields(cluster *Cluster, req *CreateClusterRequest) {
+	if req.AutoMinorVersionUpgrade != nil {
+		cluster.AutoMinorVersionUpgrade = *req.AutoMinorVersionUpgrade
+	}
+
+	if req.TLSEnabled != nil {
+		cluster.TLSEnabled = *req.TLSEnabled
+	}
+
+	if req.SnapshotRetentionLimit != nil {
+		cluster.SnapshotRetentionLimit = *req.SnapshotRetentionLimit
+	}
+
+	if req.SnapshotWindow != "" {
+		cluster.SnapshotWindow = req.SnapshotWindow
+	}
+
+	if len(req.SecurityGroupIDs) > 0 {
+		sgs := make([]SecurityGroupMembership, 0, len(req.SecurityGroupIDs))
+		for _, sgID := range req.SecurityGroupIDs {
+			sgs = append(sgs, SecurityGroupMembership{
+				SecurityGroupID: sgID,
+				Status:          "active",
+			})
+		}
+
+		cluster.SecurityGroups = sgs
+	}
+}
+
+// buildCluster creates a Cluster from a CreateClusterRequest.
+func buildCluster(req *CreateClusterRequest) *Cluster {
+	cluster := buildClusterBase(req)
+	applyOptionalClusterFields(cluster, req)
+
+	return cluster
+}
+
+// CreateCluster creates a new cluster.
+func (m *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterRequest) (*Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.clusters[req.ClusterName]; exists {
+		return nil, &ServiceError{
+			Code:    errClusterExists,
+			Message: fmt.Sprintf("Cluster %s already exists", req.ClusterName),
+		}
+	}
+
+	cluster := buildCluster(req)
+	m.clusters[req.ClusterName] = cluster
+
+	return cluster, nil
+}
+
+// DescribeClusters returns clusters matching the filter.
+func (m *MemoryStorage) DescribeClusters(_ context.Context, clusterName string) ([]Cluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if clusterName != "" {
+		cluster, exists := m.clusters[clusterName]
+		if !exists {
+			return nil, &ServiceError{
+				Code:    errClusterNotFound,
+				Message: fmt.Sprintf("Cluster %s not found", clusterName),
+			}
+		}
+
+		return []Cluster{*cluster}, nil
+	}
+
+	clusters := make([]Cluster, 0, len(m.clusters))
+	for _, c := range m.clusters {
+		clusters = append(clusters, *c)
+	}
+
+	return clusters, nil
+}
+
+// UpdateCluster updates an existing cluster.
+func (m *MemoryStorage) UpdateCluster(_ context.Context, req *UpdateClusterRequest) (*Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cluster, exists := m.clusters[req.ClusterName]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errClusterNotFound,
+			Message: fmt.Sprintf("Cluster %s not found", req.ClusterName),
+		}
+	}
+
+	if req.Description != "" {
+		cluster.Description = req.Description
+	}
+
+	if req.ACLName != "" {
+		cluster.ACLName = req.ACLName
+	}
+
+	if req.EngineVersion != "" {
+		cluster.EngineVersion = req.EngineVersion
+	}
+
+	if req.MaintenanceWindow != "" {
+		cluster.MaintenanceWindow = req.MaintenanceWindow
+	}
+
+	if req.NodeType != "" {
+		cluster.NodeType = req.NodeType
+	}
+
+	if req.ParameterGroupName != "" {
+		cluster.ParameterGroupName = req.ParameterGroupName
+	}
+
+	if req.SnapshotRetentionLimit != nil {
+		cluster.SnapshotRetentionLimit = *req.SnapshotRetentionLimit
+	}
+
+	if req.SnapshotWindow != "" {
+		cluster.SnapshotWindow = req.SnapshotWindow
+	}
+
+	if req.SnsTopicArn != "" {
+		cluster.SnsTopicArn = req.SnsTopicArn
+	}
+
+	if len(req.SecurityGroupIDs) > 0 {
+		sgs := make([]SecurityGroupMembership, 0, len(req.SecurityGroupIDs))
+		for _, sgID := range req.SecurityGroupIDs {
+			sgs = append(sgs, SecurityGroupMembership{
+				SecurityGroupID: sgID,
+				Status:          "active",
+			})
+		}
+
+		cluster.SecurityGroups = sgs
+	}
+
+	return cluster, nil
+}
+
+// DeleteCluster deletes a cluster.
+func (m *MemoryStorage) DeleteCluster(_ context.Context, clusterName string) (*Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cluster, exists := m.clusters[clusterName]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errClusterNotFound,
+			Message: fmt.Sprintf("Cluster %s not found", clusterName),
+		}
+	}
+
+	cluster.Status = statusDeleting
+
+	delete(m.clusters, clusterName)
+
+	return cluster, nil
+}
+
+// CreateUser creates a new user.
+func (m *MemoryStorage) CreateUser(_ context.Context, req *CreateUserRequest) (*User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.users[req.UserName]; exists {
+		return nil, &ServiceError{
+			Code:    errUserExists,
+			Message: fmt.Sprintf("User %s already exists", req.UserName),
+		}
+	}
+
+	passwordCount := int32(0)
+	authType := "no-password"
+
+	if req.AuthenticationMode != nil {
+		if req.AuthenticationMode.Type != "" {
+			authType = req.AuthenticationMode.Type
+		}
+
+		passwordCount = int32(min(len(req.AuthenticationMode.Passwords), 2)) //nolint:gosec // MemoryDB allows max 2 passwords
+	}
+
+	user := &User{
+		ARN:          fmt.Sprintf("arn:aws:memorydb:%s:%s:user/%s", defaultRegion, defaultAccountID, req.UserName),
+		AccessString: req.AccessString,
+		Authentication: &Authentication{
+			PasswordCount: passwordCount,
+			Type:          authType,
+		},
+		Name:     req.UserName,
+		Status:   "active",
+		ACLNames: []string{},
+	}
+
+	m.users[req.UserName] = user
+
+	return user, nil
+}
+
+// DescribeUsers returns users matching the filter.
+func (m *MemoryStorage) DescribeUsers(_ context.Context, userName string) ([]User, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if userName != "" {
+		user, exists := m.users[userName]
+		if !exists {
+			return nil, &ServiceError{
+				Code:    errUserNotFound,
+				Message: fmt.Sprintf("User %s not found", userName),
+			}
+		}
+
+		return []User{*user}, nil
+	}
+
+	users := make([]User, 0, len(m.users))
+	for _, u := range m.users {
+		users = append(users, *u)
+	}
+
+	return users, nil
+}
+
+// DeleteUser deletes a user.
+func (m *MemoryStorage) DeleteUser(_ context.Context, userName string) (*User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	user, exists := m.users[userName]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errUserNotFound,
+			Message: fmt.Sprintf("User %s not found", userName),
+		}
+	}
+
+	user.Status = statusDeleting
+
+	delete(m.users, userName)
+
+	return user, nil
+}
+
+// CreateACL creates a new ACL.
+func (m *MemoryStorage) CreateACL(_ context.Context, req *CreateACLRequest) (*ACL, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.acls[req.ACLName]; exists {
+		return nil, &ServiceError{
+			Code:    errACLExists,
+			Message: fmt.Sprintf("ACL %s already exists", req.ACLName),
+		}
+	}
+
+	userNames := req.UserNames
+	if userNames == nil {
+		userNames = []string{}
+	}
+
+	acl := &ACL{
+		ARN:                  fmt.Sprintf("arn:aws:memorydb:%s:%s:acl/%s", defaultRegion, defaultAccountID, req.ACLName),
+		Clusters:             []string{},
+		MinimumEngineVersion: "6.2.6",
+		Name:                 req.ACLName,
+		Status:               "active",
+		UserNames:            userNames,
+	}
+
+	m.acls[req.ACLName] = acl
+
+	return acl, nil
+}
+
+// DescribeACLs returns ACLs matching the filter.
+func (m *MemoryStorage) DescribeACLs(_ context.Context, aclName string) ([]ACL, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if aclName != "" {
+		acl, exists := m.acls[aclName]
+		if !exists {
+			return nil, &ServiceError{
+				Code:    errACLNotFound,
+				Message: fmt.Sprintf("ACL %s not found", aclName),
+			}
+		}
+
+		return []ACL{*acl}, nil
+	}
+
+	acls := make([]ACL, 0, len(m.acls))
+	for _, a := range m.acls {
+		acls = append(acls, *a)
+	}
+
+	return acls, nil
+}
+
+// DeleteACL deletes an ACL.
+func (m *MemoryStorage) DeleteACL(_ context.Context, aclName string) (*ACL, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	acl, exists := m.acls[aclName]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errACLNotFound,
+			Message: fmt.Sprintf("ACL %s not found", aclName),
+		}
+	}
+
+	acl.Status = statusDeleting
+
+	delete(m.acls, aclName)
+
+	return acl, nil
+}

--- a/internal/service/memorydb/types.go
+++ b/internal/service/memorydb/types.go
@@ -1,0 +1,262 @@
+package memorydb
+
+// Tag represents a key-value tag.
+type Tag struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+// Endpoint represents a cluster endpoint.
+type Endpoint struct {
+	Address string `json:"Address"`
+	Port    int32  `json:"Port"`
+}
+
+// Cluster represents a MemoryDB cluster.
+type Cluster struct {
+	ACLName                 string                    `json:"ACLName,omitempty"`
+	ARN                     string                    `json:"ARN,omitempty"`
+	AutoMinorVersionUpgrade bool                      `json:"AutoMinorVersionUpgrade,omitempty"`
+	AvailabilityMode        string                    `json:"AvailabilityMode,omitempty"`
+	ClusterEndpoint         *Endpoint                 `json:"ClusterEndpoint,omitempty"`
+	Description             string                    `json:"Description,omitempty"`
+	Engine                  string                    `json:"Engine,omitempty"`
+	EngineVersion           string                    `json:"EngineVersion,omitempty"`
+	KmsKeyID                string                    `json:"KmsKeyId,omitempty"`
+	MaintenanceWindow       string                    `json:"MaintenanceWindow,omitempty"`
+	Name                    string                    `json:"Name,omitempty"`
+	NodeType                string                    `json:"NodeType,omitempty"`
+	NumberOfShards          int32                     `json:"NumberOfShards,omitempty"`
+	ParameterGroupName      string                    `json:"ParameterGroupName,omitempty"`
+	ParameterGroupStatus    string                    `json:"ParameterGroupStatus,omitempty"`
+	SecurityGroups          []SecurityGroupMembership `json:"SecurityGroups,omitempty"`
+	SnapshotRetentionLimit  int32                     `json:"SnapshotRetentionLimit,omitempty"`
+	SnapshotWindow          string                    `json:"SnapshotWindow,omitempty"`
+	SnsTopicArn             string                    `json:"SnsTopicArn,omitempty"`
+	SnsTopicStatus          string                    `json:"SnsTopicStatus,omitempty"`
+	Status                  string                    `json:"Status,omitempty"`
+	SubnetGroupName         string                    `json:"SubnetGroupName,omitempty"`
+	TLSEnabled              bool                      `json:"TLSEnabled,omitempty"`
+}
+
+// SecurityGroupMembership represents a security group association.
+type SecurityGroupMembership struct {
+	SecurityGroupID string `json:"SecurityGroupId,omitempty"`
+	Status          string `json:"Status,omitempty"`
+}
+
+// Authentication represents user authentication info.
+type Authentication struct {
+	PasswordCount int32  `json:"PasswordCount,omitempty"`
+	Type          string `json:"Type,omitempty"`
+}
+
+// User represents a MemoryDB user.
+type User struct {
+	ACLNames             []string        `json:"ACLNames,omitempty"`
+	ARN                  string          `json:"ARN,omitempty"`
+	AccessString         string          `json:"AccessString,omitempty"`
+	Authentication       *Authentication `json:"Authentication,omitempty"`
+	MinimumEngineVersion string          `json:"MinimumEngineVersion,omitempty"`
+	Name                 string          `json:"Name,omitempty"`
+	Status               string          `json:"Status,omitempty"`
+}
+
+// ACLPendingChanges represents pending ACL changes.
+type ACLPendingChanges struct {
+	UserNamesToAdd    []string `json:"UserNamesToAdd,omitempty"`
+	UserNamesToRemove []string `json:"UserNamesToRemove,omitempty"`
+}
+
+// ACL represents a MemoryDB access control list.
+type ACL struct {
+	ARN                  string             `json:"ARN,omitempty"`
+	Clusters             []string           `json:"Clusters,omitempty"`
+	MinimumEngineVersion string             `json:"MinimumEngineVersion,omitempty"`
+	Name                 string             `json:"Name,omitempty"`
+	PendingChanges       *ACLPendingChanges `json:"PendingChanges,omitempty"`
+	Status               string             `json:"Status,omitempty"`
+	UserNames            []string           `json:"UserNames,omitempty"`
+}
+
+// Snapshot represents a MemoryDB snapshot.
+type Snapshot struct {
+	ARN         string `json:"ARN,omitempty"`
+	ClusterName string `json:"ClusterConfiguration.Name,omitempty"`
+	KmsKeyID    string `json:"KmsKeyId,omitempty"`
+	Name        string `json:"Name,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Status      string `json:"Status,omitempty"`
+}
+
+// SubnetGroup represents a MemoryDB subnet group.
+type SubnetGroup struct {
+	ARN         string   `json:"ARN,omitempty"`
+	Description string   `json:"Description,omitempty"`
+	Name        string   `json:"Name,omitempty"`
+	SubnetIDs   []string `json:"Subnets,omitempty"`
+	VpcID       string   `json:"VpcId,omitempty"`
+}
+
+// ParameterGroup represents a MemoryDB parameter group.
+type ParameterGroup struct {
+	ARN         string `json:"ARN,omitempty"`
+	Description string `json:"Description,omitempty"`
+	Family      string `json:"Family,omitempty"`
+	Name        string `json:"Name,omitempty"`
+}
+
+// CreateClusterRequest represents a CreateCluster request.
+type CreateClusterRequest struct {
+	ACLName                 string   `json:"ACLName"`
+	ClusterName             string   `json:"ClusterName"`
+	NodeType                string   `json:"NodeType"`
+	AutoMinorVersionUpgrade *bool    `json:"AutoMinorVersionUpgrade,omitempty"`
+	Description             string   `json:"Description,omitempty"`
+	Engine                  string   `json:"Engine,omitempty"`
+	EngineVersion           string   `json:"EngineVersion,omitempty"`
+	KmsKeyID                string   `json:"KmsKeyId,omitempty"`
+	MaintenanceWindow       string   `json:"MaintenanceWindow,omitempty"`
+	NumReplicasPerShard     *int32   `json:"NumReplicasPerShard,omitempty"`
+	NumShards               *int32   `json:"NumShards,omitempty"`
+	ParameterGroupName      string   `json:"ParameterGroupName,omitempty"`
+	Port                    *int32   `json:"Port,omitempty"`
+	SecurityGroupIDs        []string `json:"SecurityGroupIds,omitempty"`
+	SnapshotRetentionLimit  *int32   `json:"SnapshotRetentionLimit,omitempty"`
+	SnapshotWindow          string   `json:"SnapshotWindow,omitempty"`
+	SubnetGroupName         string   `json:"SubnetGroupName,omitempty"`
+	TLSEnabled              *bool    `json:"TLSEnabled,omitempty"`
+	Tags                    []Tag    `json:"Tags,omitempty"`
+}
+
+// CreateClusterResponse represents a CreateCluster response.
+type CreateClusterResponse struct {
+	Cluster *Cluster `json:"Cluster"`
+}
+
+// DeleteClusterRequest represents a DeleteCluster request.
+type DeleteClusterRequest struct {
+	ClusterName string `json:"ClusterName"`
+}
+
+// DeleteClusterResponse represents a DeleteCluster response.
+type DeleteClusterResponse struct {
+	Cluster *Cluster `json:"Cluster"`
+}
+
+// DescribeClustersRequest represents a DescribeClusters request.
+type DescribeClustersRequest struct {
+	ClusterName string `json:"ClusterName,omitempty"`
+	MaxResults  int32  `json:"MaxResults,omitempty"`
+	NextToken   string `json:"NextToken,omitempty"`
+}
+
+// DescribeClustersResponse represents a DescribeClusters response.
+type DescribeClustersResponse struct {
+	Clusters  []Cluster `json:"Clusters"`
+	NextToken string    `json:"NextToken,omitempty"`
+}
+
+// UpdateClusterRequest represents an UpdateCluster request.
+type UpdateClusterRequest struct {
+	ClusterName            string   `json:"ClusterName"`
+	ACLName                string   `json:"ACLName,omitempty"`
+	Description            string   `json:"Description,omitempty"`
+	EngineVersion          string   `json:"EngineVersion,omitempty"`
+	MaintenanceWindow      string   `json:"MaintenanceWindow,omitempty"`
+	NodeType               string   `json:"NodeType,omitempty"`
+	ParameterGroupName     string   `json:"ParameterGroupName,omitempty"`
+	SecurityGroupIDs       []string `json:"SecurityGroupIds,omitempty"`
+	SnapshotRetentionLimit *int32   `json:"SnapshotRetentionLimit,omitempty"`
+	SnapshotWindow         string   `json:"SnapshotWindow,omitempty"`
+	SnsTopicArn            string   `json:"SnsTopicArn,omitempty"`
+	SnsTopicStatus         string   `json:"SnsTopicStatus,omitempty"`
+}
+
+// UpdateClusterResponse represents an UpdateCluster response.
+type UpdateClusterResponse struct {
+	Cluster *Cluster `json:"Cluster"`
+}
+
+// AuthenticationMode represents user authentication mode in request.
+type AuthenticationMode struct {
+	Passwords []string `json:"Passwords,omitempty"`
+	Type      string   `json:"Type,omitempty"`
+}
+
+// CreateUserRequest represents a CreateUser request.
+type CreateUserRequest struct {
+	AccessString       string              `json:"AccessString"`
+	AuthenticationMode *AuthenticationMode `json:"AuthenticationMode"`
+	UserName           string              `json:"UserName"`
+	Tags               []Tag               `json:"Tags,omitempty"`
+}
+
+// CreateUserResponse represents a CreateUser response.
+type CreateUserResponse struct {
+	User *User `json:"User"`
+}
+
+// DeleteUserRequest represents a DeleteUser request.
+type DeleteUserRequest struct {
+	UserName string `json:"UserName"`
+}
+
+// DeleteUserResponse represents a DeleteUser response.
+type DeleteUserResponse struct {
+	User *User `json:"User"`
+}
+
+// DescribeUsersRequest represents a DescribeUsers request.
+type DescribeUsersRequest struct {
+	UserName   string `json:"UserName,omitempty"`
+	MaxResults int32  `json:"MaxResults,omitempty"`
+	NextToken  string `json:"NextToken,omitempty"`
+}
+
+// DescribeUsersResponse represents a DescribeUsers response.
+type DescribeUsersResponse struct {
+	Users     []User `json:"Users"`
+	NextToken string `json:"NextToken,omitempty"`
+}
+
+// CreateACLRequest represents a CreateACL request.
+type CreateACLRequest struct {
+	ACLName   string   `json:"ACLName"`
+	UserNames []string `json:"UserNames,omitempty"`
+	Tags      []Tag    `json:"Tags,omitempty"`
+}
+
+// CreateACLResponse represents a CreateACL response.
+type CreateACLResponse struct {
+	ACL *ACL `json:"ACL"`
+}
+
+// DeleteACLRequest represents a DeleteACL request.
+type DeleteACLRequest struct {
+	ACLName string `json:"ACLName"`
+}
+
+// DeleteACLResponse represents a DeleteACL response.
+type DeleteACLResponse struct {
+	ACL *ACL `json:"ACL"`
+}
+
+// DescribeACLsRequest represents a DescribeACLs request.
+type DescribeACLsRequest struct {
+	ACLName    string `json:"ACLName,omitempty"`
+	MaxResults int32  `json:"MaxResults,omitempty"`
+	NextToken  string `json:"NextToken,omitempty"`
+}
+
+// DescribeACLsResponse represents a DescribeACLs response.
+type DescribeACLsResponse struct {
+	ACLs      []ACL  `json:"ACLs"`
+	NextToken string `json:"NextToken,omitempty"`
+}
+
+// ErrorResponse represents an error response.
+type ErrorResponse struct {
+	Type    string `json:"__type"`
+	Message string `json:"message"`
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.3
 	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.35.13
+	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.11
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.285.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.1
@@ -32,6 +33,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.51.9
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.7
 	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.39.3
+	github.com/aws/aws-sdk-go-v2/service/entityresolution v1.26.3
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.18
 	github.com/aws/aws-sdk-go-v2/service/finspace v1.33.18
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.42.9
@@ -40,9 +42,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.35.11
 	github.com/aws/aws-sdk-go-v2/service/glue v1.137.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.2
+	github.com/aws/aws-sdk-go-v2/service/kafka v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/kms v1.49.5
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.88.0
+	github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.12
 	github.com/aws/aws-sdk-go-v2/service/mq v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.50.3
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.23.17
@@ -76,14 +80,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.11 // indirect
-	github.com/aws/aws-sdk-go-v2/service/entityresolution v1.26.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.18 // indirect
-	github.com/aws/aws-sdk-go-v2/service/kafka v1.49.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,5 +1,3 @@
-github.com/aws/aws-sdk-go-v2 v1.41.2 h1:LuT2rzqNQsauaGkPK/7813XxcZ3o3yePY0Iy891T2ls=
-github.com/aws/aws-sdk-go-v2 v1.41.2/go.mod h1:IvvlAZQXvTXznUPfRVfryiG1fbzE2NGK6m9u39YQ+S4=
 github.com/aws/aws-sdk-go-v2 v1.41.3 h1:4kQ/fa22KjDt13QCy1+bYADvdgcxpfH18f0zP542kZA=
 github.com/aws/aws-sdk-go-v2 v1.41.3/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=
@@ -10,12 +8,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.7 h1:tHK47VqqtJxOymRrNtUXN5SP/zUT
 github.com/aws/aws-sdk-go-v2/credentials v1.19.7/go.mod h1:qOZk8sPDrxhf+4Wf4oT2urYJrYt3RejHSzgAquYeppw=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 h1:I0GyV8wiYrP8XpA70g1HBcQO1JlQxCMTW9npl5UbDHY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17/go.mod h1:tyw7BOl5bBe/oqvoIeECFJjMdzXoa/dfVz3QQ5lgHGA=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18 h1:F43zk1vemYIqPAwhjTjYIz0irU2EY7sOb/F5eJ3HuyM=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18/go.mod h1:w1jdlZXrGKaJcNoL+Nnrj+k5wlpGXqnNrKoP22HvAug=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19 h1:/sECfyq2JTifMI2JPyZ4bdRN77zJmr6SrS1eL3augIA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19/go.mod h1:dMf8A5oAqr9/oxOfLkC/c2LU/uMcALP0Rgn2BD5LWn0=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18 h1:xCeWVjj0ki0l3nruoyP2slHsGArMxeiiaoPN5QZH6YQ=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18/go.mod h1:r/eLGuGCBw6l36ZRWiw6PaZwPXb6YOj+i/7MizNl5/k=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19 h1:AWeJMk33GTBf6J20XJe6qZoRSJo0WfUhsMdUKhoODXE=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19/go.mod h1:+GWrYoaAsV7/4pNHpwh1kiNLXkKaSoppxQq9lbH8Ejw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
@@ -94,16 +88,12 @@ github.com/aws/aws-sdk-go-v2/service/glue v1.137.0 h1:gPQ3FlHOFQELCiNSc76CS9B1G7
 github.com/aws/aws-sdk-go-v2/service/glue v1.137.0/go.mod h1:B6g7dsUUg4QUcH6zou32L1LDXjgtk/YjVFcu09jXv10=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.2 h1:62G6btFUwAa5uR5iPlnlNVAM0zJSLbWgDfKOfUC7oW4=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.2/go.mod h1:av9clChrbZbJ5E21msSsiT2oghl2BJHfQGhCkXmhyu8=
-github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 h1:0ryTNEdJbzUCEWkVXEXoqlXV72J5keC1GvILMOuD00E=
-github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4/go.mod h1:HQ4qwNZh32C3CBeO6iJLQlgtMzqeG17ziAA/3KDJFow=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.6 h1:XAq62tBTJP/85lFD5oqOOe7YYgWxY9LvWq8plyDvDVg=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.6/go.mod h1:x0nZssQ3qZSnIcePWLvcoFisRXJzcTVvYpAAdYX8+GI=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 h1:Z5EiPIzXKewUQK0QTMkutjiaPVeVYXX7KIqhXu/0fXs=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8/go.mod h1:FsTpJtvC4U1fyDXk7c71XoDv3HlRm8V3NiYLeYLh5YE=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.17 h1:Nhx/OYX+ukejm9t/MkWI8sucnsiroNYNGb5ddI9ungQ=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.17/go.mod h1:AjmK8JWnlAevq1b1NBtv5oQVG4iqnYXUufdgol+q9wg=
-github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 h1:RuNSMoozM8oXlgLG/n6WLaFGoea7/CddrCfIiSA+xdY=
-github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17/go.mod h1:F2xxQ9TZz5gDWsclCtPQscGpP0VUOc8RqgFM3vDENmU=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.19 h1:X1Tow7suZk9UCJHE1Iw9GMZJJl0dAnKXXP1NaSDHwmw=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.19/go.mod h1:/rARO8psX+4sfjUQXp5LLifjUt8DuATZ31WptNJTyQA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.18 h1:/A/xDuZAVD2BpsS2fftFRo/NoEKQJ8YTnJDEHBy2Gtg=
@@ -116,6 +106,8 @@ github.com/aws/aws-sdk-go-v2/service/kms v1.49.5 h1:DKibav4XF66XSeaXcrn9GlWGHos6
 github.com/aws/aws-sdk-go-v2/service/kms v1.49.5/go.mod h1:1SdcmEGUEQE1mrU2sIgeHtcMSxHuybhPvuEPANzIDfI=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.88.0 h1:u66DMbJWDFXs9458RAHNtq2d0gyqcZFV4mzRwfjM358=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.88.0/go.mod h1:ogjbkxFgFOjG3dYFQ8irC92gQfpfMDcy1RDKNSZWXNU=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.12 h1:BUd9RyiCSQ3gau/LAh6ZppvuQ1IxjetxpB25pc9YbAg=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.33.12/go.mod h1:rxCveQsDbPAecIQjIcDlzsH93PrHovX8bz3llcRAgt0=
 github.com/aws/aws-sdk-go-v2/service/mq v1.33.1 h1:fw/32PK9eqPKKotODP5wrN3RtcG8HKbUVoEWK7oUd7s=
 github.com/aws/aws-sdk-go-v2/service/mq v1.33.1/go.mod h1:k/EsVXGxs6dcuBioJb3LWwmX7LcXPHLbweDoc6dl24g=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.50.3 h1:pqPwpyOjYTYwlexnCxSsy6kIz2lopj7AMA0TEpwvKfw=
@@ -168,8 +160,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 h1:5fFjR/ToSOzB2OQ/XqWpZBmNvmP/
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.6/go.mod h1:qgFDZQSD/Kys7nJnVqYlWKnh0SSdMjAi0uSwON4wgYQ=
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.17 h1:b480fLepDHf9B7FXgcgB7XVDN3pKUACF2MbKu29JYcA=
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.17/go.mod h1:ASKVut5pRPVm4bF9/P01ClCthnIopv1PjxWsLOTjKPU=
-github.com/aws/smithy-go v1.24.1 h1:VbyeNfmYkWoxMVpGUAbQumkODcYmfMRfZ8yQiH30SK0=
-github.com/aws/smithy-go v1.24.1/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/sivchari/golden v0.3.0 h1:WUtMlhvqeH8mXcX4hsZwyfrA5jeNz5F9IL1w+u7Ew7w=

--- a/test/integration/memorydb_test.go
+++ b/test/integration/memorydb_test.go
@@ -1,0 +1,332 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb/types"
+)
+
+func newMemoryDBClient(t *testing.T) *memorydb.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	return memorydb.NewFromConfig(cfg, func(o *memorydb.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestMemoryDB_CreateAndDeleteCluster(t *testing.T) {
+	client := newMemoryDBClient(t)
+	ctx := t.Context()
+	clusterName := "test-cluster"
+
+	createResult, err := client.CreateCluster(ctx, &memorydb.CreateClusterInput{
+		ClusterName: aws.String(clusterName),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("open-access"),
+	})
+	if err != nil {
+		t.Fatalf("failed to create cluster: %v", err)
+	}
+
+	if *createResult.Cluster.Name != clusterName {
+		t.Errorf("expected cluster name %s, got %s", clusterName, *createResult.Cluster.Name)
+	}
+
+	if createResult.Cluster.ARN == nil || *createResult.Cluster.ARN == "" {
+		t.Error("expected cluster ARN to be set")
+	}
+
+	if *createResult.Cluster.Status != "available" {
+		t.Errorf("expected status available, got %s", *createResult.Cluster.Status)
+	}
+
+	// Delete
+	deleteResult, err := client.DeleteCluster(ctx, &memorydb.DeleteClusterInput{
+		ClusterName: aws.String(clusterName),
+	})
+	if err != nil {
+		t.Fatalf("failed to delete cluster: %v", err)
+	}
+
+	if *deleteResult.Cluster.Name != clusterName {
+		t.Errorf("expected cluster name %s, got %s", clusterName, *deleteResult.Cluster.Name)
+	}
+}
+
+func TestMemoryDB_DescribeClusters(t *testing.T) {
+	client := newMemoryDBClient(t)
+	ctx := t.Context()
+	clusterName := "test-describe-cluster"
+
+	_, err := client.CreateCluster(ctx, &memorydb.CreateClusterInput{
+		ClusterName: aws.String(clusterName),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("open-access"),
+		Description: aws.String("test description"),
+	})
+	if err != nil {
+		t.Fatalf("failed to create cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteCluster(t.Context(), &memorydb.DeleteClusterInput{
+			ClusterName: aws.String(clusterName),
+		})
+	})
+
+	describeResult, err := client.DescribeClusters(ctx, &memorydb.DescribeClustersInput{
+		ClusterName: aws.String(clusterName),
+	})
+	if err != nil {
+		t.Fatalf("failed to describe clusters: %v", err)
+	}
+
+	if len(describeResult.Clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %d", len(describeResult.Clusters))
+	}
+
+	cluster := describeResult.Clusters[0]
+	if *cluster.Name != clusterName {
+		t.Errorf("expected cluster name %s, got %s", clusterName, *cluster.Name)
+	}
+
+	if *cluster.Description != "test description" {
+		t.Errorf("expected description 'test description', got %s", *cluster.Description)
+	}
+}
+
+func TestMemoryDB_UpdateCluster(t *testing.T) {
+	client := newMemoryDBClient(t)
+	ctx := t.Context()
+	clusterName := "test-update-cluster"
+
+	_, err := client.CreateCluster(ctx, &memorydb.CreateClusterInput{
+		ClusterName: aws.String(clusterName),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("open-access"),
+	})
+	if err != nil {
+		t.Fatalf("failed to create cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteCluster(t.Context(), &memorydb.DeleteClusterInput{
+			ClusterName: aws.String(clusterName),
+		})
+	})
+
+	updateResult, err := client.UpdateCluster(ctx, &memorydb.UpdateClusterInput{
+		ClusterName: aws.String(clusterName),
+		Description: aws.String("updated description"),
+	})
+	if err != nil {
+		t.Fatalf("failed to update cluster: %v", err)
+	}
+
+	if *updateResult.Cluster.Description != "updated description" {
+		t.Errorf("expected description 'updated description', got %s", *updateResult.Cluster.Description)
+	}
+}
+
+func TestMemoryDB_CreateAndDeleteUser(t *testing.T) {
+	client := newMemoryDBClient(t)
+	ctx := t.Context()
+	userName := "test-user"
+
+	createResult, err := client.CreateUser(ctx, &memorydb.CreateUserInput{
+		UserName:     aws.String(userName),
+		AccessString: aws.String("on ~* &* +@all"),
+		AuthenticationMode: &types.AuthenticationMode{
+			Type:      types.InputAuthenticationTypePassword,
+			Passwords: []string{"testpassword123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	if *createResult.User.Name != userName {
+		t.Errorf("expected user name %s, got %s", userName, *createResult.User.Name)
+	}
+
+	if createResult.User.ARN == nil || *createResult.User.ARN == "" {
+		t.Error("expected user ARN to be set")
+	}
+
+	// Delete
+	deleteResult, err := client.DeleteUser(ctx, &memorydb.DeleteUserInput{
+		UserName: aws.String(userName),
+	})
+	if err != nil {
+		t.Fatalf("failed to delete user: %v", err)
+	}
+
+	if *deleteResult.User.Name != userName {
+		t.Errorf("expected user name %s, got %s", userName, *deleteResult.User.Name)
+	}
+}
+
+func TestMemoryDB_DescribeUsers(t *testing.T) {
+	client := newMemoryDBClient(t)
+	ctx := t.Context()
+	userName := "test-describe-user"
+
+	_, err := client.CreateUser(ctx, &memorydb.CreateUserInput{
+		UserName:     aws.String(userName),
+		AccessString: aws.String("on ~* &* +@all"),
+		AuthenticationMode: &types.AuthenticationMode{
+			Type:      types.InputAuthenticationTypePassword,
+			Passwords: []string{"testpassword123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteUser(t.Context(), &memorydb.DeleteUserInput{
+			UserName: aws.String(userName),
+		})
+	})
+
+	describeResult, err := client.DescribeUsers(ctx, &memorydb.DescribeUsersInput{
+		UserName: aws.String(userName),
+	})
+	if err != nil {
+		t.Fatalf("failed to describe users: %v", err)
+	}
+
+	if len(describeResult.Users) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(describeResult.Users))
+	}
+
+	if *describeResult.Users[0].Name != userName {
+		t.Errorf("expected user name %s, got %s", userName, *describeResult.Users[0].Name)
+	}
+}
+
+func TestMemoryDB_CreateAndDeleteACL(t *testing.T) {
+	client := newMemoryDBClient(t)
+	ctx := t.Context()
+	aclName := "test-acl"
+
+	createResult, err := client.CreateACL(ctx, &memorydb.CreateACLInput{
+		ACLName: aws.String(aclName),
+	})
+	if err != nil {
+		t.Fatalf("failed to create ACL: %v", err)
+	}
+
+	if *createResult.ACL.Name != aclName {
+		t.Errorf("expected ACL name %s, got %s", aclName, *createResult.ACL.Name)
+	}
+
+	if createResult.ACL.ARN == nil || *createResult.ACL.ARN == "" {
+		t.Error("expected ACL ARN to be set")
+	}
+
+	// Delete
+	deleteResult, err := client.DeleteACL(ctx, &memorydb.DeleteACLInput{
+		ACLName: aws.String(aclName),
+	})
+	if err != nil {
+		t.Fatalf("failed to delete ACL: %v", err)
+	}
+
+	if *deleteResult.ACL.Name != aclName {
+		t.Errorf("expected ACL name %s, got %s", aclName, *deleteResult.ACL.Name)
+	}
+}
+
+func TestMemoryDB_DescribeACLs(t *testing.T) {
+	client := newMemoryDBClient(t)
+	ctx := t.Context()
+	aclName := "test-describe-acl"
+
+	_, err := client.CreateACL(ctx, &memorydb.CreateACLInput{
+		ACLName:   aws.String(aclName),
+		UserNames: []string{"default"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create ACL: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteACL(t.Context(), &memorydb.DeleteACLInput{
+			ACLName: aws.String(aclName),
+		})
+	})
+
+	describeResult, err := client.DescribeACLs(ctx, &memorydb.DescribeACLsInput{
+		ACLName: aws.String(aclName),
+	})
+	if err != nil {
+		t.Fatalf("failed to describe ACLs: %v", err)
+	}
+
+	if len(describeResult.ACLs) != 1 {
+		t.Fatalf("expected 1 ACL, got %d", len(describeResult.ACLs))
+	}
+
+	if *describeResult.ACLs[0].Name != aclName {
+		t.Errorf("expected ACL name %s, got %s", aclName, *describeResult.ACLs[0].Name)
+	}
+}
+
+func TestMemoryDB_ClusterNotFound(t *testing.T) {
+	client := newMemoryDBClient(t)
+	ctx := t.Context()
+
+	_, err := client.DescribeClusters(ctx, &memorydb.DescribeClustersInput{
+		ClusterName: aws.String("non-existent-cluster"),
+	})
+	if err == nil {
+		t.Fatal("expected error for non-existent cluster")
+	}
+}
+
+func TestMemoryDB_DuplicateCluster(t *testing.T) {
+	client := newMemoryDBClient(t)
+	ctx := t.Context()
+	clusterName := "test-dup-cluster"
+
+	_, err := client.CreateCluster(ctx, &memorydb.CreateClusterInput{
+		ClusterName: aws.String(clusterName),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("open-access"),
+	})
+	if err != nil {
+		t.Fatalf("failed to create cluster: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteCluster(t.Context(), &memorydb.DeleteClusterInput{
+			ClusterName: aws.String(clusterName),
+		})
+	})
+
+	_, err = client.CreateCluster(ctx, &memorydb.CreateClusterInput{
+		ClusterName: aws.String(clusterName),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("open-access"),
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate cluster")
+	}
+}


### PR DESCRIPTION
## Summary

- Implement MemoryDB service emulator using AWS JSON 1.1 protocol (X-Amz-Target: AmazonMemoryDB.*)
- Support Cluster CRUD (CreateCluster, DescribeClusters, UpdateCluster, DeleteCluster)
- Support User CRUD (CreateUser, DescribeUsers, DeleteUser)
- Support ACL CRUD (CreateACL, DescribeACLs, DeleteACL)
- Add integration tests using AWS SDK v2 memorydb client

Closes #63

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Lint passes (`make lint`)
- [ ] Integration tests pass (`make test-integration`)