### PR TITLE
fix(ci): add HOMEBREW_TAP_GITHUB_TOKEN for goreleaser

### DIFF
--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -74,3 +74,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary
- Pass `HOMEBREW_TAP_TOKEN` secret as `HOMEBREW_TAP_GITHUB_TOKEN` env var to goreleaser
- The default `GITHUB_TOKEN` lacks cross-repo write access to `sivchari/homebrew-kumo`, causing 403 on release

## Test plan
- [ ] Merge and confirm tagpr creates v0.5.1 release
- [ ] Verify goreleaser succeeds including Homebrew cask push to `sivchari/homebrew-kumo`