### PR TITLE
feat(sts): implement AWS Security Token Service

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -266,6 +266,10 @@ linters:
       - path: internal/service/ebs/types\.go
         linters:
           - tagliatelle
+      # AWS STS API requires PascalCase JSON field names.
+      - path: internal/service/sts/types\.go
+        linters:
+          - tagliatelle
   settings:
     gocritic:
       enable-all: true

--- a/cmd/awsim/main.go
+++ b/cmd/awsim/main.go
@@ -70,6 +70,7 @@ import (
 	_ "github.com/sivchari/awsim/internal/service/sns"
 	_ "github.com/sivchari/awsim/internal/service/sqs"
 	_ "github.com/sivchari/awsim/internal/service/ssm"
+	_ "github.com/sivchari/awsim/internal/service/sts"
 	_ "github.com/sivchari/awsim/internal/service/xray"
 )
 

--- a/internal/service/sts/handlers.go
+++ b/internal/service/sts/handlers.go
@@ -1,0 +1,287 @@
+// Package sts implements the AWS Security Token Service handlers.
+package sts
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	stsXMLNS        = "https://sts.amazonaws.com/doc/2011-06-15/"
+	errInvalidParam = "InvalidParameterValue"
+	errMissingParam = "MissingParameter"
+)
+
+// DispatchAction routes the request to the appropriate handler based on Action parameter.
+func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
+	action := extractAction(r)
+
+	switch action {
+	case "AssumeRole":
+		s.handleAssumeRole(w, r)
+	case "AssumeRoleWithSAML":
+		s.handleAssumeRoleWithSAML(w, r)
+	case "AssumeRoleWithWebIdentity":
+		s.handleAssumeRoleWithWebIdentity(w, r)
+	case "GetCallerIdentity":
+		s.handleGetCallerIdentity(w, r)
+	case "GetSessionToken":
+		s.handleGetSessionToken(w, r)
+	case "GetFederationToken":
+		s.handleGetFederationToken(w, r)
+	default:
+		writeError(w, errInvalidParam, fmt.Sprintf("The action '%s' is not valid", action), http.StatusBadRequest)
+	}
+}
+
+// handleAssumeRole handles the AssumeRole action.
+func (s *Service) handleAssumeRole(w http.ResponseWriter, r *http.Request) {
+	var req AssumeRoleInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParam, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RoleArn == "" {
+		writeError(w, errMissingParam, "RoleArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RoleSessionName == "" {
+		writeError(w, errMissingParam, "RoleSessionName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	result, err := s.storage.AssumeRole(r.Context(), &req)
+	if err != nil {
+		writeError(w, "InternalServiceError", err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLAssumeRoleResponse{
+		Xmlns:            stsXMLNS,
+		AssumedRoleUser:  result.AssumedRoleUser,
+		Credentials:      result.Credentials,
+		PackedPolicySize: result.PackedPolicySize,
+		RequestID:        uuid.New().String(),
+	})
+}
+
+// handleAssumeRoleWithSAML handles the AssumeRoleWithSAML action.
+func (s *Service) handleAssumeRoleWithSAML(w http.ResponseWriter, r *http.Request) {
+	var req AssumeRoleWithSAMLInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParam, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RoleArn == "" {
+		writeError(w, errMissingParam, "RoleArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.PrincipalArn == "" {
+		writeError(w, errMissingParam, "PrincipalArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.SAMLAssertion == "" {
+		writeError(w, errMissingParam, "SAMLAssertion is required", http.StatusBadRequest)
+
+		return
+	}
+
+	result, err := s.storage.AssumeRoleWithSAML(r.Context(), &req)
+	if err != nil {
+		writeError(w, "InternalServiceError", err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLAssumeRoleWithSAMLResponse{
+		Xmlns:            stsXMLNS,
+		AssumedRoleUser:  result.AssumedRoleUser,
+		Credentials:      result.Credentials,
+		PackedPolicySize: result.PackedPolicySize,
+		RequestID:        uuid.New().String(),
+	})
+}
+
+// handleAssumeRoleWithWebIdentity handles the AssumeRoleWithWebIdentity action.
+func (s *Service) handleAssumeRoleWithWebIdentity(w http.ResponseWriter, r *http.Request) {
+	var req AssumeRoleWithWebIdentityInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParam, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RoleArn == "" {
+		writeError(w, errMissingParam, "RoleArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RoleSessionName == "" {
+		writeError(w, errMissingParam, "RoleSessionName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.WebIdentityToken == "" {
+		writeError(w, errMissingParam, "WebIdentityToken is required", http.StatusBadRequest)
+
+		return
+	}
+
+	result, err := s.storage.AssumeRoleWithWebIdentity(r.Context(), &req)
+	if err != nil {
+		writeError(w, "InternalServiceError", err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLAssumeRoleWithWebIdentityResponse{
+		Xmlns:            stsXMLNS,
+		AssumedRoleUser:  result.AssumedRoleUser,
+		Credentials:      result.Credentials,
+		PackedPolicySize: result.PackedPolicySize,
+		RequestID:        uuid.New().String(),
+	})
+}
+
+// handleGetCallerIdentity handles the GetCallerIdentity action.
+func (s *Service) handleGetCallerIdentity(w http.ResponseWriter, r *http.Request) {
+	identity, err := s.storage.GetCallerIdentity(r.Context())
+	if err != nil {
+		writeError(w, "InternalServiceError", err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLGetCallerIdentityResponse{
+		Xmlns:     stsXMLNS,
+		Account:   identity.Account,
+		Arn:       identity.Arn,
+		UserID:    identity.UserID,
+		RequestID: uuid.New().String(),
+	})
+}
+
+// handleGetSessionToken handles the GetSessionToken action.
+func (s *Service) handleGetSessionToken(w http.ResponseWriter, r *http.Request) {
+	var req GetSessionTokenInput
+
+	_ = readJSONRequest(r, &req)
+
+	creds, err := s.storage.GetSessionToken(r.Context(), &req)
+	if err != nil {
+		writeError(w, "InternalServiceError", err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLGetSessionTokenResponse{
+		Xmlns:       stsXMLNS,
+		Credentials: creds,
+		RequestID:   uuid.New().String(),
+	})
+}
+
+// handleGetFederationToken handles the GetFederationToken action.
+func (s *Service) handleGetFederationToken(w http.ResponseWriter, r *http.Request) {
+	var req GetFederationTokenInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParam, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Name == "" {
+		writeError(w, errMissingParam, "Name is required", http.StatusBadRequest)
+
+		return
+	}
+
+	result, err := s.storage.GetFederationToken(r.Context(), &req)
+	if err != nil {
+		writeError(w, "InternalServiceError", err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLGetFederationTokenResponse{
+		Xmlns:            stsXMLNS,
+		Credentials:      result.Credentials,
+		FederatedUser:    result.FederatedUser,
+		PackedPolicySize: result.PackedPolicySize,
+		RequestID:        uuid.New().String(),
+	})
+}
+
+// Helper functions.
+
+func extractAction(r *http.Request) string {
+	target := r.Header.Get("X-Amz-Target")
+	if target != "" {
+		if idx := strings.LastIndex(target, "."); idx >= 0 {
+			return target[idx+1:]
+		}
+	}
+
+	return r.URL.Query().Get("Action")
+}
+
+func readJSONRequest(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return nil
+}
+
+func writeXMLResponse(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, code, message string, status int) {
+	requestID := uuid.New().String()
+
+	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	w.Header().Set("x-amzn-RequestId", requestID)
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(XMLErrorResponse{
+		Error: XMLError{
+			Code:    code,
+			Message: message,
+		},
+		RequestID: requestID,
+	})
+}

--- a/internal/service/sts/service.go
+++ b/internal/service/sts/service.go
@@ -1,0 +1,53 @@
+package sts
+
+import (
+	"github.com/sivchari/awsim/internal/service"
+)
+
+func init() {
+	storage := NewMemoryStorage()
+	service.Register(New(storage))
+}
+
+// Service implements the STS service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new STS service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "sts"
+}
+
+// RegisterRoutes registers routes with the router.
+// STS uses Query protocol, so routes are registered via DispatchAction.
+func (s *Service) RegisterRoutes(_ service.Router) {
+	// STS uses Query protocol, routing is handled by DispatchAction.
+}
+
+// TargetPrefix returns the X-Amz-Target header prefix for STS.
+func (s *Service) TargetPrefix() string {
+	return "AWSSecurityTokenServiceV20110615"
+}
+
+// Actions returns the list of action names this service handles.
+func (s *Service) Actions() []string {
+	return []string{
+		"AssumeRole",
+		"AssumeRoleWithSAML",
+		"AssumeRoleWithWebIdentity",
+		"GetCallerIdentity",
+		"GetSessionToken",
+		"GetFederationToken",
+	}
+}
+
+// QueryProtocol is a marker method that indicates STS uses AWS Query protocol.
+func (s *Service) QueryProtocol() {}

--- a/internal/service/sts/storage.go
+++ b/internal/service/sts/storage.go
@@ -1,0 +1,170 @@
+package sts
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	defaultAccountID = "000000000000"
+
+	// Default credential expiration duration (1 hour).
+	defaultDurationSeconds = 3600
+)
+
+// Storage defines the STS storage interface.
+type Storage interface {
+	AssumeRole(ctx context.Context, input *AssumeRoleInput) (*AssumeRoleResult, error)
+	AssumeRoleWithSAML(ctx context.Context, input *AssumeRoleWithSAMLInput) (*AssumeRoleResult, error)
+	AssumeRoleWithWebIdentity(ctx context.Context, input *AssumeRoleWithWebIdentityInput) (*AssumeRoleResult, error)
+	GetCallerIdentity(ctx context.Context) (*CallerIdentity, error)
+	GetSessionToken(ctx context.Context, input *GetSessionTokenInput) (*Credentials, error)
+	GetFederationToken(ctx context.Context, input *GetFederationTokenInput) (*FederationTokenResult, error)
+}
+
+// AssumeRoleResult represents the result of an AssumeRole operation.
+type AssumeRoleResult struct {
+	AssumedRoleUser  *AssumedRoleUser
+	Credentials      *Credentials
+	PackedPolicySize int32
+}
+
+// CallerIdentity represents the caller identity.
+type CallerIdentity struct {
+	Account string
+	Arn     string
+	UserID  string
+}
+
+// FederationTokenResult represents the result of a GetFederationToken operation.
+type FederationTokenResult struct {
+	Credentials      *Credentials
+	FederatedUser    *FederatedUser
+	PackedPolicySize int32
+}
+
+// MemoryStorage implements Storage with in-memory data.
+type MemoryStorage struct{}
+
+// NewMemoryStorage creates a new MemoryStorage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{}
+}
+
+// AssumeRole generates temporary credentials for an assumed role.
+func (m *MemoryStorage) AssumeRole(_ context.Context, input *AssumeRoleInput) (*AssumeRoleResult, error) {
+	duration := resolveDuration(input.DurationSeconds)
+	creds := generateCredentials(duration)
+	roleSessionName := input.RoleSessionName
+	assumedRoleID := generateAssumedRoleID(roleSessionName)
+
+	return &AssumeRoleResult{
+		AssumedRoleUser: &AssumedRoleUser{
+			Arn:           fmt.Sprintf("arn:aws:sts::%s:assumed-role/emulated-role/%s", defaultAccountID, roleSessionName),
+			AssumedRoleID: assumedRoleID,
+		},
+		Credentials:      creds,
+		PackedPolicySize: 0,
+	}, nil
+}
+
+// AssumeRoleWithSAML generates temporary credentials for a SAML-authenticated role assumption.
+func (m *MemoryStorage) AssumeRoleWithSAML(_ context.Context, input *AssumeRoleWithSAMLInput) (*AssumeRoleResult, error) {
+	duration := resolveDuration(input.DurationSeconds)
+	creds := generateCredentials(duration)
+	assumedRoleID := generateAssumedRoleID("SAMLSession")
+
+	return &AssumeRoleResult{
+		AssumedRoleUser: &AssumedRoleUser{
+			Arn:           fmt.Sprintf("arn:aws:sts::%s:assumed-role/emulated-role/SAMLSession", defaultAccountID),
+			AssumedRoleID: assumedRoleID,
+		},
+		Credentials:      creds,
+		PackedPolicySize: 0,
+	}, nil
+}
+
+// AssumeRoleWithWebIdentity generates temporary credentials for a web identity role assumption.
+func (m *MemoryStorage) AssumeRoleWithWebIdentity(_ context.Context, input *AssumeRoleWithWebIdentityInput) (*AssumeRoleResult, error) {
+	duration := resolveDuration(input.DurationSeconds)
+	creds := generateCredentials(duration)
+	roleSessionName := input.RoleSessionName
+	assumedRoleID := generateAssumedRoleID(roleSessionName)
+
+	return &AssumeRoleResult{
+		AssumedRoleUser: &AssumedRoleUser{
+			Arn:           fmt.Sprintf("arn:aws:sts::%s:assumed-role/emulated-role/%s", defaultAccountID, roleSessionName),
+			AssumedRoleID: assumedRoleID,
+		},
+		Credentials:      creds,
+		PackedPolicySize: 0,
+	}, nil
+}
+
+// GetCallerIdentity returns the identity of the caller.
+func (m *MemoryStorage) GetCallerIdentity(_ context.Context) (*CallerIdentity, error) {
+	return &CallerIdentity{
+		Account: defaultAccountID,
+		Arn:     fmt.Sprintf("arn:aws:iam::%s:root", defaultAccountID),
+		UserID:  defaultAccountID,
+	}, nil
+}
+
+// GetSessionToken generates temporary session credentials.
+func (m *MemoryStorage) GetSessionToken(_ context.Context, input *GetSessionTokenInput) (*Credentials, error) {
+	duration := resolveDuration(input.DurationSeconds)
+
+	return generateCredentials(duration), nil
+}
+
+// GetFederationToken generates temporary credentials for a federated user.
+func (m *MemoryStorage) GetFederationToken(_ context.Context, input *GetFederationTokenInput) (*FederationTokenResult, error) {
+	duration := resolveDuration(input.DurationSeconds)
+	creds := generateCredentials(duration)
+
+	return &FederationTokenResult{
+		Credentials: creds,
+		FederatedUser: &FederatedUser{
+			Arn:             fmt.Sprintf("arn:aws:sts::%s:federated-user/%s", defaultAccountID, input.Name),
+			FederatedUserID: fmt.Sprintf("%s:%s", defaultAccountID, input.Name),
+		},
+		PackedPolicySize: 0,
+	}, nil
+}
+
+// Helper functions.
+
+func resolveDuration(durationSeconds int32) int32 {
+	if durationSeconds <= 0 {
+		return defaultDurationSeconds
+	}
+
+	return durationSeconds
+}
+
+func generateCredentials(durationSeconds int32) *Credentials {
+	expiration := time.Now().Add(time.Duration(durationSeconds) * time.Second)
+
+	return &Credentials{
+		AccessKeyID:     "ASIA" + randomHex(16),
+		SecretAccessKey: randomHex(40),
+		SessionToken:    randomHex(64),
+		Expiration:      expiration.UTC().Format(time.RFC3339),
+	}
+}
+
+func generateAssumedRoleID(sessionName string) string {
+	return fmt.Sprintf("AROA%s:%s", uuid.New().String()[:12], sessionName)
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+
+	return hex.EncodeToString(b)[:n]
+}

--- a/internal/service/sts/types.go
+++ b/internal/service/sts/types.go
@@ -1,0 +1,140 @@
+package sts
+
+import "encoding/xml"
+
+// AssumeRoleInput represents an AssumeRole request.
+type AssumeRoleInput struct {
+	RoleArn         string `json:"RoleArn"`
+	RoleSessionName string `json:"RoleSessionName"`
+	DurationSeconds int32  `json:"DurationSeconds,omitempty"`
+	ExternalID      string `json:"ExternalId,omitempty"`
+	Policy          string `json:"Policy,omitempty"`
+	SerialNumber    string `json:"SerialNumber,omitempty"`
+	TokenCode       string `json:"TokenCode,omitempty"`
+}
+
+// AssumeRoleWithSAMLInput represents an AssumeRoleWithSAML request.
+type AssumeRoleWithSAMLInput struct {
+	PrincipalArn    string `json:"PrincipalArn"`
+	RoleArn         string `json:"RoleArn"`
+	SAMLAssertion   string `json:"SAMLAssertion"`
+	DurationSeconds int32  `json:"DurationSeconds,omitempty"`
+	Policy          string `json:"Policy,omitempty"`
+}
+
+// AssumeRoleWithWebIdentityInput represents an AssumeRoleWithWebIdentity request.
+type AssumeRoleWithWebIdentityInput struct {
+	RoleArn          string `json:"RoleArn"`
+	RoleSessionName  string `json:"RoleSessionName"`
+	WebIdentityToken string `json:"WebIdentityToken"`
+	DurationSeconds  int32  `json:"DurationSeconds,omitempty"`
+	ProviderID       string `json:"ProviderId,omitempty"`
+	Policy           string `json:"Policy,omitempty"`
+}
+
+// GetSessionTokenInput represents a GetSessionToken request.
+type GetSessionTokenInput struct {
+	DurationSeconds int32  `json:"DurationSeconds,omitempty"`
+	SerialNumber    string `json:"SerialNumber,omitempty"`
+	TokenCode       string `json:"TokenCode,omitempty"`
+}
+
+// GetFederationTokenInput represents a GetFederationToken request.
+type GetFederationTokenInput struct {
+	Name            string `json:"Name"`
+	DurationSeconds int32  `json:"DurationSeconds,omitempty"`
+	Policy          string `json:"Policy,omitempty"`
+}
+
+// Credentials represents temporary security credentials.
+type Credentials struct {
+	AccessKeyID     string `xml:"AccessKeyId"`
+	SecretAccessKey string `xml:"SecretAccessKey"`
+	SessionToken    string `xml:"SessionToken"`
+	Expiration      string `xml:"Expiration"`
+}
+
+// AssumedRoleUser represents the assumed role user.
+type AssumedRoleUser struct {
+	Arn           string `xml:"Arn"`
+	AssumedRoleID string `xml:"AssumedRoleId"`
+}
+
+// FederatedUser represents the federated user.
+type FederatedUser struct {
+	Arn             string `xml:"Arn"`
+	FederatedUserID string `xml:"FederatedUserId"`
+}
+
+// XML response types.
+
+// XMLAssumeRoleResponse is the XML response for AssumeRole.
+type XMLAssumeRoleResponse struct {
+	XMLName          xml.Name         `xml:"AssumeRoleResponse"`
+	Xmlns            string           `xml:"xmlns,attr"`
+	AssumedRoleUser  *AssumedRoleUser `xml:"AssumeRoleResult>AssumedRoleUser"`
+	Credentials      *Credentials     `xml:"AssumeRoleResult>Credentials"`
+	PackedPolicySize int32            `xml:"AssumeRoleResult>PackedPolicySize"`
+	RequestID        string           `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLAssumeRoleWithSAMLResponse is the XML response for AssumeRoleWithSAML.
+type XMLAssumeRoleWithSAMLResponse struct {
+	XMLName          xml.Name         `xml:"AssumeRoleWithSAMLResponse"`
+	Xmlns            string           `xml:"xmlns,attr"`
+	AssumedRoleUser  *AssumedRoleUser `xml:"AssumeRoleWithSAMLResult>AssumedRoleUser"`
+	Credentials      *Credentials     `xml:"AssumeRoleWithSAMLResult>Credentials"`
+	PackedPolicySize int32            `xml:"AssumeRoleWithSAMLResult>PackedPolicySize"`
+	RequestID        string           `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLAssumeRoleWithWebIdentityResponse is the XML response for AssumeRoleWithWebIdentity.
+type XMLAssumeRoleWithWebIdentityResponse struct {
+	XMLName          xml.Name         `xml:"AssumeRoleWithWebIdentityResponse"`
+	Xmlns            string           `xml:"xmlns,attr"`
+	AssumedRoleUser  *AssumedRoleUser `xml:"AssumeRoleWithWebIdentityResult>AssumedRoleUser"`
+	Credentials      *Credentials     `xml:"AssumeRoleWithWebIdentityResult>Credentials"`
+	PackedPolicySize int32            `xml:"AssumeRoleWithWebIdentityResult>PackedPolicySize"`
+	RequestID        string           `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLGetCallerIdentityResponse is the XML response for GetCallerIdentity.
+type XMLGetCallerIdentityResponse struct {
+	XMLName   xml.Name `xml:"GetCallerIdentityResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	Account   string   `xml:"GetCallerIdentityResult>Account"`
+	Arn       string   `xml:"GetCallerIdentityResult>Arn"`
+	UserID    string   `xml:"GetCallerIdentityResult>UserId"`
+	RequestID string   `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLGetSessionTokenResponse is the XML response for GetSessionToken.
+type XMLGetSessionTokenResponse struct {
+	XMLName     xml.Name     `xml:"GetSessionTokenResponse"`
+	Xmlns       string       `xml:"xmlns,attr"`
+	Credentials *Credentials `xml:"GetSessionTokenResult>Credentials"`
+	RequestID   string       `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLGetFederationTokenResponse is the XML response for GetFederationToken.
+type XMLGetFederationTokenResponse struct {
+	XMLName          xml.Name       `xml:"GetFederationTokenResponse"`
+	Xmlns            string         `xml:"xmlns,attr"`
+	Credentials      *Credentials   `xml:"GetFederationTokenResult>Credentials"`
+	FederatedUser    *FederatedUser `xml:"GetFederationTokenResult>FederatedUser"`
+	PackedPolicySize int32          `xml:"GetFederationTokenResult>PackedPolicySize"`
+	RequestID        string         `xml:"ResponseMetadata>RequestId"`
+}
+
+// XMLErrorResponse is the XML error response.
+type XMLErrorResponse struct {
+	XMLName   xml.Name `xml:"ErrorResponse"`
+	Error     XMLError `xml:"Error"`
+	RequestID string   `xml:"RequestId"`
+}
+
+// XMLError is an XML error.
+type XMLError struct {
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.11
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.21
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
 	github.com/aws/aws-sdk-go-v2/service/xray v1.36.17
 	github.com/aws/smithy-go v1.24.2
 	github.com/sivchari/golden v0.3.0
@@ -91,7 +92,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect
 )
 
 replace github.com/sivchari/awsim => ../

--- a/test/integration/sts_test.go
+++ b/test/integration/sts_test.go
@@ -1,0 +1,182 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+func newSTSClient(t *testing.T) *sts.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	return sts.NewFromConfig(cfg, func(o *sts.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestSTS_GetCallerIdentity(t *testing.T) {
+	client := newSTSClient(t)
+	ctx := t.Context()
+
+	result, err := client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		t.Fatalf("failed to get caller identity: %v", err)
+	}
+
+	if result.Account == nil || *result.Account == "" {
+		t.Error("expected Account to be set")
+	}
+
+	if result.Arn == nil || *result.Arn == "" {
+		t.Error("expected Arn to be set")
+	}
+
+	if result.UserId == nil || *result.UserId == "" {
+		t.Error("expected UserId to be set")
+	}
+}
+
+func TestSTS_AssumeRole(t *testing.T) {
+	client := newSTSClient(t)
+	ctx := t.Context()
+
+	result, err := client.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::000000000000:role/test-role"),
+		RoleSessionName: aws.String("test-session"),
+	})
+	if err != nil {
+		t.Fatalf("failed to assume role: %v", err)
+	}
+
+	if result.Credentials == nil {
+		t.Fatal("expected Credentials to be set")
+	}
+
+	if result.Credentials.AccessKeyId == nil || *result.Credentials.AccessKeyId == "" {
+		t.Error("expected AccessKeyId to be set")
+	}
+
+	if result.Credentials.SecretAccessKey == nil || *result.Credentials.SecretAccessKey == "" {
+		t.Error("expected SecretAccessKey to be set")
+	}
+
+	if result.Credentials.SessionToken == nil || *result.Credentials.SessionToken == "" {
+		t.Error("expected SessionToken to be set")
+	}
+
+	if result.AssumedRoleUser == nil {
+		t.Fatal("expected AssumedRoleUser to be set")
+	}
+
+	if result.AssumedRoleUser.Arn == nil || *result.AssumedRoleUser.Arn == "" {
+		t.Error("expected AssumedRoleUser.Arn to be set")
+	}
+
+	if result.AssumedRoleUser.AssumedRoleId == nil || *result.AssumedRoleUser.AssumedRoleId == "" {
+		t.Error("expected AssumedRoleUser.AssumedRoleId to be set")
+	}
+}
+
+func TestSTS_AssumeRoleWithWebIdentity(t *testing.T) {
+	client := newSTSClient(t)
+	ctx := t.Context()
+
+	result, err := client.AssumeRoleWithWebIdentity(ctx, &sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          aws.String("arn:aws:iam::000000000000:role/web-identity-role"),
+		RoleSessionName:  aws.String("web-session"),
+		WebIdentityToken: aws.String("mock-token"),
+	})
+	if err != nil {
+		t.Fatalf("failed to assume role with web identity: %v", err)
+	}
+
+	if result.Credentials == nil {
+		t.Fatal("expected Credentials to be set")
+	}
+
+	if result.AssumedRoleUser == nil {
+		t.Fatal("expected AssumedRoleUser to be set")
+	}
+}
+
+func TestSTS_GetSessionToken(t *testing.T) {
+	client := newSTSClient(t)
+	ctx := t.Context()
+
+	result, err := client.GetSessionToken(ctx, &sts.GetSessionTokenInput{})
+	if err != nil {
+		t.Fatalf("failed to get session token: %v", err)
+	}
+
+	if result.Credentials == nil {
+		t.Fatal("expected Credentials to be set")
+	}
+
+	if result.Credentials.AccessKeyId == nil || *result.Credentials.AccessKeyId == "" {
+		t.Error("expected AccessKeyId to be set")
+	}
+
+	if result.Credentials.SecretAccessKey == nil || *result.Credentials.SecretAccessKey == "" {
+		t.Error("expected SecretAccessKey to be set")
+	}
+
+	if result.Credentials.SessionToken == nil || *result.Credentials.SessionToken == "" {
+		t.Error("expected SessionToken to be set")
+	}
+}
+
+func TestSTS_GetFederationToken(t *testing.T) {
+	client := newSTSClient(t)
+	ctx := t.Context()
+
+	result, err := client.GetFederationToken(ctx, &sts.GetFederationTokenInput{
+		Name: aws.String("test-federated-user"),
+	})
+	if err != nil {
+		t.Fatalf("failed to get federation token: %v", err)
+	}
+
+	if result.Credentials == nil {
+		t.Fatal("expected Credentials to be set")
+	}
+
+	if result.FederatedUser == nil {
+		t.Fatal("expected FederatedUser to be set")
+	}
+
+	if result.FederatedUser.Arn == nil || *result.FederatedUser.Arn == "" {
+		t.Error("expected FederatedUser.Arn to be set")
+	}
+
+	if result.FederatedUser.FederatedUserId == nil || *result.FederatedUser.FederatedUserId == "" {
+		t.Error("expected FederatedUser.FederatedUserId to be set")
+	}
+}
+
+func TestSTS_AssumeRole_MissingRoleArn(t *testing.T) {
+	client := newSTSClient(t)
+	ctx := t.Context()
+
+	_, err := client.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String(""),
+		RoleSessionName: aws.String("test-session"),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing RoleArn")
+	}
+}


### PR DESCRIPTION
## Summary
- Implement AWS STS service with AssumeRole, AssumeRoleWithSAML, AssumeRoleWithWebIdentity, GetCallerIdentity, GetSessionToken, and GetFederationToken operations
- Uses AWS Query protocol with XML responses
- Generates temporary credentials with configurable expiration duration
- Add integration tests using AWS SDK v2 STS client

## Test plan
- [ ] Integration tests pass: `TestSTS_GetCallerIdentity`, `TestSTS_AssumeRole`, `TestSTS_AssumeRoleWithWebIdentity`, `TestSTS_GetSessionToken`, `TestSTS_GetFederationToken`, `TestSTS_AssumeRole_MissingRoleArn`
- [ ] Lint passes with 0 issues
- [ ] Build succeeds

Closes #58