### PR TITLE
feat(elasticbeanstalk): implement AWS Elastic Beanstalk service

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -258,6 +258,10 @@ linters:
       - path: internal/service/glacier/types\.go
         linters:
           - tagliatelle
+      # AWS Elastic Beanstalk API requires PascalCase JSON field names.
+      - path: internal/service/elasticbeanstalk/types\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/ecs"
 	_ "github.com/sivchari/awsim/internal/service/eks"
 	_ "github.com/sivchari/awsim/internal/service/elasticache"
+	_ "github.com/sivchari/awsim/internal/service/elasticbeanstalk"
 	_ "github.com/sivchari/awsim/internal/service/elbv2"
 	_ "github.com/sivchari/awsim/internal/service/emrserverless"
 	_ "github.com/sivchari/awsim/internal/service/entityresolution"

--- a/internal/service/elasticbeanstalk/handlers.go
+++ b/internal/service/elasticbeanstalk/handlers.go
@@ -1,0 +1,336 @@
+// Package elasticbeanstalk provides AWS Elastic Beanstalk service emulation.
+package elasticbeanstalk
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// DispatchAction routes the request to the appropriate handler based on Action parameter.
+func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
+	action := extractAction(r)
+
+	switch action {
+	case "CreateApplication":
+		s.CreateApplication(w, r)
+	case "DescribeApplications":
+		s.DescribeApplications(w, r)
+	case "UpdateApplication":
+		s.UpdateApplication(w, r)
+	case "DeleteApplication":
+		s.DeleteApplication(w, r)
+	case "CreateEnvironment":
+		s.CreateEnvironment(w, r)
+	case "DescribeEnvironments":
+		s.DescribeEnvironments(w, r)
+	case "TerminateEnvironment":
+		s.TerminateEnvironment(w, r)
+	default:
+		writeError(w, "InvalidAction", fmt.Sprintf("The action '%s' is not valid", action), http.StatusBadRequest)
+	}
+}
+
+// CreateApplication handles the CreateApplication action.
+func (s *Service) CreateApplication(w http.ResponseWriter, r *http.Request) {
+	var req CreateApplicationInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errAppNotFound, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ApplicationName == "" {
+		writeError(w, errAppNotFound, "ApplicationName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	app, err := s.storage.CreateApplication(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLCreateApplicationResponse{
+		Xmlns:  ebXMLNS,
+		Result: XMLCreateApplicationResult{Application: toXMLApp(app)},
+		Meta:   XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DescribeApplications handles the DescribeApplications action.
+func (s *Service) DescribeApplications(w http.ResponseWriter, r *http.Request) {
+	var req DescribeApplicationsInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errAppNotFound, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	apps, err := s.storage.DescribeApplications(r.Context(), req.ApplicationNames)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	xmlApps := make([]XMLApplicationDescription, 0, len(apps))
+	for _, app := range apps {
+		xmlApps = append(xmlApps, toXMLApp(&app))
+	}
+
+	writeXMLResponse(w, XMLDescribeApplicationsResponse{
+		Xmlns:  ebXMLNS,
+		Result: XMLDescribeApplicationsResult{Applications: xmlApps},
+		Meta:   XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// UpdateApplication handles the UpdateApplication action.
+func (s *Service) UpdateApplication(w http.ResponseWriter, r *http.Request) {
+	var req UpdateApplicationInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errAppNotFound, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ApplicationName == "" {
+		writeError(w, errAppNotFound, "ApplicationName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	app, err := s.storage.UpdateApplication(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLUpdateApplicationResponse{
+		Xmlns:  ebXMLNS,
+		Result: XMLUpdateApplicationResult{Application: toXMLApp(app)},
+		Meta:   XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DeleteApplication handles the DeleteApplication action.
+func (s *Service) DeleteApplication(w http.ResponseWriter, r *http.Request) {
+	var req DeleteApplicationInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errAppNotFound, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ApplicationName == "" {
+		writeError(w, errAppNotFound, "ApplicationName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteApplication(r.Context(), req.ApplicationName); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLDeleteApplicationResponse{
+		Xmlns: ebXMLNS,
+		Meta:  XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// CreateEnvironment handles the CreateEnvironment action.
+func (s *Service) CreateEnvironment(w http.ResponseWriter, r *http.Request) {
+	var req CreateEnvironmentInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errEnvNotFound, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ApplicationName == "" {
+		writeError(w, errEnvNotFound, "ApplicationName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.EnvironmentName == "" {
+		writeError(w, errEnvNotFound, "EnvironmentName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	env, err := s.storage.CreateEnvironment(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLCreateEnvironmentResponse{
+		Xmlns:  ebXMLNS,
+		Result: XMLCreateEnvironmentResult{XMLEnvironmentDescription: toXMLEnv(env)},
+		Meta:   XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DescribeEnvironments handles the DescribeEnvironments action.
+func (s *Service) DescribeEnvironments(w http.ResponseWriter, r *http.Request) {
+	var req DescribeEnvironmentsInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errEnvNotFound, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	envs, err := s.storage.DescribeEnvironments(r.Context(), req.ApplicationName, req.EnvironmentNames)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	xmlEnvs := make([]XMLEnvironmentDescription, 0, len(envs))
+
+	for i := range envs {
+		xmlEnvs = append(xmlEnvs, toXMLEnv(&envs[i]))
+	}
+
+	writeXMLResponse(w, XMLDescribeEnvironmentsResponse{
+		Xmlns:  ebXMLNS,
+		Result: XMLDescribeEnvironmentsResult{Environments: xmlEnvs},
+		Meta:   XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// TerminateEnvironment handles the TerminateEnvironment action.
+func (s *Service) TerminateEnvironment(w http.ResponseWriter, r *http.Request) {
+	var req TerminateEnvironmentInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errEnvNotFound, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	envName := req.EnvironmentName
+	if envName == "" {
+		writeError(w, errEnvNotFound, "EnvironmentName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	env, err := s.storage.TerminateEnvironment(r.Context(), envName)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLTerminateEnvironmentResponse{
+		Xmlns:  ebXMLNS,
+		Result: XMLTerminateEnvironmentResult{XMLEnvironmentDescription: toXMLEnv(env)},
+		Meta:   XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// Helper functions.
+
+func toXMLApp(app *ApplicationDescription) XMLApplicationDescription {
+	return XMLApplicationDescription{
+		ApplicationName: app.ApplicationName,
+		Description:     app.Description,
+		DateCreated:     app.DateCreated,
+		DateUpdated:     app.DateUpdated,
+		ApplicationArn:  app.ApplicationArn,
+	}
+}
+
+func toXMLEnv(env *EnvironmentDescription) XMLEnvironmentDescription {
+	return XMLEnvironmentDescription{
+		ApplicationName:   env.ApplicationName,
+		EnvironmentID:     env.EnvironmentID,
+		EnvironmentName:   env.EnvironmentName,
+		Description:       env.Description,
+		SolutionStackName: env.SolutionStackName,
+		Status:            env.Status,
+		Health:            env.Health,
+		DateCreated:       env.DateCreated,
+		DateUpdated:       env.DateUpdated,
+		EnvironmentArn:    env.EnvironmentArn,
+	}
+}
+
+func extractAction(r *http.Request) string {
+	target := r.Header.Get("X-Amz-Target")
+	if target != "" {
+		if idx := strings.LastIndex(target, "."); idx >= 0 {
+			return target[idx+1:]
+		}
+	}
+
+	return r.URL.Query().Get("Action")
+}
+
+func readJSONRequest(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return nil
+}
+
+func writeXMLResponse(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, code, message string, status int) {
+	requestID := uuid.New().String()
+
+	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	w.Header().Set("x-amzn-RequestId", requestID)
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(XMLErrorResponse{
+		Error: XMLError{
+			Type:    "Sender",
+			Code:    code,
+			Message: message,
+		},
+		RequestID: requestID,
+	})
+}
+
+func handleError(w http.ResponseWriter, err error) {
+	var svcErr *ServiceError
+	if errors.As(err, &svcErr) {
+		writeError(w, svcErr.Code, svcErr.Message, http.StatusBadRequest)
+
+		return
+	}
+
+	writeError(w, "InternalFailure", err.Error(), http.StatusInternalServerError)
+}

--- a/internal/service/elasticbeanstalk/service.go
+++ b/internal/service/elasticbeanstalk/service.go
@@ -1,0 +1,52 @@
+package elasticbeanstalk
+
+import (
+	"github.com/sivchari/awsim/internal/service"
+)
+
+// Service implements the AWS Elastic Beanstalk service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new Elastic Beanstalk service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "elasticbeanstalk"
+}
+
+// TargetPrefix returns the X-Amz-Target header prefix.
+func (s *Service) TargetPrefix() string {
+	return "ElasticBeanstalk"
+}
+
+// Actions returns the list of action names this service handles.
+func (s *Service) Actions() []string {
+	return []string{
+		"CreateApplication",
+		"DescribeApplications",
+		"UpdateApplication",
+		"DeleteApplication",
+		"CreateEnvironment",
+		"DescribeEnvironments",
+		"TerminateEnvironment",
+	}
+}
+
+// QueryProtocol marks this service as using AWS Query protocol.
+func (s *Service) QueryProtocol() {}
+
+// RegisterRoutes registers routes with the router.
+func (s *Service) RegisterRoutes(_ service.Router) {
+	// Query protocol services use DispatchAction for routing.
+}
+
+func init() {
+	service.Register(New(NewMemoryStorage()))
+}

--- a/internal/service/elasticbeanstalk/storage.go
+++ b/internal/service/elasticbeanstalk/storage.go
@@ -1,0 +1,228 @@
+package elasticbeanstalk
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	defaultRegion    = "us-east-1"
+	defaultAccountID = "000000000000"
+
+	errAppNotFound = "InvalidParameterValue"
+	errAppExists   = "InvalidParameterValue"
+	errEnvNotFound = "InvalidParameterValue"
+)
+
+// ServiceError represents an Elastic Beanstalk service error.
+type ServiceError struct {
+	Code    string
+	Message string
+}
+
+func (e *ServiceError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Storage defines the Elastic Beanstalk storage interface.
+type Storage interface {
+	CreateApplication(ctx context.Context, req *CreateApplicationInput) (*ApplicationDescription, error)
+	DescribeApplications(ctx context.Context, names []string) ([]ApplicationDescription, error)
+	UpdateApplication(ctx context.Context, req *UpdateApplicationInput) (*ApplicationDescription, error)
+	DeleteApplication(ctx context.Context, name string) error
+
+	CreateEnvironment(ctx context.Context, req *CreateEnvironmentInput) (*EnvironmentDescription, error)
+	DescribeEnvironments(ctx context.Context, appName string, envNames []string) ([]EnvironmentDescription, error)
+	TerminateEnvironment(ctx context.Context, envName string) (*EnvironmentDescription, error)
+}
+
+// MemoryStorage implements Storage with in-memory data.
+type MemoryStorage struct {
+	mu           sync.RWMutex
+	applications map[string]*ApplicationDescription
+	environments map[string]*EnvironmentDescription
+}
+
+// NewMemoryStorage creates a new MemoryStorage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		applications: make(map[string]*ApplicationDescription),
+		environments: make(map[string]*EnvironmentDescription),
+	}
+}
+
+// CreateApplication creates a new application.
+func (m *MemoryStorage) CreateApplication(_ context.Context, req *CreateApplicationInput) (*ApplicationDescription, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.applications[req.ApplicationName]; exists {
+		return nil, &ServiceError{
+			Code:    errAppExists,
+			Message: fmt.Sprintf("Application %s already exists.", req.ApplicationName),
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	app := &ApplicationDescription{
+		ApplicationName: req.ApplicationName,
+		Description:     req.Description,
+		DateCreated:     now,
+		DateUpdated:     now,
+		ApplicationArn:  fmt.Sprintf("arn:aws:elasticbeanstalk:%s:%s:application/%s", defaultRegion, defaultAccountID, req.ApplicationName),
+	}
+
+	m.applications[req.ApplicationName] = app
+
+	return app, nil
+}
+
+// DescribeApplications returns applications matching the filter.
+func (m *MemoryStorage) DescribeApplications(_ context.Context, names []string) ([]ApplicationDescription, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(names) > 0 {
+		apps := make([]ApplicationDescription, 0, len(names))
+
+		for _, name := range names {
+			if app, exists := m.applications[name]; exists {
+				apps = append(apps, *app)
+			}
+		}
+
+		return apps, nil
+	}
+
+	apps := make([]ApplicationDescription, 0, len(m.applications))
+	for _, app := range m.applications {
+		apps = append(apps, *app)
+	}
+
+	return apps, nil
+}
+
+// UpdateApplication updates an existing application.
+func (m *MemoryStorage) UpdateApplication(_ context.Context, req *UpdateApplicationInput) (*ApplicationDescription, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	app, exists := m.applications[req.ApplicationName]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errAppNotFound,
+			Message: fmt.Sprintf("No Application named '%s' found.", req.ApplicationName),
+		}
+	}
+
+	if req.Description != "" {
+		app.Description = req.Description
+	}
+
+	app.DateUpdated = time.Now().UTC().Format(time.RFC3339)
+
+	return app, nil
+}
+
+// DeleteApplication deletes an application.
+func (m *MemoryStorage) DeleteApplication(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.applications[name]; !exists {
+		return &ServiceError{
+			Code:    errAppNotFound,
+			Message: fmt.Sprintf("No Application named '%s' found.", name),
+		}
+	}
+
+	delete(m.applications, name)
+
+	return nil
+}
+
+// CreateEnvironment creates a new environment.
+func (m *MemoryStorage) CreateEnvironment(_ context.Context, req *CreateEnvironmentInput) (*EnvironmentDescription, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.environments[req.EnvironmentName]; exists {
+		return nil, &ServiceError{
+			Code:    errEnvNotFound,
+			Message: fmt.Sprintf("Environment %s already exists.", req.EnvironmentName),
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	envID := "e-" + uuid.New().String()[:8]
+	env := &EnvironmentDescription{
+		ApplicationName:   req.ApplicationName,
+		EnvironmentID:     envID,
+		EnvironmentName:   req.EnvironmentName,
+		Description:       req.Description,
+		SolutionStackName: req.SolutionStackName,
+		Status:            "Ready",
+		Health:            "Green",
+		DateCreated:       now,
+		DateUpdated:       now,
+		EnvironmentArn:    fmt.Sprintf("arn:aws:elasticbeanstalk:%s:%s:environment/%s/%s", defaultRegion, defaultAccountID, req.ApplicationName, req.EnvironmentName),
+	}
+
+	m.environments[req.EnvironmentName] = env
+
+	return env, nil
+}
+
+// DescribeEnvironments returns environments matching the filter.
+func (m *MemoryStorage) DescribeEnvironments(_ context.Context, appName string, envNames []string) ([]EnvironmentDescription, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(envNames) > 0 {
+		envs := make([]EnvironmentDescription, 0, len(envNames))
+
+		for _, name := range envNames {
+			if env, exists := m.environments[name]; exists {
+				if appName == "" || env.ApplicationName == appName {
+					envs = append(envs, *env)
+				}
+			}
+		}
+
+		return envs, nil
+	}
+
+	envs := make([]EnvironmentDescription, 0, len(m.environments))
+
+	for _, env := range m.environments {
+		if appName == "" || env.ApplicationName == appName {
+			envs = append(envs, *env)
+		}
+	}
+
+	return envs, nil
+}
+
+// TerminateEnvironment terminates an environment.
+func (m *MemoryStorage) TerminateEnvironment(_ context.Context, envName string) (*EnvironmentDescription, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	env, exists := m.environments[envName]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errEnvNotFound,
+			Message: fmt.Sprintf("No Environment found for EnvironmentName = '%s'.", envName),
+		}
+	}
+
+	env.Status = "Terminated"
+
+	delete(m.environments, envName)
+
+	return env, nil
+}

--- a/internal/service/elasticbeanstalk/types.go
+++ b/internal/service/elasticbeanstalk/types.go
@@ -1,0 +1,202 @@
+package elasticbeanstalk
+
+import "encoding/xml"
+
+const ebXMLNS = "https://elasticbeanstalk.amazonaws.com/docs/2010-12-01/"
+
+// ApplicationDescription represents an Elastic Beanstalk application.
+type ApplicationDescription struct {
+	ApplicationName string `json:"ApplicationName"`
+	Description     string `json:"Description,omitempty"`
+	DateCreated     string `json:"DateCreated,omitempty"`
+	DateUpdated     string `json:"DateUpdated,omitempty"`
+	ApplicationArn  string `json:"ApplicationArn,omitempty"`
+}
+
+// EnvironmentDescription represents an Elastic Beanstalk environment.
+type EnvironmentDescription struct {
+	ApplicationName   string `json:"ApplicationName"`
+	EnvironmentID     string `json:"EnvironmentId,omitempty"`
+	EnvironmentName   string `json:"EnvironmentName"`
+	Description       string `json:"Description,omitempty"`
+	SolutionStackName string `json:"SolutionStackName,omitempty"`
+	Status            string `json:"Status,omitempty"`
+	Health            string `json:"Health,omitempty"`
+	DateCreated       string `json:"DateCreated,omitempty"`
+	DateUpdated       string `json:"DateUpdated,omitempty"`
+	EnvironmentArn    string `json:"EnvironmentArn,omitempty"`
+	CNAME             string `json:"CNAME,omitempty"`
+	EndpointURL       string `json:"EndpointURL,omitempty"`
+}
+
+// CreateApplicationInput represents a CreateApplication request.
+type CreateApplicationInput struct {
+	ApplicationName string `json:"ApplicationName"`
+	Description     string `json:"Description,omitempty"`
+}
+
+// CreateEnvironmentInput represents a CreateEnvironment request.
+type CreateEnvironmentInput struct {
+	ApplicationName   string `json:"ApplicationName"`
+	EnvironmentName   string `json:"EnvironmentName"`
+	Description       string `json:"Description,omitempty"`
+	SolutionStackName string `json:"SolutionStackName,omitempty"`
+}
+
+// DescribeApplicationsInput represents a DescribeApplications request.
+type DescribeApplicationsInput struct {
+	ApplicationNames []string `json:"ApplicationNames,omitempty"`
+}
+
+// DescribeEnvironmentsInput represents a DescribeEnvironments request.
+type DescribeEnvironmentsInput struct {
+	ApplicationName  string   `json:"ApplicationName,omitempty"`
+	EnvironmentNames []string `json:"EnvironmentNames,omitempty"`
+	EnvironmentIDs   []string `json:"EnvironmentIds,omitempty"`
+}
+
+// UpdateApplicationInput represents an UpdateApplication request.
+type UpdateApplicationInput struct {
+	ApplicationName string `json:"ApplicationName"`
+	Description     string `json:"Description,omitempty"`
+}
+
+// DeleteApplicationInput represents a DeleteApplication request.
+type DeleteApplicationInput struct {
+	ApplicationName string `json:"ApplicationName"`
+}
+
+// TerminateEnvironmentInput represents a TerminateEnvironment request.
+type TerminateEnvironmentInput struct {
+	EnvironmentID   string `json:"EnvironmentId,omitempty"`
+	EnvironmentName string `json:"EnvironmentName,omitempty"`
+}
+
+// XML response types.
+
+// XMLCreateApplicationResponse wraps the CreateApplication XML response.
+type XMLCreateApplicationResponse struct {
+	XMLName xml.Name                   `xml:"CreateApplicationResponse"`
+	Xmlns   string                     `xml:"xmlns,attr"`
+	Result  XMLCreateApplicationResult `xml:"CreateApplicationResult"`
+	Meta    XMLResponseMetadata        `xml:"ResponseMetadata"`
+}
+
+// XMLCreateApplicationResult contains the application in the result.
+type XMLCreateApplicationResult struct {
+	Application XMLApplicationDescription `xml:"Application"`
+}
+
+// XMLDescribeApplicationsResponse wraps the DescribeApplications XML response.
+type XMLDescribeApplicationsResponse struct {
+	XMLName xml.Name                      `xml:"DescribeApplicationsResponse"`
+	Xmlns   string                        `xml:"xmlns,attr"`
+	Result  XMLDescribeApplicationsResult `xml:"DescribeApplicationsResult"`
+	Meta    XMLResponseMetadata           `xml:"ResponseMetadata"`
+}
+
+// XMLDescribeApplicationsResult contains the list of applications.
+type XMLDescribeApplicationsResult struct {
+	Applications []XMLApplicationDescription `xml:"Applications>member"`
+}
+
+// XMLUpdateApplicationResponse wraps the UpdateApplication XML response.
+type XMLUpdateApplicationResponse struct {
+	XMLName xml.Name                   `xml:"UpdateApplicationResponse"`
+	Xmlns   string                     `xml:"xmlns,attr"`
+	Result  XMLUpdateApplicationResult `xml:"UpdateApplicationResult"`
+	Meta    XMLResponseMetadata        `xml:"ResponseMetadata"`
+}
+
+// XMLUpdateApplicationResult contains the updated application.
+type XMLUpdateApplicationResult struct {
+	Application XMLApplicationDescription `xml:"Application"`
+}
+
+// XMLDeleteApplicationResponse wraps the DeleteApplication XML response.
+type XMLDeleteApplicationResponse struct {
+	XMLName xml.Name            `xml:"DeleteApplicationResponse"`
+	Xmlns   string              `xml:"xmlns,attr"`
+	Meta    XMLResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// XMLCreateEnvironmentResponse wraps the CreateEnvironment XML response.
+type XMLCreateEnvironmentResponse struct {
+	XMLName xml.Name                   `xml:"CreateEnvironmentResponse"`
+	Xmlns   string                     `xml:"xmlns,attr"`
+	Result  XMLCreateEnvironmentResult `xml:"CreateEnvironmentResult"`
+	Meta    XMLResponseMetadata        `xml:"ResponseMetadata"`
+}
+
+// XMLCreateEnvironmentResult contains the environment.
+type XMLCreateEnvironmentResult struct {
+	XMLEnvironmentDescription
+}
+
+// XMLDescribeEnvironmentsResponse wraps the DescribeEnvironments XML response.
+type XMLDescribeEnvironmentsResponse struct {
+	XMLName xml.Name                      `xml:"DescribeEnvironmentsResponse"`
+	Xmlns   string                        `xml:"xmlns,attr"`
+	Result  XMLDescribeEnvironmentsResult `xml:"DescribeEnvironmentsResult"`
+	Meta    XMLResponseMetadata           `xml:"ResponseMetadata"`
+}
+
+// XMLDescribeEnvironmentsResult contains the list of environments.
+type XMLDescribeEnvironmentsResult struct {
+	Environments []XMLEnvironmentDescription `xml:"Environments>member"`
+}
+
+// XMLTerminateEnvironmentResponse wraps the TerminateEnvironment XML response.
+type XMLTerminateEnvironmentResponse struct {
+	XMLName xml.Name                      `xml:"TerminateEnvironmentResponse"`
+	Xmlns   string                        `xml:"xmlns,attr"`
+	Result  XMLTerminateEnvironmentResult `xml:"TerminateEnvironmentResult"`
+	Meta    XMLResponseMetadata           `xml:"ResponseMetadata"`
+}
+
+// XMLTerminateEnvironmentResult contains the terminated environment.
+type XMLTerminateEnvironmentResult struct {
+	XMLEnvironmentDescription
+}
+
+// XMLApplicationDescription represents an application in XML.
+type XMLApplicationDescription struct {
+	ApplicationName string `xml:"ApplicationName"`
+	Description     string `xml:"Description,omitempty"`
+	DateCreated     string `xml:"DateCreated"`
+	DateUpdated     string `xml:"DateUpdated"`
+	ApplicationArn  string `xml:"ApplicationArn"`
+}
+
+// XMLEnvironmentDescription represents an environment in XML.
+type XMLEnvironmentDescription struct {
+	ApplicationName   string `xml:"ApplicationName"`
+	EnvironmentID     string `xml:"EnvironmentId"`
+	EnvironmentName   string `xml:"EnvironmentName"`
+	Description       string `xml:"Description,omitempty"`
+	SolutionStackName string `xml:"SolutionStackName,omitempty"`
+	Status            string `xml:"Status"`
+	Health            string `xml:"Health"`
+	DateCreated       string `xml:"DateCreated"`
+	DateUpdated       string `xml:"DateUpdated"`
+	EnvironmentArn    string `xml:"EnvironmentArn"`
+}
+
+// XMLResponseMetadata holds the request ID.
+type XMLResponseMetadata struct {
+	RequestID string `xml:"RequestId"`
+}
+
+// XMLErrorResponse represents an error response.
+type XMLErrorResponse struct {
+	XMLName   xml.Name `xml:"ErrorResponse"`
+	Error     XMLError `xml:"Error"`
+	RequestID string   `xml:"RequestId"`
+}
+
+// XMLError represents the error detail.
+type XMLError struct {
+	Type    string `xml:"Type"`
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.80.0
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.51.9
+	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.7
 	github.com/aws/aws-sdk-go-v2/service/emrserverless v1.39.3
 	github.com/aws/aws-sdk-go-v2/service/entityresolution v1.26.3

--- a/test/go.sum
+++ b/test/go.sum
@@ -66,6 +66,8 @@ github.com/aws/aws-sdk-go-v2/service/eks v1.80.0 h1:moQGV8cPbVTN7r2Xte1Mybku35QD
 github.com/aws/aws-sdk-go-v2/service/eks v1.80.0/go.mod h1:Qg678m+87sCuJhcsZojenz8mblYG+Tq86V4m3hjVz0s=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.51.9 h1:hTgZLyNoDWphZUtTtcvQh0LP6TZO0mtdSfZK/GObDLk=
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.51.9/go.mod h1:91RkIYy9ubykxB50XGYDsbljLZnrZ6rp/Urt4rZrbwQ=
+github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.0 h1:p9R6ckEzoRaNFlfYTi9OEeq/ruUGta3fB3vEktiLNnM=
+github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.0/go.mod h1:ioNYrNI58Ot4BudAASL6+fBAzGveXzXObdGGs8evSiY=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.7 h1:txeoy+BxL/Xef6Cl8zAq4ZewY7c+KnQ3gPSMSTTkTt4=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.7/go.mod h1:tv2v97S1V5kkp/1vneSYad5Cnrbo+4vfiNNAKCWNKIk=
 github.com/aws/aws-sdk-go-v2/service/emrserverless v1.39.3 h1:VyyYx+0dPDLFPPTvUlO1Qgntlgi6I8RmEEx98192jaw=

--- a/test/integration/elasticbeanstalk_test.go
+++ b/test/integration/elasticbeanstalk_test.go
@@ -1,0 +1,246 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk"
+)
+
+func newElasticBeanstalkClient(t *testing.T) *elasticbeanstalk.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	return elasticbeanstalk.NewFromConfig(cfg, func(o *elasticbeanstalk.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestElasticBeanstalk_CreateAndDeleteApplication(t *testing.T) {
+	client := newElasticBeanstalkClient(t)
+	ctx := t.Context()
+	appName := "test-app"
+
+	createResult, err := client.CreateApplication(ctx, &elasticbeanstalk.CreateApplicationInput{
+		ApplicationName: aws.String(appName),
+		Description:     aws.String("test application"),
+	})
+	if err != nil {
+		t.Fatalf("failed to create application: %v", err)
+	}
+
+	if *createResult.Application.ApplicationName != appName {
+		t.Errorf("expected app name %s, got %s", appName, *createResult.Application.ApplicationName)
+	}
+
+	if createResult.Application.ApplicationArn == nil || *createResult.Application.ApplicationArn == "" {
+		t.Error("expected application ARN to be set")
+	}
+
+	// Delete
+	_, err = client.DeleteApplication(ctx, &elasticbeanstalk.DeleteApplicationInput{
+		ApplicationName: aws.String(appName),
+	})
+	if err != nil {
+		t.Fatalf("failed to delete application: %v", err)
+	}
+}
+
+func TestElasticBeanstalk_DescribeApplications(t *testing.T) {
+	client := newElasticBeanstalkClient(t)
+	ctx := t.Context()
+	appName := "test-describe-app"
+
+	_, err := client.CreateApplication(ctx, &elasticbeanstalk.CreateApplicationInput{
+		ApplicationName: aws.String(appName),
+		Description:     aws.String("describe test"),
+	})
+	if err != nil {
+		t.Fatalf("failed to create application: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteApplication(t.Context(), &elasticbeanstalk.DeleteApplicationInput{
+			ApplicationName: aws.String(appName),
+		})
+	})
+
+	describeResult, err := client.DescribeApplications(ctx, &elasticbeanstalk.DescribeApplicationsInput{
+		ApplicationNames: []string{appName},
+	})
+	if err != nil {
+		t.Fatalf("failed to describe applications: %v", err)
+	}
+
+	if len(describeResult.Applications) != 1 {
+		t.Fatalf("expected 1 application, got %d", len(describeResult.Applications))
+	}
+
+	if *describeResult.Applications[0].ApplicationName != appName {
+		t.Errorf("expected app name %s, got %s", appName, *describeResult.Applications[0].ApplicationName)
+	}
+}
+
+func TestElasticBeanstalk_UpdateApplication(t *testing.T) {
+	client := newElasticBeanstalkClient(t)
+	ctx := t.Context()
+	appName := "test-update-app"
+
+	_, err := client.CreateApplication(ctx, &elasticbeanstalk.CreateApplicationInput{
+		ApplicationName: aws.String(appName),
+	})
+	if err != nil {
+		t.Fatalf("failed to create application: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteApplication(t.Context(), &elasticbeanstalk.DeleteApplicationInput{
+			ApplicationName: aws.String(appName),
+		})
+	})
+
+	updateResult, err := client.UpdateApplication(ctx, &elasticbeanstalk.UpdateApplicationInput{
+		ApplicationName: aws.String(appName),
+		Description:     aws.String("updated description"),
+	})
+	if err != nil {
+		t.Fatalf("failed to update application: %v", err)
+	}
+
+	if *updateResult.Application.Description != "updated description" {
+		t.Errorf("expected description 'updated description', got %s", *updateResult.Application.Description)
+	}
+}
+
+func TestElasticBeanstalk_CreateAndTerminateEnvironment(t *testing.T) {
+	client := newElasticBeanstalkClient(t)
+	ctx := t.Context()
+	appName := "test-env-app"
+	envName := "test-env"
+
+	_, err := client.CreateApplication(ctx, &elasticbeanstalk.CreateApplicationInput{
+		ApplicationName: aws.String(appName),
+	})
+	if err != nil {
+		t.Fatalf("failed to create application: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteApplication(t.Context(), &elasticbeanstalk.DeleteApplicationInput{
+			ApplicationName: aws.String(appName),
+		})
+	})
+
+	createResult, err := client.CreateEnvironment(ctx, &elasticbeanstalk.CreateEnvironmentInput{
+		ApplicationName: aws.String(appName),
+		EnvironmentName: aws.String(envName),
+	})
+	if err != nil {
+		t.Fatalf("failed to create environment: %v", err)
+	}
+
+	if *createResult.EnvironmentName != envName {
+		t.Errorf("expected env name %s, got %s", envName, *createResult.EnvironmentName)
+	}
+
+	if createResult.EnvironmentId == nil || *createResult.EnvironmentId == "" {
+		t.Error("expected environment ID to be set")
+	}
+
+	// Terminate
+	terminateResult, err := client.TerminateEnvironment(ctx, &elasticbeanstalk.TerminateEnvironmentInput{
+		EnvironmentName: aws.String(envName),
+	})
+	if err != nil {
+		t.Fatalf("failed to terminate environment: %v", err)
+	}
+
+	if *terminateResult.EnvironmentName != envName {
+		t.Errorf("expected env name %s, got %s", envName, *terminateResult.EnvironmentName)
+	}
+}
+
+func TestElasticBeanstalk_DescribeEnvironments(t *testing.T) {
+	client := newElasticBeanstalkClient(t)
+	ctx := t.Context()
+	appName := "test-desc-env-app"
+	envName := "test-desc-env"
+
+	_, err := client.CreateApplication(ctx, &elasticbeanstalk.CreateApplicationInput{
+		ApplicationName: aws.String(appName),
+	})
+	if err != nil {
+		t.Fatalf("failed to create application: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.TerminateEnvironment(t.Context(), &elasticbeanstalk.TerminateEnvironmentInput{
+			EnvironmentName: aws.String(envName),
+		})
+		_, _ = client.DeleteApplication(t.Context(), &elasticbeanstalk.DeleteApplicationInput{
+			ApplicationName: aws.String(appName),
+		})
+	})
+
+	_, err = client.CreateEnvironment(ctx, &elasticbeanstalk.CreateEnvironmentInput{
+		ApplicationName: aws.String(appName),
+		EnvironmentName: aws.String(envName),
+	})
+	if err != nil {
+		t.Fatalf("failed to create environment: %v", err)
+	}
+
+	describeResult, err := client.DescribeEnvironments(ctx, &elasticbeanstalk.DescribeEnvironmentsInput{
+		EnvironmentNames: []string{envName},
+	})
+	if err != nil {
+		t.Fatalf("failed to describe environments: %v", err)
+	}
+
+	if len(describeResult.Environments) != 1 {
+		t.Fatalf("expected 1 environment, got %d", len(describeResult.Environments))
+	}
+
+	if *describeResult.Environments[0].EnvironmentName != envName {
+		t.Errorf("expected env name %s, got %s", envName, *describeResult.Environments[0].EnvironmentName)
+	}
+}
+
+func TestElasticBeanstalk_DuplicateApplication(t *testing.T) {
+	client := newElasticBeanstalkClient(t)
+	ctx := t.Context()
+	appName := "test-dup-app"
+
+	_, err := client.CreateApplication(ctx, &elasticbeanstalk.CreateApplicationInput{
+		ApplicationName: aws.String(appName),
+	})
+	if err != nil {
+		t.Fatalf("failed to create application: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteApplication(t.Context(), &elasticbeanstalk.DeleteApplicationInput{
+			ApplicationName: aws.String(appName),
+		})
+	})
+
+	_, err = client.CreateApplication(ctx, &elasticbeanstalk.CreateApplicationInput{
+		ApplicationName: aws.String(appName),
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate application")
+	}
+}


### PR DESCRIPTION
## Summary

- Implement Elastic Beanstalk service emulator using AWS Query protocol (XML responses)
- Support Application CRUD: CreateApplication, DescribeApplications, UpdateApplication, DeleteApplication
- Support Environment lifecycle: CreateEnvironment, DescribeEnvironments, TerminateEnvironment
- Add integration tests using AWS SDK v2 elasticbeanstalk client

Closes #60

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Lint passes (`make lint`)
- [ ] Integration tests pass (`make test-integration`)