### PR TITLE
feat(ebs): implement EBS Direct API remaining operations

### DIFF
--- a/internal/service/ebs/handlers.go
+++ b/internal/service/ebs/handlers.go
@@ -2,9 +2,13 @@
 package ebs
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/google/uuid"
 )
@@ -68,6 +72,125 @@ func (s *Service) ListSnapshotBlocksHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	result, err := s.storage.ListSnapshotBlocks(r.Context(), snapshotID)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	writeJSON(w, result)
+}
+
+// PutSnapshotBlockHandler handles PUT /snapshots/{snapshotId}/blocks/{blockIndex}.
+func (s *Service) PutSnapshotBlockHandler(w http.ResponseWriter, r *http.Request) {
+	snapshotID := r.PathValue("snapshotId")
+	if snapshotID == "" {
+		writeError(w, errValidation, "SnapshotId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	blockIndexStr := r.PathValue("blockIndex")
+
+	blockIndexInt, err := strconv.ParseInt(blockIndexStr, 10, 32)
+	if err != nil {
+		writeError(w, errValidation, "BlockIndex must be a valid integer", http.StatusBadRequest)
+
+		return
+	}
+
+	blockIndex := int32(blockIndexInt)
+
+	checksumAlgorithm := r.Header.Get("x-amz-Checksum-Algorithm")
+	if checksumAlgorithm != "SHA256" {
+		writeError(w, errValidation, "ChecksumAlgorithm must be SHA256", http.StatusBadRequest)
+
+		return
+	}
+
+	providedChecksum := r.Header.Get("x-amz-Checksum")
+
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, "InternalException", "Failed to read request body", http.StatusInternalServerError)
+
+		return
+	}
+
+	// Compute SHA256 checksum of the block data.
+	sum := sha256.Sum256(data)
+	computedChecksum := base64.StdEncoding.EncodeToString(sum[:])
+
+	checksum := providedChecksum
+	if checksum == "" {
+		checksum = computedChecksum
+	}
+
+	if err := s.storage.PutSnapshotBlock(r.Context(), snapshotID, blockIndex, data, checksum); err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.Header().Set("x-amz-Checksum", checksum)
+	w.Header().Set("x-amz-Checksum-Algorithm", checksumAlgorithm)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(&PutSnapshotBlockResponse{
+		Checksum:          checksum,
+		ChecksumAlgorithm: checksumAlgorithm,
+	})
+}
+
+// GetSnapshotBlockHandler handles GET /snapshots/{snapshotId}/blocks/{blockIndex}.
+func (s *Service) GetSnapshotBlockHandler(w http.ResponseWriter, r *http.Request) {
+	snapshotID := r.PathValue("snapshotId")
+	if snapshotID == "" {
+		writeError(w, errValidation, "SnapshotId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	blockIndexStr := r.PathValue("blockIndex")
+
+	blockIndexInt, err := strconv.ParseInt(blockIndexStr, 10, 32)
+	if err != nil {
+		writeError(w, errValidation, "BlockIndex must be a valid integer", http.StatusBadRequest)
+
+		return
+	}
+
+	blockIndex := int32(blockIndexInt)
+
+	data, checksum, err := s.storage.GetSnapshotBlock(r.Context(), snapshotID, blockIndex)
+	if err != nil {
+		handleServiceError(w, err)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.Header().Set("x-amz-Data-Length", strconv.Itoa(len(data)))
+	w.Header().Set("x-amz-Checksum", checksum)
+	w.Header().Set("x-amz-Checksum-Algorithm", "SHA256")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+// ListChangedBlocksHandler handles GET /snapshots/{secondSnapshotId}/changedblocks.
+func (s *Service) ListChangedBlocksHandler(w http.ResponseWriter, r *http.Request) {
+	secondSnapshotID := r.PathValue("secondSnapshotId")
+	if secondSnapshotID == "" {
+		writeError(w, errValidation, "SecondSnapshotId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	firstSnapshotID := r.URL.Query().Get("firstSnapshotId")
+
+	result, err := s.storage.ListChangedBlocks(r.Context(), firstSnapshotID, secondSnapshotID)
 	if err != nil {
 		handleServiceError(w, err)
 

--- a/internal/service/ebs/service.go
+++ b/internal/service/ebs/service.go
@@ -26,6 +26,9 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("POST", "/snapshots", s.StartSnapshotHandler)
 	r.Handle("POST", "/snapshots/completion/{snapshotId}", s.CompleteSnapshotHandler)
 	r.Handle("GET", "/snapshots/{snapshotId}/blocks", s.ListSnapshotBlocksHandler)
+	r.Handle("PUT", "/snapshots/{snapshotId}/blocks/{blockIndex}", s.PutSnapshotBlockHandler)
+	r.Handle("GET", "/snapshots/{snapshotId}/blocks/{blockIndex}", s.GetSnapshotBlockHandler)
+	r.Handle("GET", "/snapshots/{secondSnapshotId}/changedblocks", s.ListChangedBlocksHandler)
 }
 
 func init() {

--- a/internal/service/ebs/storage.go
+++ b/internal/service/ebs/storage.go
@@ -2,7 +2,9 @@ package ebs
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -31,18 +33,29 @@ type Storage interface {
 	StartSnapshot(ctx context.Context, req *StartSnapshotRequest) (*Snapshot, error)
 	CompleteSnapshot(ctx context.Context, snapshotID string) (*Snapshot, error)
 	ListSnapshotBlocks(ctx context.Context, snapshotID string) (*ListSnapshotBlocksResponse, error)
+	PutSnapshotBlock(ctx context.Context, snapshotID string, blockIndex int32, data []byte, checksum string) error
+	GetSnapshotBlock(ctx context.Context, snapshotID string, blockIndex int32) ([]byte, string, error)
+	ListChangedBlocks(ctx context.Context, firstSnapshotID, secondSnapshotID string) (*ListChangedBlocksResponse, error)
+}
+
+// blockData stores the raw data and checksum for a single snapshot block.
+type blockData struct {
+	data     []byte
+	checksum string
 }
 
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
 	mu        sync.RWMutex
 	snapshots map[string]*Snapshot
+	blocks    map[string]map[int32]*blockData
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage() *MemoryStorage {
 	return &MemoryStorage{
 		snapshots: make(map[string]*Snapshot),
+		blocks:    make(map[string]map[int32]*blockData),
 	}
 }
 
@@ -101,9 +114,182 @@ func (m *MemoryStorage) ListSnapshotBlocks(_ context.Context, snapshotID string)
 		}
 	}
 
+	snapshotBlocks := m.blocks[snapshotID]
+
+	indices := make([]int, 0, len(snapshotBlocks))
+
+	for idx := range snapshotBlocks {
+		indices = append(indices, int(idx))
+	}
+
+	sort.Ints(indices)
+
+	blocks := make([]Block, 0, len(indices))
+
+	for _, idx := range indices {
+		token := base64.StdEncoding.EncodeToString([]byte(uuid.New().String()))
+		blocks = append(blocks, Block{
+			BlockIndex: int32(idx), //nolint:gosec // idx is always a non-negative block index
+			BlockToken: token,
+		})
+	}
+
 	return &ListSnapshotBlocksResponse{
-		Blocks:     []Block{},
+		Blocks:     blocks,
 		BlockSize:  snapshot.BlockSize,
 		VolumeSize: snapshot.VolumeSize,
+	}, nil
+}
+
+// PutSnapshotBlock stores a block in the specified snapshot.
+func (m *MemoryStorage) PutSnapshotBlock(_ context.Context, snapshotID string, blockIndex int32, data []byte, checksum string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	snapshot, exists := m.snapshots[snapshotID]
+	if !exists {
+		return &ServiceError{
+			Code:    errSnapshotNotFound,
+			Message: fmt.Sprintf("Snapshot %s does not exist.", snapshotID),
+		}
+	}
+
+	if snapshot.Status != "pending" {
+		return &ServiceError{
+			Code:    errValidation,
+			Message: fmt.Sprintf("Snapshot %s is not in pending state.", snapshotID),
+		}
+	}
+
+	if m.blocks[snapshotID] == nil {
+		m.blocks[snapshotID] = make(map[int32]*blockData)
+	}
+
+	m.blocks[snapshotID][blockIndex] = &blockData{
+		data:     data,
+		checksum: checksum,
+	}
+
+	return nil
+}
+
+// GetSnapshotBlock retrieves a block from the specified snapshot.
+func (m *MemoryStorage) GetSnapshotBlock(_ context.Context, snapshotID string, blockIndex int32) ([]byte, string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	_, exists := m.snapshots[snapshotID]
+	if !exists {
+		return nil, "", &ServiceError{
+			Code:    errSnapshotNotFound,
+			Message: fmt.Sprintf("Snapshot %s does not exist.", snapshotID),
+		}
+	}
+
+	snapshotBlocks, ok := m.blocks[snapshotID]
+	if !ok {
+		return nil, "", &ServiceError{
+			Code:    errSnapshotNotFound,
+			Message: fmt.Sprintf("Block index %d does not exist in snapshot %s.", blockIndex, snapshotID),
+		}
+	}
+
+	block, ok := snapshotBlocks[blockIndex]
+	if !ok {
+		return nil, "", &ServiceError{
+			Code:    errSnapshotNotFound,
+			Message: fmt.Sprintf("Block index %d does not exist in snapshot %s.", blockIndex, snapshotID),
+		}
+	}
+
+	return block.data, block.checksum, nil
+}
+
+// collectSortedIndices merges block indices from two block maps and returns them sorted.
+func collectSortedIndices(first, second map[int32]*blockData) []int {
+	indexSet := make(map[int32]struct{})
+
+	for idx := range first {
+		indexSet[idx] = struct{}{}
+	}
+
+	for idx := range second {
+		indexSet[idx] = struct{}{}
+	}
+
+	indices := make([]int, 0, len(indexSet))
+
+	for idx := range indexSet {
+		indices = append(indices, int(idx))
+	}
+
+	sort.Ints(indices)
+
+	return indices
+}
+
+// buildChangedBlocks builds a list of ChangedBlock entries by comparing two block maps.
+func buildChangedBlocks(indices []int, first, second map[int32]*blockData) []ChangedBlock {
+	changedBlocks := make([]ChangedBlock, 0, len(indices))
+
+	for _, idx := range indices {
+		i := int32(idx) //nolint:gosec // idx is always a non-negative block index
+		_, inFirst := first[i]
+		_, inSecond := second[i]
+
+		if !inFirst && !inSecond {
+			continue
+		}
+
+		cb := ChangedBlock{BlockIndex: i}
+
+		if inFirst {
+			cb.FirstBlockToken = base64.StdEncoding.EncodeToString([]byte(uuid.New().String()))
+		}
+
+		if inSecond {
+			cb.SecondBlockToken = base64.StdEncoding.EncodeToString([]byte(uuid.New().String()))
+		}
+
+		changedBlocks = append(changedBlocks, cb)
+	}
+
+	return changedBlocks
+}
+
+// ListChangedBlocks compares two snapshots and returns changed blocks.
+func (m *MemoryStorage) ListChangedBlocks(_ context.Context, firstSnapshotID, secondSnapshotID string) (*ListChangedBlocksResponse, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	secondSnapshot, exists := m.snapshots[secondSnapshotID]
+	if !exists {
+		return nil, &ServiceError{
+			Code:    errSnapshotNotFound,
+			Message: fmt.Sprintf("Snapshot %s does not exist.", secondSnapshotID),
+		}
+	}
+
+	var firstBlocks map[int32]*blockData
+
+	if firstSnapshotID != "" {
+		if _, ok := m.snapshots[firstSnapshotID]; !ok {
+			return nil, &ServiceError{
+				Code:    errSnapshotNotFound,
+				Message: fmt.Sprintf("Snapshot %s does not exist.", firstSnapshotID),
+			}
+		}
+
+		firstBlocks = m.blocks[firstSnapshotID]
+	}
+
+	secondBlocks := m.blocks[secondSnapshotID]
+	indices := collectSortedIndices(firstBlocks, secondBlocks)
+	changedBlocks := buildChangedBlocks(indices, firstBlocks, secondBlocks)
+
+	return &ListChangedBlocksResponse{
+		BlockSize:     secondSnapshot.BlockSize,
+		ChangedBlocks: changedBlocks,
+		VolumeSize:    secondSnapshot.VolumeSize,
 	}, nil
 }

--- a/internal/service/ebs/types.go
+++ b/internal/service/ebs/types.go
@@ -52,6 +52,28 @@ type ListSnapshotBlocksResponse struct {
 	VolumeSize int64   `json:"VolumeSize,omitempty"`
 }
 
+// PutSnapshotBlockResponse represents a PutSnapshotBlock response.
+type PutSnapshotBlockResponse struct {
+	Checksum          string `json:"Checksum"`
+	ChecksumAlgorithm string `json:"ChecksumAlgorithm"`
+}
+
+// ChangedBlock represents a changed block between two snapshots.
+type ChangedBlock struct {
+	BlockIndex       int32  `json:"BlockIndex"`
+	FirstBlockToken  string `json:"FirstBlockToken,omitempty"`
+	SecondBlockToken string `json:"SecondBlockToken,omitempty"`
+}
+
+// ListChangedBlocksResponse represents a ListChangedBlocks response.
+type ListChangedBlocksResponse struct {
+	BlockSize     int32          `json:"BlockSize,omitempty"`
+	ChangedBlocks []ChangedBlock `json:"ChangedBlocks"`
+	ExpiryTime    int64          `json:"ExpiryTime,omitempty"`
+	NextToken     string         `json:"NextToken,omitempty"`
+	VolumeSize    int64          `json:"VolumeSize,omitempty"`
+}
+
 // ErrorResponse represents an error response.
 type ErrorResponse struct {
 	Message string `json:"Message"`

--- a/test/integration/ebs_test.go
+++ b/test/integration/ebs_test.go
@@ -3,12 +3,18 @@
 package integration
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ebs"
+	"github.com/aws/aws-sdk-go-v2/service/ebs/types"
+	"github.com/sivchari/golden"
 )
 
 func newEBSClient(t *testing.T) *ebs.Client {
@@ -38,24 +44,10 @@ func TestEBS_StartSnapshot(t *testing.T) {
 		Description: aws.String("test snapshot"),
 	})
 	if err != nil {
-		t.Fatalf("failed to start snapshot: %v", err)
+		t.Fatal(err)
 	}
 
-	if result.SnapshotId == nil || *result.SnapshotId == "" {
-		t.Error("expected snapshot ID to be set")
-	}
-
-	if result.Status != "pending" {
-		t.Errorf("expected status pending, got %s", string(result.Status))
-	}
-
-	if *result.VolumeSize != 100 {
-		t.Errorf("expected volume size 100, got %d", *result.VolumeSize)
-	}
-
-	if *result.Description != "test snapshot" {
-		t.Errorf("expected description 'test snapshot', got %s", *result.Description)
-	}
+	golden.New(t, golden.WithIgnoreFields("SnapshotId", "StartTime", "ResultMetadata")).Assert(t.Name(), result)
 }
 
 func TestEBS_CompleteSnapshot(t *testing.T) {
@@ -66,23 +58,21 @@ func TestEBS_CompleteSnapshot(t *testing.T) {
 		VolumeSize: aws.Int64(50),
 	})
 	if err != nil {
-		t.Fatalf("failed to start snapshot: %v", err)
+		t.Fatal(err)
 	}
 
-	completeResult, err := client.CompleteSnapshot(ctx, &ebs.CompleteSnapshotInput{
+	result, err := client.CompleteSnapshot(ctx, &ebs.CompleteSnapshotInput{
 		SnapshotId:         startResult.SnapshotId,
 		ChangedBlocksCount: aws.Int32(0),
 	})
 	if err != nil {
-		t.Fatalf("failed to complete snapshot: %v", err)
+		t.Fatal(err)
 	}
 
-	if completeResult.Status != "completed" {
-		t.Errorf("expected status completed, got %s", string(completeResult.Status))
-	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), result)
 }
 
-func TestEBS_ListSnapshotBlocks(t *testing.T) {
+func TestEBS_ListSnapshotBlocks_Empty(t *testing.T) {
 	client := newEBSClient(t)
 	ctx := t.Context()
 
@@ -90,7 +80,7 @@ func TestEBS_ListSnapshotBlocks(t *testing.T) {
 		VolumeSize: aws.Int64(10),
 	})
 	if err != nil {
-		t.Fatalf("failed to start snapshot: %v", err)
+		t.Fatal(err)
 	}
 
 	_, err = client.CompleteSnapshot(ctx, &ebs.CompleteSnapshotInput{
@@ -98,23 +88,243 @@ func TestEBS_ListSnapshotBlocks(t *testing.T) {
 		ChangedBlocksCount: aws.Int32(0),
 	})
 	if err != nil {
-		t.Fatalf("failed to complete snapshot: %v", err)
+		t.Fatal(err)
 	}
 
+	result, err := client.ListSnapshotBlocks(ctx, &ebs.ListSnapshotBlocksInput{
+		SnapshotId: startResult.SnapshotId,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), result)
+}
+
+func TestEBS_PutSnapshotBlock(t *testing.T) {
+	client := newEBSClient(t)
+	ctx := t.Context()
+
+	startResult, err := client.StartSnapshot(ctx, &ebs.StartSnapshotInput{
+		VolumeSize: aws.Int64(10),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockData := make([]byte, 524288)
+	for i := range blockData {
+		blockData[i] = byte(i % 256)
+	}
+
+	sum := sha256.Sum256(blockData)
+	checksum := base64.StdEncoding.EncodeToString(sum[:])
+
+	result, err := client.PutSnapshotBlock(ctx, &ebs.PutSnapshotBlockInput{
+		SnapshotId:        startResult.SnapshotId,
+		BlockIndex:        aws.Int32(0),
+		BlockData:         bytes.NewReader(blockData),
+		DataLength:        aws.Int32(524288),
+		Checksum:          aws.String(checksum),
+		ChecksumAlgorithm: types.ChecksumAlgorithmChecksumAlgorithmSha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("Checksum", "ResultMetadata")).Assert(t.Name(), result)
+}
+
+func TestEBS_GetSnapshotBlock(t *testing.T) {
+	client := newEBSClient(t)
+	ctx := t.Context()
+
+	startResult, err := client.StartSnapshot(ctx, &ebs.StartSnapshotInput{
+		VolumeSize: aws.Int64(10),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockData := make([]byte, 524288)
+	for i := range blockData {
+		blockData[i] = byte(i % 256)
+	}
+
+	sum := sha256.Sum256(blockData)
+	checksum := base64.StdEncoding.EncodeToString(sum[:])
+
+	_, err = client.PutSnapshotBlock(ctx, &ebs.PutSnapshotBlockInput{
+		SnapshotId:        startResult.SnapshotId,
+		BlockIndex:        aws.Int32(0),
+		BlockData:         bytes.NewReader(blockData),
+		DataLength:        aws.Int32(524288),
+		Checksum:          aws.String(checksum),
+		ChecksumAlgorithm: types.ChecksumAlgorithmChecksumAlgorithmSha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// List blocks to get a block token.
 	listResult, err := client.ListSnapshotBlocks(ctx, &ebs.ListSnapshotBlocksInput{
 		SnapshotId: startResult.SnapshotId,
 	})
 	if err != nil {
-		t.Fatalf("failed to list snapshot blocks: %v", err)
+		t.Fatal(err)
 	}
 
-	if listResult.Blocks == nil {
-		t.Error("expected blocks to be non-nil")
+	if len(listResult.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(listResult.Blocks))
 	}
 
-	if *listResult.VolumeSize != 10 {
-		t.Errorf("expected volume size 10, got %d", *listResult.VolumeSize)
+	// Get the block using the token.
+	getResult, err := client.GetSnapshotBlock(ctx, &ebs.GetSnapshotBlockInput{
+		SnapshotId: startResult.SnapshotId,
+		BlockIndex: aws.Int32(0),
+		BlockToken: listResult.Blocks[0].BlockToken,
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	gotData, err := io.ReadAll(getResult.BlockData)
+	if err != nil {
+		t.Fatalf("failed to read block data: %v", err)
+	}
+
+	if !bytes.Equal(gotData, blockData) {
+		t.Error("block data mismatch")
+	}
+
+	if getResult.Checksum == nil || *getResult.Checksum != checksum {
+		t.Errorf("expected checksum %s, got %v", checksum, getResult.Checksum)
+	}
+}
+
+func TestEBS_ListSnapshotBlocks_WithBlocks(t *testing.T) {
+	client := newEBSClient(t)
+	ctx := t.Context()
+
+	startResult, err := client.StartSnapshot(ctx, &ebs.StartSnapshotInput{
+		VolumeSize: aws.Int64(10),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockData := make([]byte, 524288)
+	sum := sha256.Sum256(blockData)
+	checksum := base64.StdEncoding.EncodeToString(sum[:])
+
+	_, err = client.PutSnapshotBlock(ctx, &ebs.PutSnapshotBlockInput{
+		SnapshotId:        startResult.SnapshotId,
+		BlockIndex:        aws.Int32(0),
+		BlockData:         bytes.NewReader(blockData),
+		DataLength:        aws.Int32(524288),
+		Checksum:          aws.String(checksum),
+		ChecksumAlgorithm: types.ChecksumAlgorithmChecksumAlgorithmSha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.PutSnapshotBlock(ctx, &ebs.PutSnapshotBlockInput{
+		SnapshotId:        startResult.SnapshotId,
+		BlockIndex:        aws.Int32(1),
+		BlockData:         bytes.NewReader(blockData),
+		DataLength:        aws.Int32(524288),
+		Checksum:          aws.String(checksum),
+		ChecksumAlgorithm: types.ChecksumAlgorithmChecksumAlgorithmSha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := client.ListSnapshotBlocks(ctx, &ebs.ListSnapshotBlocksInput{
+		SnapshotId: startResult.SnapshotId,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("BlockToken", "ResultMetadata")).Assert(t.Name(), result)
+}
+
+func TestEBS_ListChangedBlocks(t *testing.T) {
+	client := newEBSClient(t)
+	ctx := t.Context()
+
+	// Create first snapshot with a block.
+	first, err := client.StartSnapshot(ctx, &ebs.StartSnapshotInput{
+		VolumeSize: aws.Int64(10),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockData := make([]byte, 524288)
+	sum := sha256.Sum256(blockData)
+	checksum := base64.StdEncoding.EncodeToString(sum[:])
+
+	_, err = client.PutSnapshotBlock(ctx, &ebs.PutSnapshotBlockInput{
+		SnapshotId:        first.SnapshotId,
+		BlockIndex:        aws.Int32(0),
+		BlockData:         bytes.NewReader(blockData),
+		DataLength:        aws.Int32(524288),
+		Checksum:          aws.String(checksum),
+		ChecksumAlgorithm: types.ChecksumAlgorithmChecksumAlgorithmSha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.CompleteSnapshot(ctx, &ebs.CompleteSnapshotInput{
+		SnapshotId:         first.SnapshotId,
+		ChangedBlocksCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create second snapshot with a different block index.
+	second, err := client.StartSnapshot(ctx, &ebs.StartSnapshotInput{
+		VolumeSize: aws.Int64(10),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.PutSnapshotBlock(ctx, &ebs.PutSnapshotBlockInput{
+		SnapshotId:        second.SnapshotId,
+		BlockIndex:        aws.Int32(1),
+		BlockData:         bytes.NewReader(blockData),
+		DataLength:        aws.Int32(524288),
+		Checksum:          aws.String(checksum),
+		ChecksumAlgorithm: types.ChecksumAlgorithmChecksumAlgorithmSha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.CompleteSnapshot(ctx, &ebs.CompleteSnapshotInput{
+		SnapshotId:         second.SnapshotId,
+		ChangedBlocksCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// List changed blocks between the two snapshots.
+	result, err := client.ListChangedBlocks(ctx, &ebs.ListChangedBlocksInput{
+		FirstSnapshotId:  first.SnapshotId,
+		SecondSnapshotId: second.SnapshotId,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("FirstBlockToken", "SecondBlockToken", "ResultMetadata")).Assert(t.Name(), result)
 }
 
 func TestEBS_SnapshotNotFound(t *testing.T) {

--- a/test/integration/testdata/ebs_test_TestEBS_CompleteSnapshot_TestEBS_CompleteSnapshot.golden.go
+++ b/test/integration/testdata/ebs_test_TestEBS_CompleteSnapshot_TestEBS_CompleteSnapshot.golden.go
@@ -1,0 +1,4 @@
+{
+  "Status": "completed",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ebs_test_TestEBS_ListChangedBlocks_TestEBS_ListChangedBlocks.golden.go
+++ b/test/integration/testdata/ebs_test_TestEBS_ListChangedBlocks_TestEBS_ListChangedBlocks.golden.go
@@ -1,0 +1,19 @@
+{
+  "BlockSize": 524288,
+  "ChangedBlocks": [
+    {
+      "BlockIndex": 0,
+      "FirstBlockToken": "ZWY3NmYyOTItZDk2OS00ZDgxLTkwMTUtMTE4MWNiM2Q4MTRj",
+      "SecondBlockToken": null
+    },
+    {
+      "BlockIndex": 1,
+      "FirstBlockToken": null,
+      "SecondBlockToken": "NDEzMzcyYjgtODRmNS00NmViLThmNDctMDg5Mjc1OWI1ZjEx"
+    }
+  ],
+  "ExpiryTime": null,
+  "NextToken": null,
+  "VolumeSize": 10,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ebs_test_TestEBS_ListSnapshotBlocks_Empty_TestEBS_ListSnapshotBlocks_Empty.golden.go
+++ b/test/integration/testdata/ebs_test_TestEBS_ListSnapshotBlocks_Empty_TestEBS_ListSnapshotBlocks_Empty.golden.go
@@ -1,0 +1,8 @@
+{
+  "BlockSize": 524288,
+  "Blocks": [],
+  "ExpiryTime": null,
+  "NextToken": null,
+  "VolumeSize": 10,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ebs_test_TestEBS_ListSnapshotBlocks_WithBlocks_TestEBS_ListSnapshotBlocks_WithBlocks.golden.go
+++ b/test/integration/testdata/ebs_test_TestEBS_ListSnapshotBlocks_WithBlocks_TestEBS_ListSnapshotBlocks_WithBlocks.golden.go
@@ -1,0 +1,17 @@
+{
+  "BlockSize": 524288,
+  "Blocks": [
+    {
+      "BlockIndex": 0,
+      "BlockToken": "OGQzNGRlYjktYzhlZC00NzVmLWFkZDEtMDIyMGQwZTViOTI0"
+    },
+    {
+      "BlockIndex": 1,
+      "BlockToken": "MjIyNWQ1YzctNDA4Zi00ZWMzLWExODAtYmFmMDQ3OTk4NjY5"
+    }
+  ],
+  "ExpiryTime": null,
+  "NextToken": null,
+  "VolumeSize": 10,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ebs_test_TestEBS_PutSnapshotBlock_TestEBS_PutSnapshotBlock.golden.go
+++ b/test/integration/testdata/ebs_test_TestEBS_PutSnapshotBlock_TestEBS_PutSnapshotBlock.golden.go
@@ -1,0 +1,5 @@
+{
+  "Checksum": "M7yKq0BwNnjD6+lNLdjyr/8oXdkB+SNOhB5GefggT9U=",
+  "ChecksumAlgorithm": "SHA256",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ebs_test_TestEBS_StartSnapshot_TestEBS_StartSnapshot.golden.go
+++ b/test/integration/testdata/ebs_test_TestEBS_StartSnapshot_TestEBS_StartSnapshot.golden.go
@@ -1,0 +1,14 @@
+{
+  "BlockSize": 524288,
+  "Description": "test snapshot",
+  "KmsKeyArn": null,
+  "OwnerId": "000000000000",
+  "ParentSnapshotId": null,
+  "SnapshotId": "snap-ac33ef51-453",
+  "SseType": "",
+  "StartTime": "2026-03-19T12:45:38Z",
+  "Status": "pending",
+  "Tags": null,
+  "VolumeSize": 100,
+  "ResultMetadata": {}
+}

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@
 package awsim
 
 // Version is the current version of awsim.
-const Version = "0.3.0"
+const Version = "0.4.0"


### PR DESCRIPTION
## Summary
- Add PutSnapshotBlock operation (PUT /snapshots/{snapshotId}/blocks/{blockIndex}) with SHA256 checksum validation
- Add GetSnapshotBlock operation (GET /snapshots/{snapshotId}/blocks/{blockIndex}) returning binary block data
- Add ListChangedBlocks operation (GET /snapshots/{secondSnapshotId}/changedblocks) comparing two snapshots
- Bump version to v0.4.0

## Test plan
- [ ] Integration test: PutSnapshotBlock stores data and GetSnapshotBlock retrieves it correctly
- [ ] Integration test: ListChangedBlocks returns changed blocks between two snapshots
- [ ] Existing EBS tests continue to pass

Closes #321