### PR TITLE
feat: add Homebrew tap support via goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,6 +69,18 @@ dockers:
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.source=https://github.com/sivchari/kumo"
 
+homebrew_casks:
+  - name: kumo
+    ids:
+      - kumo
+    binaries:
+      - kumo
+    homepage: "https://github.com/sivchari/kumo"
+    description: "A lightweight AWS service emulator for CI/CD environments"
+    repository:
+      owner: sivchari
+      name: homebrew-kumo
+
 docker_manifests:
   - name_template: "ghcr.io/sivchari/kumo:{{ .Version }}"
     image_templates:


### PR DESCRIPTION
## Summary

- Add `brews` section to `.goreleaser.yml` to automatically publish the kumo formula to `sivchari/homebrew-tap` on release
- After merge and next release, users can install via `brew install sivchari/tap/kumo`

## Test plan

- [ ] CI passes (lint, unit tests, integration tests)
- [ ] Verify formula is published after next release