### PR TITLE
fix(ci): set repository token for homebrew cask in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,6 +80,7 @@ homebrew_casks:
     repository:
       owner: sivchari
       name: homebrew-kumo
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
 docker_manifests:
   - name_template: "ghcr.io/sivchari/kumo:{{ .Version }}"


### PR DESCRIPTION
## Summary
- Add `repository.token` field to `homebrew_casks` in `.goreleaser.yml`
- Without this, goreleaser uses the default `GITHUB_TOKEN` which lacks write access to `sivchari/homebrew-kumo`

## Test plan
- [ ] Merge and confirm tagpr creates next release
- [ ] Verify goreleaser succeeds including Homebrew cask push