### PR TITLE
feat(storage): add optional persistent storage via KUMO_DATA_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/sivchari/kumo/actions/workflows/integration-test.yaml"><img src="https://github.com/sivchari/kumo/actions/workflows/integration-test.yaml/badge.svg" alt="Integration Tests"></a>
 </p>
 
-<p align="center">A lightweight AWS service emulator written in Go.<br>Designed for CI/CD environments where authentication-free local AWS testing is needed.</p>
+<p align="center">A lightweight AWS service emulator written in Go.<br>Works as both a CI/CD testing tool and a local development server with optional data persistence.</p>
 
 ## Features
 
@@ -17,6 +17,7 @@
 - **Docker support** - Run as a container
 - **Lightweight** - Fast startup, minimal resource usage
 - **AWS SDK v2 compatible** - Works seamlessly with Go AWS SDK v2
+- **Optional data persistence** - Survive restarts with `KUMO_DATA_DIR`
 
 ## Supported Services (71 services)
 
@@ -145,10 +146,19 @@
 
 ## Quick Start
 
-### Docker (Recommended)
+### Docker
 
 ```bash
 docker run -p 4566:4566 ghcr.io/sivchari/kumo:latest
+```
+
+With data persistence:
+
+```bash
+docker run -p 4566:4566 \
+  -e KUMO_DATA_DIR=/data \
+  -v kumo-data:/data \
+  ghcr.io/sivchari/kumo:latest
 ```
 
 ### Binary
@@ -159,6 +169,9 @@ make build
 
 # Run
 ./bin/kumo
+
+# Run with data persistence
+KUMO_DATA_DIR=./data ./bin/kumo
 ```
 
 ### Docker Compose
@@ -169,6 +182,23 @@ services:
     image: ghcr.io/sivchari/kumo:latest
     ports:
       - "4566:4566"
+```
+
+With data persistence:
+
+```yaml
+services:
+  kumo:
+    image: ghcr.io/sivchari/kumo:latest
+    ports:
+      - "4566:4566"
+    environment:
+      - KUMO_DATA_DIR=/data
+    volumes:
+      - kumo-data:/data
+
+volumes:
+  kumo-data:
 ```
 
 ## Usage Examples
@@ -357,6 +387,34 @@ Environment variables:
 | `KUMO_HOST` | `0.0.0.0` | Server bind address |
 | `KUMO_PORT` | `4566` | Server port |
 | `KUMO_LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
+| `KUMO_DATA_DIR` | (unset) | Directory for persistent storage. When unset, data is in-memory only. |
+
+## Data Persistence
+
+By default kumo runs as a pure in-memory emulator -- all data is lost when the process stops. This is ideal for CI/CD pipelines where each test run starts from a clean state.
+
+For local development, set `KUMO_DATA_DIR` to enable persistent storage:
+
+```bash
+KUMO_DATA_DIR=./data ./bin/kumo
+```
+
+When enabled:
+
+- On startup, each service loads its previous state from `$KUMO_DATA_DIR/{service}.json`.
+- On graceful shutdown (SIGTERM/SIGINT), each service saves its current state.
+- The data directory is created automatically if it does not exist.
+- Writes are atomic (tmp file + rename) to prevent corruption on crash.
+- Ephemeral state (SQS in-flight messages, S3 multipart uploads) is not persisted.
+
+```
+$KUMO_DATA_DIR/
+  s3.json
+  sqs.json
+  dynamodb.json
+  iam.json
+  ...
+```
 
 ## Development
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -183,6 +184,15 @@ func (s *Server) Start() error {
 // Shutdown gracefully shuts down the server.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Info("shutting down server")
+
+	// Save snapshots for services that implement io.Closer.
+	for _, svc := range s.registry.All() {
+		if c, ok := svc.(io.Closer); ok {
+			if err := c.Close(); err != nil {
+				s.logger.Error("failed to save snapshot", "service", svc.Name(), "error", err)
+			}
+		}
+	}
 
 	if err := s.server.Shutdown(ctx); err != nil {
 		return fmt.Errorf("failed to shutdown server: %w", err)

--- a/internal/service/acm/service.go
+++ b/internal/service/acm/service.go
@@ -1,11 +1,23 @@
 package acm
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the ACM service.
@@ -39,3 +51,14 @@ func (s *Service) TargetPrefix() string {
 
 // JSONProtocol is a marker method that indicates ACM uses AWS JSON 1.1 protocol.
 func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/acm/storage.go
+++ b/internal/service/acm/storage.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -28,17 +31,91 @@ type Storage interface {
 	ImportCertificate(ctx context.Context, req *ImportCertificateInput) (*Certificate, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data structures.
 type MemoryStorage struct {
-	mu           sync.RWMutex
-	certificates map[string]*Certificate
+	mu           sync.RWMutex            `json:"-"`
+	Certificates map[string]*Certificate `json:"certificates"`
+	dataDir      string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		certificates: make(map[string]*Certificate),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Certificates: make(map[string]*Certificate),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "acm", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Certificates == nil {
+		s.Certificates = make(map[string]*Certificate)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "acm", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // buildDomainValidations creates domain validation options for the certificate.
@@ -118,7 +195,7 @@ func (s *MemoryStorage) RequestCertificate(_ context.Context, req *RequestCertif
 		Tags:                    req.Tags,
 	}
 
-	s.certificates[arn] = cert
+	s.Certificates[arn] = cert
 
 	return cert, nil
 }
@@ -128,7 +205,7 @@ func (s *MemoryStorage) DescribeCertificate(_ context.Context, arn string) (*Cer
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	cert, exists := s.certificates[arn]
+	cert, exists := s.Certificates[arn]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -148,9 +225,9 @@ func (s *MemoryStorage) ListCertificates(_ context.Context, statuses []string, m
 		maxItems = 100
 	}
 
-	certs := make([]*Certificate, 0, len(s.certificates))
+	certs := make([]*Certificate, 0, len(s.Certificates))
 
-	for _, cert := range s.certificates {
+	for _, cert := range s.Certificates {
 		// Filter by status if specified.
 		if len(statuses) > 0 && !slices.Contains(statuses, cert.Status) {
 			continue
@@ -172,14 +249,14 @@ func (s *MemoryStorage) DeleteCertificate(_ context.Context, arn string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.certificates[arn]; !exists {
+	if _, exists := s.Certificates[arn]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Certificate with arn %s not found", arn),
 		}
 	}
 
-	delete(s.certificates, arn)
+	delete(s.Certificates, arn)
 
 	return nil
 }
@@ -189,7 +266,7 @@ func (s *MemoryStorage) GetCertificate(_ context.Context, arn string) (*Certific
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	cert, exists := s.certificates[arn]
+	cert, exists := s.Certificates[arn]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -265,7 +342,7 @@ func (s *MemoryStorage) ImportCertificate(_ context.Context, req *ImportCertific
 		Tags:               req.Tags,
 	}
 
-	s.certificates[arn] = cert
+	s.Certificates[arn] = cert
 
 	return cert, nil
 }

--- a/internal/service/amplify/service.go
+++ b/internal/service/amplify/service.go
@@ -1,11 +1,23 @@
 package amplify
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage()
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	storage := NewMemoryStorage(opts...)
 	service.Register(New(storage))
 }
 
@@ -45,4 +57,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("GET", "/apps/{appId}/branches", s.ListBranches)
 	r.Handle("GET", "/apps/{appId}/branches/{branchName}", s.GetBranch)
 	r.Handle("DELETE", "/apps/{appId}/branches/{branchName}", s.DeleteBranch)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/amplify/storage.go
+++ b/internal/service/amplify/storage.go
@@ -2,11 +2,14 @@ package amplify
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -42,19 +45,97 @@ type Storage interface {
 	DeleteBranch(ctx context.Context, appID, branchName string) (*Branch, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu       sync.RWMutex
-	apps     map[string]*App
-	branches map[string]map[string]*Branch // appID -> branchName -> Branch
+	mu       sync.RWMutex                  `json:"-"`
+	Apps     map[string]*App               `json:"apps"`
+	Branches map[string]map[string]*Branch `json:"branches"` // appID -> branchName -> Branch
+	dataDir  string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		apps:     make(map[string]*App),
-		branches: make(map[string]map[string]*Branch),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Apps:     make(map[string]*App),
+		Branches: make(map[string]map[string]*Branch),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "amplify", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Apps == nil {
+		m.Apps = make(map[string]*App)
+	}
+
+	if m.Branches == nil {
+		m.Branches = make(map[string]map[string]*Branch)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "amplify", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateApp creates a new Amplify app.
@@ -86,8 +167,8 @@ func (m *MemoryStorage) CreateApp(_ context.Context, input *CreateAppInput) (*Ap
 		Tags:                  input.Tags,
 	}
 
-	m.apps[appID] = app
-	m.branches[appID] = make(map[string]*Branch)
+	m.Apps[appID] = app
+	m.Branches[appID] = make(map[string]*Branch)
 
 	return app, nil
 }
@@ -97,7 +178,7 @@ func (m *MemoryStorage) GetApp(_ context.Context, appID string) (*App, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	app, exists := m.apps[appID]
+	app, exists := m.Apps[appID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errAppNotFound,
@@ -114,8 +195,8 @@ func (m *MemoryStorage) ListApps(_ context.Context) ([]App, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	apps := make([]App, 0, len(m.apps))
-	for _, app := range m.apps {
+	apps := make([]App, 0, len(m.Apps))
+	for _, app := range m.Apps {
 		apps = append(apps, *app)
 	}
 
@@ -127,7 +208,7 @@ func (m *MemoryStorage) UpdateApp(_ context.Context, appID string, input *Update
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	app, exists := m.apps[appID]
+	app, exists := m.Apps[appID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errAppNotFound,
@@ -170,7 +251,7 @@ func (m *MemoryStorage) DeleteApp(_ context.Context, appID string) (*App, error)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	app, exists := m.apps[appID]
+	app, exists := m.Apps[appID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errAppNotFound,
@@ -179,9 +260,9 @@ func (m *MemoryStorage) DeleteApp(_ context.Context, appID string) (*App, error)
 		}
 	}
 
-	delete(m.apps, appID)
+	delete(m.Apps, appID)
 
-	delete(m.branches, appID)
+	delete(m.Branches, appID)
 
 	return app, nil
 }
@@ -191,7 +272,7 @@ func (m *MemoryStorage) CreateBranch(_ context.Context, appID string, input *Cre
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.apps[appID]; !exists {
+	if _, exists := m.Apps[appID]; !exists {
 		return nil, &ServiceError{
 			Code:    errAppNotFound,
 			Message: fmt.Sprintf("App not found for appId: %s", appID),
@@ -226,7 +307,7 @@ func (m *MemoryStorage) CreateBranch(_ context.Context, appID string, input *Cre
 		Tags:                     input.Tags,
 	}
 
-	m.branches[appID][input.BranchName] = branch
+	m.Branches[appID][input.BranchName] = branch
 
 	return branch, nil
 }
@@ -236,7 +317,7 @@ func (m *MemoryStorage) GetBranch(_ context.Context, appID, branchName string) (
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	appBranches, exists := m.branches[appID]
+	appBranches, exists := m.Branches[appID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errAppNotFound,
@@ -262,7 +343,7 @@ func (m *MemoryStorage) ListBranches(_ context.Context, appID string) ([]Branch,
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.apps[appID]; !exists {
+	if _, exists := m.Apps[appID]; !exists {
 		return nil, &ServiceError{
 			Code:    errAppNotFound,
 			Message: fmt.Sprintf("App not found for appId: %s", appID),
@@ -270,7 +351,7 @@ func (m *MemoryStorage) ListBranches(_ context.Context, appID string) ([]Branch,
 		}
 	}
 
-	appBranches := m.branches[appID]
+	appBranches := m.Branches[appID]
 	branches := make([]Branch, 0, len(appBranches))
 
 	for _, branch := range appBranches {
@@ -285,7 +366,7 @@ func (m *MemoryStorage) DeleteBranch(_ context.Context, appID, branchName string
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	appBranches, exists := m.branches[appID]
+	appBranches, exists := m.Branches[appID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errAppNotFound,

--- a/internal/service/apigateway/service.go
+++ b/internal/service/apigateway/service.go
@@ -2,11 +2,23 @@
 package apigateway
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the API Gateway service.
@@ -59,4 +71,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.HandleFunc("GET", "/apigateway/restapis/{restApiId}/stages", s.GetStages)
 	r.HandleFunc("GET", "/apigateway/restapis/{restApiId}/stages/{stageName}", s.GetStage)
 	r.HandleFunc("DELETE", "/apigateway/restapis/{restApiId}/stages/{stageName}", s.DeleteStage)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/apigateway/storage.go
+++ b/internal/service/apigateway/storage.go
@@ -2,11 +2,14 @@ package apigateway
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -48,25 +51,99 @@ type Storage interface {
 	DeleteStage(ctx context.Context, restAPIID, stageName string) error
 }
 
-// MemoryStorage implements Storage with in-memory data.
-type MemoryStorage struct {
-	mu       sync.RWMutex
-	restAPIs map[string]*restAPIData
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
 }
 
-// restAPIData holds REST API information and its resources.
-type restAPIData struct {
-	api         *RestAPI
-	resources   map[string]*Resource // keyed by resource ID
-	deployments map[string]*Deployment
-	stages      map[string]*Stage // keyed by stage name
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
+// MemoryStorage implements Storage with in-memory data.
+type MemoryStorage struct {
+	mu       sync.RWMutex            `json:"-"`
+	RestAPIs map[string]*RestAPIData `json:"restApis"`
+	dataDir  string
+}
+
+// RestAPIData holds REST API information and its resources.
+type RestAPIData struct {
+	API         *RestAPI               `json:"api"`
+	Resources   map[string]*Resource   `json:"resources"` // keyed by resource ID
+	Deployments map[string]*Deployment `json:"deployments"`
+	Stages      map[string]*Stage      `json:"stages"` // keyed by stage name
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		restAPIs: make(map[string]*restAPIData),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		RestAPIs: make(map[string]*RestAPIData),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "apigateway", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.RestAPIs == nil {
+		s.RestAPIs = make(map[string]*RestAPIData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "apigateway", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateRestAPI creates a new REST API.
@@ -98,11 +175,11 @@ func (s *MemoryStorage) CreateRestAPI(_ context.Context, req *CreateRestAPIReque
 		ResourceMethods: make(map[string]Method),
 	}
 
-	s.restAPIs[id] = &restAPIData{
-		api:         api,
-		resources:   map[string]*Resource{rootResourceID: rootResource},
-		deployments: make(map[string]*Deployment),
-		stages:      make(map[string]*Stage),
+	s.RestAPIs[id] = &RestAPIData{
+		API:         api,
+		Resources:   map[string]*Resource{rootResourceID: rootResource},
+		Deployments: make(map[string]*Deployment),
+		Stages:      make(map[string]*Stage),
 	}
 
 	return api, nil
@@ -113,12 +190,12 @@ func (s *MemoryStorage) GetRestAPI(_ context.Context, restAPIID string) (*RestAP
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	return data.api, nil
+	return data.API, nil
 }
 
 // GetRestAPIs returns all REST APIs.
@@ -132,8 +209,8 @@ func (s *MemoryStorage) GetRestAPIs(_ context.Context, limit int32, _ string) ([
 
 	var apis []*RestAPI
 
-	for _, data := range s.restAPIs {
-		apis = append(apis, data.api)
+	for _, data := range s.RestAPIs {
+		apis = append(apis, data.API)
 
 		if int32(len(apis)) >= limit { //nolint:gosec // slice length bounded by limit parameter
 			break
@@ -148,11 +225,11 @@ func (s *MemoryStorage) DeleteRestAPI(_ context.Context, restAPIID string) error
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.restAPIs[restAPIID]; !exists {
+	if _, exists := s.RestAPIs[restAPIID]; !exists {
 		return &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	delete(s.restAPIs, restAPIID)
+	delete(s.RestAPIs, restAPIID)
 
 	return nil
 }
@@ -162,12 +239,12 @@ func (s *MemoryStorage) CreateResource(_ context.Context, restAPIID, parentID, p
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	parent, exists := data.resources[parentID]
+	parent, exists := data.Resources[parentID]
 	if !exists {
 		return nil, &ServiceError{Code: errResourceNotFound, Message: "Invalid resource identifier specified"}
 	}
@@ -183,7 +260,7 @@ func (s *MemoryStorage) CreateResource(_ context.Context, restAPIID, parentID, p
 		ResourceMethods: make(map[string]Method),
 	}
 
-	data.resources[id] = resource
+	data.Resources[id] = resource
 
 	return resource, nil
 }
@@ -193,12 +270,12 @@ func (s *MemoryStorage) GetResource(_ context.Context, restAPIID, resourceID str
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	resource, exists := data.resources[resourceID]
+	resource, exists := data.Resources[resourceID]
 	if !exists {
 		return nil, &ServiceError{Code: errResourceNotFound, Message: "Invalid resource identifier specified"}
 	}
@@ -211,7 +288,7 @@ func (s *MemoryStorage) GetResources(_ context.Context, restAPIID string, limit 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, "", &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
@@ -222,7 +299,7 @@ func (s *MemoryStorage) GetResources(_ context.Context, restAPIID string, limit 
 
 	var resources []*Resource
 
-	for _, r := range data.resources {
+	for _, r := range data.Resources {
 		resources = append(resources, r)
 
 		if int32(len(resources)) >= limit { //nolint:gosec // slice length bounded by limit parameter
@@ -238,12 +315,12 @@ func (s *MemoryStorage) DeleteResource(_ context.Context, restAPIID, resourceID 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	resource, exists := data.resources[resourceID]
+	resource, exists := data.Resources[resourceID]
 	if !exists {
 		return &ServiceError{Code: errResourceNotFound, Message: "Invalid resource identifier specified"}
 	}
@@ -253,7 +330,7 @@ func (s *MemoryStorage) DeleteResource(_ context.Context, restAPIID, resourceID 
 		return &ServiceError{Code: errBadRequest, Message: "Cannot delete root resource"}
 	}
 
-	delete(data.resources, resourceID)
+	delete(data.Resources, resourceID)
 
 	return nil
 }
@@ -263,12 +340,12 @@ func (s *MemoryStorage) PutMethod(_ context.Context, restAPIID, resourceID, http
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	resource, exists := data.resources[resourceID]
+	resource, exists := data.Resources[resourceID]
 	if !exists {
 		return nil, &ServiceError{Code: errResourceNotFound, Message: "Invalid resource identifier specified"}
 	}
@@ -290,12 +367,12 @@ func (s *MemoryStorage) GetMethod(_ context.Context, restAPIID, resourceID, http
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	resource, exists := data.resources[resourceID]
+	resource, exists := data.Resources[resourceID]
 	if !exists {
 		return nil, &ServiceError{Code: errResourceNotFound, Message: "Invalid resource identifier specified"}
 	}
@@ -313,12 +390,12 @@ func (s *MemoryStorage) PutIntegration(_ context.Context, restAPIID, resourceID,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	resource, exists := data.resources[resourceID]
+	resource, exists := data.Resources[resourceID]
 	if !exists {
 		return nil, &ServiceError{Code: errResourceNotFound, Message: "Invalid resource identifier specified"}
 	}
@@ -354,12 +431,12 @@ func (s *MemoryStorage) GetIntegration(_ context.Context, restAPIID, resourceID,
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	resource, exists := data.resources[resourceID]
+	resource, exists := data.Resources[resourceID]
 	if !exists {
 		return nil, &ServiceError{Code: errResourceNotFound, Message: "Invalid resource identifier specified"}
 	}
@@ -381,7 +458,7 @@ func (s *MemoryStorage) CreateDeployment(_ context.Context, restAPIID string, re
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
@@ -395,7 +472,7 @@ func (s *MemoryStorage) CreateDeployment(_ context.Context, restAPIID string, re
 		CreatedDate: now,
 	}
 
-	data.deployments[id] = deployment
+	data.Deployments[id] = deployment
 
 	// If stage name is specified, create or update the stage.
 	if req.StageName != "" {
@@ -405,7 +482,7 @@ func (s *MemoryStorage) CreateDeployment(_ context.Context, restAPIID string, re
 			CreatedDate:     now,
 			LastUpdatedDate: now,
 		}
-		data.stages[req.StageName] = stage
+		data.Stages[req.StageName] = stage
 	}
 
 	return deployment, nil
@@ -416,12 +493,12 @@ func (s *MemoryStorage) GetDeployment(_ context.Context, restAPIID, deploymentID
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	deployment, exists := data.deployments[deploymentID]
+	deployment, exists := data.Deployments[deploymentID]
 	if !exists {
 		return nil, &ServiceError{Code: errDeploymentNotFound, Message: "Invalid deployment identifier specified"}
 	}
@@ -434,7 +511,7 @@ func (s *MemoryStorage) GetDeployments(_ context.Context, restAPIID string, limi
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, "", &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
@@ -445,7 +522,7 @@ func (s *MemoryStorage) GetDeployments(_ context.Context, restAPIID string, limi
 
 	var deployments []*Deployment
 
-	for _, d := range data.deployments {
+	for _, d := range data.Deployments {
 		deployments = append(deployments, d)
 
 		if int32(len(deployments)) >= limit { //nolint:gosec // slice length bounded by limit parameter
@@ -461,16 +538,16 @@ func (s *MemoryStorage) DeleteDeployment(_ context.Context, restAPIID, deploymen
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	if _, exists := data.deployments[deploymentID]; !exists {
+	if _, exists := data.Deployments[deploymentID]; !exists {
 		return &ServiceError{Code: errDeploymentNotFound, Message: "Invalid deployment identifier specified"}
 	}
 
-	delete(data.deployments, deploymentID)
+	delete(data.Deployments, deploymentID)
 
 	return nil
 }
@@ -480,13 +557,13 @@ func (s *MemoryStorage) CreateStage(_ context.Context, restAPIID string, req *Cr
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
 	// Verify deployment exists.
-	if _, exists := data.deployments[req.DeploymentID]; !exists {
+	if _, exists := data.Deployments[req.DeploymentID]; !exists {
 		return nil, &ServiceError{Code: errDeploymentNotFound, Message: "Invalid deployment identifier specified"}
 	}
 
@@ -503,7 +580,7 @@ func (s *MemoryStorage) CreateStage(_ context.Context, restAPIID string, req *Cr
 		Tags:                req.Tags,
 	}
 
-	data.stages[req.StageName] = stage
+	data.Stages[req.StageName] = stage
 
 	return stage, nil
 }
@@ -513,12 +590,12 @@ func (s *MemoryStorage) GetStage(_ context.Context, restAPIID, stageName string)
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	stage, exists := data.stages[stageName]
+	stage, exists := data.Stages[stageName]
 	if !exists {
 		return nil, &ServiceError{Code: errStageNotFound, Message: "Invalid stage identifier specified"}
 	}
@@ -531,14 +608,14 @@ func (s *MemoryStorage) GetStages(_ context.Context, restAPIID string) ([]*Stage
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
 	var stages []*Stage
 
-	for _, stage := range data.stages {
+	for _, stage := range data.Stages {
 		stages = append(stages, stage)
 	}
 
@@ -550,16 +627,16 @@ func (s *MemoryStorage) DeleteStage(_ context.Context, restAPIID, stageName stri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.restAPIs[restAPIID]
+	data, exists := s.RestAPIs[restAPIID]
 	if !exists {
 		return &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	if _, exists := data.stages[stageName]; !exists {
+	if _, exists := data.Stages[stageName]; !exists {
 		return &ServiceError{Code: errStageNotFound, Message: "Invalid stage identifier specified"}
 	}
 
-	delete(data.stages, stageName)
+	delete(data.Stages, stageName)
 
 	return nil
 }

--- a/internal/service/appmesh/service.go
+++ b/internal/service/appmesh/service.go
@@ -1,6 +1,12 @@
 package appmesh
 
-import "github.com/sivchari/kumo/internal/service"
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // Service implements the App Mesh service.
 type Service struct {
@@ -14,8 +20,16 @@ func New(storage Storage) *Service {
 	}
 }
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Name returns the service name.
@@ -63,3 +77,14 @@ func (s *Service) RegisterRoutes(r service.Router) {
 
 // Compile-time interface check.
 var _ service.Service = (*Service)(nil)
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/appmesh/storage.go
+++ b/internal/service/appmesh/storage.go
@@ -2,11 +2,14 @@ package appmesh
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -52,25 +55,115 @@ type Storage interface {
 	DeleteRoute(ctx context.Context, meshName, virtualRouterName, routeName string) (*RouteData, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory storage.
 type MemoryStorage struct {
-	mu              sync.RWMutex
-	meshes          map[string]*MeshData
-	virtualNodes    map[string]map[string]*VirtualNodeData      // meshName -> virtualNodeName -> data
-	virtualServices map[string]map[string]*VirtualServiceData   // meshName -> virtualServiceName -> data
-	virtualRouters  map[string]map[string]*VirtualRouterData    // meshName -> virtualRouterName -> data
-	routes          map[string]map[string]map[string]*RouteData // meshName -> virtualRouterName -> routeName -> data
+	mu              sync.RWMutex                                `json:"-"`
+	Meshes          map[string]*MeshData                        `json:"meshes"`
+	VirtualNodes    map[string]map[string]*VirtualNodeData      `json:"virtualNodes"`    // meshName -> virtualNodeName -> data
+	VirtualServices map[string]map[string]*VirtualServiceData   `json:"virtualServices"` // meshName -> virtualServiceName -> data
+	VirtualRouters  map[string]map[string]*VirtualRouterData    `json:"virtualRouters"`  // meshName -> virtualRouterName -> data
+	Routes          map[string]map[string]map[string]*RouteData `json:"routes"`          // meshName -> virtualRouterName -> routeName -> data
+	dataDir         string
 }
 
 // NewMemoryStorage creates a new MemoryStorage instance.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		meshes:          make(map[string]*MeshData),
-		virtualNodes:    make(map[string]map[string]*VirtualNodeData),
-		virtualServices: make(map[string]map[string]*VirtualServiceData),
-		virtualRouters:  make(map[string]map[string]*VirtualRouterData),
-		routes:          make(map[string]map[string]map[string]*RouteData),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Meshes:          make(map[string]*MeshData),
+		VirtualNodes:    make(map[string]map[string]*VirtualNodeData),
+		VirtualServices: make(map[string]map[string]*VirtualServiceData),
+		VirtualRouters:  make(map[string]map[string]*VirtualRouterData),
+		Routes:          make(map[string]map[string]map[string]*RouteData),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "appmesh", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Meshes == nil {
+		m.Meshes = make(map[string]*MeshData)
+	}
+
+	if m.VirtualNodes == nil {
+		m.VirtualNodes = make(map[string]map[string]*VirtualNodeData)
+	}
+
+	if m.VirtualServices == nil {
+		m.VirtualServices = make(map[string]map[string]*VirtualServiceData)
+	}
+
+	if m.VirtualRouters == nil {
+		m.VirtualRouters = make(map[string]map[string]*VirtualRouterData)
+	}
+
+	if m.Routes == nil {
+		m.Routes = make(map[string]map[string]map[string]*RouteData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "appmesh", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // --- Mesh Operations ---
@@ -80,7 +173,7 @@ func (m *MemoryStorage) CreateMesh(_ context.Context, req *CreateMeshInput) (*Me
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[req.MeshName]; exists {
+	if _, exists := m.Meshes[req.MeshName]; exists {
 		return nil, &Error{
 			Code:    errConflictException,
 			Message: fmt.Sprintf("Mesh %s already exists", req.MeshName),
@@ -106,11 +199,11 @@ func (m *MemoryStorage) CreateMesh(_ context.Context, req *CreateMeshInput) (*Me
 		Status: ResourceStatus{Status: StatusActive},
 	}
 
-	m.meshes[req.MeshName] = mesh
-	m.virtualNodes[req.MeshName] = make(map[string]*VirtualNodeData)
-	m.virtualServices[req.MeshName] = make(map[string]*VirtualServiceData)
-	m.virtualRouters[req.MeshName] = make(map[string]*VirtualRouterData)
-	m.routes[req.MeshName] = make(map[string]map[string]*RouteData)
+	m.Meshes[req.MeshName] = mesh
+	m.VirtualNodes[req.MeshName] = make(map[string]*VirtualNodeData)
+	m.VirtualServices[req.MeshName] = make(map[string]*VirtualServiceData)
+	m.VirtualRouters[req.MeshName] = make(map[string]*VirtualRouterData)
+	m.Routes[req.MeshName] = make(map[string]map[string]*RouteData)
 
 	return mesh, nil
 }
@@ -120,7 +213,7 @@ func (m *MemoryStorage) DescribeMesh(_ context.Context, meshName string) (*MeshD
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	mesh, exists := m.meshes[meshName]
+	mesh, exists := m.Meshes[meshName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -141,9 +234,9 @@ func (m *MemoryStorage) ListMeshes(_ context.Context, req *ListMeshesInput) (*Li
 		limit = 100
 	}
 
-	meshRefs := make([]MeshRef, 0, len(m.meshes))
+	meshRefs := make([]MeshRef, 0, len(m.Meshes))
 
-	for _, mesh := range m.meshes {
+	for _, mesh := range m.Meshes {
 		meshRefs = append(meshRefs, MeshRef{
 			Arn:           mesh.Metadata.Arn,
 			CreatedAt:     mesh.Metadata.CreatedAt,
@@ -169,7 +262,7 @@ func (m *MemoryStorage) UpdateMesh(_ context.Context, req *UpdateMeshInput) (*Me
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	mesh, exists := m.meshes[req.MeshName]
+	mesh, exists := m.Meshes[req.MeshName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -189,7 +282,7 @@ func (m *MemoryStorage) DeleteMesh(_ context.Context, meshName string) (*MeshDat
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	mesh, exists := m.meshes[meshName]
+	mesh, exists := m.Meshes[meshName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -198,21 +291,21 @@ func (m *MemoryStorage) DeleteMesh(_ context.Context, meshName string) (*MeshDat
 	}
 
 	// Check if mesh has any child resources.
-	if len(m.virtualNodes[meshName]) > 0 {
+	if len(m.VirtualNodes[meshName]) > 0 {
 		return nil, &Error{
 			Code:    errResourceInUseException,
 			Message: fmt.Sprintf("Mesh %s has virtual nodes and cannot be deleted", meshName),
 		}
 	}
 
-	if len(m.virtualServices[meshName]) > 0 {
+	if len(m.VirtualServices[meshName]) > 0 {
 		return nil, &Error{
 			Code:    errResourceInUseException,
 			Message: fmt.Sprintf("Mesh %s has virtual services and cannot be deleted", meshName),
 		}
 	}
 
-	if len(m.virtualRouters[meshName]) > 0 {
+	if len(m.VirtualRouters[meshName]) > 0 {
 		return nil, &Error{
 			Code:    errResourceInUseException,
 			Message: fmt.Sprintf("Mesh %s has virtual routers and cannot be deleted", meshName),
@@ -221,11 +314,11 @@ func (m *MemoryStorage) DeleteMesh(_ context.Context, meshName string) (*MeshDat
 
 	mesh.Status.Status = StatusDeleted
 
-	delete(m.meshes, meshName)
-	delete(m.virtualNodes, meshName)
-	delete(m.virtualServices, meshName)
-	delete(m.virtualRouters, meshName)
-	delete(m.routes, meshName)
+	delete(m.Meshes, meshName)
+	delete(m.VirtualNodes, meshName)
+	delete(m.VirtualServices, meshName)
+	delete(m.VirtualRouters, meshName)
+	delete(m.Routes, meshName)
 
 	return mesh, nil
 }
@@ -237,14 +330,14 @@ func (m *MemoryStorage) CreateVirtualNode(_ context.Context, req *CreateVirtualN
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
 		}
 	}
 
-	if _, exists := m.virtualNodes[req.MeshName][req.VirtualNodeName]; exists {
+	if _, exists := m.VirtualNodes[req.MeshName][req.VirtualNodeName]; exists {
 		return nil, &Error{
 			Code:    errConflictException,
 			Message: fmt.Sprintf("VirtualNode %s already exists in mesh %s", req.VirtualNodeName, req.MeshName),
@@ -272,7 +365,7 @@ func (m *MemoryStorage) CreateVirtualNode(_ context.Context, req *CreateVirtualN
 		Status: ResourceStatus{Status: StatusActive},
 	}
 
-	m.virtualNodes[req.MeshName][req.VirtualNodeName] = node
+	m.VirtualNodes[req.MeshName][req.VirtualNodeName] = node
 
 	return node, nil
 }
@@ -282,14 +375,14 @@ func (m *MemoryStorage) DescribeVirtualNode(_ context.Context, meshName, virtual
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.meshes[meshName]; !exists {
+	if _, exists := m.Meshes[meshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", meshName),
 		}
 	}
 
-	node, exists := m.virtualNodes[meshName][virtualNodeName]
+	node, exists := m.VirtualNodes[meshName][virtualNodeName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -305,7 +398,7 @@ func (m *MemoryStorage) ListVirtualNodes(_ context.Context, req *ListVirtualNode
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
@@ -319,7 +412,7 @@ func (m *MemoryStorage) ListVirtualNodes(_ context.Context, req *ListVirtualNode
 
 	nodeRefs := make([]VirtualNodeRef, 0)
 
-	for _, node := range m.virtualNodes[req.MeshName] {
+	for _, node := range m.VirtualNodes[req.MeshName] {
 		nodeRefs = append(nodeRefs, VirtualNodeRef{
 			Arn:             node.Metadata.Arn,
 			CreatedAt:       node.Metadata.CreatedAt,
@@ -346,14 +439,14 @@ func (m *MemoryStorage) UpdateVirtualNode(_ context.Context, req *UpdateVirtualN
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
 		}
 	}
 
-	node, exists := m.virtualNodes[req.MeshName][req.VirtualNodeName]
+	node, exists := m.VirtualNodes[req.MeshName][req.VirtualNodeName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -373,14 +466,14 @@ func (m *MemoryStorage) DeleteVirtualNode(_ context.Context, meshName, virtualNo
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[meshName]; !exists {
+	if _, exists := m.Meshes[meshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", meshName),
 		}
 	}
 
-	node, exists := m.virtualNodes[meshName][virtualNodeName]
+	node, exists := m.VirtualNodes[meshName][virtualNodeName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -390,7 +483,7 @@ func (m *MemoryStorage) DeleteVirtualNode(_ context.Context, meshName, virtualNo
 
 	node.Status.Status = StatusDeleted
 
-	delete(m.virtualNodes[meshName], virtualNodeName)
+	delete(m.VirtualNodes[meshName], virtualNodeName)
 
 	return node, nil
 }
@@ -402,14 +495,14 @@ func (m *MemoryStorage) CreateVirtualService(_ context.Context, req *CreateVirtu
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
 		}
 	}
 
-	if _, exists := m.virtualServices[req.MeshName][req.VirtualServiceName]; exists {
+	if _, exists := m.VirtualServices[req.MeshName][req.VirtualServiceName]; exists {
 		return nil, &Error{
 			Code:    errConflictException,
 			Message: fmt.Sprintf("VirtualService %s already exists in mesh %s", req.VirtualServiceName, req.MeshName),
@@ -437,7 +530,7 @@ func (m *MemoryStorage) CreateVirtualService(_ context.Context, req *CreateVirtu
 		Status: ResourceStatus{Status: StatusActive},
 	}
 
-	m.virtualServices[req.MeshName][req.VirtualServiceName] = service
+	m.VirtualServices[req.MeshName][req.VirtualServiceName] = service
 
 	return service, nil
 }
@@ -447,14 +540,14 @@ func (m *MemoryStorage) DescribeVirtualService(_ context.Context, meshName, virt
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.meshes[meshName]; !exists {
+	if _, exists := m.Meshes[meshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", meshName),
 		}
 	}
 
-	service, exists := m.virtualServices[meshName][virtualServiceName]
+	service, exists := m.VirtualServices[meshName][virtualServiceName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -470,7 +563,7 @@ func (m *MemoryStorage) ListVirtualServices(_ context.Context, req *ListVirtualS
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
@@ -484,7 +577,7 @@ func (m *MemoryStorage) ListVirtualServices(_ context.Context, req *ListVirtualS
 
 	serviceRefs := make([]VirtualServiceRef, 0)
 
-	for _, service := range m.virtualServices[req.MeshName] {
+	for _, service := range m.VirtualServices[req.MeshName] {
 		serviceRefs = append(serviceRefs, VirtualServiceRef{
 			Arn:                service.Metadata.Arn,
 			CreatedAt:          service.Metadata.CreatedAt,
@@ -511,14 +604,14 @@ func (m *MemoryStorage) UpdateVirtualService(_ context.Context, req *UpdateVirtu
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
 		}
 	}
 
-	service, exists := m.virtualServices[req.MeshName][req.VirtualServiceName]
+	service, exists := m.VirtualServices[req.MeshName][req.VirtualServiceName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -538,14 +631,14 @@ func (m *MemoryStorage) DeleteVirtualService(_ context.Context, meshName, virtua
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[meshName]; !exists {
+	if _, exists := m.Meshes[meshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", meshName),
 		}
 	}
 
-	service, exists := m.virtualServices[meshName][virtualServiceName]
+	service, exists := m.VirtualServices[meshName][virtualServiceName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -555,7 +648,7 @@ func (m *MemoryStorage) DeleteVirtualService(_ context.Context, meshName, virtua
 
 	service.Status.Status = StatusDeleted
 
-	delete(m.virtualServices[meshName], virtualServiceName)
+	delete(m.VirtualServices[meshName], virtualServiceName)
 
 	return service, nil
 }
@@ -567,14 +660,14 @@ func (m *MemoryStorage) CreateVirtualRouter(_ context.Context, req *CreateVirtua
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
 		}
 	}
 
-	if _, exists := m.virtualRouters[req.MeshName][req.VirtualRouterName]; exists {
+	if _, exists := m.VirtualRouters[req.MeshName][req.VirtualRouterName]; exists {
 		return nil, &Error{
 			Code:    errConflictException,
 			Message: fmt.Sprintf("VirtualRouter %s already exists in mesh %s", req.VirtualRouterName, req.MeshName),
@@ -602,8 +695,8 @@ func (m *MemoryStorage) CreateVirtualRouter(_ context.Context, req *CreateVirtua
 		Status: ResourceStatus{Status: StatusActive},
 	}
 
-	m.virtualRouters[req.MeshName][req.VirtualRouterName] = router
-	m.routes[req.MeshName][req.VirtualRouterName] = make(map[string]*RouteData)
+	m.VirtualRouters[req.MeshName][req.VirtualRouterName] = router
+	m.Routes[req.MeshName][req.VirtualRouterName] = make(map[string]*RouteData)
 
 	return router, nil
 }
@@ -613,14 +706,14 @@ func (m *MemoryStorage) DescribeVirtualRouter(_ context.Context, meshName, virtu
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.meshes[meshName]; !exists {
+	if _, exists := m.Meshes[meshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", meshName),
 		}
 	}
 
-	router, exists := m.virtualRouters[meshName][virtualRouterName]
+	router, exists := m.VirtualRouters[meshName][virtualRouterName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -636,7 +729,7 @@ func (m *MemoryStorage) ListVirtualRouters(_ context.Context, req *ListVirtualRo
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
@@ -650,7 +743,7 @@ func (m *MemoryStorage) ListVirtualRouters(_ context.Context, req *ListVirtualRo
 
 	routerRefs := make([]VirtualRouterRef, 0)
 
-	for _, router := range m.virtualRouters[req.MeshName] {
+	for _, router := range m.VirtualRouters[req.MeshName] {
 		routerRefs = append(routerRefs, VirtualRouterRef{
 			Arn:               router.Metadata.Arn,
 			CreatedAt:         router.Metadata.CreatedAt,
@@ -677,14 +770,14 @@ func (m *MemoryStorage) UpdateVirtualRouter(_ context.Context, req *UpdateVirtua
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
 		}
 	}
 
-	router, exists := m.virtualRouters[req.MeshName][req.VirtualRouterName]
+	router, exists := m.VirtualRouters[req.MeshName][req.VirtualRouterName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -704,14 +797,14 @@ func (m *MemoryStorage) DeleteVirtualRouter(_ context.Context, meshName, virtual
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[meshName]; !exists {
+	if _, exists := m.Meshes[meshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", meshName),
 		}
 	}
 
-	router, exists := m.virtualRouters[meshName][virtualRouterName]
+	router, exists := m.VirtualRouters[meshName][virtualRouterName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -720,7 +813,7 @@ func (m *MemoryStorage) DeleteVirtualRouter(_ context.Context, meshName, virtual
 	}
 
 	// Check if router has any routes.
-	if len(m.routes[meshName][virtualRouterName]) > 0 {
+	if len(m.Routes[meshName][virtualRouterName]) > 0 {
 		return nil, &Error{
 			Code:    errResourceInUseException,
 			Message: fmt.Sprintf("VirtualRouter %s has routes and cannot be deleted", virtualRouterName),
@@ -729,8 +822,8 @@ func (m *MemoryStorage) DeleteVirtualRouter(_ context.Context, meshName, virtual
 
 	router.Status.Status = StatusDeleted
 
-	delete(m.virtualRouters[meshName], virtualRouterName)
-	delete(m.routes[meshName], virtualRouterName)
+	delete(m.VirtualRouters[meshName], virtualRouterName)
+	delete(m.Routes[meshName], virtualRouterName)
 
 	return router, nil
 }
@@ -742,21 +835,21 @@ func (m *MemoryStorage) CreateRoute(_ context.Context, req *CreateRouteInput) (*
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
 		}
 	}
 
-	if _, exists := m.virtualRouters[req.MeshName][req.VirtualRouterName]; !exists {
+	if _, exists := m.VirtualRouters[req.MeshName][req.VirtualRouterName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("VirtualRouter %s not found in mesh %s", req.VirtualRouterName, req.MeshName),
 		}
 	}
 
-	if _, exists := m.routes[req.MeshName][req.VirtualRouterName][req.RouteName]; exists {
+	if _, exists := m.Routes[req.MeshName][req.VirtualRouterName][req.RouteName]; exists {
 		return nil, &Error{
 			Code:    errConflictException,
 			Message: fmt.Sprintf("Route %s already exists in virtual router %s", req.RouteName, req.VirtualRouterName),
@@ -785,7 +878,7 @@ func (m *MemoryStorage) CreateRoute(_ context.Context, req *CreateRouteInput) (*
 		Status: ResourceStatus{Status: StatusActive},
 	}
 
-	m.routes[req.MeshName][req.VirtualRouterName][req.RouteName] = route
+	m.Routes[req.MeshName][req.VirtualRouterName][req.RouteName] = route
 
 	return route, nil
 }
@@ -795,21 +888,21 @@ func (m *MemoryStorage) DescribeRoute(_ context.Context, meshName, virtualRouter
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.meshes[meshName]; !exists {
+	if _, exists := m.Meshes[meshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", meshName),
 		}
 	}
 
-	if _, exists := m.virtualRouters[meshName][virtualRouterName]; !exists {
+	if _, exists := m.VirtualRouters[meshName][virtualRouterName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("VirtualRouter %s not found in mesh %s", virtualRouterName, meshName),
 		}
 	}
 
-	route, exists := m.routes[meshName][virtualRouterName][routeName]
+	route, exists := m.Routes[meshName][virtualRouterName][routeName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -825,14 +918,14 @@ func (m *MemoryStorage) ListRoutes(_ context.Context, req *ListRoutesInput) (*Li
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
 		}
 	}
 
-	if _, exists := m.virtualRouters[req.MeshName][req.VirtualRouterName]; !exists {
+	if _, exists := m.VirtualRouters[req.MeshName][req.VirtualRouterName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("VirtualRouter %s not found in mesh %s", req.VirtualRouterName, req.MeshName),
@@ -846,7 +939,7 @@ func (m *MemoryStorage) ListRoutes(_ context.Context, req *ListRoutesInput) (*Li
 
 	routeRefs := make([]RouteRef, 0)
 
-	for _, route := range m.routes[req.MeshName][req.VirtualRouterName] {
+	for _, route := range m.Routes[req.MeshName][req.VirtualRouterName] {
 		routeRefs = append(routeRefs, RouteRef{
 			Arn:               route.Metadata.Arn,
 			CreatedAt:         route.Metadata.CreatedAt,
@@ -874,21 +967,21 @@ func (m *MemoryStorage) UpdateRoute(_ context.Context, req *UpdateRouteInput) (*
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[req.MeshName]; !exists {
+	if _, exists := m.Meshes[req.MeshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", req.MeshName),
 		}
 	}
 
-	if _, exists := m.virtualRouters[req.MeshName][req.VirtualRouterName]; !exists {
+	if _, exists := m.VirtualRouters[req.MeshName][req.VirtualRouterName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("VirtualRouter %s not found in mesh %s", req.VirtualRouterName, req.MeshName),
 		}
 	}
 
-	route, exists := m.routes[req.MeshName][req.VirtualRouterName][req.RouteName]
+	route, exists := m.Routes[req.MeshName][req.VirtualRouterName][req.RouteName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -908,21 +1001,21 @@ func (m *MemoryStorage) DeleteRoute(_ context.Context, meshName, virtualRouterNa
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.meshes[meshName]; !exists {
+	if _, exists := m.Meshes[meshName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Mesh %s not found", meshName),
 		}
 	}
 
-	if _, exists := m.virtualRouters[meshName][virtualRouterName]; !exists {
+	if _, exists := m.VirtualRouters[meshName][virtualRouterName]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("VirtualRouter %s not found in mesh %s", virtualRouterName, meshName),
 		}
 	}
 
-	route, exists := m.routes[meshName][virtualRouterName][routeName]
+	route, exists := m.Routes[meshName][virtualRouterName][routeName]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -932,7 +1025,7 @@ func (m *MemoryStorage) DeleteRoute(_ context.Context, meshName, virtualRouterNa
 
 	route.Status.Status = StatusDeleted
 
-	delete(m.routes[meshName][virtualRouterName], routeName)
+	delete(m.Routes[meshName][virtualRouterName], routeName)
 
 	return route, nil
 }

--- a/internal/service/appsync/service.go
+++ b/internal/service/appsync/service.go
@@ -1,11 +1,23 @@
 package appsync
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the AppSync service.
@@ -43,4 +55,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 
 	// Schema operations.
 	r.HandleFunc("POST", "/appsync/v1/apis/{apiId}/schemacreation", s.StartSchemaCreation)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/appsync/storage.go
+++ b/internal/service/appsync/storage.go
@@ -3,12 +3,15 @@ package appsync
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
 	"sync"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -29,25 +32,99 @@ type Storage interface {
 	StartSchemaCreation(ctx context.Context, apiID string, definition []byte) (*SchemaCreationStatus, error)
 }
 
-// apiData holds all data associated with a GraphQL API.
-type apiData struct {
-	api         *GraphqlAPI
-	dataSources map[string]*DataSource // key: name
-	resolvers   map[string]*Resolver   // key: typeName:fieldName
-	schema      *SchemaCreationStatus
+// APIData holds all data associated with a GraphQL API.
+type APIData struct {
+	API         *GraphqlAPI            `json:"api"`
+	DataSources map[string]*DataSource `json:"dataSources"` // key: name
+	Resolvers   map[string]*Resolver   `json:"resolvers"`   // key: typeName:fieldName
+	Schema      *SchemaCreationStatus  `json:"schema"`
 }
+
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
 
 // MemoryStorage implements Storage with in-memory data structures.
 type MemoryStorage struct {
-	mu   sync.RWMutex
-	apis map[string]*apiData // key: apiID
+	mu      sync.RWMutex        `json:"-"`
+	APIs    map[string]*APIData `json:"apis"` // key: apiID
+	dataDir string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		apis: make(map[string]*apiData),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		APIs: make(map[string]*APIData),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "appsync", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.APIs == nil {
+		s.APIs = make(map[string]*APIData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "appsync", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateGraphqlAPI creates a new GraphQL API.
@@ -98,10 +175,10 @@ func (s *MemoryStorage) CreateGraphqlAPI(_ context.Context, input *CreateGraphql
 		EnhancedMetricsConfig:             input.EnhancedMetricsConfig,
 	}
 
-	s.apis[apiID] = &apiData{
-		api:         api,
-		dataSources: make(map[string]*DataSource),
-		resolvers:   make(map[string]*Resolver),
+	s.APIs[apiID] = &APIData{
+		API:         api,
+		DataSources: make(map[string]*DataSource),
+		Resolvers:   make(map[string]*Resolver),
 	}
 
 	return api, nil
@@ -112,14 +189,14 @@ func (s *MemoryStorage) DeleteGraphqlAPI(_ context.Context, apiID string) error 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.apis[apiID]; !exists {
+	if _, exists := s.APIs[apiID]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("GraphQL API %s not found", apiID),
 		}
 	}
 
-	delete(s.apis, apiID)
+	delete(s.APIs, apiID)
 
 	return nil
 }
@@ -129,7 +206,7 @@ func (s *MemoryStorage) GetGraphqlAPI(_ context.Context, apiID string) (*Graphql
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.apis[apiID]
+	data, exists := s.APIs[apiID]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -137,7 +214,7 @@ func (s *MemoryStorage) GetGraphqlAPI(_ context.Context, apiID string) (*Graphql
 		}
 	}
 
-	return data.api, nil
+	return data.API, nil
 }
 
 // defaultMaxResults is the default number of results to return.
@@ -149,20 +226,20 @@ func (s *MemoryStorage) ListGraphqlAPIs(_ context.Context, input *ListGraphqlAPI
 	defer s.mu.RUnlock()
 
 	// Collect all matching APIs.
-	allAPIs := make([]GraphqlAPI, 0, len(s.apis))
+	allAPIs := make([]GraphqlAPI, 0, len(s.APIs))
 
-	for _, data := range s.apis {
+	for _, data := range s.APIs {
 		// Filter by API type if specified.
-		if input.APIType != "" && data.api.APIType != input.APIType {
+		if input.APIType != "" && data.API.APIType != input.APIType {
 			continue
 		}
 
 		// Filter by owner if specified.
-		if input.Owner != "" && data.api.Owner != input.Owner {
+		if input.Owner != "" && data.API.Owner != input.Owner {
 			continue
 		}
 
-		allAPIs = append(allAPIs, *data.api)
+		allAPIs = append(allAPIs, *data.API)
 	}
 
 	// Sort by API ID for consistent pagination.
@@ -210,7 +287,7 @@ func (s *MemoryStorage) CreateDataSource(_ context.Context, input *CreateDataSou
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.apis[input.APIID]
+	data, exists := s.APIs[input.APIID]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -232,7 +309,7 @@ func (s *MemoryStorage) CreateDataSource(_ context.Context, input *CreateDataSou
 		}
 	}
 
-	if _, exists := data.dataSources[input.Name]; exists {
+	if _, exists := data.DataSources[input.Name]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("Data source %s already exists", input.Name),
@@ -258,7 +335,7 @@ func (s *MemoryStorage) CreateDataSource(_ context.Context, input *CreateDataSou
 		MetricsConfig:            input.MetricsConfig,
 	}
 
-	data.dataSources[input.Name] = dataSource
+	data.DataSources[input.Name] = dataSource
 
 	return dataSource, nil
 }
@@ -268,7 +345,7 @@ func (s *MemoryStorage) CreateResolver(_ context.Context, input *CreateResolverI
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.apis[input.APIID]
+	data, exists := s.APIs[input.APIID]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -292,7 +369,7 @@ func (s *MemoryStorage) CreateResolver(_ context.Context, input *CreateResolverI
 
 	resolverKey := fmt.Sprintf("%s:%s", input.TypeName, input.FieldName)
 
-	if _, exists := data.resolvers[resolverKey]; exists {
+	if _, exists := data.Resolvers[resolverKey]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("Resolver for %s.%s already exists", input.TypeName, input.FieldName),
@@ -319,7 +396,7 @@ func (s *MemoryStorage) CreateResolver(_ context.Context, input *CreateResolverI
 		MetricsConfig:           input.MetricsConfig,
 	}
 
-	data.resolvers[resolverKey] = resolver
+	data.Resolvers[resolverKey] = resolver
 
 	return resolver, nil
 }
@@ -329,7 +406,7 @@ func (s *MemoryStorage) StartSchemaCreation(_ context.Context, apiID string, _ [
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.apis[apiID]
+	data, exists := s.APIs[apiID]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -344,7 +421,7 @@ func (s *MemoryStorage) StartSchemaCreation(_ context.Context, apiID string, _ [
 		Details: "Schema created successfully",
 	}
 
-	data.schema = status
+	data.Schema = status
 
 	return status, nil
 }

--- a/internal/service/athena/service.go
+++ b/internal/service/athena/service.go
@@ -2,11 +2,23 @@
 package athena
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the Athena service.
@@ -40,3 +52,14 @@ func (s *Service) TargetPrefix() string {
 
 // JSONProtocol is a marker method that indicates Athena uses AWS JSON 1.1 protocol.
 func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/athena/storage.go
+++ b/internal/service/athena/storage.go
@@ -2,11 +2,14 @@ package athena
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes for Athena.
@@ -25,30 +28,111 @@ type Storage interface {
 	DeleteWorkGroup(ctx context.Context, name string, recursiveDelete bool) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu              sync.RWMutex
-	queryExecutions map[string]*QueryExecution
-	workGroups      map[string]*WorkGroup
-	queryResults    map[string]*ResultSet
+	mu              sync.RWMutex               `json:"-"`
+	QueryExecutions map[string]*QueryExecution `json:"queryExecutions"`
+	WorkGroups      map[string]*WorkGroup      `json:"workGroups"`
+	QueryResults    map[string]*ResultSet      `json:"queryResults"`
+	dataDir         string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	s := &MemoryStorage{
-		queryExecutions: make(map[string]*QueryExecution),
-		workGroups:      make(map[string]*WorkGroup),
-		queryResults:    make(map[string]*ResultSet),
+		QueryExecutions: make(map[string]*QueryExecution),
+		WorkGroups:      make(map[string]*WorkGroup),
+		QueryResults:    make(map[string]*ResultSet),
 	}
 
 	// Create the default "primary" workgroup.
-	s.workGroups["primary"] = &WorkGroup{
+	s.WorkGroups["primary"] = &WorkGroup{
 		Name:         "primary",
 		State:        WorkGroupStateEnabled,
 		CreationTime: time.Now(),
 	}
 
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "athena", s)
+	}
+
 	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.QueryExecutions == nil {
+		s.QueryExecutions = make(map[string]*QueryExecution)
+	}
+
+	if s.WorkGroups == nil {
+		s.WorkGroups = make(map[string]*WorkGroup)
+	}
+
+	if s.QueryResults == nil {
+		s.QueryResults = make(map[string]*ResultSet)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "athena", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // StartQueryExecution starts a new query execution.
@@ -61,7 +145,7 @@ func (s *MemoryStorage) StartQueryExecution(_ context.Context, query, workGroup 
 	}
 
 	// Verify workgroup exists.
-	if _, ok := s.workGroups[workGroup]; !ok {
+	if _, ok := s.WorkGroups[workGroup]; !ok {
 		return nil, &ServiceError{
 			Code:    errInvalidRequestException,
 			Message: fmt.Sprintf("WorkGroup %s is not found.", workGroup),
@@ -99,8 +183,8 @@ func (s *MemoryStorage) StartQueryExecution(_ context.Context, query, workGroup 
 		},
 	}
 
-	s.queryExecutions[queryExecutionID] = qe
-	s.queryResults[queryExecutionID] = createMockResultSet()
+	s.QueryExecutions[queryExecutionID] = qe
+	s.QueryResults[queryExecutionID] = createMockResultSet()
 
 	return qe, nil
 }
@@ -125,7 +209,7 @@ func (s *MemoryStorage) StopQueryExecution(_ context.Context, queryExecutionID s
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	qe, ok := s.queryExecutions[queryExecutionID]
+	qe, ok := s.QueryExecutions[queryExecutionID]
 	if !ok {
 		return &ServiceError{
 			Code:    errInvalidRequestException,
@@ -149,7 +233,7 @@ func (s *MemoryStorage) GetQueryExecution(_ context.Context, queryExecutionID st
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	qe, ok := s.queryExecutions[queryExecutionID]
+	qe, ok := s.QueryExecutions[queryExecutionID]
 	if !ok {
 		return nil, &ServiceError{
 			Code:    errInvalidRequestException,
@@ -165,7 +249,7 @@ func (s *MemoryStorage) GetQueryResults(_ context.Context, queryExecutionID, _ s
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	qe, ok := s.queryExecutions[queryExecutionID]
+	qe, ok := s.QueryExecutions[queryExecutionID]
 	if !ok {
 		return nil, "", &ServiceError{
 			Code:    errInvalidRequestException,
@@ -180,7 +264,7 @@ func (s *MemoryStorage) GetQueryResults(_ context.Context, queryExecutionID, _ s
 		}
 	}
 
-	rs, ok := s.queryResults[queryExecutionID]
+	rs, ok := s.QueryResults[queryExecutionID]
 	if !ok {
 		// Return empty result set.
 		return &ResultSet{
@@ -203,7 +287,7 @@ func (s *MemoryStorage) ListQueryExecutions(_ context.Context, workGroup, _ stri
 
 	ids := make([]string, 0)
 
-	for id, qe := range s.queryExecutions {
+	for id, qe := range s.QueryExecutions {
 		if workGroup != "" && qe.WorkGroup != workGroup {
 			continue
 		}
@@ -223,7 +307,7 @@ func (s *MemoryStorage) CreateWorkGroup(_ context.Context, name string, configur
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.workGroups[name]; ok {
+	if _, ok := s.WorkGroups[name]; ok {
 		return &ServiceError{
 			Code:    errInvalidRequestException,
 			Message: fmt.Sprintf("WorkGroup %s already exists.", name),
@@ -238,7 +322,7 @@ func (s *MemoryStorage) CreateWorkGroup(_ context.Context, name string, configur
 		CreationTime:  time.Now(),
 	}
 
-	s.workGroups[name] = wg
+	s.WorkGroups[name] = wg
 
 	return nil
 }
@@ -255,7 +339,7 @@ func (s *MemoryStorage) DeleteWorkGroup(_ context.Context, name string, recursiv
 		}
 	}
 
-	if _, ok := s.workGroups[name]; !ok {
+	if _, ok := s.WorkGroups[name]; !ok {
 		return &ServiceError{
 			Code:    errInvalidRequestException,
 			Message: fmt.Sprintf("WorkGroup %s is not found.", name),
@@ -264,7 +348,7 @@ func (s *MemoryStorage) DeleteWorkGroup(_ context.Context, name string, recursiv
 
 	// Check if there are any query executions in this workgroup.
 	if !recursiveDelete {
-		for _, qe := range s.queryExecutions {
+		for _, qe := range s.QueryExecutions {
 			if qe.WorkGroup == name {
 				return &ServiceError{
 					Code:    errInvalidRequestException,
@@ -276,15 +360,15 @@ func (s *MemoryStorage) DeleteWorkGroup(_ context.Context, name string, recursiv
 
 	// Delete query executions if recursive delete.
 	if recursiveDelete {
-		for id, qe := range s.queryExecutions {
+		for id, qe := range s.QueryExecutions {
 			if qe.WorkGroup == name {
-				delete(s.queryExecutions, id)
-				delete(s.queryResults, id)
+				delete(s.QueryExecutions, id)
+				delete(s.QueryResults, id)
 			}
 		}
 	}
 
-	delete(s.workGroups, name)
+	delete(s.WorkGroups, name)
 
 	return nil
 }

--- a/internal/service/backup/service.go
+++ b/internal/service/backup/service.go
@@ -1,11 +1,23 @@
 package backup
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage()
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	storage := NewMemoryStorage(opts...)
 	service.Register(New(storage))
 }
 
@@ -50,4 +62,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("GET", "/backup/plans/{backupPlanId}/selections/{selectionId}", s.GetBackupSelection)
 	r.Handle("GET", "/backup/plans/{backupPlanId}/selections", s.ListBackupSelections)
 	r.Handle("DELETE", "/backup/plans/{backupPlanId}/selections/{selectionId}", s.DeleteBackupSelection)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/backup/storage.go
+++ b/internal/service/backup/storage.go
@@ -1,11 +1,14 @@
 package backup
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the interface for Backup storage operations.
@@ -26,21 +29,103 @@ type Storage interface {
 	DeleteSelection(planID, selectionID string) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage is an in-memory implementation of Storage.
 type MemoryStorage struct {
-	mu         sync.RWMutex
-	vaults     map[string]*Vault
-	plans      map[string]*Plan
-	selections map[string]map[string]*Selection // planID -> selectionID -> selection
+	mu         sync.RWMutex                     `json:"-"`
+	Vaults     map[string]*Vault                `json:"vaults"`
+	Plans      map[string]*Plan                 `json:"plans"`
+	Selections map[string]map[string]*Selection `json:"selections"` // planID -> selectionID -> selection
+	dataDir    string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		vaults:     make(map[string]*Vault),
-		plans:      make(map[string]*Plan),
-		selections: make(map[string]map[string]*Selection),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Vaults:     make(map[string]*Vault),
+		Plans:      make(map[string]*Plan),
+		Selections: make(map[string]map[string]*Selection),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "backup", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Vaults == nil {
+		m.Vaults = make(map[string]*Vault)
+	}
+
+	if m.Plans == nil {
+		m.Plans = make(map[string]*Plan)
+	}
+
+	if m.Selections == nil {
+		m.Selections = make(map[string]map[string]*Selection)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "backup", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 func epochNow() float64 {
@@ -52,7 +137,7 @@ func (m *MemoryStorage) CreateVault(name string, input *CreateBackupVaultInput) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.vaults[name]; exists {
+	if _, exists := m.Vaults[name]; exists {
 		return nil, fmt.Errorf("AlreadyExistsException: backup vault %s already exists", name)
 	}
 
@@ -67,7 +152,7 @@ func (m *MemoryStorage) CreateVault(name string, input *CreateBackupVaultInput) 
 		vault.EncryptionKeyArn = input.EncryptionKeyArn
 	}
 
-	m.vaults[name] = vault
+	m.Vaults[name] = vault
 
 	return vault, nil
 }
@@ -77,7 +162,7 @@ func (m *MemoryStorage) DescribeVault(name string) (*Vault, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	vault, ok := m.vaults[name]
+	vault, ok := m.Vaults[name]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: backup vault %s not found", name)
 	}
@@ -90,8 +175,8 @@ func (m *MemoryStorage) ListVaults() []Vault {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	vaults := make([]Vault, 0, len(m.vaults))
-	for _, v := range m.vaults {
+	vaults := make([]Vault, 0, len(m.Vaults))
+	for _, v := range m.Vaults {
 		vaults = append(vaults, *v)
 	}
 
@@ -103,11 +188,11 @@ func (m *MemoryStorage) DeleteVault(name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.vaults[name]; !ok {
+	if _, ok := m.Vaults[name]; !ok {
 		return fmt.Errorf("ResourceNotFoundException: backup vault %s not found", name)
 	}
 
-	delete(m.vaults, name)
+	delete(m.Vaults, name)
 
 	return nil
 }
@@ -144,7 +229,7 @@ func (m *MemoryStorage) CreatePlan(input *CreateBackupPlanInput) (*Plan, error) 
 		VersionID:    versionID,
 	}
 
-	m.plans[planID] = plan
+	m.Plans[planID] = plan
 
 	return plan, nil
 }
@@ -154,7 +239,7 @@ func (m *MemoryStorage) GetPlan(planID string) (*Plan, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	plan, ok := m.plans[planID]
+	plan, ok := m.Plans[planID]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: backup plan %s not found", planID)
 	}
@@ -167,8 +252,8 @@ func (m *MemoryStorage) ListPlans() []PlanListMember {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	plans := make([]PlanListMember, 0, len(m.plans))
-	for _, p := range m.plans {
+	plans := make([]PlanListMember, 0, len(m.Plans))
+	for _, p := range m.Plans {
 		plans = append(plans, PlanListMember{
 			BackupPlanArn:  p.BackupPlanArn,
 			BackupPlanID:   p.BackupPlanID,
@@ -186,12 +271,12 @@ func (m *MemoryStorage) DeletePlan(planID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.plans[planID]; !ok {
+	if _, ok := m.Plans[planID]; !ok {
 		return fmt.Errorf("ResourceNotFoundException: backup plan %s not found", planID)
 	}
 
-	delete(m.plans, planID)
-	delete(m.selections, planID)
+	delete(m.Plans, planID)
+	delete(m.Selections, planID)
 
 	return nil
 }
@@ -201,7 +286,7 @@ func (m *MemoryStorage) CreateSelection(planID string, input *CreateBackupSelect
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.plans[planID]; !ok {
+	if _, ok := m.Plans[planID]; !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: backup plan %s not found", planID)
 	}
 
@@ -218,11 +303,11 @@ func (m *MemoryStorage) CreateSelection(planID string, input *CreateBackupSelect
 		CreationDate: epochNow(),
 	}
 
-	if m.selections[planID] == nil {
-		m.selections[planID] = make(map[string]*Selection)
+	if m.Selections[planID] == nil {
+		m.Selections[planID] = make(map[string]*Selection)
 	}
 
-	m.selections[planID][selectionID] = selection
+	m.Selections[planID][selectionID] = selection
 
 	return selection, nil
 }
@@ -232,7 +317,7 @@ func (m *MemoryStorage) GetSelection(planID, selectionID string) (*Selection, er
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	planSelections, ok := m.selections[planID]
+	planSelections, ok := m.Selections[planID]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: backup selection %s not found", selectionID)
 	}
@@ -250,7 +335,7 @@ func (m *MemoryStorage) ListSelections(planID string) []SelectionListMember {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	planSelections := m.selections[planID]
+	planSelections := m.Selections[planID]
 	selections := make([]SelectionListMember, 0, len(planSelections))
 
 	for _, s := range planSelections {
@@ -271,7 +356,7 @@ func (m *MemoryStorage) DeleteSelection(planID, selectionID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	planSelections, ok := m.selections[planID]
+	planSelections, ok := m.Selections[planID]
 	if !ok {
 		return fmt.Errorf("ResourceNotFoundException: backup selection %s not found", selectionID)
 	}

--- a/internal/service/batch/service.go
+++ b/internal/service/batch/service.go
@@ -1,11 +1,23 @@
 package batch
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the Batch service.
@@ -45,4 +57,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("POST", "/v1/submitjob", s.SubmitJob)
 	r.Handle("POST", "/v1/describejobs", s.DescribeJobs)
 	r.Handle("POST", "/v1/terminatejob", s.TerminateJob)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/batch/storage.go
+++ b/internal/service/batch/storage.go
@@ -2,10 +2,13 @@ package batch
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -29,25 +32,115 @@ type Storage interface {
 	TerminateJob(ctx context.Context, jobID, reason string) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data structures.
 type MemoryStorage struct {
-	mu                  sync.RWMutex
-	computeEnvironments map[string]*ComputeEnvironment // key: name
-	jobQueues           map[string]*JobQueue           // key: name
-	jobDefinitions      map[string]*JobDefinition      // key: name:revision
-	jobs                map[string]*Job                // key: jobID
-	jobDefRevisions     map[string]int32               // key: name -> latest revision
+	mu                  sync.RWMutex                   `json:"-"`
+	ComputeEnvironments map[string]*ComputeEnvironment `json:"computeEnvironments"` // key: name
+	JobQueues           map[string]*JobQueue           `json:"jobQueues"`           // key: name
+	JobDefinitions      map[string]*JobDefinition      `json:"jobDefinitions"`      // key: name:revision
+	Jobs                map[string]*Job                `json:"jobs"`                // key: jobID
+	JobDefRevisions     map[string]int32               `json:"jobDefRevisions"`     // key: name -> latest revision
+	dataDir             string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		computeEnvironments: make(map[string]*ComputeEnvironment),
-		jobQueues:           make(map[string]*JobQueue),
-		jobDefinitions:      make(map[string]*JobDefinition),
-		jobs:                make(map[string]*Job),
-		jobDefRevisions:     make(map[string]int32),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		ComputeEnvironments: make(map[string]*ComputeEnvironment),
+		JobQueues:           make(map[string]*JobQueue),
+		JobDefinitions:      make(map[string]*JobDefinition),
+		Jobs:                make(map[string]*Job),
+		JobDefRevisions:     make(map[string]int32),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "batch", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.ComputeEnvironments == nil {
+		s.ComputeEnvironments = make(map[string]*ComputeEnvironment)
+	}
+
+	if s.JobQueues == nil {
+		s.JobQueues = make(map[string]*JobQueue)
+	}
+
+	if s.JobDefinitions == nil {
+		s.JobDefinitions = make(map[string]*JobDefinition)
+	}
+
+	if s.Jobs == nil {
+		s.Jobs = make(map[string]*Job)
+	}
+
+	if s.JobDefRevisions == nil {
+		s.JobDefRevisions = make(map[string]int32)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "batch", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateComputeEnvironment creates a new compute environment.
@@ -62,7 +155,7 @@ func (s *MemoryStorage) CreateComputeEnvironment(_ context.Context, input *Creat
 		}
 	}
 
-	if _, exists := s.computeEnvironments[input.ComputeEnvironmentName]; exists {
+	if _, exists := s.ComputeEnvironments[input.ComputeEnvironmentName]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("Compute environment %s already exists", input.ComputeEnvironmentName),
@@ -89,7 +182,7 @@ func (s *MemoryStorage) CreateComputeEnvironment(_ context.Context, input *Creat
 		UUID:                   uuid.New().String(),
 	}
 
-	s.computeEnvironments[input.ComputeEnvironmentName] = ce
+	s.ComputeEnvironments[input.ComputeEnvironmentName] = ce
 
 	return ce, nil
 }
@@ -99,14 +192,14 @@ func (s *MemoryStorage) DeleteComputeEnvironment(_ context.Context, name string)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.computeEnvironments[name]; !exists {
+	if _, exists := s.ComputeEnvironments[name]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Compute environment %s not found", name),
 		}
 	}
 
-	delete(s.computeEnvironments, name)
+	delete(s.ComputeEnvironments, name)
 
 	return nil
 }
@@ -120,13 +213,13 @@ func (s *MemoryStorage) DescribeComputeEnvironments(_ context.Context, names []s
 
 	if len(names) == 0 {
 		// Return all compute environments.
-		for _, ce := range s.computeEnvironments {
+		for _, ce := range s.ComputeEnvironments {
 			result = append(result, *ce)
 		}
 	} else {
 		// Return specified compute environments.
 		for _, name := range names {
-			if ce, exists := s.computeEnvironments[name]; exists {
+			if ce, exists := s.ComputeEnvironments[name]; exists {
 				result = append(result, *ce)
 			}
 		}
@@ -147,7 +240,7 @@ func (s *MemoryStorage) CreateJobQueue(_ context.Context, input *CreateJobQueueI
 		}
 	}
 
-	if _, exists := s.jobQueues[input.JobQueueName]; exists {
+	if _, exists := s.JobQueues[input.JobQueueName]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("Job queue %s already exists", input.JobQueueName),
@@ -173,7 +266,7 @@ func (s *MemoryStorage) CreateJobQueue(_ context.Context, input *CreateJobQueueI
 		Tags:                     input.Tags,
 	}
 
-	s.jobQueues[input.JobQueueName] = jq
+	s.JobQueues[input.JobQueueName] = jq
 
 	return jq, nil
 }
@@ -183,14 +276,14 @@ func (s *MemoryStorage) DeleteJobQueue(_ context.Context, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.jobQueues[name]; !exists {
+	if _, exists := s.JobQueues[name]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Job queue %s not found", name),
 		}
 	}
 
-	delete(s.jobQueues, name)
+	delete(s.JobQueues, name)
 
 	return nil
 }
@@ -204,13 +297,13 @@ func (s *MemoryStorage) DescribeJobQueues(_ context.Context, names []string) ([]
 
 	if len(names) == 0 {
 		// Return all job queues.
-		for _, jq := range s.jobQueues {
+		for _, jq := range s.JobQueues {
 			result = append(result, *jq)
 		}
 	} else {
 		// Return specified job queues.
 		for _, name := range names {
-			if jq, exists := s.jobQueues[name]; exists {
+			if jq, exists := s.JobQueues[name]; exists {
 				result = append(result, *jq)
 			}
 		}
@@ -239,8 +332,8 @@ func (s *MemoryStorage) RegisterJobDefinition(_ context.Context, input *Register
 	}
 
 	// Increment revision.
-	revision := s.jobDefRevisions[input.JobDefinitionName] + 1
-	s.jobDefRevisions[input.JobDefinitionName] = revision
+	revision := s.JobDefRevisions[input.JobDefinitionName] + 1
+	s.JobDefRevisions[input.JobDefinitionName] = revision
 
 	jdARN := fmt.Sprintf("arn:aws:batch:us-east-1:000000000000:job-definition/%s:%d", input.JobDefinitionName, revision)
 	jdKey := fmt.Sprintf("%s:%d", input.JobDefinitionName, revision)
@@ -263,7 +356,7 @@ func (s *MemoryStorage) RegisterJobDefinition(_ context.Context, input *Register
 		Type:                 input.Type,
 	}
 
-	s.jobDefinitions[jdKey] = jd
+	s.JobDefinitions[jdKey] = jd
 
 	return jd, nil
 }
@@ -315,7 +408,7 @@ func (s *MemoryStorage) SubmitJob(_ context.Context, input *SubmitJobInput) (*Jo
 		Timeout:            input.Timeout,
 	}
 
-	s.jobs[jobID] = job
+	s.Jobs[jobID] = job
 
 	return job, nil
 }
@@ -328,7 +421,7 @@ func (s *MemoryStorage) DescribeJobs(_ context.Context, jobIDs []string) ([]Job,
 	var result []Job
 
 	for _, id := range jobIDs {
-		if job, exists := s.jobs[id]; exists {
+		if job, exists := s.Jobs[id]; exists {
 			result = append(result, *job)
 		}
 	}
@@ -341,7 +434,7 @@ func (s *MemoryStorage) TerminateJob(_ context.Context, jobID, reason string) er
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	job, exists := s.jobs[jobID]
+	job, exists := s.Jobs[jobID]
 	if !exists {
 		return &Error{
 			Code:    errNotFound,

--- a/internal/service/ce/service.go
+++ b/internal/service/ce/service.go
@@ -1,14 +1,26 @@
 package ce
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
 // Compile-time check to ensure Service implements service.Service.
 var _ service.Service = (*Service)(nil)
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the AWS Cost Explorer service.
@@ -39,4 +51,15 @@ func (s *Service) JSONProtocol() {}
 // RegisterRoutes registers the routes for this service.
 func (s *Service) RegisterRoutes(_ service.Router) {
 	// JSON protocol services use DispatchAction for routing
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/ce/storage.go
+++ b/internal/service/ce/storage.go
@@ -2,12 +2,15 @@ package ce
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -42,17 +45,91 @@ type Storage interface {
 	ListCostCategoryDefinitions(ctx context.Context, req *ListCostCategoryDefinitionsRequest) (*ListCostCategoryDefinitionsResponse, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements in-memory storage for Cost Explorer.
 type MemoryStorage struct {
-	mu             sync.RWMutex
-	costCategories map[string]*CostCategoryDefinition
+	mu             sync.RWMutex                       `json:"-"`
+	CostCategories map[string]*CostCategoryDefinition `json:"costCategories"`
+	dataDir        string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		costCategories: make(map[string]*CostCategoryDefinition),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		CostCategories: make(map[string]*CostCategoryDefinition),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "ce", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.CostCategories == nil {
+		s.CostCategories = make(map[string]*CostCategoryDefinition)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "ce", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // GetCostAndUsage retrieves cost and usage data.
@@ -185,7 +262,7 @@ func (s *MemoryStorage) CreateCostCategoryDefinition(_ context.Context, req *Cre
 	defer s.mu.Unlock()
 
 	// Check for duplicate name
-	for _, cc := range s.costCategories {
+	for _, cc := range s.CostCategories {
 		if cc.Name == req.Name {
 			return nil, &ServiceError{
 				Code:    errValidation,
@@ -218,7 +295,7 @@ func (s *MemoryStorage) CreateCostCategoryDefinition(_ context.Context, req *Cre
 		},
 	}
 
-	s.costCategories[arn] = cc
+	s.CostCategories[arn] = cc
 
 	return cc, nil
 }
@@ -228,7 +305,7 @@ func (s *MemoryStorage) DescribeCostCategoryDefinition(_ context.Context, arn st
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	cc, ok := s.costCategories[arn]
+	cc, ok := s.CostCategories[arn]
 	if !ok {
 		return nil, &ServiceError{
 			Code:    errNotFound,
@@ -244,14 +321,14 @@ func (s *MemoryStorage) DeleteCostCategoryDefinition(_ context.Context, arn stri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.costCategories[arn]; !ok {
+	if _, ok := s.CostCategories[arn]; !ok {
 		return &ServiceError{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Cost category with ARN %s not found", arn),
 		}
 	}
 
-	delete(s.costCategories, arn)
+	delete(s.CostCategories, arn)
 
 	return nil
 }
@@ -261,9 +338,9 @@ func (s *MemoryStorage) ListCostCategoryDefinitions(_ context.Context, _ *ListCo
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	refs := make([]CostCategoryReference, 0, len(s.costCategories))
+	refs := make([]CostCategoryReference, 0, len(s.CostCategories))
 
-	for _, cc := range s.costCategories {
+	for _, cc := range s.CostCategories {
 		refs = append(refs, CostCategoryReference{
 			CostCategoryArn: cc.CostCategoryArn,
 			Name:            cc.Name,

--- a/internal/service/cloudformation/service.go
+++ b/internal/service/cloudformation/service.go
@@ -1,13 +1,24 @@
 package cloudformation
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the CloudFormation service.
@@ -63,4 +74,15 @@ var (
 // HandleRequest handles HTTP requests for the CloudFormation service.
 func (s *Service) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	s.DispatchAction(w, r)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/cloudformation/storage.go
+++ b/internal/service/cloudformation/storage.go
@@ -3,11 +3,14 @@ package cloudformation
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"slices"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the interface for CloudFormation storage operations.
@@ -22,17 +25,91 @@ type Storage interface {
 	ValidateTemplate(ctx context.Context, templateBody string) (*TemplateValidationResult, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage is an in-memory implementation of Storage.
 type MemoryStorage struct {
-	mu     sync.RWMutex
-	stacks map[string]*Stack // key: stackName
+	mu      sync.RWMutex      `json:"-"`
+	Stacks  map[string]*Stack `json:"stacks"` // key: stackName
+	dataDir string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		stacks: make(map[string]*Stack),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Stacks: make(map[string]*Stack),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "cloudformation", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Stacks == nil {
+		m.Stacks = make(map[string]*Stack)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "cloudformation", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateStack creates a new stack.
@@ -44,7 +121,7 @@ func (m *MemoryStorage) CreateStack(_ context.Context, req *CreateStackRequest) 
 		return nil, &Error{Code: "ValidationError", Message: "StackName is required"}
 	}
 
-	if _, exists := m.stacks[req.StackName]; exists {
+	if _, exists := m.Stacks[req.StackName]; exists {
 		return nil, &Error{Code: "AlreadyExistsException", Message: "Stack already exists"}
 	}
 
@@ -69,7 +146,7 @@ func (m *MemoryStorage) CreateStack(_ context.Context, req *CreateStackRequest) 
 		Resources:       resources,
 	}
 
-	m.stacks[req.StackName] = stack
+	m.Stacks[req.StackName] = stack
 
 	return stack, nil
 }
@@ -79,7 +156,7 @@ func (m *MemoryStorage) DeleteStack(_ context.Context, stackName string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	stack, exists := m.stacks[stackName]
+	stack, exists := m.Stacks[stackName]
 	if !exists {
 		return &Error{Code: "StackNotFoundException", Message: "Stack not found"}
 	}
@@ -89,7 +166,7 @@ func (m *MemoryStorage) DeleteStack(_ context.Context, stackName string) error {
 	stack.DeletionTime = time.Now()
 
 	// Keep the stack for ListStacks but prevent DescribeStacks from returning it.
-	delete(m.stacks, stackName)
+	delete(m.Stacks, stackName)
 
 	return nil
 }
@@ -100,7 +177,7 @@ func (m *MemoryStorage) DescribeStacks(_ context.Context, stackName string) ([]*
 	defer m.mu.RUnlock()
 
 	if stackName != "" {
-		stack, exists := m.stacks[stackName]
+		stack, exists := m.Stacks[stackName]
 		if !exists {
 			return nil, &Error{Code: "StackNotFoundException", Message: "Stack not found"}
 		}
@@ -109,8 +186,8 @@ func (m *MemoryStorage) DescribeStacks(_ context.Context, stackName string) ([]*
 	}
 
 	// Return all stacks.
-	result := make([]*Stack, 0, len(m.stacks))
-	for _, stack := range m.stacks {
+	result := make([]*Stack, 0, len(m.Stacks))
+	for _, stack := range m.Stacks {
 		result = append(result, stack)
 	}
 
@@ -122,9 +199,9 @@ func (m *MemoryStorage) ListStacks(_ context.Context, statusFilter []string) ([]
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]*Stack, 0, len(m.stacks))
+	result := make([]*Stack, 0, len(m.Stacks))
 
-	for _, stack := range m.stacks {
+	for _, stack := range m.Stacks {
 		if len(statusFilter) > 0 {
 			if !containsStatus(statusFilter, stack.StackStatus) {
 				continue
@@ -142,7 +219,7 @@ func (m *MemoryStorage) UpdateStack(_ context.Context, req *UpdateStackRequest) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	stack, exists := m.stacks[req.StackName]
+	stack, exists := m.Stacks[req.StackName]
 	if !exists {
 		return nil, &Error{Code: "StackNotFoundException", Message: "Stack not found"}
 	}
@@ -171,7 +248,7 @@ func (m *MemoryStorage) DescribeStackResources(_ context.Context, stackName, log
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	stack, exists := m.stacks[stackName]
+	stack, exists := m.Stacks[stackName]
 	if !exists {
 		return nil, &Error{Code: "StackNotFoundException", Message: "Stack not found"}
 	}
@@ -199,7 +276,7 @@ func (m *MemoryStorage) GetTemplate(_ context.Context, stackName string) (string
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	stack, exists := m.stacks[stackName]
+	stack, exists := m.Stacks[stackName]
 	if !exists {
 		return "", &Error{Code: "StackNotFoundException", Message: "Stack not found"}
 	}

--- a/internal/service/cloudfront/service.go
+++ b/internal/service/cloudfront/service.go
@@ -1,11 +1,23 @@
 package cloudfront
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the CloudFront service.
@@ -38,4 +50,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	// Invalidation operations.
 	r.Handle("POST", "/2020-05-31/distribution/{id}/invalidation", s.CreateInvalidation)
 	r.Handle("GET", "/2020-05-31/distribution/{id}/invalidation/{invalidationId}", s.GetInvalidation)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/cloudfront/storage.go
+++ b/internal/service/cloudfront/storage.go
@@ -2,11 +2,14 @@ package cloudfront
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the CloudFront storage interface.
@@ -21,19 +24,97 @@ type Storage interface {
 	ListInvalidations(ctx context.Context, distributionID, marker string, maxItems int) ([]*Invalidation, string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu            sync.RWMutex
-	distributions map[string]*Distribution
-	invalidations map[string]map[string]*Invalidation // distributionID -> invalidationID -> Invalidation
+	mu            sync.RWMutex                        `json:"-"`
+	Distributions map[string]*Distribution            `json:"distributions"`
+	Invalidations map[string]map[string]*Invalidation `json:"invalidations"` // distributionID -> invalidationID -> Invalidation
+	dataDir       string
 }
 
 // NewMemoryStorage creates a new memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		distributions: make(map[string]*Distribution),
-		invalidations: make(map[string]map[string]*Invalidation),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Distributions: make(map[string]*Distribution),
+		Invalidations: make(map[string]map[string]*Invalidation),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "cloudfront", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Distributions == nil {
+		s.Distributions = make(map[string]*Distribution)
+	}
+
+	if s.Invalidations == nil {
+		s.Invalidations = make(map[string]map[string]*Invalidation)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "cloudfront", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // Error represents a CloudFront error.
@@ -52,7 +133,7 @@ func (s *MemoryStorage) CreateDistribution(_ context.Context, config *CreateDist
 	defer s.mu.Unlock()
 
 	// Check for duplicate caller reference.
-	for _, d := range s.distributions {
+	for _, d := range s.Distributions {
 		if d.DistributionConfig != nil && d.DistributionConfig.CallerReference == config.CallerReference {
 			return nil, &Error{
 				Code:    errDistributionAlreadyExists,
@@ -90,7 +171,7 @@ func (s *MemoryStorage) CreateDistribution(_ context.Context, config *CreateDist
 		ActiveTrustedKeyGroups: &ActiveTrustedKeyGroups{Enabled: false, Quantity: 0},
 	}
 
-	s.distributions[id] = dist
+	s.Distributions[id] = dist
 
 	return dist, nil
 }
@@ -100,7 +181,7 @@ func (s *MemoryStorage) GetDistribution(_ context.Context, id string) (*Distribu
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	dist, exists := s.distributions[id]
+	dist, exists := s.Distributions[id]
 	if !exists {
 		return nil, &Error{
 			Code:    errDistributionNotFound,
@@ -120,8 +201,8 @@ func (s *MemoryStorage) ListDistributions(_ context.Context, marker string, maxI
 		maxItems = 100
 	}
 
-	dists := make([]*Distribution, 0, len(s.distributions))
-	for _, d := range s.distributions {
+	dists := make([]*Distribution, 0, len(s.Distributions))
+	for _, d := range s.Distributions {
 		dists = append(dists, d)
 	}
 
@@ -160,7 +241,7 @@ func (s *MemoryStorage) UpdateDistribution(_ context.Context, id string, config 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	dist, exists := s.distributions[id]
+	dist, exists := s.Distributions[id]
 	if !exists {
 		return nil, &Error{
 			Code:    errDistributionNotFound,
@@ -203,7 +284,7 @@ func (s *MemoryStorage) DeleteDistribution(_ context.Context, id, etag string) e
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	dist, exists := s.distributions[id]
+	dist, exists := s.Distributions[id]
 	if !exists {
 		return &Error{
 			Code:    errDistributionNotFound,
@@ -219,8 +300,8 @@ func (s *MemoryStorage) DeleteDistribution(_ context.Context, id, etag string) e
 		}
 	}
 
-	delete(s.distributions, id)
-	delete(s.invalidations, id)
+	delete(s.Distributions, id)
+	delete(s.Invalidations, id)
 
 	return nil
 }
@@ -231,7 +312,7 @@ func (s *MemoryStorage) CreateInvalidation(_ context.Context, distributionID str
 	defer s.mu.Unlock()
 
 	// Check if distribution exists.
-	if _, exists := s.distributions[distributionID]; !exists {
+	if _, exists := s.Distributions[distributionID]; !exists {
 		return nil, &Error{
 			Code:    errDistributionNotFound,
 			Message: fmt.Sprintf("The distribution with id %s does not exist", distributionID),
@@ -253,11 +334,11 @@ func (s *MemoryStorage) CreateInvalidation(_ context.Context, distributionID str
 	}
 
 	// Store invalidation.
-	if s.invalidations[distributionID] == nil {
-		s.invalidations[distributionID] = make(map[string]*Invalidation)
+	if s.Invalidations[distributionID] == nil {
+		s.Invalidations[distributionID] = make(map[string]*Invalidation)
 	}
 
-	s.invalidations[distributionID][id] = inv
+	s.Invalidations[distributionID][id] = inv
 
 	return inv, nil
 }
@@ -268,14 +349,14 @@ func (s *MemoryStorage) GetInvalidation(_ context.Context, distributionID, inval
 	defer s.mu.RUnlock()
 
 	// Check if distribution exists.
-	if _, exists := s.distributions[distributionID]; !exists {
+	if _, exists := s.Distributions[distributionID]; !exists {
 		return nil, &Error{
 			Code:    errDistributionNotFound,
 			Message: fmt.Sprintf("The distribution with id %s does not exist", distributionID),
 		}
 	}
 
-	invMap, exists := s.invalidations[distributionID]
+	invMap, exists := s.Invalidations[distributionID]
 	if !exists {
 		return nil, &Error{
 			Code:    errNoSuchInvalidation,
@@ -300,7 +381,7 @@ func (s *MemoryStorage) ListInvalidations(_ context.Context, distributionID, mar
 	defer s.mu.RUnlock()
 
 	// Check if distribution exists.
-	if _, exists := s.distributions[distributionID]; !exists {
+	if _, exists := s.Distributions[distributionID]; !exists {
 		return nil, "", &Error{
 			Code:    errDistributionNotFound,
 			Message: fmt.Sprintf("The distribution with id %s does not exist", distributionID),
@@ -311,7 +392,7 @@ func (s *MemoryStorage) ListInvalidations(_ context.Context, distributionID, mar
 		maxItems = 100
 	}
 
-	invMap := s.invalidations[distributionID]
+	invMap := s.Invalidations[distributionID]
 	if invMap == nil {
 		return []*Invalidation{}, "", nil
 	}

--- a/internal/service/cloudtrail/service.go
+++ b/internal/service/cloudtrail/service.go
@@ -2,6 +2,10 @@
 package cloudtrail
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
@@ -36,6 +40,25 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// Routes are dispatched by the server based on X-Amz-Target.
 }
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/cloudtrail/storage.go
+++ b/internal/service/cloudtrail/storage.go
@@ -2,8 +2,12 @@ package cloudtrail
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -31,21 +35,95 @@ type Storage interface {
 	GetTrailStatus(ctx context.Context, name string) (*Trail, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu        sync.RWMutex
-	trails    map[string]*Trail
+	mu        sync.RWMutex      `json:"-"`
+	Trails    map[string]*Trail `json:"trails"`
 	region    string
 	accountID string
+	dataDir   string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		trails:    make(map[string]*Trail),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Trails:    make(map[string]*Trail),
 		region:    defaultRegion,
 		accountID: defaultAccountID,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "cloudtrail", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Trails == nil {
+		m.Trails = make(map[string]*Trail)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "cloudtrail", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateTrail creates a new trail.
@@ -61,7 +139,7 @@ func (m *MemoryStorage) CreateTrail(_ context.Context, req *CreateTrailRequest) 
 		return nil, &Error{Code: errValidationError, Message: "S3 bucket name is required"}
 	}
 
-	if _, exists := m.trails[req.Name]; exists {
+	if _, exists := m.Trails[req.Name]; exists {
 		return nil, &Error{Code: errTrailAlreadyExists, Message: "Trail already exists"}
 	}
 
@@ -100,7 +178,7 @@ func (m *MemoryStorage) CreateTrail(_ context.Context, req *CreateTrailRequest) 
 		trail.IsOrganizationTrail = *req.IsOrganizationTrail
 	}
 
-	m.trails[req.Name] = trail
+	m.Trails[req.Name] = trail
 
 	return trail, nil
 }
@@ -110,11 +188,11 @@ func (m *MemoryStorage) DeleteTrail(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.trails[name]; !exists {
+	if _, exists := m.Trails[name]; !exists {
 		return &Error{Code: errTrailNotFound, Message: "Trail not found"}
 	}
 
-	delete(m.trails, name)
+	delete(m.Trails, name)
 
 	return nil
 }
@@ -124,7 +202,7 @@ func (m *MemoryStorage) GetTrail(_ context.Context, name string) (*Trail, error)
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	trail, exists := m.trails[name]
+	trail, exists := m.Trails[name]
 	if !exists {
 		return nil, &Error{Code: errTrailNotFound, Message: "Trail not found"}
 	}
@@ -139,8 +217,8 @@ func (m *MemoryStorage) DescribeTrails(_ context.Context, names []string) ([]*Tr
 
 	if len(names) == 0 {
 		// Return all trails.
-		result := make([]*Trail, 0, len(m.trails))
-		for _, trail := range m.trails {
+		result := make([]*Trail, 0, len(m.Trails))
+		for _, trail := range m.Trails {
 			result = append(result, trail)
 		}
 
@@ -151,7 +229,7 @@ func (m *MemoryStorage) DescribeTrails(_ context.Context, names []string) ([]*Tr
 	result := make([]*Trail, 0, len(names))
 
 	for _, name := range names {
-		if trail, exists := m.trails[name]; exists {
+		if trail, exists := m.Trails[name]; exists {
 			result = append(result, trail)
 		}
 	}
@@ -164,7 +242,7 @@ func (m *MemoryStorage) StartLogging(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	trail, exists := m.trails[name]
+	trail, exists := m.Trails[name]
 	if !exists {
 		return &Error{Code: errTrailNotFound, Message: "Trail not found"}
 	}
@@ -179,7 +257,7 @@ func (m *MemoryStorage) StopLogging(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	trail, exists := m.trails[name]
+	trail, exists := m.Trails[name]
 	if !exists {
 		return &Error{Code: errTrailNotFound, Message: "Trail not found"}
 	}
@@ -201,7 +279,7 @@ func (m *MemoryStorage) GetTrailStatus(_ context.Context, name string) (*Trail, 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	trail, exists := m.trails[name]
+	trail, exists := m.Trails[name]
 	if !exists {
 		return nil, &Error{Code: errTrailNotFound, Message: "Trail not found"}
 	}

--- a/internal/service/cloudwatch/service.go
+++ b/internal/service/cloudwatch/service.go
@@ -1,14 +1,25 @@
 package cloudwatch
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/sivchari/kumo/internal/server"
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage("")
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	storage := NewMemoryStorage("", opts...)
 	service.Register(New(storage))
 }
 
@@ -63,4 +74,15 @@ func (s *Service) DispatchCBORAction(w http.ResponseWriter, r *http.Request, ope
 	default:
 		server.WriteCBORError(w, "InvalidAction", "The action "+operation+" is not valid", http.StatusBadRequest)
 	}
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/cloudwatch/storage.go
+++ b/internal/service/cloudwatch/storage.go
@@ -2,12 +2,15 @@ package cloudwatch
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // defaultAccountID is the default AWS account ID used in the emulator.
@@ -24,36 +27,148 @@ type Storage interface {
 	DescribeAlarms(ctx context.Context, req *DescribeAlarmsRequest) (*DescribeAlarmsResult, error)
 }
 
-// metricKey uniquely identifies a metric.
-type metricKey struct {
-	namespace  string
-	metricName string
-	dimensions string // sorted dimension string for consistency
+// MetricKey uniquely identifies a metric.
+type MetricKey struct {
+	Namespace  string `json:"namespace"`
+	MetricName string `json:"metricName"`
+	Dimensions string `json:"dimensions"` // sorted dimension string for consistency
 }
 
-// storedMetric holds metric data in memory.
-type storedMetric struct {
-	namespace  string
-	metricName string
-	dimensions []Dimension
-	datapoints []MetricDatapoint
+// StoredMetric holds metric data in memory.
+type StoredMetric struct {
+	Namespace  string            `json:"namespace"`
+	MetricName string            `json:"metricName"`
+	Dimensions []Dimension       `json:"dimensions"`
+	Datapoints []MetricDatapoint `json:"datapoints"`
 }
+
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
 
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu      sync.RWMutex
-	metrics map[metricKey]*storedMetric
-	alarms  map[string]*Alarm
+	mu      sync.RWMutex                `json:"-"`
+	Metrics map[MetricKey]*StoredMetric `json:"metrics"`
+	Alarms  map[string]*Alarm           `json:"alarms"`
 	baseURL string
+	dataDir string
 }
 
 // NewMemoryStorage creates a new in-memory CloudWatch storage.
-func NewMemoryStorage(baseURL string) *MemoryStorage {
-	return &MemoryStorage{
-		metrics: make(map[metricKey]*storedMetric),
-		alarms:  make(map[string]*Alarm),
+func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Metrics: make(map[MetricKey]*StoredMetric),
+		Alarms:  make(map[string]*Alarm),
 		baseURL: baseURL,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "monitoring", s)
+	}
+
+	return s
+}
+
+// metricKeyToString converts a MetricKey to a string for JSON map keys.
+func metricKeyToString(k MetricKey) string {
+	return k.Namespace + "|" + k.MetricName + "|" + k.Dimensions
+}
+
+// stringToMetricKey converts a string back to a MetricKey.
+func stringToMetricKey(s string) MetricKey {
+	parts := strings.SplitN(s, "|", 3)
+	if len(parts) != 3 {
+		return MetricKey{}
+	}
+
+	return MetricKey{
+		Namespace:  parts[0],
+		MetricName: parts[1],
+		Dimensions: parts[2],
+	}
+}
+
+// marshalableStorage is a JSON-serializable representation of MemoryStorage.
+type marshalableStorage struct {
+	Metrics map[string]*StoredMetric `json:"metrics"`
+	Alarms  map[string]*Alarm        `json:"alarms"`
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	m := &marshalableStorage{
+		Metrics: make(map[string]*StoredMetric, len(s.Metrics)),
+		Alarms:  s.Alarms,
+	}
+
+	for k, v := range s.Metrics {
+		m.Metrics[metricKeyToString(k)] = v
+	}
+
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var m marshalableStorage
+
+	if err := json.Unmarshal(data, &m); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	s.Metrics = make(map[MetricKey]*StoredMetric, len(m.Metrics))
+
+	for k, v := range m.Metrics {
+		s.Metrics[stringToMetricKey(k)] = v
+	}
+
+	s.Alarms = m.Alarms
+
+	if s.Alarms == nil {
+		s.Alarms = make(map[string]*Alarm)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "monitoring", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // PutMetricData stores metric data.
@@ -65,15 +180,15 @@ func (s *MemoryStorage) PutMetricData(_ context.Context, namespace string, metri
 		datum := &metricData[i]
 		key := s.makeMetricKey(namespace, datum.MetricName, datum.Dimensions)
 
-		metric, exists := s.metrics[key]
+		metric, exists := s.Metrics[key]
 		if !exists {
-			metric = &storedMetric{
-				namespace:  namespace,
-				metricName: datum.MetricName,
-				dimensions: datum.Dimensions,
-				datapoints: make([]MetricDatapoint, 0),
+			metric = &StoredMetric{
+				Namespace:  namespace,
+				MetricName: datum.MetricName,
+				Dimensions: datum.Dimensions,
+				Datapoints: make([]MetricDatapoint, 0),
 			}
-			s.metrics[key] = metric
+			s.Metrics[key] = metric
 		}
 
 		timestamp := datum.Timestamp
@@ -88,23 +203,23 @@ func (s *MemoryStorage) PutMetricData(_ context.Context, namespace string, metri
 }
 
 // appendDatapoints adds datapoints to the metric based on the datum type.
-func (s *MemoryStorage) appendDatapoints(metric *storedMetric, datum *MetricDatum, timestamp string) {
+func (s *MemoryStorage) appendDatapoints(metric *StoredMetric, datum *MetricDatum, timestamp string) {
 	switch {
 	case datum.Value != nil:
-		metric.datapoints = append(metric.datapoints, MetricDatapoint{
+		metric.Datapoints = append(metric.Datapoints, MetricDatapoint{
 			Timestamp: timestamp,
 			Value:     *datum.Value,
 			Unit:      datum.Unit,
 		})
 	case datum.StatisticValues != nil:
-		metric.datapoints = append(metric.datapoints, MetricDatapoint{
+		metric.Datapoints = append(metric.Datapoints, MetricDatapoint{
 			Timestamp: timestamp,
 			Value:     datum.StatisticValues.Sum / datum.StatisticValues.SampleCount,
 			Unit:      datum.Unit,
 		})
 	case len(datum.Values) > 0:
 		for _, v := range datum.Values {
-			metric.datapoints = append(metric.datapoints, MetricDatapoint{
+			metric.Datapoints = append(metric.Datapoints, MetricDatapoint{
 				Timestamp: timestamp,
 				Value:     v,
 				Unit:      datum.Unit,
@@ -131,7 +246,7 @@ func (s *MemoryStorage) GetMetricData(_ context.Context, req *GetMetricDataReque
 			query.MetricStat.Metric.Dimensions,
 		)
 
-		metric, exists := s.metrics[key]
+		metric, exists := s.Metrics[key]
 		if !exists {
 			results = append(results, MetricDataResult{
 				ID:         query.ID,
@@ -146,7 +261,7 @@ func (s *MemoryStorage) GetMetricData(_ context.Context, req *GetMetricDataReque
 		timestamps := make([]string, 0)
 		values := make([]float64, 0)
 
-		for _, dp := range metric.datapoints {
+		for _, dp := range metric.Datapoints {
 			if s.isInTimeRange(dp.Timestamp, req.StartTime, req.EndTime) {
 				timestamps = append(timestamps, dp.Timestamp)
 				values = append(values, dp.Value)
@@ -179,7 +294,7 @@ func (s *MemoryStorage) GetMetricStatistics(_ context.Context, req *GetMetricSta
 
 	key := s.makeMetricKey(req.Namespace, req.MetricName, req.Dimensions)
 
-	metric, exists := s.metrics[key]
+	metric, exists := s.Metrics[key]
 	if !exists {
 		return &GetMetricStatisticsResult{
 			Label:      req.MetricName,
@@ -190,7 +305,7 @@ func (s *MemoryStorage) GetMetricStatistics(_ context.Context, req *GetMetricSta
 	// Collect datapoints in time range.
 	var filteredPoints []MetricDatapoint
 
-	for _, dp := range metric.datapoints {
+	for _, dp := range metric.Datapoints {
 		if s.isInTimeRange(dp.Timestamp, req.StartTime, req.EndTime) {
 			filteredPoints = append(filteredPoints, dp)
 		}
@@ -219,26 +334,26 @@ func (s *MemoryStorage) ListMetrics(_ context.Context, req *ListMetricsRequest) 
 
 	metrics := make([]Metric, 0)
 
-	for _, m := range s.metrics {
+	for _, m := range s.Metrics {
 		// Filter by namespace.
-		if req.Namespace != "" && m.namespace != req.Namespace {
+		if req.Namespace != "" && m.Namespace != req.Namespace {
 			continue
 		}
 
 		// Filter by metric name.
-		if req.MetricName != "" && m.metricName != req.MetricName {
+		if req.MetricName != "" && m.MetricName != req.MetricName {
 			continue
 		}
 
 		// Filter by dimensions.
-		if !s.matchesDimensionFilters(m.dimensions, req.Dimensions) {
+		if !s.matchesDimensionFilters(m.Dimensions, req.Dimensions) {
 			continue
 		}
 
 		metrics = append(metrics, Metric{
-			Namespace:  m.namespace,
-			MetricName: m.metricName,
-			Dimensions: m.dimensions,
+			Namespace:  m.Namespace,
+			MetricName: m.MetricName,
+			Dimensions: m.Dimensions,
 		})
 	}
 
@@ -298,7 +413,7 @@ func (s *MemoryStorage) PutMetricAlarm(_ context.Context, req *PutMetricAlarmReq
 		CreatedAt:          now,
 	}
 
-	s.alarms[req.AlarmName] = alarm
+	s.Alarms[req.AlarmName] = alarm
 
 	return nil
 }
@@ -309,7 +424,7 @@ func (s *MemoryStorage) DeleteAlarms(_ context.Context, alarmNames []string) err
 	defer s.mu.Unlock()
 
 	for _, name := range alarmNames {
-		if _, exists := s.alarms[name]; !exists {
+		if _, exists := s.Alarms[name]; !exists {
 			return &Error{
 				Code:    "ResourceNotFound",
 				Message: fmt.Sprintf("Alarm %s does not exist", name),
@@ -318,7 +433,7 @@ func (s *MemoryStorage) DeleteAlarms(_ context.Context, alarmNames []string) err
 	}
 
 	for _, name := range alarmNames {
-		delete(s.alarms, name)
+		delete(s.Alarms, name)
 	}
 
 	return nil
@@ -331,7 +446,7 @@ func (s *MemoryStorage) DescribeAlarms(_ context.Context, req *DescribeAlarmsReq
 
 	alarms := make([]MetricAlarm, 0)
 
-	for _, alarm := range s.alarms {
+	for _, alarm := range s.Alarms {
 		if !s.alarmMatchesFilter(alarm, req) {
 			continue
 		}
@@ -401,7 +516,7 @@ func convertAlarmToJSON(alarm *Alarm) MetricAlarm {
 }
 
 // makeMetricKey creates a unique key for a metric.
-func (s *MemoryStorage) makeMetricKey(namespace, metricName string, dimensions []Dimension) metricKey {
+func (s *MemoryStorage) makeMetricKey(namespace, metricName string, dimensions []Dimension) MetricKey {
 	// Sort dimensions for consistent key generation.
 	sorted := make([]Dimension, len(dimensions))
 	copy(sorted, dimensions)
@@ -415,10 +530,10 @@ func (s *MemoryStorage) makeMetricKey(namespace, metricName string, dimensions [
 		dimParts = append(dimParts, fmt.Sprintf("%s=%s", d.Name, d.Value))
 	}
 
-	return metricKey{
-		namespace:  namespace,
-		metricName: metricName,
-		dimensions: strings.Join(dimParts, ","),
+	return MetricKey{
+		Namespace:  namespace,
+		MetricName: metricName,
+		Dimensions: strings.Join(dimParts, ","),
 	}
 }
 

--- a/internal/service/cloudwatchlogs/service.go
+++ b/internal/service/cloudwatchlogs/service.go
@@ -1,13 +1,25 @@
 package cloudwatchlogs
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
 const defaultBaseURL = "http://localhost:4566"
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage(defaultBaseURL), defaultBaseURL))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(defaultBaseURL, opts...), defaultBaseURL))
 }
 
 // Service implements the CloudWatch Logs service.
@@ -43,3 +55,14 @@ func (s *Service) TargetPrefix() string {
 
 // JSONProtocol is a marker method that indicates CloudWatch Logs uses AWS JSON 1.1 protocol.
 func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/cloudwatchlogs/storage.go
+++ b/internal/service/cloudwatchlogs/storage.go
@@ -2,6 +2,7 @@ package cloudwatchlogs
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
@@ -10,6 +11,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -32,31 +35,105 @@ type Storage interface {
 	DescribeLogStreams(ctx context.Context, req *DescribeLogStreamsRequest) (*DescribeLogStreamsResponse, error)
 }
 
-// logStreamData holds log stream data with events.
-type logStreamData struct {
-	stream *LogStream
-	events []*LogEvent
+// LogStreamData holds log stream data with events.
+type LogStreamData struct {
+	Stream *LogStream  `json:"stream"`
+	Events []*LogEvent `json:"events"`
 }
 
-// logGroupData holds log group data with streams.
-type logGroupData struct {
-	group   *LogGroup
-	streams map[string]*logStreamData
+// LogGroupData holds log group data with streams.
+type LogGroupData struct {
+	Group   *LogGroup                 `json:"group"`
+	Streams map[string]*LogStreamData `json:"streams"`
 }
+
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
 
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu        sync.RWMutex
-	logGroups map[string]*logGroupData
+	mu        sync.RWMutex             `json:"-"`
+	LogGroups map[string]*LogGroupData `json:"logGroups"`
 	baseURL   string
+	dataDir   string
 }
 
 // NewMemoryStorage creates a new in-memory CloudWatch Logs storage.
-func NewMemoryStorage(baseURL string) *MemoryStorage {
-	return &MemoryStorage{
-		logGroups: make(map[string]*logGroupData),
+func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		LogGroups: make(map[string]*LogGroupData),
 		baseURL:   baseURL,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "logs", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.LogGroups == nil {
+		m.LogGroups = make(map[string]*LogGroupData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "logs", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateLogGroup creates a new log group.
@@ -64,7 +141,7 @@ func (m *MemoryStorage) CreateLogGroup(_ context.Context, req *CreateLogGroupReq
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.logGroups[req.LogGroupName]; exists {
+	if _, exists := m.LogGroups[req.LogGroupName]; exists {
 		return &LogsError{
 			Code:    "ResourceAlreadyExistsException",
 			Message: fmt.Sprintf("The specified log group already exists: %s", req.LogGroupName),
@@ -80,9 +157,9 @@ func (m *MemoryStorage) CreateLogGroup(_ context.Context, req *CreateLogGroupReq
 		LogGroupClass: req.LogGroupClass,
 	}
 
-	m.logGroups[req.LogGroupName] = &logGroupData{
-		group:   logGroup,
-		streams: make(map[string]*logStreamData),
+	m.LogGroups[req.LogGroupName] = &LogGroupData{
+		Group:   logGroup,
+		Streams: make(map[string]*LogStreamData),
 	}
 
 	return nil
@@ -93,14 +170,14 @@ func (m *MemoryStorage) DeleteLogGroup(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.logGroups[name]; !exists {
+	if _, exists := m.LogGroups[name]; !exists {
 		return &LogsError{
 			Code:    "ResourceNotFoundException",
 			Message: fmt.Sprintf("The specified log group does not exist: %s", name),
 		}
 	}
 
-	delete(m.logGroups, name)
+	delete(m.LogGroups, name)
 
 	return nil
 }
@@ -110,7 +187,7 @@ func (m *MemoryStorage) CreateLogStream(_ context.Context, groupName, streamName
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	groupData, exists := m.logGroups[groupName]
+	groupData, exists := m.LogGroups[groupName]
 	if !exists {
 		return &LogsError{
 			Code:    "ResourceNotFoundException",
@@ -118,7 +195,7 @@ func (m *MemoryStorage) CreateLogStream(_ context.Context, groupName, streamName
 		}
 	}
 
-	if _, exists := groupData.streams[streamName]; exists {
+	if _, exists := groupData.Streams[streamName]; exists {
 		return &LogsError{
 			Code:    "ResourceAlreadyExistsException",
 			Message: fmt.Sprintf("The specified log stream already exists: %s", streamName),
@@ -133,9 +210,9 @@ func (m *MemoryStorage) CreateLogStream(_ context.Context, groupName, streamName
 		LogStreamARN:        m.buildLogStreamARN(groupName, streamName),
 	}
 
-	groupData.streams[streamName] = &logStreamData{
-		stream: stream,
-		events: make([]*LogEvent, 0),
+	groupData.Streams[streamName] = &LogStreamData{
+		Stream: stream,
+		Events: make([]*LogEvent, 0),
 	}
 
 	return nil
@@ -146,7 +223,7 @@ func (m *MemoryStorage) DeleteLogStream(_ context.Context, groupName, streamName
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	groupData, exists := m.logGroups[groupName]
+	groupData, exists := m.LogGroups[groupName]
 	if !exists {
 		return &LogsError{
 			Code:    "ResourceNotFoundException",
@@ -154,14 +231,14 @@ func (m *MemoryStorage) DeleteLogStream(_ context.Context, groupName, streamName
 		}
 	}
 
-	if _, exists := groupData.streams[streamName]; !exists {
+	if _, exists := groupData.Streams[streamName]; !exists {
 		return &LogsError{
 			Code:    "ResourceNotFoundException",
 			Message: fmt.Sprintf("The specified log stream does not exist: %s", streamName),
 		}
 	}
 
-	delete(groupData.streams, streamName)
+	delete(groupData.Streams, streamName)
 
 	return nil
 }
@@ -171,7 +248,7 @@ func (m *MemoryStorage) PutLogEvents(_ context.Context, groupName, streamName st
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	groupData, exists := m.logGroups[groupName]
+	groupData, exists := m.LogGroups[groupName]
 	if !exists {
 		return nil, &LogsError{
 			Code:    "ResourceNotFoundException",
@@ -179,7 +256,7 @@ func (m *MemoryStorage) PutLogEvents(_ context.Context, groupName, streamName st
 		}
 	}
 
-	streamData, exists := groupData.streams[streamName]
+	streamData, exists := groupData.Streams[streamName]
 	if !exists {
 		return nil, &LogsError{
 			Code:    "ResourceNotFoundException",
@@ -194,24 +271,24 @@ func (m *MemoryStorage) PutLogEvents(_ context.Context, groupName, streamName st
 			Timestamp: event.Timestamp,
 			Message:   event.Message,
 		}
-		streamData.events = append(streamData.events, logEvent)
+		streamData.Events = append(streamData.Events, logEvent)
 
 		// Update stream timestamps
-		if streamData.stream.FirstEventTimestamp == nil {
-			streamData.stream.FirstEventTimestamp = &event.Timestamp
+		if streamData.Stream.FirstEventTimestamp == nil {
+			streamData.Stream.FirstEventTimestamp = &event.Timestamp
 		}
 
-		streamData.stream.LastEventTimestamp = &event.Timestamp
-		streamData.stream.LastIngestionTime = &now
-		streamData.stream.StoredBytes += int64(len(event.Message))
+		streamData.Stream.LastEventTimestamp = &event.Timestamp
+		streamData.Stream.LastIngestionTime = &now
+		streamData.Stream.StoredBytes += int64(len(event.Message))
 	}
 
 	// Update group stored bytes
-	groupData.group.StoredBytes += sumEventBytes(events)
+	groupData.Group.StoredBytes += sumEventBytes(events)
 
 	// Generate new sequence token
 	newToken := uuid.New().String()
-	streamData.stream.UploadSequenceToken = newToken
+	streamData.Stream.UploadSequenceToken = newToken
 
 	return &PutLogEventsResponse{
 		NextSequenceToken: newToken,
@@ -223,7 +300,7 @@ func (m *MemoryStorage) GetLogEvents(_ context.Context, req *GetLogEventsRequest
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	groupData, exists := m.logGroups[req.LogGroupName]
+	groupData, exists := m.LogGroups[req.LogGroupName]
 	if !exists {
 		return nil, &LogsError{
 			Code:    "ResourceNotFoundException",
@@ -231,7 +308,7 @@ func (m *MemoryStorage) GetLogEvents(_ context.Context, req *GetLogEventsRequest
 		}
 	}
 
-	streamData, exists := groupData.streams[req.LogStreamName]
+	streamData, exists := groupData.Streams[req.LogStreamName]
 	if !exists {
 		return nil, &LogsError{
 			Code:    "ResourceNotFoundException",
@@ -245,7 +322,7 @@ func (m *MemoryStorage) GetLogEvents(_ context.Context, req *GetLogEventsRequest
 	}
 
 	// Filter events by time range
-	filteredEvents := filterEventsByTime(streamData.events, req.StartTime, req.EndTime)
+	filteredEvents := filterEventsByTime(streamData.Events, req.StartTime, req.EndTime)
 
 	// Sort events
 	startFromHead := req.StartFromHead != nil && *req.StartFromHead
@@ -293,7 +370,7 @@ func (m *MemoryStorage) FilterLogEvents(_ context.Context, req *FilterLogEventsR
 		groupName = req.LogGroupIdentifier
 	}
 
-	groupData, exists := m.logGroups[groupName]
+	groupData, exists := m.LogGroups[groupName]
 	if !exists {
 		return nil, &LogsError{
 			Code:    "ResourceNotFoundException",
@@ -321,12 +398,12 @@ func (m *MemoryStorage) FilterLogEvents(_ context.Context, req *FilterLogEventsR
 }
 
 // filterEventsFromStreams filters events from log streams based on request criteria.
-func (m *MemoryStorage) filterEventsFromStreams(groupData *logGroupData, req *FilterLogEventsRequest) ([]FilteredLogEvent, []SearchedLogStream) {
+func (m *MemoryStorage) filterEventsFromStreams(groupData *LogGroupData, req *FilterLogEventsRequest) ([]FilteredLogEvent, []SearchedLogStream) {
 	var allEvents []FilteredLogEvent
 
 	var searchedStreams []SearchedLogStream
 
-	for streamName, streamData := range groupData.streams {
+	for streamName, streamData := range groupData.Streams {
 		if !m.shouldIncludeStream(streamName, req.LogStreamNames, req.LogStreamNamePrefix) {
 			continue
 		}
@@ -336,7 +413,7 @@ func (m *MemoryStorage) filterEventsFromStreams(groupData *logGroupData, req *Fi
 			SearchedCompletely: true,
 		})
 
-		events := m.filterStreamEvents(streamName, streamData.events, req)
+		events := m.filterStreamEvents(streamName, streamData.Events, req)
 		allEvents = append(allEvents, events...)
 	}
 
@@ -428,12 +505,12 @@ func (m *MemoryStorage) DescribeLogGroups(_ context.Context, req *DescribeLogGro
 func (m *MemoryStorage) filterLogGroups(req *DescribeLogGroupsRequest) []LogGroupResponse {
 	var groups []LogGroupResponse
 
-	for name, groupData := range m.logGroups {
-		if !m.matchLogGroupFilters(name, groupData.group, req) {
+	for name, groupData := range m.LogGroups {
+		if !m.matchLogGroupFilters(name, groupData.Group, req) {
 			continue
 		}
 
-		groups = append(groups, buildLogGroupResponse(groupData.group))
+		groups = append(groups, buildLogGroupResponse(groupData.Group))
 	}
 
 	return groups
@@ -510,7 +587,7 @@ func (m *MemoryStorage) DescribeLogStreams(_ context.Context, req *DescribeLogSt
 		groupName = req.LogGroupIdentifier
 	}
 
-	groupData, exists := m.logGroups[groupName]
+	groupData, exists := m.LogGroups[groupName]
 	if !exists {
 		return nil, &LogsError{
 			Code:    "ResourceNotFoundException",
@@ -530,15 +607,15 @@ func (m *MemoryStorage) DescribeLogStreams(_ context.Context, req *DescribeLogSt
 }
 
 // filterLogStreams filters log streams based on prefix.
-func (m *MemoryStorage) filterLogStreams(groupData *logGroupData, prefix string) []LogStreamResponse {
+func (m *MemoryStorage) filterLogStreams(groupData *LogGroupData, prefix string) []LogStreamResponse {
 	var streams []LogStreamResponse
 
-	for name, streamData := range groupData.streams {
+	for name, streamData := range groupData.Streams {
 		if prefix != "" && !strings.HasPrefix(name, prefix) {
 			continue
 		}
 
-		streams = append(streams, buildLogStreamResponse(streamData.stream))
+		streams = append(streams, buildLogStreamResponse(streamData.Stream))
 	}
 
 	return streams

--- a/internal/service/codeconnections/service.go
+++ b/internal/service/codeconnections/service.go
@@ -1,6 +1,10 @@
 package codeconnections
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
@@ -34,6 +38,25 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// JSON protocol services use DispatchAction for routing
 }
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/codeconnections/storage.go
+++ b/internal/service/codeconnections/storage.go
@@ -2,11 +2,14 @@ package codeconnections
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes for CodeConnections.
@@ -43,25 +46,107 @@ type Storage interface {
 	UntagResource(ctx context.Context, resourceArn string, tagKeys []string) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu              sync.RWMutex
-	connections     map[string]*Connection
-	hosts           map[string]*Host
-	repositoryLinks map[string]*RepositoryLink
+	mu              sync.RWMutex               `json:"-"`
+	Connections     map[string]*Connection     `json:"connections"`
+	Hosts           map[string]*Host           `json:"hosts"`
+	RepositoryLinks map[string]*RepositoryLink `json:"repositoryLinks"`
 	accountID       string
 	region          string
+	dataDir         string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		connections:     make(map[string]*Connection),
-		hosts:           make(map[string]*Host),
-		repositoryLinks: make(map[string]*RepositoryLink),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Connections:     make(map[string]*Connection),
+		Hosts:           make(map[string]*Host),
+		RepositoryLinks: make(map[string]*RepositoryLink),
 		accountID:       "000000000000",
 		region:          "us-east-1",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "codeconnections", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Connections == nil {
+		s.Connections = make(map[string]*Connection)
+	}
+
+	if s.Hosts == nil {
+		s.Hosts = make(map[string]*Host)
+	}
+
+	if s.RepositoryLinks == nil {
+		s.RepositoryLinks = make(map[string]*RepositoryLink)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "codeconnections", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateConnection creates a new connection.
@@ -88,7 +173,7 @@ func (s *MemoryStorage) CreateConnection(_ context.Context, name, providerType, 
 		Tags:             tagMap,
 	}
 
-	s.connections[connectionArn] = conn
+	s.Connections[connectionArn] = conn
 
 	return conn, nil
 }
@@ -98,7 +183,7 @@ func (s *MemoryStorage) GetConnection(_ context.Context, connectionArn string) (
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	conn, ok := s.connections[connectionArn]
+	conn, ok := s.Connections[connectionArn]
 	if !ok {
 		return nil, &ServiceError{
 			Code:    errResourceNotFoundException,
@@ -114,14 +199,14 @@ func (s *MemoryStorage) DeleteConnection(_ context.Context, connectionArn string
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.connections[connectionArn]; !ok {
+	if _, ok := s.Connections[connectionArn]; !ok {
 		return &ServiceError{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Connection %s not found.", connectionArn),
 		}
 	}
 
-	delete(s.connections, connectionArn)
+	delete(s.Connections, connectionArn)
 
 	return nil
 }
@@ -137,7 +222,7 @@ func (s *MemoryStorage) ListConnections(_ context.Context, providerTypeFilter, h
 
 	connections := make([]*Connection, 0)
 
-	for _, conn := range s.connections {
+	for _, conn := range s.Connections {
 		if providerTypeFilter != "" && string(conn.ProviderType) != providerTypeFilter {
 			continue
 		}
@@ -180,7 +265,7 @@ func (s *MemoryStorage) CreateHost(_ context.Context, name, providerType, provid
 		Tags:             tagMap,
 	}
 
-	s.hosts[hostArn] = host
+	s.Hosts[hostArn] = host
 
 	return host, nil
 }
@@ -190,7 +275,7 @@ func (s *MemoryStorage) GetHost(_ context.Context, hostArn string) (*Host, error
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	host, ok := s.hosts[hostArn]
+	host, ok := s.Hosts[hostArn]
 	if !ok {
 		return nil, &ServiceError{
 			Code:    errResourceNotFoundException,
@@ -206,7 +291,7 @@ func (s *MemoryStorage) DeleteHost(_ context.Context, hostArn string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.hosts[hostArn]; !ok {
+	if _, ok := s.Hosts[hostArn]; !ok {
 		return &ServiceError{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Host %s not found.", hostArn),
@@ -214,7 +299,7 @@ func (s *MemoryStorage) DeleteHost(_ context.Context, hostArn string) error {
 	}
 
 	// Check if any connection uses this host
-	for _, conn := range s.connections {
+	for _, conn := range s.Connections {
 		if conn.HostArn == hostArn {
 			return &ServiceError{
 				Code:    errConflictException,
@@ -223,7 +308,7 @@ func (s *MemoryStorage) DeleteHost(_ context.Context, hostArn string) error {
 		}
 	}
 
-	delete(s.hosts, hostArn)
+	delete(s.Hosts, hostArn)
 
 	return nil
 }
@@ -239,7 +324,7 @@ func (s *MemoryStorage) ListHosts(_ context.Context, _ string, maxResults int32)
 
 	hosts := make([]*Host, 0)
 
-	for _, host := range s.hosts {
+	for _, host := range s.Hosts {
 		hosts = append(hosts, host)
 
 		if len(hosts) >= int(maxResults) {
@@ -255,7 +340,7 @@ func (s *MemoryStorage) UpdateHost(_ context.Context, hostArn, providerEndpoint 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	host, ok := s.hosts[hostArn]
+	host, ok := s.Hosts[hostArn]
 	if !ok {
 		return &ServiceError{
 			Code:    errResourceNotFoundException,
@@ -280,7 +365,7 @@ func (s *MemoryStorage) CreateRepositoryLink(_ context.Context, connectionArn, o
 	defer s.mu.Unlock()
 
 	// Verify connection exists
-	conn, ok := s.connections[connectionArn]
+	conn, ok := s.Connections[connectionArn]
 	if !ok {
 		return nil, &ServiceError{
 			Code:    errResourceNotFoundException,
@@ -308,7 +393,7 @@ func (s *MemoryStorage) CreateRepositoryLink(_ context.Context, connectionArn, o
 		Tags:              tagMap,
 	}
 
-	s.repositoryLinks[repositoryLinkID] = repoLink
+	s.RepositoryLinks[repositoryLinkID] = repoLink
 
 	return repoLink, nil
 }
@@ -318,7 +403,7 @@ func (s *MemoryStorage) GetRepositoryLink(_ context.Context, repositoryLinkID st
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	repoLink, ok := s.repositoryLinks[repositoryLinkID]
+	repoLink, ok := s.RepositoryLinks[repositoryLinkID]
 	if !ok {
 		return nil, &ServiceError{
 			Code:    errResourceNotFoundException,
@@ -334,14 +419,14 @@ func (s *MemoryStorage) DeleteRepositoryLink(_ context.Context, repositoryLinkID
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.repositoryLinks[repositoryLinkID]; !ok {
+	if _, ok := s.RepositoryLinks[repositoryLinkID]; !ok {
 		return &ServiceError{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("RepositoryLink %s not found.", repositoryLinkID),
 		}
 	}
 
-	delete(s.repositoryLinks, repositoryLinkID)
+	delete(s.RepositoryLinks, repositoryLinkID)
 
 	return nil
 }
@@ -357,7 +442,7 @@ func (s *MemoryStorage) ListRepositoryLinks(_ context.Context, _ string, maxResu
 
 	links := make([]*RepositoryLink, 0)
 
-	for _, link := range s.repositoryLinks {
+	for _, link := range s.RepositoryLinks {
 		links = append(links, link)
 
 		if len(links) >= int(maxResults) {
@@ -373,7 +458,7 @@ func (s *MemoryStorage) UpdateRepositoryLink(_ context.Context, repositoryLinkID
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	repoLink, ok := s.repositoryLinks[repositoryLinkID]
+	repoLink, ok := s.RepositoryLinks[repositoryLinkID]
 	if !ok {
 		return nil, &ServiceError{
 			Code:    errResourceNotFoundException,
@@ -383,7 +468,7 @@ func (s *MemoryStorage) UpdateRepositoryLink(_ context.Context, repositoryLinkID
 
 	if connectionArn != "" {
 		// Verify new connection exists
-		conn, ok := s.connections[connectionArn]
+		conn, ok := s.Connections[connectionArn]
 		if !ok {
 			return nil, &ServiceError{
 				Code:    errResourceNotFoundException,
@@ -410,13 +495,13 @@ func (s *MemoryStorage) ListTagsForResource(_ context.Context, resourceArn strin
 	var tagMap map[string]string
 
 	// Check connections
-	if conn, ok := s.connections[resourceArn]; ok {
+	if conn, ok := s.Connections[resourceArn]; ok {
 		tagMap = conn.Tags
-	} else if host, ok := s.hosts[resourceArn]; ok {
+	} else if host, ok := s.Hosts[resourceArn]; ok {
 		tagMap = host.Tags
 	} else {
 		// Check repository links by ARN
-		for _, link := range s.repositoryLinks {
+		for _, link := range s.RepositoryLinks {
 			if link.RepositoryLinkArn == resourceArn {
 				tagMap = link.Tags
 
@@ -448,13 +533,13 @@ func (s *MemoryStorage) TagResource(_ context.Context, resourceArn string, tags 
 	var tagMap map[string]string
 
 	// Check connections
-	if conn, ok := s.connections[resourceArn]; ok {
+	if conn, ok := s.Connections[resourceArn]; ok {
 		tagMap = conn.Tags
-	} else if host, ok := s.hosts[resourceArn]; ok {
+	} else if host, ok := s.Hosts[resourceArn]; ok {
 		tagMap = host.Tags
 	} else {
 		// Check repository links by ARN
-		for _, link := range s.repositoryLinks {
+		for _, link := range s.RepositoryLinks {
 			if link.RepositoryLinkArn == resourceArn {
 				tagMap = link.Tags
 
@@ -485,13 +570,13 @@ func (s *MemoryStorage) UntagResource(_ context.Context, resourceArn string, tag
 	var tagMap map[string]string
 
 	// Check connections
-	if conn, ok := s.connections[resourceArn]; ok {
+	if conn, ok := s.Connections[resourceArn]; ok {
 		tagMap = conn.Tags
-	} else if host, ok := s.hosts[resourceArn]; ok {
+	} else if host, ok := s.Hosts[resourceArn]; ok {
 		tagMap = host.Tags
 	} else {
 		// Check repository links by ARN
-		for _, link := range s.repositoryLinks {
+		for _, link := range s.RepositoryLinks {
 			if link.RepositoryLinkArn == resourceArn {
 				tagMap = link.Tags
 

--- a/internal/service/codeguruprofiler/service.go
+++ b/internal/service/codeguruprofiler/service.go
@@ -1,11 +1,23 @@
 package codeguruprofiler
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage()
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	storage := NewMemoryStorage(opts...)
 	service.Register(New(storage))
 }
 
@@ -38,4 +50,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("GET", "/profilingGroups/{profilingGroupName}", s.DescribeProfilingGroup)
 	r.Handle("PUT", "/profilingGroups/{profilingGroupName}", s.UpdateProfilingGroup)
 	r.Handle("DELETE", "/profilingGroups/{profilingGroupName}", s.DeleteProfilingGroup)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/codeguruprofiler/storage.go
+++ b/internal/service/codeguruprofiler/storage.go
@@ -1,11 +1,14 @@
 package codeguruprofiler
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the interface for CodeGuru Profiler storage operations.
@@ -17,17 +20,91 @@ type Storage interface {
 	ListProfilingGroups() []ProfilingGroup
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage is an in-memory implementation of Storage.
 type MemoryStorage struct {
-	mu     sync.RWMutex
-	groups map[string]*ProfilingGroup
+	mu      sync.RWMutex               `json:"-"`
+	Groups  map[string]*ProfilingGroup `json:"groups"`
+	dataDir string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		groups: make(map[string]*ProfilingGroup),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Groups: make(map[string]*ProfilingGroup),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "codeguru-profiler", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Groups == nil {
+		m.Groups = make(map[string]*ProfilingGroup)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "codeguru-profiler", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateProfilingGroup creates a new profiling group.
@@ -60,7 +137,7 @@ func (m *MemoryStorage) CreateProfilingGroup(input *CreateProfilingGroupInput) *
 		}
 	}
 
-	m.groups[input.ProfilingGroupName] = group
+	m.Groups[input.ProfilingGroupName] = group
 
 	return group
 }
@@ -70,7 +147,7 @@ func (m *MemoryStorage) DescribeProfilingGroup(name string) (*ProfilingGroup, er
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	group, ok := m.groups[name]
+	group, ok := m.Groups[name]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: profiling group %s not found", name)
 	}
@@ -83,7 +160,7 @@ func (m *MemoryStorage) UpdateProfilingGroup(name string, input *UpdateProfiling
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	group, ok := m.groups[name]
+	group, ok := m.Groups[name]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: profiling group %s not found", name)
 	}
@@ -102,11 +179,11 @@ func (m *MemoryStorage) DeleteProfilingGroup(name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.groups[name]; !ok {
+	if _, ok := m.Groups[name]; !ok {
 		return fmt.Errorf("ResourceNotFoundException: profiling group %s not found", name)
 	}
 
-	delete(m.groups, name)
+	delete(m.Groups, name)
 
 	return nil
 }
@@ -116,8 +193,8 @@ func (m *MemoryStorage) ListProfilingGroups() []ProfilingGroup {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]ProfilingGroup, 0, len(m.groups))
-	for _, group := range m.groups {
+	result := make([]ProfilingGroup, 0, len(m.Groups))
+	for _, group := range m.Groups {
 		result = append(result, *group)
 	}
 

--- a/internal/service/codegurureviewer/service.go
+++ b/internal/service/codegurureviewer/service.go
@@ -1,11 +1,23 @@
 package codegurureviewer
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage()
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	storage := NewMemoryStorage(opts...)
 	service.Register(New(storage))
 }
 
@@ -49,4 +61,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("PUT", "/feedback", s.PutRecommendationFeedback)
 	r.Handle("GET", "/feedback/{CodeReviewArn}", s.DescribeRecommendationFeedback)
 	r.Handle("GET", "/feedback/{CodeReviewArn}/RecommendationFeedback", s.ListRecommendationFeedback)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/codegurureviewer/storage.go
+++ b/internal/service/codegurureviewer/storage.go
@@ -1,11 +1,14 @@
 package codegurureviewer
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 func epochNow() float64 {
@@ -30,21 +33,103 @@ type Storage interface {
 	ListRecommendationFeedback(codeReviewArn string) []RecommendationFeedback
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage is an in-memory implementation of Storage.
 type MemoryStorage struct {
-	mu           sync.RWMutex
-	associations map[string]*RepositoryAssociation
-	codeReviews  map[string]*CodeReview
-	feedback     map[string]map[string]*RecommendationFeedback // codeReviewArn -> recommendationID -> feedback
+	mu           sync.RWMutex                                  `json:"-"`
+	Associations map[string]*RepositoryAssociation             `json:"associations"`
+	CodeReviews  map[string]*CodeReview                        `json:"codeReviews"`
+	Feedback     map[string]map[string]*RecommendationFeedback `json:"feedback"` // codeReviewArn -> recommendationID -> feedback
+	dataDir      string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		associations: make(map[string]*RepositoryAssociation),
-		codeReviews:  make(map[string]*CodeReview),
-		feedback:     make(map[string]map[string]*RecommendationFeedback),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Associations: make(map[string]*RepositoryAssociation),
+		CodeReviews:  make(map[string]*CodeReview),
+		Feedback:     make(map[string]map[string]*RecommendationFeedback),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "codeguru-reviewer", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Associations == nil {
+		m.Associations = make(map[string]*RepositoryAssociation)
+	}
+
+	if m.CodeReviews == nil {
+		m.CodeReviews = make(map[string]*CodeReview)
+	}
+
+	if m.Feedback == nil {
+		m.Feedback = make(map[string]map[string]*RecommendationFeedback)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "codeguru-reviewer", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // AssociateRepository creates a new repository association.
@@ -71,7 +156,7 @@ func (m *MemoryStorage) AssociateRepository(input *AssociateRepositoryInput) *Re
 		Tags:                 input.Tags,
 	}
 
-	m.associations[arn] = assoc
+	m.Associations[arn] = assoc
 
 	return assoc
 }
@@ -105,7 +190,7 @@ func (m *MemoryStorage) DescribeRepositoryAssociation(arn string) (*RepositoryAs
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	assoc, ok := m.associations[arn]
+	assoc, ok := m.Associations[arn]
 	if !ok {
 		return nil, fmt.Errorf("NotFoundException: repository association %s not found", arn)
 	}
@@ -118,7 +203,7 @@ func (m *MemoryStorage) DisassociateRepository(arn string) (*RepositoryAssociati
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	assoc, ok := m.associations[arn]
+	assoc, ok := m.Associations[arn]
 	if !ok {
 		return nil, fmt.Errorf("NotFoundException: repository association %s not found", arn)
 	}
@@ -126,7 +211,7 @@ func (m *MemoryStorage) DisassociateRepository(arn string) (*RepositoryAssociati
 	assoc.State = "Disassociated"
 	assoc.LastUpdatedTimeStamp = epochNow()
 
-	delete(m.associations, arn)
+	delete(m.Associations, arn)
 
 	return assoc, nil
 }
@@ -136,8 +221,8 @@ func (m *MemoryStorage) ListRepositoryAssociations() []RepositoryAssociationSumm
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]RepositoryAssociationSummary, 0, len(m.associations))
-	for _, assoc := range m.associations {
+	result := make([]RepositoryAssociationSummary, 0, len(m.Associations))
+	for _, assoc := range m.Associations {
 		result = append(result, RepositoryAssociationSummary{
 			AssociationArn:       assoc.AssociationArn,
 			AssociationID:        assoc.AssociationID,
@@ -159,7 +244,7 @@ func (m *MemoryStorage) CreateCodeReview(input *CreateCodeReviewInput) (*CodeRev
 	defer m.mu.Unlock()
 
 	// Find the association.
-	assoc, ok := m.associations[input.RepositoryAssociationArn]
+	assoc, ok := m.Associations[input.RepositoryAssociationArn]
 	if !ok {
 		return nil, fmt.Errorf("NotFoundException: repository association %s not found", input.RepositoryAssociationArn)
 	}
@@ -181,7 +266,7 @@ func (m *MemoryStorage) CreateCodeReview(input *CreateCodeReviewInput) (*CodeRev
 		Type:                 "RepositoryAnalysis",
 	}
 
-	m.codeReviews[arn] = review
+	m.CodeReviews[arn] = review
 
 	return review, nil
 }
@@ -191,7 +276,7 @@ func (m *MemoryStorage) DescribeCodeReview(arn string) (*CodeReview, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	review, ok := m.codeReviews[arn]
+	review, ok := m.CodeReviews[arn]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: code review %s not found", arn)
 	}
@@ -204,8 +289,8 @@ func (m *MemoryStorage) ListCodeReviews() []CodeReview {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]CodeReview, 0, len(m.codeReviews))
-	for _, review := range m.codeReviews {
+	result := make([]CodeReview, 0, len(m.CodeReviews))
+	for _, review := range m.CodeReviews {
 		result = append(result, *review)
 	}
 
@@ -222,14 +307,14 @@ func (m *MemoryStorage) PutRecommendationFeedback(input *PutRecommendationFeedba
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.codeReviews[input.CodeReviewArn]; !ok {
+	if _, ok := m.CodeReviews[input.CodeReviewArn]; !ok {
 		return fmt.Errorf("ResourceNotFoundException: code review %s not found", input.CodeReviewArn)
 	}
 
 	now := epochNow()
 
-	if m.feedback[input.CodeReviewArn] == nil {
-		m.feedback[input.CodeReviewArn] = make(map[string]*RecommendationFeedback)
+	if m.Feedback[input.CodeReviewArn] == nil {
+		m.Feedback[input.CodeReviewArn] = make(map[string]*RecommendationFeedback)
 	}
 
 	fb := &RecommendationFeedback{
@@ -241,7 +326,7 @@ func (m *MemoryStorage) PutRecommendationFeedback(input *PutRecommendationFeedba
 		UserID:               "test-user",
 	}
 
-	m.feedback[input.CodeReviewArn][input.RecommendationID] = fb
+	m.Feedback[input.CodeReviewArn][input.RecommendationID] = fb
 
 	return nil
 }
@@ -251,7 +336,7 @@ func (m *MemoryStorage) DescribeRecommendationFeedback(codeReviewArn, recommenda
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	fbMap, ok := m.feedback[codeReviewArn]
+	fbMap, ok := m.Feedback[codeReviewArn]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: feedback not found")
 	}
@@ -269,7 +354,7 @@ func (m *MemoryStorage) ListRecommendationFeedback(codeReviewArn string) []Recom
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	fbMap := m.feedback[codeReviewArn]
+	fbMap := m.Feedback[codeReviewArn]
 	result := make([]RecommendationFeedback, 0, len(fbMap))
 
 	for _, fb := range fbMap {

--- a/internal/service/cognito/service.go
+++ b/internal/service/cognito/service.go
@@ -2,6 +2,10 @@
 package cognito
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
@@ -34,6 +38,25 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// Routes are handled by DispatchAction.
 }
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/cognito/storage.go
+++ b/internal/service/cognito/storage.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -53,23 +56,109 @@ type Storage interface {
 	GetUserPoolClientByID(ctx context.Context, clientID string) (*UserPoolClient, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu                sync.RWMutex
-	userPools         map[string]*UserPool
-	userPoolClients   map[string]*UserPoolClient
-	users             map[string]map[string]*User // userPoolID -> username -> User
-	confirmationCodes map[string]string           // username -> code
+	mu                sync.RWMutex                `json:"-"`
+	UserPools         map[string]*UserPool        `json:"userPools"`
+	UserPoolClients   map[string]*UserPoolClient  `json:"userPoolClients"`
+	Users             map[string]map[string]*User `json:"users"`             // userPoolID -> username -> User
+	ConfirmationCodes map[string]string           `json:"confirmationCodes"` // username -> code
+	dataDir           string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		userPools:         make(map[string]*UserPool),
-		userPoolClients:   make(map[string]*UserPoolClient),
-		users:             make(map[string]map[string]*User),
-		confirmationCodes: make(map[string]string),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		UserPools:         make(map[string]*UserPool),
+		UserPoolClients:   make(map[string]*UserPoolClient),
+		Users:             make(map[string]map[string]*User),
+		ConfirmationCodes: make(map[string]string),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "cognito-idp", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.UserPools == nil {
+		s.UserPools = make(map[string]*UserPool)
+	}
+
+	if s.UserPoolClients == nil {
+		s.UserPoolClients = make(map[string]*UserPoolClient)
+	}
+
+	if s.Users == nil {
+		s.Users = make(map[string]map[string]*User)
+	}
+
+	if s.ConfirmationCodes == nil {
+		s.ConfirmationCodes = make(map[string]string)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "cognito-idp", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateUserPool creates a new user pool.
@@ -122,8 +211,8 @@ func (s *MemoryStorage) CreateUserPool(_ context.Context, req *CreateUserPoolReq
 		}
 	}
 
-	s.userPools[poolID] = pool
-	s.users[poolID] = make(map[string]*User)
+	s.UserPools[poolID] = pool
+	s.Users[poolID] = make(map[string]*User)
 
 	return pool, nil
 }
@@ -133,7 +222,7 @@ func (s *MemoryStorage) GetUserPool(_ context.Context, userPoolID string) (*User
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	pool, ok := s.userPools[userPoolID]
+	pool, ok := s.UserPools[userPoolID]
 	if !ok {
 		return nil, &ServiceError{Code: errUserPoolNotFound, Message: "User pool not found"}
 	}
@@ -150,9 +239,9 @@ func (s *MemoryStorage) ListUserPools(_ context.Context, maxResults int32, _ str
 		maxResults = 60
 	}
 
-	pools := make([]*UserPool, 0, len(s.userPools))
+	pools := make([]*UserPool, 0, len(s.UserPools))
 
-	for _, pool := range s.userPools {
+	for _, pool := range s.UserPools {
 		pools = append(pools, pool)
 
 		if len(pools) >= int(maxResults) {
@@ -168,20 +257,20 @@ func (s *MemoryStorage) DeleteUserPool(_ context.Context, userPoolID string) err
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.userPools[userPoolID]; !ok {
+	if _, ok := s.UserPools[userPoolID]; !ok {
 		return &ServiceError{Code: errUserPoolNotFound, Message: "User pool not found"}
 	}
 
 	// Delete associated clients.
-	for clientID, client := range s.userPoolClients {
+	for clientID, client := range s.UserPoolClients {
 		if client.UserPoolID == userPoolID {
-			delete(s.userPoolClients, clientID)
+			delete(s.UserPoolClients, clientID)
 		}
 	}
 
 	// Delete associated users.
-	delete(s.users, userPoolID)
-	delete(s.userPools, userPoolID)
+	delete(s.Users, userPoolID)
+	delete(s.UserPools, userPoolID)
 
 	return nil
 }
@@ -191,7 +280,7 @@ func (s *MemoryStorage) CreateUserPoolClient(_ context.Context, req *CreateUserP
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.userPools[req.UserPoolID]; !ok {
+	if _, ok := s.UserPools[req.UserPoolID]; !ok {
 		return nil, &ServiceError{Code: errUserPoolNotFound, Message: "User pool not found"}
 	}
 
@@ -233,7 +322,7 @@ func (s *MemoryStorage) CreateUserPoolClient(_ context.Context, req *CreateUserP
 		client.IDTokenValidity = 60
 	}
 
-	s.userPoolClients[clientID] = client
+	s.UserPoolClients[clientID] = client
 
 	return client, nil
 }
@@ -243,7 +332,7 @@ func (s *MemoryStorage) GetUserPoolClient(_ context.Context, userPoolID, clientI
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	client, ok := s.userPoolClients[clientID]
+	client, ok := s.UserPoolClients[clientID]
 	if !ok || client.UserPoolID != userPoolID {
 		return nil, &ServiceError{Code: errUserPoolClientNotFound, Message: "User pool client not found"}
 	}
@@ -262,7 +351,7 @@ func (s *MemoryStorage) ListUserPoolClients(_ context.Context, userPoolID string
 
 	clients := make([]*UserPoolClient, 0)
 
-	for _, client := range s.userPoolClients {
+	for _, client := range s.UserPoolClients {
 		if client.UserPoolID == userPoolID {
 			clients = append(clients, client)
 
@@ -280,12 +369,12 @@ func (s *MemoryStorage) DeleteUserPoolClient(_ context.Context, userPoolID, clie
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	client, ok := s.userPoolClients[clientID]
+	client, ok := s.UserPoolClients[clientID]
 	if !ok || client.UserPoolID != userPoolID {
 		return &ServiceError{Code: errUserPoolClientNotFound, Message: "User pool client not found"}
 	}
 
-	delete(s.userPoolClients, clientID)
+	delete(s.UserPoolClients, clientID)
 
 	return nil
 }
@@ -295,11 +384,11 @@ func (s *MemoryStorage) AdminCreateUser(_ context.Context, req *AdminCreateUserR
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.userPools[req.UserPoolID]; !ok {
+	if _, ok := s.UserPools[req.UserPoolID]; !ok {
 		return nil, &ServiceError{Code: errUserPoolNotFound, Message: "User pool not found"}
 	}
 
-	if _, ok := s.users[req.UserPoolID][req.Username]; ok {
+	if _, ok := s.Users[req.UserPoolID][req.Username]; ok {
 		return nil, &ServiceError{Code: errUsernameExists, Message: "User already exists"}
 	}
 
@@ -322,7 +411,7 @@ func (s *MemoryStorage) AdminCreateUser(_ context.Context, req *AdminCreateUserR
 		}
 	}
 
-	s.users[req.UserPoolID][req.Username] = user
+	s.Users[req.UserPoolID][req.Username] = user
 
 	return user, nil
 }
@@ -332,7 +421,7 @@ func (s *MemoryStorage) AdminGetUser(_ context.Context, userPoolID, username str
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	users, ok := s.users[userPoolID]
+	users, ok := s.Users[userPoolID]
 	if !ok {
 		return nil, &ServiceError{Code: errUserPoolNotFound, Message: "User pool not found"}
 	}
@@ -350,7 +439,7 @@ func (s *MemoryStorage) AdminDeleteUser(_ context.Context, userPoolID, username 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	users, ok := s.users[userPoolID]
+	users, ok := s.Users[userPoolID]
 	if !ok {
 		return &ServiceError{Code: errUserPoolNotFound, Message: "User pool not found"}
 	}
@@ -373,7 +462,7 @@ func (s *MemoryStorage) ListUsers(_ context.Context, userPoolID string, limit in
 		limit = 60
 	}
 
-	users, ok := s.users[userPoolID]
+	users, ok := s.Users[userPoolID]
 	if !ok {
 		return nil, "", &ServiceError{Code: errUserPoolNotFound, Message: "User pool not found"}
 	}
@@ -399,7 +488,7 @@ func (s *MemoryStorage) SignUp(_ context.Context, req *SignUpRequest) (*User, er
 	// Find user pool by client ID.
 	var userPoolID string
 
-	for _, client := range s.userPoolClients {
+	for _, client := range s.UserPoolClients {
 		if client.ClientID == req.ClientID {
 			userPoolID = client.UserPoolID
 
@@ -411,7 +500,7 @@ func (s *MemoryStorage) SignUp(_ context.Context, req *SignUpRequest) (*User, er
 		return nil, &ServiceError{Code: errInvalidParameter, Message: "Invalid client ID"}
 	}
 
-	if _, ok := s.users[userPoolID][req.Username]; ok {
+	if _, ok := s.Users[userPoolID][req.Username]; ok {
 		return nil, &ServiceError{Code: errUsernameExists, Message: "User already exists"}
 	}
 
@@ -434,10 +523,10 @@ func (s *MemoryStorage) SignUp(_ context.Context, req *SignUpRequest) (*User, er
 		}
 	}
 
-	s.users[userPoolID][req.Username] = user
+	s.Users[userPoolID][req.Username] = user
 
 	// Generate confirmation code (simulated).
-	s.confirmationCodes[req.Username] = "123456"
+	s.ConfirmationCodes[req.Username] = "123456"
 
 	return user, nil
 }
@@ -450,7 +539,7 @@ func (s *MemoryStorage) ConfirmSignUp(_ context.Context, clientID, username, cod
 	// Find user pool by client ID.
 	var userPoolID string
 
-	for _, client := range s.userPoolClients {
+	for _, client := range s.UserPoolClients {
 		if client.ClientID == clientID {
 			userPoolID = client.UserPoolID
 
@@ -462,14 +551,14 @@ func (s *MemoryStorage) ConfirmSignUp(_ context.Context, clientID, username, cod
 		return &ServiceError{Code: errInvalidParameter, Message: "Invalid client ID"}
 	}
 
-	user, ok := s.users[userPoolID][username]
+	user, ok := s.Users[userPoolID][username]
 	if !ok {
 		return &ServiceError{Code: errUserNotFound, Message: "User not found"}
 	}
 
 	// In a real implementation, we would verify the code.
 	// For testing, we accept any code or the default "123456".
-	expectedCode := s.confirmationCodes[username]
+	expectedCode := s.ConfirmationCodes[username]
 	if expectedCode != "" && code != expectedCode && code != "123456" {
 		return &ServiceError{Code: errInvalidParameter, Message: "Invalid confirmation code"}
 	}
@@ -477,7 +566,7 @@ func (s *MemoryStorage) ConfirmSignUp(_ context.Context, clientID, username, cod
 	user.UserStatus = UserStatusConfirmed
 	user.UserLastModified = time.Now()
 
-	delete(s.confirmationCodes, username)
+	delete(s.ConfirmationCodes, username)
 
 	return nil
 }
@@ -490,7 +579,7 @@ func (s *MemoryStorage) InitiateAuth(_ context.Context, req *InitiateAuthRequest
 	// Find user pool by client ID.
 	var userPoolID string
 
-	for _, client := range s.userPoolClients {
+	for _, client := range s.UserPoolClients {
 		if client.ClientID == req.ClientID {
 			userPoolID = client.UserPoolID
 
@@ -505,7 +594,7 @@ func (s *MemoryStorage) InitiateAuth(_ context.Context, req *InitiateAuthRequest
 	username := req.AuthParameters["USERNAME"]
 	password := req.AuthParameters["PASSWORD"]
 
-	user, ok := s.users[userPoolID][username]
+	user, ok := s.Users[userPoolID][username]
 	if !ok {
 		return nil, &ServiceError{Code: errUserNotFound, Message: "User not found"}
 	}
@@ -539,12 +628,12 @@ func (s *MemoryStorage) GetUserPoolByClientID(_ context.Context, clientID string
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	client, ok := s.userPoolClients[clientID]
+	client, ok := s.UserPoolClients[clientID]
 	if !ok {
 		return nil, &ServiceError{Code: errUserPoolClientNotFound, Message: "User pool client not found"}
 	}
 
-	pool, ok := s.userPools[client.UserPoolID]
+	pool, ok := s.UserPools[client.UserPoolID]
 	if !ok {
 		return nil, &ServiceError{Code: errUserPoolNotFound, Message: "User pool not found"}
 	}
@@ -557,7 +646,7 @@ func (s *MemoryStorage) GetUserPoolClientByID(_ context.Context, clientID string
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	client, ok := s.userPoolClients[clientID]
+	client, ok := s.UserPoolClients[clientID]
 	if !ok {
 		return nil, &ServiceError{Code: errUserPoolClientNotFound, Message: "User pool client not found"}
 	}

--- a/internal/service/configservice/service.go
+++ b/internal/service/configservice/service.go
@@ -2,6 +2,10 @@
 package configservice
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
@@ -36,8 +40,16 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// Routes are dispatched by the server based on X-Amz-Target.
 }
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Ensure Service implements required interfaces.
@@ -45,3 +57,14 @@ var (
 	_ service.Service             = (*Service)(nil)
 	_ service.JSONProtocolService = (*Service)(nil)
 )
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/configservice/storage.go
+++ b/internal/service/configservice/storage.go
@@ -2,10 +2,14 @@ package configservice
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -38,25 +42,107 @@ type Storage interface {
 	GetComplianceDetailsByConfigRule(ctx context.Context, req *GetComplianceDetailsByConfigRuleRequest) ([]*EvaluationResult, string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu               sync.RWMutex
-	recorders        map[string]*ConfigurationRecorder
-	recorderStatuses map[string]*ConfigurationRecorderStatus
-	rules            map[string]*ConfigRule
+	mu               sync.RWMutex                            `json:"-"`
+	Recorders        map[string]*ConfigurationRecorder       `json:"recorders"`
+	RecorderStatuses map[string]*ConfigurationRecorderStatus `json:"recorderStatuses"`
+	Rules            map[string]*ConfigRule                  `json:"rules"`
 	region           string
 	accountID        string
+	dataDir          string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		recorders:        make(map[string]*ConfigurationRecorder),
-		recorderStatuses: make(map[string]*ConfigurationRecorderStatus),
-		rules:            make(map[string]*ConfigRule),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Recorders:        make(map[string]*ConfigurationRecorder),
+		RecorderStatuses: make(map[string]*ConfigurationRecorderStatus),
+		Rules:            make(map[string]*ConfigRule),
 		region:           defaultRegion,
 		accountID:        defaultAccountID,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "configservice", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Recorders == nil {
+		m.Recorders = make(map[string]*ConfigurationRecorder)
+	}
+
+	if m.RecorderStatuses == nil {
+		m.RecorderStatuses = make(map[string]*ConfigurationRecorderStatus)
+	}
+
+	if m.Rules == nil {
+		m.Rules = make(map[string]*ConfigRule)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "configservice", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // PutConfigurationRecorder creates or updates a configuration recorder.
@@ -75,8 +161,8 @@ func (m *MemoryStorage) PutConfigurationRecorder(_ context.Context, req *PutConf
 	}
 
 	// AWS Config allows only one configuration recorder per region
-	if len(m.recorders) > 0 {
-		if _, exists := m.recorders[input.Name]; !exists {
+	if len(m.Recorders) > 0 {
+		if _, exists := m.Recorders[input.Name]; !exists {
 			return &Error{Code: errMaxNumberOfConfigurationRecordersExceeded, Message: "Only one configuration recorder is allowed per region"}
 		}
 	}
@@ -99,11 +185,11 @@ func (m *MemoryStorage) PutConfigurationRecorder(_ context.Context, req *PutConf
 		}
 	}
 
-	m.recorders[input.Name] = recorder
+	m.Recorders[input.Name] = recorder
 
 	// Initialize status if not exists
-	if _, exists := m.recorderStatuses[input.Name]; !exists {
-		m.recorderStatuses[input.Name] = &ConfigurationRecorderStatus{
+	if _, exists := m.RecorderStatuses[input.Name]; !exists {
+		m.RecorderStatuses[input.Name] = &ConfigurationRecorderStatus{
 			Name:       input.Name,
 			Recording:  false,
 			LastStatus: "Pending",
@@ -118,12 +204,12 @@ func (m *MemoryStorage) DeleteConfigurationRecorder(_ context.Context, name stri
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.recorders[name]; !exists {
+	if _, exists := m.Recorders[name]; !exists {
 		return &Error{Code: errNoSuchConfigurationRecorder, Message: "Configuration recorder not found"}
 	}
 
-	delete(m.recorders, name)
-	delete(m.recorderStatuses, name)
+	delete(m.Recorders, name)
+	delete(m.RecorderStatuses, name)
 
 	return nil
 }
@@ -135,8 +221,8 @@ func (m *MemoryStorage) DescribeConfigurationRecorders(_ context.Context, names 
 
 	if len(names) == 0 {
 		// Return all recorders
-		result := make([]*ConfigurationRecorder, 0, len(m.recorders))
-		for _, recorder := range m.recorders {
+		result := make([]*ConfigurationRecorder, 0, len(m.Recorders))
+		for _, recorder := range m.Recorders {
 			result = append(result, recorder)
 		}
 
@@ -147,7 +233,7 @@ func (m *MemoryStorage) DescribeConfigurationRecorders(_ context.Context, names 
 	result := make([]*ConfigurationRecorder, 0, len(names))
 
 	for _, name := range names {
-		if recorder, exists := m.recorders[name]; exists {
+		if recorder, exists := m.Recorders[name]; exists {
 			result = append(result, recorder)
 		}
 	}
@@ -160,11 +246,11 @@ func (m *MemoryStorage) StartConfigurationRecorder(_ context.Context, name strin
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.recorders[name]; !exists {
+	if _, exists := m.Recorders[name]; !exists {
 		return &Error{Code: errNoSuchConfigurationRecorder, Message: "Configuration recorder not found"}
 	}
 
-	status := m.recorderStatuses[name]
+	status := m.RecorderStatuses[name]
 	status.Recording = true
 	status.LastStatus = "SUCCESS"
 
@@ -179,11 +265,11 @@ func (m *MemoryStorage) StopConfigurationRecorder(_ context.Context, name string
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.recorders[name]; !exists {
+	if _, exists := m.Recorders[name]; !exists {
 		return &Error{Code: errNoSuchConfigurationRecorder, Message: "Configuration recorder not found"}
 	}
 
-	status := m.recorderStatuses[name]
+	status := m.RecorderStatuses[name]
 	status.Recording = false
 
 	now := time.Now()
@@ -212,7 +298,7 @@ func (m *MemoryStorage) PutConfigRule(_ context.Context, req *PutConfigRuleReque
 	}
 
 	// Check if rule exists (update case)
-	existing, exists := m.rules[input.ConfigRuleName]
+	existing, exists := m.Rules[input.ConfigRuleName]
 
 	var ruleID string
 
@@ -244,7 +330,7 @@ func (m *MemoryStorage) PutConfigRule(_ context.Context, req *PutConfigRuleReque
 		}
 	}
 
-	m.rules[input.ConfigRuleName] = rule
+	m.Rules[input.ConfigRuleName] = rule
 
 	return rule, nil
 }
@@ -254,11 +340,11 @@ func (m *MemoryStorage) DeleteConfigRule(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.rules[name]; !exists {
+	if _, exists := m.Rules[name]; !exists {
 		return &Error{Code: errNoSuchConfigRule, Message: "Config rule not found"}
 	}
 
-	delete(m.rules, name)
+	delete(m.Rules, name)
 
 	return nil
 }
@@ -270,8 +356,8 @@ func (m *MemoryStorage) DescribeConfigRules(_ context.Context, names []string) (
 
 	if len(names) == 0 {
 		// Return all rules
-		result := make([]*ConfigRule, 0, len(m.rules))
-		for _, rule := range m.rules {
+		result := make([]*ConfigRule, 0, len(m.Rules))
+		for _, rule := range m.Rules {
 			result = append(result, rule)
 		}
 
@@ -282,7 +368,7 @@ func (m *MemoryStorage) DescribeConfigRules(_ context.Context, names []string) (
 	result := make([]*ConfigRule, 0, len(names))
 
 	for _, name := range names {
-		if rule, exists := m.rules[name]; exists {
+		if rule, exists := m.Rules[name]; exists {
 			result = append(result, rule)
 		}
 	}
@@ -296,7 +382,7 @@ func (m *MemoryStorage) GetComplianceDetailsByConfigRule(_ context.Context, req 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.rules[req.ConfigRuleName]; !exists {
+	if _, exists := m.Rules[req.ConfigRuleName]; !exists {
 		return nil, "", &Error{Code: errNoSuchConfigRule, Message: "Config rule not found"}
 	}
 

--- a/internal/service/dataexchange/service.go
+++ b/internal/service/dataexchange/service.go
@@ -1,11 +1,23 @@
 package dataexchange
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage()
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	storage := NewMemoryStorage(opts...)
 	service.Register(New(storage))
 }
 
@@ -51,4 +63,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("POST", "/v1/jobs", s.CreateJob)
 	r.Handle("GET", "/v1/jobs", s.ListJobs)
 	r.Handle("GET", "/v1/jobs/{jobId}", s.GetJob)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/dataexchange/storage.go
+++ b/internal/service/dataexchange/storage.go
@@ -1,11 +1,14 @@
 package dataexchange
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the interface for Data Exchange storage operations.
@@ -27,21 +30,103 @@ type Storage interface {
 	ListJobs() []Job
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage is an in-memory implementation of Storage.
 type MemoryStorage struct {
-	mu        sync.RWMutex
-	dataSets  map[string]*DataSet
-	revisions map[string]map[string]*Revision // dataSetID -> revisionID -> revision
-	jobs      map[string]*Job
+	mu        sync.RWMutex                    `json:"-"`
+	DataSets  map[string]*DataSet             `json:"dataSets"`
+	Revisions map[string]map[string]*Revision `json:"revisions"` // dataSetID -> revisionID -> revision
+	Jobs      map[string]*Job                 `json:"jobs"`
+	dataDir   string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		dataSets:  make(map[string]*DataSet),
-		revisions: make(map[string]map[string]*Revision),
-		jobs:      make(map[string]*Job),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		DataSets:  make(map[string]*DataSet),
+		Revisions: make(map[string]map[string]*Revision),
+		Jobs:      make(map[string]*Job),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "dataexchange", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.DataSets == nil {
+		m.DataSets = make(map[string]*DataSet)
+	}
+
+	if m.Revisions == nil {
+		m.Revisions = make(map[string]map[string]*Revision)
+	}
+
+	if m.Jobs == nil {
+		m.Jobs = make(map[string]*Job)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "dataexchange", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateDataSet creates a new data set.
@@ -64,7 +149,7 @@ func (m *MemoryStorage) CreateDataSet(input *CreateDataSetInput) *DataSet {
 		Tags:        input.Tags,
 	}
 
-	m.dataSets[id] = ds
+	m.DataSets[id] = ds
 
 	return ds
 }
@@ -74,7 +159,7 @@ func (m *MemoryStorage) GetDataSet(id string) (*DataSet, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	ds, ok := m.dataSets[id]
+	ds, ok := m.DataSets[id]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: data set %s not found", id)
 	}
@@ -87,8 +172,8 @@ func (m *MemoryStorage) ListDataSets() []DataSet {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]DataSet, 0, len(m.dataSets))
-	for _, ds := range m.dataSets {
+	result := make([]DataSet, 0, len(m.DataSets))
+	for _, ds := range m.DataSets {
 		result = append(result, *ds)
 	}
 
@@ -100,7 +185,7 @@ func (m *MemoryStorage) UpdateDataSet(id string, input *UpdateDataSetInput) (*Da
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	ds, ok := m.dataSets[id]
+	ds, ok := m.DataSets[id]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: data set %s not found", id)
 	}
@@ -123,12 +208,12 @@ func (m *MemoryStorage) DeleteDataSet(id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.dataSets[id]; !ok {
+	if _, ok := m.DataSets[id]; !ok {
 		return fmt.Errorf("ResourceNotFoundException: data set %s not found", id)
 	}
 
-	delete(m.dataSets, id)
-	delete(m.revisions, id)
+	delete(m.DataSets, id)
+	delete(m.Revisions, id)
 
 	return nil
 }
@@ -138,7 +223,7 @@ func (m *MemoryStorage) CreateRevision(dataSetID string, input *CreateRevisionIn
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.dataSets[dataSetID]; !ok {
+	if _, ok := m.DataSets[dataSetID]; !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: data set %s not found", dataSetID)
 	}
 
@@ -154,11 +239,11 @@ func (m *MemoryStorage) CreateRevision(dataSetID string, input *CreateRevisionIn
 		UpdatedAt: now,
 	}
 
-	if m.revisions[dataSetID] == nil {
-		m.revisions[dataSetID] = make(map[string]*Revision)
+	if m.Revisions[dataSetID] == nil {
+		m.Revisions[dataSetID] = make(map[string]*Revision)
 	}
 
-	m.revisions[dataSetID][id] = rev
+	m.Revisions[dataSetID][id] = rev
 
 	return rev, nil
 }
@@ -168,7 +253,7 @@ func (m *MemoryStorage) GetRevision(dataSetID, revisionID string) (*Revision, er
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	dsRevisions, ok := m.revisions[dataSetID]
+	dsRevisions, ok := m.Revisions[dataSetID]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: revision %s not found", revisionID)
 	}
@@ -186,11 +271,11 @@ func (m *MemoryStorage) ListRevisions(dataSetID string) ([]Revision, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, ok := m.dataSets[dataSetID]; !ok {
+	if _, ok := m.DataSets[dataSetID]; !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: data set %s not found", dataSetID)
 	}
 
-	dsRevisions := m.revisions[dataSetID]
+	dsRevisions := m.Revisions[dataSetID]
 	result := make([]Revision, 0, len(dsRevisions))
 
 	for _, rev := range dsRevisions {
@@ -205,7 +290,7 @@ func (m *MemoryStorage) UpdateRevision(dataSetID, revisionID string, input *Upda
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	dsRevisions, ok := m.revisions[dataSetID]
+	dsRevisions, ok := m.Revisions[dataSetID]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: revision %s not found", revisionID)
 	}
@@ -233,7 +318,7 @@ func (m *MemoryStorage) DeleteRevision(dataSetID, revisionID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	dsRevisions, ok := m.revisions[dataSetID]
+	dsRevisions, ok := m.Revisions[dataSetID]
 	if !ok {
 		return fmt.Errorf("ResourceNotFoundException: revision %s not found", revisionID)
 	}
@@ -264,7 +349,7 @@ func (m *MemoryStorage) CreateJob(input *CreateJobInput) *Job {
 		UpdatedAt: now,
 	}
 
-	m.jobs[id] = job
+	m.Jobs[id] = job
 
 	return job
 }
@@ -274,7 +359,7 @@ func (m *MemoryStorage) GetJob(id string) (*Job, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	job, ok := m.jobs[id]
+	job, ok := m.Jobs[id]
 	if !ok {
 		return nil, fmt.Errorf("ResourceNotFoundException: job %s not found", id)
 	}
@@ -287,8 +372,8 @@ func (m *MemoryStorage) ListJobs() []Job {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]Job, 0, len(m.jobs))
-	for _, job := range m.jobs {
+	result := make([]Job, 0, len(m.Jobs))
+	for _, job := range m.Jobs {
 		result = append(result, *job)
 	}
 

--- a/internal/service/dlm/service.go
+++ b/internal/service/dlm/service.go
@@ -2,11 +2,23 @@
 package dlm
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the DLM service.
@@ -35,3 +47,14 @@ func (s *Service) RegisterRoutes(r service.Router) {
 
 // Ensure Service implements service.Service.
 var _ service.Service = (*Service)(nil)
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/dlm/storage.go
+++ b/internal/service/dlm/storage.go
@@ -2,11 +2,14 @@ package dlm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -32,21 +35,95 @@ type Storage interface {
 	DeleteLifecyclePolicy(ctx context.Context, policyID string) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu        sync.RWMutex
-	policies  map[string]*LifecyclePolicy
+	mu        sync.RWMutex                `json:"-"`
+	Policies  map[string]*LifecyclePolicy `json:"policies"`
 	region    string
 	accountID string
+	dataDir   string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		policies:  make(map[string]*LifecyclePolicy),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Policies:  make(map[string]*LifecyclePolicy),
 		region:    defaultRegion,
 		accountID: defaultAccountID,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "dlm", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Policies == nil {
+		m.Policies = make(map[string]*LifecyclePolicy)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "dlm", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateLifecyclePolicy creates a new lifecycle policy.
@@ -71,7 +148,7 @@ func (m *MemoryStorage) CreateLifecyclePolicy(_ context.Context, req *CreateLife
 		DefaultPolicy:    req.DefaultPolicy != "",
 	}
 
-	m.policies[policyID] = policy
+	m.Policies[policyID] = policy
 
 	return policy, nil
 }
@@ -81,7 +158,7 @@ func (m *MemoryStorage) GetLifecyclePolicy(_ context.Context, policyID string) (
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	policy, exists := m.policies[policyID]
+	policy, exists := m.Policies[policyID]
 	if !exists {
 		return nil, &Error{Code: errResourceNotFound, Message: "Lifecycle policy not found: " + policyID}
 	}
@@ -94,7 +171,7 @@ func (m *MemoryStorage) GetLifecyclePolicies(_ context.Context, policyIDs []stri
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]*LifecyclePolicySummary, 0, len(m.policies))
+	result := make([]*LifecyclePolicySummary, 0, len(m.Policies))
 
 	// If specific policy IDs are requested, filter by them.
 	if len(policyIDs) > 0 {
@@ -103,7 +180,7 @@ func (m *MemoryStorage) GetLifecyclePolicies(_ context.Context, policyIDs []stri
 			policyIDSet[id] = true
 		}
 
-		for _, policy := range m.policies {
+		for _, policy := range m.Policies {
 			if !policyIDSet[policy.PolicyID] {
 				continue
 			}
@@ -119,7 +196,7 @@ func (m *MemoryStorage) GetLifecyclePolicies(_ context.Context, policyIDs []stri
 	}
 
 	// Otherwise, return all policies that match filters.
-	for _, policy := range m.policies {
+	for _, policy := range m.Policies {
 		if !matchesFilters(policy, state, resourceTypes, targetTags) {
 			continue
 		}
@@ -135,7 +212,7 @@ func (m *MemoryStorage) UpdateLifecyclePolicy(_ context.Context, policyID string
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	policy, exists := m.policies[policyID]
+	policy, exists := m.Policies[policyID]
 	if !exists {
 		return &Error{Code: errResourceNotFound, Message: "Lifecycle policy not found: " + policyID}
 	}
@@ -166,11 +243,11 @@ func (m *MemoryStorage) DeleteLifecyclePolicy(_ context.Context, policyID string
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.policies[policyID]; !exists {
+	if _, exists := m.Policies[policyID]; !exists {
 		return &Error{Code: errResourceNotFound, Message: "Lifecycle policy not found: " + policyID}
 	}
 
-	delete(m.policies, policyID)
+	delete(m.Policies, policyID)
 
 	return nil
 }

--- a/internal/service/ds/service.go
+++ b/internal/service/ds/service.go
@@ -1,13 +1,27 @@
 package ds
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	svc := NewService()
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	svc := &Service{
+		storage: NewMemoryStorage(opts...),
+	}
+
 	service.Register(svc)
 }
 
@@ -64,3 +78,14 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 
 // JSONProtocol is a marker method for JSON protocol services.
 func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/ds/storage.go
+++ b/internal/service/ds/storage.go
@@ -2,12 +2,15 @@ package ds
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the Directory Service storage interface.
@@ -20,23 +23,101 @@ type Storage interface {
 	DeleteSnapshot(ctx context.Context, snapshotID string) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu          sync.RWMutex
-	directories map[string]*Directory
-	snapshots   map[string]*Snapshot
+	mu          sync.RWMutex          `json:"-"`
+	Directories map[string]*Directory `json:"directories"`
+	Snapshots   map[string]*Snapshot  `json:"snapshots"`
 	region      string
 	accountID   string
+	dataDir     string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		directories: make(map[string]*Directory),
-		snapshots:   make(map[string]*Snapshot),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Directories: make(map[string]*Directory),
+		Snapshots:   make(map[string]*Snapshot),
 		region:      "us-east-1",
 		accountID:   "123456789012",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "ds", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Directories == nil {
+		s.Directories = make(map[string]*Directory)
+	}
+
+	if s.Snapshots == nil {
+		s.Snapshots = make(map[string]*Snapshot)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "ds", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateDirectory creates a new directory.
@@ -45,7 +126,7 @@ func (s *MemoryStorage) CreateDirectory(_ context.Context, req *CreateDirectoryR
 	defer s.mu.Unlock()
 
 	// Check for duplicate directory name.
-	for _, d := range s.directories {
+	for _, d := range s.Directories {
 		if d.Name == req.Name {
 			return nil, &Error{
 				Type:    ErrEntityAlreadyExists,
@@ -89,7 +170,7 @@ func (s *MemoryStorage) CreateDirectory(_ context.Context, req *CreateDirectoryR
 		StageLastUpdatedAt: now,
 	}
 
-	s.directories[directoryID] = directory
+	s.Directories[directoryID] = directory
 
 	return directory, nil
 }
@@ -108,13 +189,13 @@ func (s *MemoryStorage) DescribeDirectories(_ context.Context, directoryIDs []st
 	if len(directoryIDs) > 0 {
 		// Return specific directories.
 		for _, id := range directoryIDs {
-			if d, exists := s.directories[id]; exists {
+			if d, exists := s.Directories[id]; exists {
 				directories = append(directories, d)
 			}
 		}
 	} else {
 		// Return all directories.
-		for _, d := range s.directories {
+		for _, d := range s.Directories {
 			directories = append(directories, d)
 		}
 	}
@@ -153,14 +234,14 @@ func (s *MemoryStorage) DeleteDirectory(_ context.Context, directoryID string) e
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.directories[directoryID]; !exists {
+	if _, exists := s.Directories[directoryID]; !exists {
 		return &Error{
 			Type:    ErrEntityDoesNotExist,
 			Message: fmt.Sprintf("Directory %s does not exist", directoryID),
 		}
 	}
 
-	delete(s.directories, directoryID)
+	delete(s.Directories, directoryID)
 
 	return nil
 }
@@ -170,7 +251,7 @@ func (s *MemoryStorage) CreateSnapshot(_ context.Context, directoryID, name stri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.directories[directoryID]; !exists {
+	if _, exists := s.Directories[directoryID]; !exists {
 		return nil, &Error{
 			Type:    ErrEntityDoesNotExist,
 			Message: fmt.Sprintf("Directory %s does not exist", directoryID),
@@ -189,7 +270,7 @@ func (s *MemoryStorage) CreateSnapshot(_ context.Context, directoryID, name stri
 		StartTime:   now,
 	}
 
-	s.snapshots[snapshotID] = snapshot
+	s.Snapshots[snapshotID] = snapshot
 
 	return snapshot, nil
 }
@@ -208,7 +289,7 @@ func (s *MemoryStorage) DescribeSnapshots(_ context.Context, directoryID string,
 	if len(snapshotIDs) > 0 {
 		// Return specific snapshots.
 		for _, id := range snapshotIDs {
-			snap, exists := s.snapshots[id]
+			snap, exists := s.Snapshots[id]
 			if !exists {
 				continue
 			}
@@ -221,7 +302,7 @@ func (s *MemoryStorage) DescribeSnapshots(_ context.Context, directoryID string,
 		}
 	} else {
 		// Return all snapshots.
-		for _, snap := range s.snapshots {
+		for _, snap := range s.Snapshots {
 			if directoryID != "" && snap.DirectoryID != directoryID {
 				continue
 			}
@@ -264,14 +345,14 @@ func (s *MemoryStorage) DeleteSnapshot(_ context.Context, snapshotID string) err
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.snapshots[snapshotID]; !exists {
+	if _, exists := s.Snapshots[snapshotID]; !exists {
 		return &Error{
 			Type:    ErrEntityDoesNotExist,
 			Message: fmt.Sprintf("Snapshot %s does not exist", snapshotID),
 		}
 	}
 
-	delete(s.snapshots, snapshotID)
+	delete(s.Snapshots, snapshotID)
 
 	return nil
 }

--- a/internal/service/dynamodb/service.go
+++ b/internal/service/dynamodb/service.go
@@ -1,13 +1,25 @@
 package dynamodb
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
 
 const defaultBaseURL = "http://localhost:4566"
 
 func init() {
-	service.Register(New(NewMemoryStorage(defaultBaseURL)))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(defaultBaseURL, opts...)))
 }
 
 // Service implements the DynamoDB service.
@@ -41,3 +53,14 @@ func (s *Service) TargetPrefix() string {
 
 // JSONProtocol is a marker method that indicates DynamoDB uses AWS JSON 1.0 protocol.
 func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -30,24 +33,98 @@ type Storage interface {
 	Scan(ctx context.Context, tableName string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item) ([]Item, Item, int, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu      sync.RWMutex
-	tables  map[string]*tableData
+	mu      sync.RWMutex          `json:"-"`
+	Tables  map[string]*tableData `json:"tables"`
 	baseURL string
+	dataDir string
 }
 
 type tableData struct {
-	table *Table
-	items map[string]Item // key is the serialized primary key
+	Table *Table          `json:"table"`
+	Items map[string]Item `json:"items"`
 }
 
 // NewMemoryStorage creates a new in-memory DynamoDB storage.
-func NewMemoryStorage(baseURL string) *MemoryStorage {
-	return &MemoryStorage{
-		tables:  make(map[string]*tableData),
+func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Tables:  make(map[string]*tableData),
 		baseURL: baseURL,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "dynamodb", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Tables == nil {
+		m.Tables = make(map[string]*tableData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "dynamodb", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateTable creates a new table.
@@ -55,7 +132,7 @@ func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.tables[req.TableName]; exists {
+	if _, exists := m.Tables[req.TableName]; exists {
 		return nil, &TableError{
 			Code:    "ResourceInUseException",
 			Message: fmt.Sprintf("Table already exists: %s", req.TableName),
@@ -81,9 +158,9 @@ func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) 
 		DeletionProtection:    req.DeletionProtectionEnabled,
 	}
 
-	m.tables[req.TableName] = &tableData{
-		table: table,
-		items: make(map[string]Item),
+	m.Tables[req.TableName] = &tableData{
+		Table: table,
+		Items: make(map[string]Item),
 	}
 
 	return table, nil
@@ -94,7 +171,7 @@ func (m *MemoryStorage) DeleteTable(_ context.Context, tableName string) (*Table
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	td, exists := m.tables[tableName]
+	td, exists := m.Tables[tableName]
 	if !exists {
 		return nil, &TableError{
 			Code:    "ResourceNotFoundException",
@@ -102,10 +179,10 @@ func (m *MemoryStorage) DeleteTable(_ context.Context, tableName string) (*Table
 		}
 	}
 
-	table := td.table
+	table := td.Table
 	table.TableStatus = "DELETING"
 
-	delete(m.tables, tableName)
+	delete(m.Tables, tableName)
 
 	return table, nil
 }
@@ -119,8 +196,8 @@ func (m *MemoryStorage) ListTables(_ context.Context, exclusiveStartTableName st
 		limit = 100
 	}
 
-	names := make([]string, 0, len(m.tables))
-	for name := range m.tables {
+	names := make([]string, 0, len(m.Tables))
+	for name := range m.Tables {
 		names = append(names, name)
 	}
 
@@ -160,7 +237,7 @@ func (m *MemoryStorage) DescribeTable(_ context.Context, tableName string) (*Tab
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	td, exists := m.tables[tableName]
+	td, exists := m.Tables[tableName]
 	if !exists {
 		return nil, &TableError{
 			Code:    "ResourceNotFoundException",
@@ -169,9 +246,9 @@ func (m *MemoryStorage) DescribeTable(_ context.Context, tableName string) (*Tab
 	}
 
 	// Update item count.
-	td.table.ItemCount = int64(len(td.items))
+	td.Table.ItemCount = int64(len(td.Items))
 
-	return td.table, nil
+	return td.Table, nil
 }
 
 // PutItem puts an item into a table.
@@ -179,7 +256,7 @@ func (m *MemoryStorage) PutItem(_ context.Context, tableName string, item Item, 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	td, exists := m.tables[tableName]
+	td, exists := m.Tables[tableName]
 	if !exists {
 		return nil, &TableError{
 			Code:    "ResourceNotFoundException",
@@ -187,17 +264,17 @@ func (m *MemoryStorage) PutItem(_ context.Context, tableName string, item Item, 
 		}
 	}
 
-	key := m.serializeKey(td.table, item)
+	key := m.serializeKey(td.Table, item)
 
 	var oldItem Item
 
 	if returnOld {
-		if existing, ok := td.items[key]; ok {
+		if existing, ok := td.Items[key]; ok {
 			oldItem = m.copyItem(existing)
 		}
 	}
 
-	td.items[key] = m.copyItem(item)
+	td.Items[key] = m.copyItem(item)
 
 	return oldItem, nil
 }
@@ -207,7 +284,7 @@ func (m *MemoryStorage) GetItem(_ context.Context, tableName string, key Item) (
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	td, exists := m.tables[tableName]
+	td, exists := m.Tables[tableName]
 	if !exists {
 		return nil, &TableError{
 			Code:    "ResourceNotFoundException",
@@ -215,8 +292,8 @@ func (m *MemoryStorage) GetItem(_ context.Context, tableName string, key Item) (
 		}
 	}
 
-	keyStr := m.serializeKey(td.table, key)
-	if item, ok := td.items[keyStr]; ok {
+	keyStr := m.serializeKey(td.Table, key)
+	if item, ok := td.Items[keyStr]; ok {
 		return m.copyItem(item), nil
 	}
 
@@ -229,7 +306,7 @@ func (m *MemoryStorage) DeleteItem(_ context.Context, tableName string, key Item
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	td, exists := m.tables[tableName]
+	td, exists := m.Tables[tableName]
 	if !exists {
 		return nil, &TableError{
 			Code:    "ResourceNotFoundException",
@@ -237,16 +314,16 @@ func (m *MemoryStorage) DeleteItem(_ context.Context, tableName string, key Item
 		}
 	}
 
-	keyStr := m.serializeKey(td.table, key)
+	keyStr := m.serializeKey(td.Table, key)
 
 	var oldItem Item
 
-	if existing, ok := td.items[keyStr]; ok {
+	if existing, ok := td.Items[keyStr]; ok {
 		if returnOld {
 			oldItem = m.copyItem(existing)
 		}
 
-		delete(td.items, keyStr)
+		delete(td.Items, keyStr)
 	}
 
 	return oldItem, nil
@@ -257,7 +334,7 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	td, exists := m.tables[tableName]
+	td, exists := m.Tables[tableName]
 	if !exists {
 		return nil, &TableError{
 			Code:    "ResourceNotFoundException",
@@ -265,8 +342,8 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 		}
 	}
 
-	keyStr := m.serializeKey(td.table, key)
-	item, itemExists := td.items[keyStr]
+	keyStr := m.serializeKey(td.Table, key)
+	item, itemExists := td.Items[keyStr]
 
 	var oldItem Item
 	if itemExists {
@@ -281,7 +358,7 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 		item = m.applyUpdateExpression(item, updateExpr, exprNames, exprValues)
 	}
 
-	td.items[keyStr] = item
+	td.Items[keyStr] = item
 
 	// Return based on returnValues.
 	switch returnValues {
@@ -309,7 +386,7 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, keyCondExpr, filterE
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	td, exists := m.tables[tableName]
+	td, exists := m.Tables[tableName]
 	if !exists {
 		return nil, nil, 0, &TableError{
 			Code:    "ResourceNotFoundException",
@@ -320,7 +397,7 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, keyCondExpr, filterE
 	// Get partition key attribute name.
 	var partitionKeyName string
 
-	for _, ks := range td.table.KeySchema {
+	for _, ks := range td.Table.KeySchema {
 		if ks.KeyType == "HASH" {
 			partitionKeyName = ks.AttributeName
 
@@ -336,7 +413,7 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, keyCondExpr, filterE
 
 	scannedCount := 0
 
-	for _, item := range td.items {
+	for _, item := range td.Items {
 		scannedCount++
 
 		// Check partition key match.
@@ -370,10 +447,10 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, keyCondExpr, filterE
 	startIdx := 0
 
 	if exclusiveStartKey != nil {
-		startKeyStr := m.serializeKey(td.table, exclusiveStartKey)
+		startKeyStr := m.serializeKey(td.Table, exclusiveStartKey)
 
 		for i, item := range results {
-			itemKeyStr := m.serializeKey(td.table, item)
+			itemKeyStr := m.serializeKey(td.Table, item)
 			if itemKeyStr == startKeyStr {
 				startIdx = i + 1
 
@@ -392,7 +469,7 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, keyCondExpr, filterE
 
 	if limit > 0 && len(results) > limit {
 		results = results[:limit]
-		lastEvaluatedKey = m.extractKey(td.table, results[len(results)-1])
+		lastEvaluatedKey = m.extractKey(td.Table, results[len(results)-1])
 	}
 
 	return results, lastEvaluatedKey, scannedCount, nil
@@ -405,7 +482,7 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	td, exists := m.tables[tableName]
+	td, exists := m.Tables[tableName]
 	if !exists {
 		return nil, nil, 0, &TableError{
 			Code:    "ResourceNotFoundException",
@@ -418,7 +495,7 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 
 	scannedCount := 0
 
-	for _, item := range td.items {
+	for _, item := range td.Items {
 		scannedCount++
 
 		// Apply filter expression.
@@ -431,8 +508,8 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 
 	// Sort by key for consistent pagination.
 	sort.Slice(results, func(i, j int) bool {
-		keyI := m.serializeKey(td.table, results[i])
-		keyJ := m.serializeKey(td.table, results[j])
+		keyI := m.serializeKey(td.Table, results[i])
+		keyJ := m.serializeKey(td.Table, results[j])
 
 		return keyI < keyJ
 	})
@@ -441,10 +518,10 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 	startIdx := 0
 
 	if exclusiveStartKey != nil {
-		startKeyStr := m.serializeKey(td.table, exclusiveStartKey)
+		startKeyStr := m.serializeKey(td.Table, exclusiveStartKey)
 
 		for i, item := range results {
-			itemKeyStr := m.serializeKey(td.table, item)
+			itemKeyStr := m.serializeKey(td.Table, item)
 			if itemKeyStr == startKeyStr {
 				startIdx = i + 1
 
@@ -463,7 +540,7 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 
 	if limit > 0 && len(results) > limit {
 		results = results[:limit]
-		lastEvaluatedKey = m.extractKey(td.table, results[len(results)-1])
+		lastEvaluatedKey = m.extractKey(td.Table, results[len(results)-1])
 	}
 
 	return results, lastEvaluatedKey, scannedCount, nil

--- a/internal/service/ebs/service.go
+++ b/internal/service/ebs/service.go
@@ -1,8 +1,15 @@
 package ebs
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
 
 // Service implements the AWS EBS direct API service.
 type Service struct {
@@ -31,6 +38,22 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("GET", "/snapshots/{secondSnapshotId}/changedblocks", s.ListChangedBlocksHandler)
 }
 
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }

--- a/internal/service/ebs/storage.go
+++ b/internal/service/ebs/storage.go
@@ -3,12 +3,15 @@ package ebs
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -38,25 +41,103 @@ type Storage interface {
 	ListChangedBlocks(ctx context.Context, firstSnapshotID, secondSnapshotID string) (*ListChangedBlocksResponse, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // blockData stores the raw data and checksum for a single snapshot block.
 type blockData struct {
-	data     []byte
-	checksum string
+	Data     []byte `json:"data"`
+	Checksum string `json:"checksum"`
 }
 
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu        sync.RWMutex
-	snapshots map[string]*Snapshot
-	blocks    map[string]map[int32]*blockData
+	mu        sync.RWMutex                    `json:"-"`
+	Snapshots map[string]*Snapshot            `json:"snapshots"`
+	Blocks    map[string]map[int32]*blockData `json:"blocks"`
+	dataDir   string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		snapshots: make(map[string]*Snapshot),
-		blocks:    make(map[string]map[int32]*blockData),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Snapshots: make(map[string]*Snapshot),
+		Blocks:    make(map[string]map[int32]*blockData),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "ebs", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Snapshots == nil {
+		m.Snapshots = make(map[string]*Snapshot)
+	}
+
+	if m.Blocks == nil {
+		m.Blocks = make(map[string]map[int32]*blockData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "ebs", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // StartSnapshot starts a new snapshot.
@@ -78,7 +159,7 @@ func (m *MemoryStorage) StartSnapshot(_ context.Context, req *StartSnapshotReque
 		VolumeSize:       req.VolumeSize,
 	}
 
-	m.snapshots[snapshotID] = snapshot
+	m.Snapshots[snapshotID] = snapshot
 
 	return snapshot, nil
 }
@@ -88,7 +169,7 @@ func (m *MemoryStorage) CompleteSnapshot(_ context.Context, snapshotID string) (
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	snapshot, exists := m.snapshots[snapshotID]
+	snapshot, exists := m.Snapshots[snapshotID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errSnapshotNotFound,
@@ -106,7 +187,7 @@ func (m *MemoryStorage) ListSnapshotBlocks(_ context.Context, snapshotID string)
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	snapshot, exists := m.snapshots[snapshotID]
+	snapshot, exists := m.Snapshots[snapshotID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errSnapshotNotFound,
@@ -114,7 +195,7 @@ func (m *MemoryStorage) ListSnapshotBlocks(_ context.Context, snapshotID string)
 		}
 	}
 
-	snapshotBlocks := m.blocks[snapshotID]
+	snapshotBlocks := m.Blocks[snapshotID]
 
 	indices := make([]int, 0, len(snapshotBlocks))
 
@@ -146,7 +227,7 @@ func (m *MemoryStorage) PutSnapshotBlock(_ context.Context, snapshotID string, b
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	snapshot, exists := m.snapshots[snapshotID]
+	snapshot, exists := m.Snapshots[snapshotID]
 	if !exists {
 		return &ServiceError{
 			Code:    errSnapshotNotFound,
@@ -161,13 +242,13 @@ func (m *MemoryStorage) PutSnapshotBlock(_ context.Context, snapshotID string, b
 		}
 	}
 
-	if m.blocks[snapshotID] == nil {
-		m.blocks[snapshotID] = make(map[int32]*blockData)
+	if m.Blocks[snapshotID] == nil {
+		m.Blocks[snapshotID] = make(map[int32]*blockData)
 	}
 
-	m.blocks[snapshotID][blockIndex] = &blockData{
-		data:     data,
-		checksum: checksum,
+	m.Blocks[snapshotID][blockIndex] = &blockData{
+		Data:     data,
+		Checksum: checksum,
 	}
 
 	return nil
@@ -178,7 +259,7 @@ func (m *MemoryStorage) GetSnapshotBlock(_ context.Context, snapshotID string, b
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	_, exists := m.snapshots[snapshotID]
+	_, exists := m.Snapshots[snapshotID]
 	if !exists {
 		return nil, "", &ServiceError{
 			Code:    errSnapshotNotFound,
@@ -186,7 +267,7 @@ func (m *MemoryStorage) GetSnapshotBlock(_ context.Context, snapshotID string, b
 		}
 	}
 
-	snapshotBlocks, ok := m.blocks[snapshotID]
+	snapshotBlocks, ok := m.Blocks[snapshotID]
 	if !ok {
 		return nil, "", &ServiceError{
 			Code:    errSnapshotNotFound,
@@ -202,7 +283,7 @@ func (m *MemoryStorage) GetSnapshotBlock(_ context.Context, snapshotID string, b
 		}
 	}
 
-	return block.data, block.checksum, nil
+	return block.Data, block.Checksum, nil
 }
 
 // collectSortedIndices merges block indices from two block maps and returns them sorted.
@@ -262,7 +343,7 @@ func (m *MemoryStorage) ListChangedBlocks(_ context.Context, firstSnapshotID, se
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	secondSnapshot, exists := m.snapshots[secondSnapshotID]
+	secondSnapshot, exists := m.Snapshots[secondSnapshotID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errSnapshotNotFound,
@@ -273,17 +354,17 @@ func (m *MemoryStorage) ListChangedBlocks(_ context.Context, firstSnapshotID, se
 	var firstBlocks map[int32]*blockData
 
 	if firstSnapshotID != "" {
-		if _, ok := m.snapshots[firstSnapshotID]; !ok {
+		if _, ok := m.Snapshots[firstSnapshotID]; !ok {
 			return nil, &ServiceError{
 				Code:    errSnapshotNotFound,
 				Message: fmt.Sprintf("Snapshot %s does not exist.", firstSnapshotID),
 			}
 		}
 
-		firstBlocks = m.blocks[firstSnapshotID]
+		firstBlocks = m.Blocks[firstSnapshotID]
 	}
 
-	secondBlocks := m.blocks[secondSnapshotID]
+	secondBlocks := m.Blocks[secondSnapshotID]
 	indices := collectSortedIndices(firstBlocks, secondBlocks)
 	changedBlocks := buildChangedBlocks(indices, firstBlocks, secondBlocks)
 

--- a/internal/service/ec2/service.go
+++ b/internal/service/ec2/service.go
@@ -1,12 +1,23 @@
 package ec2
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage()
-	service.Register(New(storage))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the EC2 service.
@@ -83,3 +94,14 @@ func (s *Service) Actions() []string {
 
 // QueryProtocol is a marker method that indicates EC2 uses AWS Query protocol.
 func (s *Service) QueryProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/ec2/storage.go
+++ b/internal/service/ec2/storage.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"sync"
@@ -14,6 +15,24 @@ import (
 
 	"github.com/google/uuid"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/sivchari/kumo/internal/storage"
+)
+
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
 )
 
 const defaultAccountID = "000000000000"
@@ -100,33 +119,121 @@ type Reservation struct {
 
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu             sync.RWMutex
-	instances      map[string]*Instance
-	reservations   map[string]*Reservation
-	securityGroups map[string]*SecurityGroup
-	keyPairs       map[string]*KeyPair
-
-	// VPC resources
-	vpcs             map[string]*Vpc
-	subnets          map[string]*Subnet
-	internetGateways map[string]*InternetGateway
-	routeTables      map[string]*RouteTable
-	natGateways      map[string]*NatGateway
+	mu               sync.RWMutex                `json:"-"`
+	Instances        map[string]*Instance        `json:"instances"`
+	Reservations     map[string]*Reservation     `json:"reservations"`
+	SecurityGroups   map[string]*SecurityGroup   `json:"securityGroups"`
+	KeyPairs         map[string]*KeyPair         `json:"keyPairs"`
+	Vpcs             map[string]*Vpc             `json:"vpcs"`
+	Subnets          map[string]*Subnet          `json:"subnets"`
+	InternetGateways map[string]*InternetGateway `json:"internetGateways"`
+	RouteTables      map[string]*RouteTable      `json:"routeTables"`
+	NatGateways      map[string]*NatGateway      `json:"natGateways"`
+	dataDir          string
 }
 
 // NewMemoryStorage creates a new in-memory EC2 storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		instances:        make(map[string]*Instance),
-		reservations:     make(map[string]*Reservation),
-		securityGroups:   make(map[string]*SecurityGroup),
-		keyPairs:         make(map[string]*KeyPair),
-		vpcs:             make(map[string]*Vpc),
-		subnets:          make(map[string]*Subnet),
-		internetGateways: make(map[string]*InternetGateway),
-		routeTables:      make(map[string]*RouteTable),
-		natGateways:      make(map[string]*NatGateway),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Instances:        make(map[string]*Instance),
+		Reservations:     make(map[string]*Reservation),
+		SecurityGroups:   make(map[string]*SecurityGroup),
+		KeyPairs:         make(map[string]*KeyPair),
+		Vpcs:             make(map[string]*Vpc),
+		Subnets:          make(map[string]*Subnet),
+		InternetGateways: make(map[string]*InternetGateway),
+		RouteTables:      make(map[string]*RouteTable),
+		NatGateways:      make(map[string]*NatGateway),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "ec2", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Instances == nil {
+		m.Instances = make(map[string]*Instance)
+	}
+
+	if m.Reservations == nil {
+		m.Reservations = make(map[string]*Reservation)
+	}
+
+	if m.SecurityGroups == nil {
+		m.SecurityGroups = make(map[string]*SecurityGroup)
+	}
+
+	if m.KeyPairs == nil {
+		m.KeyPairs = make(map[string]*KeyPair)
+	}
+
+	if m.Vpcs == nil {
+		m.Vpcs = make(map[string]*Vpc)
+	}
+
+	if m.Subnets == nil {
+		m.Subnets = make(map[string]*Subnet)
+	}
+
+	if m.InternetGateways == nil {
+		m.InternetGateways = make(map[string]*InternetGateway)
+	}
+
+	if m.RouteTables == nil {
+		m.RouteTables = make(map[string]*RouteTable)
+	}
+
+	if m.NatGateways == nil {
+		m.NatGateways = make(map[string]*NatGateway)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "ec2", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // RunInstances creates new EC2 instances.
@@ -155,10 +262,10 @@ func (m *MemoryStorage) RunInstances(_ context.Context, req *RunInstancesRequest
 			SecurityGroups:   m.resolveSecurityGroups(req.SecurityGroupIDs, req.SecurityGroups),
 		}
 		instances = append(instances, instance)
-		m.instances[instance.InstanceID] = instance
+		m.Instances[instance.InstanceID] = instance
 	}
 
-	m.reservations[reservationID] = &Reservation{
+	m.Reservations[reservationID] = &Reservation{
 		ReservationID: reservationID,
 		OwnerID:       defaultAccountID,
 		Instances:     instances,
@@ -175,7 +282,7 @@ func (m *MemoryStorage) TerminateInstances(_ context.Context, instanceIDs []stri
 	var changes []InstanceStateChange
 
 	for _, id := range instanceIDs {
-		instance, exists := m.instances[id]
+		instance, exists := m.Instances[id]
 		if !exists {
 			return nil, &Error{
 				Code:    "InvalidInstanceID.NotFound",
@@ -202,8 +309,8 @@ func (m *MemoryStorage) DescribeInstances(_ context.Context, instanceIDs []strin
 	defer m.mu.RUnlock()
 
 	if len(instanceIDs) == 0 {
-		reservations := make([]*Reservation, 0, len(m.reservations))
-		for _, r := range m.reservations {
+		reservations := make([]*Reservation, 0, len(m.Reservations))
+		for _, r := range m.Reservations {
 			reservations = append(reservations, r)
 		}
 
@@ -213,7 +320,7 @@ func (m *MemoryStorage) DescribeInstances(_ context.Context, instanceIDs []strin
 	reservationMap := make(map[string]*Reservation)
 
 	for _, id := range instanceIDs {
-		instance, exists := m.instances[id]
+		instance, exists := m.Instances[id]
 		if !exists {
 			return nil, &Error{
 				Code:    "InvalidInstanceID.NotFound",
@@ -221,7 +328,7 @@ func (m *MemoryStorage) DescribeInstances(_ context.Context, instanceIDs []strin
 			}
 		}
 
-		for resID, res := range m.reservations {
+		for resID, res := range m.Reservations {
 			for _, inst := range res.Instances {
 				if inst.InstanceID == id {
 					if _, ok := reservationMap[resID]; !ok {
@@ -254,7 +361,7 @@ func (m *MemoryStorage) StartInstances(_ context.Context, instanceIDs []string) 
 	var changes []InstanceStateChange
 
 	for _, id := range instanceIDs {
-		instance, exists := m.instances[id]
+		instance, exists := m.Instances[id]
 		if !exists {
 			return nil, &Error{
 				Code:    "InvalidInstanceID.NotFound",
@@ -283,7 +390,7 @@ func (m *MemoryStorage) StopInstances(_ context.Context, instanceIDs []string) (
 	var changes []InstanceStateChange
 
 	for _, id := range instanceIDs {
-		instance, exists := m.instances[id]
+		instance, exists := m.Instances[id]
 		if !exists {
 			return nil, &Error{
 				Code:    "InvalidInstanceID.NotFound",
@@ -309,7 +416,7 @@ func (m *MemoryStorage) CreateSecurityGroup(_ context.Context, req *CreateSecuri
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for _, sg := range m.securityGroups {
+	for _, sg := range m.SecurityGroups {
 		if sg.GroupName == req.GroupName {
 			return nil, &Error{
 				Code:    "InvalidGroup.Duplicate",
@@ -327,7 +434,7 @@ func (m *MemoryStorage) CreateSecurityGroup(_ context.Context, req *CreateSecuri
 		EgressRules:  []IPPermission{},
 	}
 
-	m.securityGroups[sg.GroupID] = sg
+	m.SecurityGroups[sg.GroupID] = sg
 
 	return sg, nil
 }
@@ -338,21 +445,21 @@ func (m *MemoryStorage) DeleteSecurityGroup(_ context.Context, groupID, groupNam
 	defer m.mu.Unlock()
 
 	if groupID != "" {
-		if _, exists := m.securityGroups[groupID]; !exists {
+		if _, exists := m.SecurityGroups[groupID]; !exists {
 			return &Error{
 				Code:    "InvalidGroup.NotFound",
 				Message: fmt.Sprintf("The security group '%s' does not exist", groupID),
 			}
 		}
 
-		delete(m.securityGroups, groupID)
+		delete(m.SecurityGroups, groupID)
 
 		return nil
 	}
 
-	for id, sg := range m.securityGroups {
+	for id, sg := range m.SecurityGroups {
 		if sg.GroupName == groupName {
-			delete(m.securityGroups, id)
+			delete(m.SecurityGroups, id)
 
 			return nil
 		}
@@ -387,7 +494,7 @@ func (m *MemoryStorage) AuthorizeSecurityGroupEgress(_ context.Context, groupID 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	sg, exists := m.securityGroups[groupID]
+	sg, exists := m.SecurityGroups[groupID]
 	if !exists {
 		return &Error{
 			Code:    "InvalidGroup.NotFound",
@@ -405,7 +512,7 @@ func (m *MemoryStorage) CreateKeyPair(_ context.Context, keyName, _ string) (*Ke
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for _, kp := range m.keyPairs {
+	for _, kp := range m.KeyPairs {
 		if kp.KeyName == keyName {
 			return nil, &Error{
 				Code:    "InvalidKeyPair.Duplicate",
@@ -445,7 +552,7 @@ func (m *MemoryStorage) CreateKeyPair(_ context.Context, keyName, _ string) (*Ke
 		CreateTime:     time.Now(),
 	}
 
-	m.keyPairs[kp.KeyPairID] = kp
+	m.KeyPairs[kp.KeyPairID] = kp
 
 	return kp, nil
 }
@@ -456,21 +563,21 @@ func (m *MemoryStorage) DeleteKeyPair(_ context.Context, keyName, keyPairID stri
 	defer m.mu.Unlock()
 
 	if keyPairID != "" {
-		if _, exists := m.keyPairs[keyPairID]; !exists {
+		if _, exists := m.KeyPairs[keyPairID]; !exists {
 			return &Error{
 				Code:    "InvalidKeyPair.NotFound",
 				Message: fmt.Sprintf("The key pair '%s' does not exist", keyPairID),
 			}
 		}
 
-		delete(m.keyPairs, keyPairID)
+		delete(m.KeyPairs, keyPairID)
 
 		return nil
 	}
 
-	for id, kp := range m.keyPairs {
+	for id, kp := range m.KeyPairs {
 		if kp.KeyName == keyName {
-			delete(m.keyPairs, id)
+			delete(m.KeyPairs, id)
 
 			return nil
 		}
@@ -501,9 +608,9 @@ func (m *MemoryStorage) DescribeKeyPairs(_ context.Context, keyNames, keyPairIDs
 
 // listAllKeyPairs returns all key pairs without KeyMaterial.
 func (m *MemoryStorage) listAllKeyPairs() []*KeyPair {
-	keyPairs := make([]*KeyPair, 0, len(m.keyPairs))
+	keyPairs := make([]*KeyPair, 0, len(m.KeyPairs))
 
-	for _, kp := range m.keyPairs {
+	for _, kp := range m.KeyPairs {
 		keyPairs = append(keyPairs, copyKeyPairInfo(kp))
 	}
 
@@ -524,7 +631,7 @@ func (m *MemoryStorage) collectKeyPairs(keyNames, keyPairIDs []string) (map[stri
 	}
 
 	for _, id := range keyPairIDs {
-		kp, exists := m.keyPairs[id]
+		kp, exists := m.KeyPairs[id]
 		if !exists {
 			return nil, &Error{
 				Code:    "InvalidKeyPair.NotFound",
@@ -540,7 +647,7 @@ func (m *MemoryStorage) collectKeyPairs(keyNames, keyPairIDs []string) (map[stri
 
 // findKeyPairByName finds a key pair by name.
 func (m *MemoryStorage) findKeyPairByName(name string) (*KeyPair, error) {
-	for _, kp := range m.keyPairs {
+	for _, kp := range m.KeyPairs {
 		if kp.KeyName == name {
 			return kp, nil
 		}
@@ -576,10 +683,10 @@ func copyKeyPairInfo(kp *KeyPair) *KeyPair {
 // findSecurityGroup finds a security group by ID or name.
 func (m *MemoryStorage) findSecurityGroup(groupID, groupName string) *SecurityGroup {
 	if groupID != "" {
-		return m.securityGroups[groupID]
+		return m.SecurityGroups[groupID]
 	}
 
-	for _, sg := range m.securityGroups {
+	for _, sg := range m.SecurityGroups {
 		if sg.GroupName == groupName {
 			return sg
 		}
@@ -593,7 +700,7 @@ func (m *MemoryStorage) resolveSecurityGroups(groupIDs, groupNames []string) []G
 	var result []GroupIdentifier
 
 	for _, id := range groupIDs {
-		if sg, exists := m.securityGroups[id]; exists {
+		if sg, exists := m.SecurityGroups[id]; exists {
 			result = append(result, GroupIdentifier{
 				GroupID:   sg.GroupID,
 				GroupName: sg.GroupName,
@@ -602,7 +709,7 @@ func (m *MemoryStorage) resolveSecurityGroups(groupIDs, groupNames []string) []G
 	}
 
 	for _, name := range groupNames {
-		for _, sg := range m.securityGroups {
+		for _, sg := range m.SecurityGroups {
 			if sg.GroupName == name {
 				result = append(result, GroupIdentifier{
 					GroupID:   sg.GroupID,
@@ -660,7 +767,7 @@ func (m *MemoryStorage) CreateVpc(_ context.Context, req *CreateVpcRequest) (*Vp
 		vpc.InstanceTenancy = "default"
 	}
 
-	m.vpcs[vpc.VpcID] = vpc
+	m.Vpcs[vpc.VpcID] = vpc
 
 	return vpc, nil
 }
@@ -670,7 +777,7 @@ func (m *MemoryStorage) DeleteVpc(_ context.Context, vpcID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.vpcs[vpcID]; !exists {
+	if _, exists := m.Vpcs[vpcID]; !exists {
 		return &Error{
 			Code:    "InvalidVpcID.NotFound",
 			Message: fmt.Sprintf("The vpc ID '%s' does not exist", vpcID),
@@ -678,7 +785,7 @@ func (m *MemoryStorage) DeleteVpc(_ context.Context, vpcID string) error {
 	}
 
 	// Check for dependencies
-	for _, subnet := range m.subnets {
+	for _, subnet := range m.Subnets {
 		if subnet.VpcID == vpcID {
 			return &Error{
 				Code:    "DependencyViolation",
@@ -687,7 +794,7 @@ func (m *MemoryStorage) DeleteVpc(_ context.Context, vpcID string) error {
 		}
 	}
 
-	for _, igw := range m.internetGateways {
+	for _, igw := range m.InternetGateways {
 		for _, attachment := range igw.Attachments {
 			if attachment.VpcID == vpcID {
 				return &Error{
@@ -698,7 +805,7 @@ func (m *MemoryStorage) DeleteVpc(_ context.Context, vpcID string) error {
 		}
 	}
 
-	delete(m.vpcs, vpcID)
+	delete(m.Vpcs, vpcID)
 
 	return nil
 }
@@ -709,8 +816,8 @@ func (m *MemoryStorage) DescribeVpcs(_ context.Context, vpcIDs []string) ([]*Vpc
 	defer m.mu.RUnlock()
 
 	if len(vpcIDs) == 0 {
-		vpcs := make([]*Vpc, 0, len(m.vpcs))
-		for _, vpc := range m.vpcs {
+		vpcs := make([]*Vpc, 0, len(m.Vpcs))
+		for _, vpc := range m.Vpcs {
 			vpcs = append(vpcs, vpc)
 		}
 
@@ -720,7 +827,7 @@ func (m *MemoryStorage) DescribeVpcs(_ context.Context, vpcIDs []string) ([]*Vpc
 	vpcs := make([]*Vpc, 0, len(vpcIDs))
 
 	for _, id := range vpcIDs {
-		vpc, exists := m.vpcs[id]
+		vpc, exists := m.Vpcs[id]
 		if !exists {
 			return nil, &Error{
 				Code:    "InvalidVpcID.NotFound",
@@ -739,7 +846,7 @@ func (m *MemoryStorage) CreateSubnet(_ context.Context, req *CreateSubnetRequest
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.vpcs[req.VpcID]; !exists {
+	if _, exists := m.Vpcs[req.VpcID]; !exists {
 		return nil, &Error{
 			Code:    "InvalidVpcID.NotFound",
 			Message: fmt.Sprintf("The vpc ID '%s' does not exist", req.VpcID),
@@ -761,7 +868,7 @@ func (m *MemoryStorage) CreateSubnet(_ context.Context, req *CreateSubnetRequest
 		subnet.AvailabilityZone = "us-east-1a"
 	}
 
-	m.subnets[subnet.SubnetID] = subnet
+	m.Subnets[subnet.SubnetID] = subnet
 
 	return subnet, nil
 }
@@ -771,14 +878,14 @@ func (m *MemoryStorage) DeleteSubnet(_ context.Context, subnetID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.subnets[subnetID]; !exists {
+	if _, exists := m.Subnets[subnetID]; !exists {
 		return &Error{
 			Code:    "InvalidSubnetID.NotFound",
 			Message: fmt.Sprintf("The subnet ID '%s' does not exist", subnetID),
 		}
 	}
 
-	delete(m.subnets, subnetID)
+	delete(m.Subnets, subnetID)
 
 	return nil
 }
@@ -791,7 +898,7 @@ func (m *MemoryStorage) DescribeSubnets(_ context.Context, subnetIDs []string, f
 	var subnets []*Subnet
 
 	if len(subnetIDs) == 0 {
-		for _, subnet := range m.subnets {
+		for _, subnet := range m.Subnets {
 			if m.matchSubnetFilters(subnet, filters) {
 				subnets = append(subnets, subnet)
 			}
@@ -801,7 +908,7 @@ func (m *MemoryStorage) DescribeSubnets(_ context.Context, subnetIDs []string, f
 	}
 
 	for _, id := range subnetIDs {
-		subnet, exists := m.subnets[id]
+		subnet, exists := m.Subnets[id]
 		if !exists {
 			return nil, &Error{
 				Code:    "InvalidSubnetID.NotFound",
@@ -850,7 +957,7 @@ func (m *MemoryStorage) CreateInternetGateway(_ context.Context, _ *CreateIntern
 		Tags:              []Tag{},
 	}
 
-	m.internetGateways[igw.InternetGatewayID] = igw
+	m.InternetGateways[igw.InternetGatewayID] = igw
 
 	return igw, nil
 }
@@ -860,7 +967,7 @@ func (m *MemoryStorage) AttachInternetGateway(_ context.Context, igwID, vpcID st
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	igw, exists := m.internetGateways[igwID]
+	igw, exists := m.InternetGateways[igwID]
 	if !exists {
 		return &Error{
 			Code:    "InvalidInternetGatewayID.NotFound",
@@ -868,7 +975,7 @@ func (m *MemoryStorage) AttachInternetGateway(_ context.Context, igwID, vpcID st
 		}
 	}
 
-	if _, exists := m.vpcs[vpcID]; !exists {
+	if _, exists := m.Vpcs[vpcID]; !exists {
 		return &Error{
 			Code:    "InvalidVpcID.NotFound",
 			Message: fmt.Sprintf("The vpc ID '%s' does not exist", vpcID),
@@ -899,8 +1006,8 @@ func (m *MemoryStorage) DescribeInternetGateways(_ context.Context, igwIDs []str
 	defer m.mu.RUnlock()
 
 	if len(igwIDs) == 0 {
-		igws := make([]*InternetGateway, 0, len(m.internetGateways))
-		for _, igw := range m.internetGateways {
+		igws := make([]*InternetGateway, 0, len(m.InternetGateways))
+		for _, igw := range m.InternetGateways {
 			igws = append(igws, igw)
 		}
 
@@ -910,7 +1017,7 @@ func (m *MemoryStorage) DescribeInternetGateways(_ context.Context, igwIDs []str
 	igws := make([]*InternetGateway, 0, len(igwIDs))
 
 	for _, id := range igwIDs {
-		igw, exists := m.internetGateways[id]
+		igw, exists := m.InternetGateways[id]
 		if !exists {
 			return nil, &Error{
 				Code:    "InvalidInternetGatewayID.NotFound",
@@ -929,7 +1036,7 @@ func (m *MemoryStorage) CreateRouteTable(_ context.Context, req *CreateRouteTabl
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.vpcs[req.VpcID]; !exists {
+	if _, exists := m.Vpcs[req.VpcID]; !exists {
 		return nil, &Error{
 			Code:    "InvalidVpcID.NotFound",
 			Message: fmt.Sprintf("The vpc ID '%s' does not exist", req.VpcID),
@@ -950,7 +1057,7 @@ func (m *MemoryStorage) CreateRouteTable(_ context.Context, req *CreateRouteTabl
 		Tags:         []Tag{},
 	}
 
-	m.routeTables[rt.RouteTableID] = rt
+	m.RouteTables[rt.RouteTableID] = rt
 
 	return rt, nil
 }
@@ -960,7 +1067,7 @@ func (m *MemoryStorage) CreateRoute(_ context.Context, req *CreateRouteRequest) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	rt, exists := m.routeTables[req.RouteTableID]
+	rt, exists := m.RouteTables[req.RouteTableID]
 	if !exists {
 		return &Error{
 			Code:    "InvalidRouteTableID.NotFound",
@@ -995,7 +1102,7 @@ func (m *MemoryStorage) AssociateRouteTable(_ context.Context, req *AssociateRou
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	rt, exists := m.routeTables[req.RouteTableID]
+	rt, exists := m.RouteTables[req.RouteTableID]
 	if !exists {
 		return "", &Error{
 			Code:    "InvalidRouteTableID.NotFound",
@@ -1003,7 +1110,7 @@ func (m *MemoryStorage) AssociateRouteTable(_ context.Context, req *AssociateRou
 		}
 	}
 
-	if _, exists := m.subnets[req.SubnetID]; !exists {
+	if _, exists := m.Subnets[req.SubnetID]; !exists {
 		return "", &Error{
 			Code:    "InvalidSubnetID.NotFound",
 			Message: fmt.Sprintf("The subnet ID '%s' does not exist", req.SubnetID),
@@ -1027,8 +1134,8 @@ func (m *MemoryStorage) DescribeRouteTables(_ context.Context, rtbIDs []string) 
 	defer m.mu.RUnlock()
 
 	if len(rtbIDs) == 0 {
-		rts := make([]*RouteTable, 0, len(m.routeTables))
-		for _, rt := range m.routeTables {
+		rts := make([]*RouteTable, 0, len(m.RouteTables))
+		for _, rt := range m.RouteTables {
 			rts = append(rts, rt)
 		}
 
@@ -1038,7 +1145,7 @@ func (m *MemoryStorage) DescribeRouteTables(_ context.Context, rtbIDs []string) 
 	rts := make([]*RouteTable, 0, len(rtbIDs))
 
 	for _, id := range rtbIDs {
-		rt, exists := m.routeTables[id]
+		rt, exists := m.RouteTables[id]
 		if !exists {
 			return nil, &Error{
 				Code:    "InvalidRouteTableId.NotFound",
@@ -1057,7 +1164,7 @@ func (m *MemoryStorage) CreateNatGateway(_ context.Context, req *CreateNatGatewa
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	subnet, exists := m.subnets[req.SubnetID]
+	subnet, exists := m.Subnets[req.SubnetID]
 	if !exists {
 		return nil, &Error{
 			Code:    "InvalidSubnetID.NotFound",
@@ -1080,7 +1187,7 @@ func (m *MemoryStorage) CreateNatGateway(_ context.Context, req *CreateNatGatewa
 		natgw.AllocationID = req.AllocationID
 	}
 
-	m.natGateways[natgw.NatGatewayID] = natgw
+	m.NatGateways[natgw.NatGatewayID] = natgw
 
 	return natgw, nil
 }
@@ -1091,8 +1198,8 @@ func (m *MemoryStorage) DescribeNatGateways(_ context.Context, natgwIDs []string
 	defer m.mu.RUnlock()
 
 	if len(natgwIDs) == 0 {
-		natgws := make([]*NatGateway, 0, len(m.natGateways))
-		for _, natgw := range m.natGateways {
+		natgws := make([]*NatGateway, 0, len(m.NatGateways))
+		for _, natgw := range m.NatGateways {
 			natgws = append(natgws, natgw)
 		}
 
@@ -1102,7 +1209,7 @@ func (m *MemoryStorage) DescribeNatGateways(_ context.Context, natgwIDs []string
 	natgws := make([]*NatGateway, 0, len(natgwIDs))
 
 	for _, id := range natgwIDs {
-		natgw, exists := m.natGateways[id]
+		natgw, exists := m.NatGateways[id]
 		if !exists {
 			return nil, &Error{
 				Code:    "NatGatewayNotFound",

--- a/internal/service/ecr/service.go
+++ b/internal/service/ecr/service.go
@@ -2,8 +2,15 @@
 package ecr
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
 
 // Service is the ECR service.
 type Service struct {
@@ -37,5 +44,21 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 }
 
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/ecr/storage.go
+++ b/internal/service/ecr/storage.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -31,27 +34,101 @@ type Storage interface {
 	DispatchAction(action string) bool
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu           sync.RWMutex
-	repositories map[string]*repositoryData
+	mu           sync.RWMutex               `json:"-"`
+	Repositories map[string]*repositoryData `json:"repositories"`
 	region       string
 	accountID    string
+	dataDir      string
 }
 
 // repositoryData holds repository information and its images.
 type repositoryData struct {
-	repository *Repository
-	images     map[string]*Image // keyed by digest
+	Repository *Repository       `json:"repository"`
+	Images     map[string]*Image `json:"images"`
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		repositories: make(map[string]*repositoryData),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Repositories: make(map[string]*repositoryData),
 		region:       "us-east-1",
 		accountID:    "000000000000",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "ecr", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Repositories == nil {
+		s.Repositories = make(map[string]*repositoryData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "ecr", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateRepository creates a new repository.
@@ -59,7 +136,7 @@ func (s *MemoryStorage) CreateRepository(_ context.Context, req *CreateRepositor
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.repositories[req.RepositoryName]; exists {
+	if _, exists := s.Repositories[req.RepositoryName]; exists {
 		return nil, &ServiceError{Code: errRepositoryAlreadyExists, Message: "Repository already exists"}
 	}
 
@@ -80,9 +157,9 @@ func (s *MemoryStorage) CreateRepository(_ context.Context, req *CreateRepositor
 		EncryptionConfiguration:    req.EncryptionConfiguration,
 	}
 
-	s.repositories[req.RepositoryName] = &repositoryData{
-		repository: repo,
-		images:     make(map[string]*Image),
+	s.Repositories[req.RepositoryName] = &repositoryData{
+		Repository: repo,
+		Images:     make(map[string]*Image),
 	}
 
 	return repo, nil
@@ -93,18 +170,18 @@ func (s *MemoryStorage) DeleteRepository(_ context.Context, repositoryName strin
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	rd, exists := s.repositories[repositoryName]
+	rd, exists := s.Repositories[repositoryName]
 	if !exists {
 		return nil, &ServiceError{Code: errRepositoryNotFound, Message: "Repository does not exist"}
 	}
 
-	if !force && len(rd.images) > 0 {
+	if !force && len(rd.Images) > 0 {
 		return nil, &ServiceError{Code: errInvalidParameter, Message: "Repository contains images"}
 	}
 
-	delete(s.repositories, repositoryName)
+	delete(s.Repositories, repositoryName)
 
-	return rd.repository, nil
+	return rd.Repository, nil
 }
 
 // DescribeRepositories describes repositories.
@@ -120,13 +197,13 @@ func (s *MemoryStorage) DescribeRepositories(_ context.Context, names []string, 
 
 	if len(names) > 0 {
 		for _, name := range names {
-			if rd, exists := s.repositories[name]; exists {
-				repos = append(repos, rd.repository)
+			if rd, exists := s.Repositories[name]; exists {
+				repos = append(repos, rd.Repository)
 			}
 		}
 	} else {
-		for _, rd := range s.repositories {
-			repos = append(repos, rd.repository)
+		for _, rd := range s.Repositories {
+			repos = append(repos, rd.Repository)
 		}
 	}
 
@@ -146,7 +223,7 @@ func (s *MemoryStorage) ListImages(_ context.Context, repositoryName string, max
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	rd, exists := s.repositories[repositoryName]
+	rd, exists := s.Repositories[repositoryName]
 	if !exists {
 		return nil, "", &ServiceError{Code: errRepositoryNotFound, Message: "Repository does not exist"}
 	}
@@ -156,8 +233,8 @@ func (s *MemoryStorage) ListImages(_ context.Context, repositoryName string, max
 	}
 
 	// Collect all images into a slice for sorting
-	images := make([]*Image, 0, len(rd.images))
-	for _, img := range rd.images {
+	images := make([]*Image, 0, len(rd.Images))
+	for _, img := range rd.Images {
 		images = append(images, img)
 	}
 
@@ -206,7 +283,7 @@ func (s *MemoryStorage) PutImage(_ context.Context, repositoryName, imageManifes
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	rd, exists := s.repositories[repositoryName]
+	rd, exists := s.Repositories[repositoryName]
 	if !exists {
 		return nil, &ServiceError{Code: errRepositoryNotFound, Message: "Repository does not exist"}
 	}
@@ -225,7 +302,7 @@ func (s *MemoryStorage) PutImage(_ context.Context, repositoryName, imageManifes
 		PushedAt: time.Now(),
 	}
 
-	rd.images[digest] = img
+	rd.Images[digest] = img
 
 	return img, nil
 }
@@ -235,7 +312,7 @@ func (s *MemoryStorage) BatchGetImage(_ context.Context, repositoryName string, 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	rd, exists := s.repositories[repositoryName]
+	rd, exists := s.Repositories[repositoryName]
 	if !exists {
 		return nil, nil, &ServiceError{Code: errRepositoryNotFound, Message: "Repository does not exist"}
 	}
@@ -247,7 +324,7 @@ func (s *MemoryStorage) BatchGetImage(_ context.Context, repositoryName string, 
 	for _, id := range imageIDs {
 		found := false
 
-		for _, img := range rd.images {
+		for _, img := range rd.Images {
 			if (id.ImageDigest != "" && img.ImageDigest == id.ImageDigest) ||
 				(id.ImageTag != "" && img.ImageID.ImageTag == id.ImageTag) {
 				images = append(images, img)
@@ -274,7 +351,7 @@ func (s *MemoryStorage) BatchDeleteImage(_ context.Context, repositoryName strin
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	rd, exists := s.repositories[repositoryName]
+	rd, exists := s.Repositories[repositoryName]
 	if !exists {
 		return nil, nil, &ServiceError{Code: errRepositoryNotFound, Message: "Repository does not exist"}
 	}
@@ -286,10 +363,10 @@ func (s *MemoryStorage) BatchDeleteImage(_ context.Context, repositoryName strin
 	for _, id := range imageIDs {
 		found := false
 
-		for digest, img := range rd.images {
+		for digest, img := range rd.Images {
 			if (id.ImageDigest != "" && img.ImageDigest == id.ImageDigest) ||
 				(id.ImageTag != "" && img.ImageID.ImageTag == id.ImageTag) {
-				delete(rd.images, digest)
+				delete(rd.Images, digest)
 
 				deleted = append(deleted, ImageIdentifier{
 					ImageDigest: img.ImageDigest,

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1,11 +1,23 @@
 package ecs
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the ECS service.
@@ -39,3 +51,14 @@ func (s *Service) TargetPrefix() string {
 
 // JSONProtocol is a marker method that indicates ECS uses AWS JSON 1.1 protocol.
 func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/ecs/storage.go
+++ b/internal/service/ecs/storage.go
@@ -2,12 +2,15 @@ package ecs
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -43,25 +46,115 @@ type Storage interface {
 	UpdateService(ctx context.Context, req *UpdateServiceRequest) (*ServiceResource, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu              sync.RWMutex
-	clusters        map[string]*Cluster
-	taskDefinitions map[string]*TaskDefinition
-	taskDefFamilies map[string][]string // family -> list of task definition ARNs
-	tasks           map[string]*Task
-	services        map[string]*ServiceResource
+	mu              sync.RWMutex                `json:"-"`
+	Clusters        map[string]*Cluster         `json:"clusters"`
+	TaskDefinitions map[string]*TaskDefinition  `json:"taskDefinitions"`
+	TaskDefFamilies map[string][]string         `json:"taskDefFamilies"`
+	Tasks           map[string]*Task            `json:"tasks"`
+	Services        map[string]*ServiceResource `json:"services"`
+	dataDir         string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		clusters:        make(map[string]*Cluster),
-		taskDefinitions: make(map[string]*TaskDefinition),
-		taskDefFamilies: make(map[string][]string),
-		tasks:           make(map[string]*Task),
-		services:        make(map[string]*ServiceResource),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Clusters:        make(map[string]*Cluster),
+		TaskDefinitions: make(map[string]*TaskDefinition),
+		TaskDefFamilies: make(map[string][]string),
+		Tasks:           make(map[string]*Task),
+		Services:        make(map[string]*ServiceResource),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "ecs", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Clusters == nil {
+		m.Clusters = make(map[string]*Cluster)
+	}
+
+	if m.TaskDefinitions == nil {
+		m.TaskDefinitions = make(map[string]*TaskDefinition)
+	}
+
+	if m.TaskDefFamilies == nil {
+		m.TaskDefFamilies = make(map[string][]string)
+	}
+
+	if m.Tasks == nil {
+		m.Tasks = make(map[string]*Task)
+	}
+
+	if m.Services == nil {
+		m.Services = make(map[string]*ServiceResource)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "ecs", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 func generateID() string {
@@ -101,7 +194,7 @@ func (m *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 	arn := clusterArn(name)
 
 	// Check if cluster already exists.
-	if existing, ok := m.clusters[arn]; ok {
+	if existing, ok := m.Clusters[arn]; ok {
 		return existing, nil
 	}
 
@@ -112,7 +205,7 @@ func (m *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 		Tags:        req.Tags,
 	}
 
-	m.clusters[arn] = cluster
+	m.Clusters[arn] = cluster
 
 	return cluster, nil
 }
@@ -124,7 +217,7 @@ func (m *MemoryStorage) DeleteCluster(_ context.Context, cluster string) (*Clust
 
 	arn := m.resolveClusterArn(cluster)
 
-	existing, ok := m.clusters[arn]
+	existing, ok := m.Clusters[arn]
 	if !ok {
 		return nil, &Error{
 			Code:    "ClusterNotFoundException",
@@ -149,7 +242,7 @@ func (m *MemoryStorage) DeleteCluster(_ context.Context, cluster string) (*Clust
 
 	existing.Status = statusInactive
 
-	delete(m.clusters, arn)
+	delete(m.Clusters, arn)
 
 	return existing, nil
 }
@@ -166,7 +259,7 @@ func (m *MemoryStorage) DescribeClusters(_ context.Context, clusters []string) (
 
 	// If no clusters specified, return all.
 	if len(clusters) == 0 {
-		for _, c := range m.clusters {
+		for _, c := range m.Clusters {
 			result = append(result, *c)
 		}
 
@@ -176,7 +269,7 @@ func (m *MemoryStorage) DescribeClusters(_ context.Context, clusters []string) (
 	for _, cluster := range clusters {
 		arn := m.resolveClusterArn(cluster)
 
-		if c, ok := m.clusters[arn]; ok {
+		if c, ok := m.Clusters[arn]; ok {
 			result = append(result, *c)
 		} else {
 			failures = append(failures, Failure{
@@ -194,8 +287,8 @@ func (m *MemoryStorage) ListClusters(_ context.Context, _ int, _ string) ([]stri
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	arns := make([]string, 0, len(m.clusters))
-	for arn := range m.clusters {
+	arns := make([]string, 0, len(m.Clusters))
+	for arn := range m.Clusters {
 		arns = append(arns, arn)
 	}
 
@@ -209,7 +302,7 @@ func (m *MemoryStorage) RegisterTaskDefinition(_ context.Context, req *RegisterT
 
 	// Determine revision number.
 	revision := 1
-	if existing, ok := m.taskDefFamilies[req.Family]; ok {
+	if existing, ok := m.TaskDefFamilies[req.Family]; ok {
 		revision = len(existing) + 1
 	}
 
@@ -230,8 +323,8 @@ func (m *MemoryStorage) RegisterTaskDefinition(_ context.Context, req *RegisterT
 		Tags:                    req.Tags,
 	}
 
-	m.taskDefinitions[arn] = td
-	m.taskDefFamilies[req.Family] = append(m.taskDefFamilies[req.Family], arn)
+	m.TaskDefinitions[arn] = td
+	m.TaskDefFamilies[req.Family] = append(m.TaskDefFamilies[req.Family], arn)
 
 	return td, nil
 }
@@ -243,7 +336,7 @@ func (m *MemoryStorage) DeregisterTaskDefinition(_ context.Context, taskDefiniti
 
 	arn := m.resolveTaskDefinitionArn(taskDefinition)
 
-	td, ok := m.taskDefinitions[arn]
+	td, ok := m.TaskDefinitions[arn]
 	if !ok {
 		return nil, &Error{
 			Code:    "ClientException",
@@ -290,7 +383,7 @@ func (m *MemoryStorage) RunTask(_ context.Context, req *RunTaskRequest) ([]Task,
 }
 
 func (m *MemoryStorage) getOrCreateCluster(clusterArn, clusterName string) (*Cluster, error) {
-	cluster, ok := m.clusters[clusterArn]
+	cluster, ok := m.Clusters[clusterArn]
 	if ok {
 		return cluster, nil
 	}
@@ -301,7 +394,7 @@ func (m *MemoryStorage) getOrCreateCluster(clusterArn, clusterName string) (*Clu
 			ClusterName: "default",
 			Status:      statusActive,
 		}
-		m.clusters[clusterArn] = cluster
+		m.Clusters[clusterArn] = cluster
 
 		return cluster, nil
 	}
@@ -315,7 +408,7 @@ func (m *MemoryStorage) getOrCreateCluster(clusterArn, clusterName string) (*Clu
 func (m *MemoryStorage) getTaskDefinitionForRun(taskDef string) (*TaskDefinition, error) {
 	tdArn := m.resolveTaskDefinitionArn(taskDef)
 
-	td, ok := m.taskDefinitions[tdArn]
+	td, ok := m.TaskDefinitions[tdArn]
 	if !ok {
 		return nil, &Error{
 			Code:    "ClientException",
@@ -332,7 +425,7 @@ func (m *MemoryStorage) createTasks(clusterArn string, td *TaskDefinition, req *
 
 	for range count {
 		task := m.createSingleTask(clusterArn, td, tdArn, req, launchType)
-		m.tasks[task.TaskArn] = &task
+		m.Tasks[task.TaskArn] = &task
 		tasks = append(tasks, task)
 	}
 
@@ -382,10 +475,10 @@ func (m *MemoryStorage) StopTask(_ context.Context, cluster, taskID, reason stri
 
 	clusterArn := m.resolveClusterArn(cluster)
 
-	task, ok := m.tasks[taskID]
+	task, ok := m.Tasks[taskID]
 	if !ok {
 		// Try to find by short ID.
-		for arn, t := range m.tasks {
+		for arn, t := range m.Tasks {
 			if strings.HasSuffix(arn, "/"+taskID) && t.ClusterArn == clusterArn {
 				task = t
 
@@ -411,7 +504,7 @@ func (m *MemoryStorage) StopTask(_ context.Context, cluster, taskID, reason stri
 	}
 
 	// Update cluster task count.
-	if c, ok := m.clusters[task.ClusterArn]; ok && c.RunningTasksCount > 0 {
+	if c, ok := m.Clusters[task.ClusterArn]; ok && c.RunningTasksCount > 0 {
 		c.RunningTasksCount--
 	}
 
@@ -433,7 +526,7 @@ func (m *MemoryStorage) DescribeTasks(_ context.Context, cluster string, taskIDs
 	for _, taskID := range taskIDs {
 		found := false
 
-		for arn, task := range m.tasks {
+		for arn, task := range m.Tasks {
 			if task.ClusterArn != clusterArn {
 				continue
 			}
@@ -464,7 +557,7 @@ func (m *MemoryStorage) CreateService(_ context.Context, req *CreateServiceReque
 
 	clusterArn := m.resolveClusterArn(req.Cluster)
 
-	cluster, ok := m.clusters[clusterArn]
+	cluster, ok := m.Clusters[clusterArn]
 	if !ok {
 		return nil, &Error{
 			Code:    "ClusterNotFoundException",
@@ -476,7 +569,7 @@ func (m *MemoryStorage) CreateService(_ context.Context, req *CreateServiceReque
 	arn := serviceArn(clusterName, req.ServiceName)
 
 	// Check if service already exists.
-	if _, ok := m.services[arn]; ok {
+	if _, ok := m.Services[arn]; ok {
 		return nil, &Error{
 			Code:    "ServiceAlreadyExistsException",
 			Message: "A service with that name already exists",
@@ -514,7 +607,7 @@ func (m *MemoryStorage) CreateService(_ context.Context, req *CreateServiceReque
 		Tags: req.Tags,
 	}
 
-	m.services[arn] = svc
+	m.Services[arn] = svc
 	cluster.ActiveServicesCount++
 
 	return svc, nil
@@ -530,10 +623,10 @@ func (m *MemoryStorage) DeleteService(_ context.Context, cluster, service string
 	svcArn := serviceArn(clusterName, service)
 
 	// Try to find by ARN or name.
-	svc, ok := m.services[svcArn]
+	svc, ok := m.Services[svcArn]
 	if !ok {
 		// Try to find by full ARN.
-		svc, ok = m.services[service]
+		svc, ok = m.Services[service]
 		if !ok {
 			return nil, &Error{
 				Code:    "ServiceNotFoundException",
@@ -553,10 +646,10 @@ func (m *MemoryStorage) DeleteService(_ context.Context, cluster, service string
 
 	svc.Status = statusDraining
 
-	delete(m.services, svcArn)
+	delete(m.Services, svcArn)
 
 	// Update cluster service count.
-	if c, ok := m.clusters[svc.ClusterArn]; ok && c.ActiveServicesCount > 0 {
+	if c, ok := m.Clusters[svc.ClusterArn]; ok && c.ActiveServicesCount > 0 {
 		c.ActiveServicesCount--
 	}
 
@@ -573,9 +666,9 @@ func (m *MemoryStorage) UpdateService(_ context.Context, req *UpdateServiceReque
 	svcArn := serviceArn(clusterName, req.Service)
 
 	// Try to find by ARN or name.
-	svc, ok := m.services[svcArn]
+	svc, ok := m.Services[svcArn]
 	if !ok {
-		svc, ok = m.services[req.Service]
+		svc, ok = m.Services[req.Service]
 		if !ok {
 			return nil, &Error{
 				Code:    "ServiceNotFoundException",
@@ -629,7 +722,7 @@ func (m *MemoryStorage) resolveTaskDefinitionArn(taskDefinition string) string {
 	}
 
 	// Try to find latest revision.
-	if arns, ok := m.taskDefFamilies[taskDefinition]; ok && len(arns) > 0 {
+	if arns, ok := m.TaskDefFamilies[taskDefinition]; ok && len(arns) > 0 {
 		return arns[len(arns)-1]
 	}
 

--- a/internal/service/eks/service.go
+++ b/internal/service/eks/service.go
@@ -2,13 +2,24 @@
 package eks
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the EKS service.
@@ -45,4 +56,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 // This is needed because the router might match both DescribeCluster and ListNodegroups.
 func (s *Service) handleClusterGet(w http.ResponseWriter, r *http.Request) {
 	s.DescribeCluster(w, r)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/eks/storage.go
+++ b/internal/service/eks/storage.go
@@ -3,11 +3,14 @@ package eks
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -31,23 +34,101 @@ type Storage interface {
 	ListNodegroups(ctx context.Context, clusterName string, maxResults int, nextToken string) ([]string, string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu         sync.RWMutex
-	clusters   map[string]*Cluster
-	nodegroups map[string]map[string]*Nodegroup // clusterName -> nodegroupName -> Nodegroup
+	mu         sync.RWMutex                     `json:"-"`
+	Clusters   map[string]*Cluster              `json:"clusters"`
+	Nodegroups map[string]map[string]*Nodegroup `json:"nodegroups"`
 	region     string
 	accountID  string
+	dataDir    string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		clusters:   make(map[string]*Cluster),
-		nodegroups: make(map[string]map[string]*Nodegroup),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Clusters:   make(map[string]*Cluster),
+		Nodegroups: make(map[string]map[string]*Nodegroup),
 		region:     "us-east-1",
 		accountID:  "123456789012",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "eks", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Clusters == nil {
+		s.Clusters = make(map[string]*Cluster)
+	}
+
+	if s.Nodegroups == nil {
+		s.Nodegroups = make(map[string]map[string]*Nodegroup)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "eks", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateCluster creates a new EKS cluster.
@@ -55,7 +136,7 @@ func (s *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.clusters[req.Name]; exists {
+	if _, exists := s.Clusters[req.Name]; exists {
 		return nil, &Error{
 			Code:    "ResourceInUseException",
 			Message: fmt.Sprintf("Cluster already exists with name: %s", req.Name),
@@ -65,8 +146,8 @@ func (s *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 	cluster := s.buildCluster(req)
 	cluster.Status = statusActive
 
-	s.clusters[req.Name] = cluster
-	s.nodegroups[req.Name] = make(map[string]*Nodegroup)
+	s.Clusters[req.Name] = cluster
+	s.Nodegroups[req.Name] = make(map[string]*Nodegroup)
 
 	return cluster, nil
 }
@@ -152,7 +233,7 @@ func (s *MemoryStorage) DeleteCluster(_ context.Context, name string) (*Cluster,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cluster, exists := s.clusters[name]
+	cluster, exists := s.Clusters[name]
 	if !exists {
 		return nil, &Error{
 			Code:    "ResourceNotFoundException",
@@ -161,7 +242,7 @@ func (s *MemoryStorage) DeleteCluster(_ context.Context, name string) (*Cluster,
 	}
 
 	// Check if there are any nodegroups.
-	if nodegroups, ok := s.nodegroups[name]; ok && len(nodegroups) > 0 {
+	if nodegroups, ok := s.Nodegroups[name]; ok && len(nodegroups) > 0 {
 		return nil, &Error{
 			Code:    "ResourceInUseException",
 			Message: "Cluster has nodegroups attached",
@@ -170,8 +251,8 @@ func (s *MemoryStorage) DeleteCluster(_ context.Context, name string) (*Cluster,
 
 	cluster.Status = statusDeleting
 
-	delete(s.clusters, name)
-	delete(s.nodegroups, name)
+	delete(s.Clusters, name)
+	delete(s.Nodegroups, name)
 
 	return cluster, nil
 }
@@ -181,7 +262,7 @@ func (s *MemoryStorage) DescribeCluster(_ context.Context, name string) (*Cluste
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	cluster, exists := s.clusters[name]
+	cluster, exists := s.Clusters[name]
 	if !exists {
 		return nil, &Error{
 			Code:    "ResourceNotFoundException",
@@ -197,8 +278,8 @@ func (s *MemoryStorage) ListClusters(_ context.Context, _ int, _ string) ([]stri
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	names := make([]string, 0, len(s.clusters))
-	for name := range s.clusters {
+	names := make([]string, 0, len(s.Clusters))
+	for name := range s.Clusters {
 		names = append(names, name)
 	}
 
@@ -210,7 +291,7 @@ func (s *MemoryStorage) CreateNodegroup(_ context.Context, req *CreateNodegroupR
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cluster, exists := s.clusters[req.ClusterName]
+	cluster, exists := s.Clusters[req.ClusterName]
 	if !exists {
 		return nil, &Error{
 			Code:    "ResourceNotFoundException",
@@ -218,7 +299,7 @@ func (s *MemoryStorage) CreateNodegroup(_ context.Context, req *CreateNodegroupR
 		}
 	}
 
-	if _, exists := s.nodegroups[req.ClusterName][req.NodegroupName]; exists {
+	if _, exists := s.Nodegroups[req.ClusterName][req.NodegroupName]; exists {
 		return nil, &Error{
 			Code:    "ResourceInUseException",
 			Message: fmt.Sprintf("Nodegroup already exists with name: %s", req.NodegroupName),
@@ -228,7 +309,7 @@ func (s *MemoryStorage) CreateNodegroup(_ context.Context, req *CreateNodegroupR
 	nodegroup := s.buildNodegroup(req, cluster.Version)
 	nodegroup.Status = statusActive
 
-	s.nodegroups[req.ClusterName][req.NodegroupName] = nodegroup
+	s.Nodegroups[req.ClusterName][req.NodegroupName] = nodegroup
 
 	return nodegroup, nil
 }
@@ -296,14 +377,14 @@ func (s *MemoryStorage) DeleteNodegroup(_ context.Context, clusterName, nodegrou
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.clusters[clusterName]; !exists {
+	if _, exists := s.Clusters[clusterName]; !exists {
 		return nil, &Error{
 			Code:    "ResourceNotFoundException",
 			Message: fmt.Sprintf("No cluster found for name: %s", clusterName),
 		}
 	}
 
-	nodegroups, exists := s.nodegroups[clusterName]
+	nodegroups, exists := s.Nodegroups[clusterName]
 	if !exists {
 		return nil, &Error{
 			Code:    "ResourceNotFoundException",
@@ -321,7 +402,7 @@ func (s *MemoryStorage) DeleteNodegroup(_ context.Context, clusterName, nodegrou
 
 	nodegroup.Status = statusDeleting
 
-	delete(s.nodegroups[clusterName], nodegroupName)
+	delete(s.Nodegroups[clusterName], nodegroupName)
 
 	return nodegroup, nil
 }
@@ -331,14 +412,14 @@ func (s *MemoryStorage) DescribeNodegroup(_ context.Context, clusterName, nodegr
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if _, exists := s.clusters[clusterName]; !exists {
+	if _, exists := s.Clusters[clusterName]; !exists {
 		return nil, &Error{
 			Code:    "ResourceNotFoundException",
 			Message: fmt.Sprintf("No cluster found for name: %s", clusterName),
 		}
 	}
 
-	nodegroups, exists := s.nodegroups[clusterName]
+	nodegroups, exists := s.Nodegroups[clusterName]
 	if !exists {
 		return nil, &Error{
 			Code:    "ResourceNotFoundException",
@@ -362,14 +443,14 @@ func (s *MemoryStorage) ListNodegroups(_ context.Context, clusterName string, _ 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if _, exists := s.clusters[clusterName]; !exists {
+	if _, exists := s.Clusters[clusterName]; !exists {
 		return nil, "", &Error{
 			Code:    "ResourceNotFoundException",
 			Message: fmt.Sprintf("No cluster found for name: %s", clusterName),
 		}
 	}
 
-	nodegroups, exists := s.nodegroups[clusterName]
+	nodegroups, exists := s.Nodegroups[clusterName]
 	if !exists {
 		return []string{}, "", nil
 	}

--- a/internal/service/elasticache/service.go
+++ b/internal/service/elasticache/service.go
@@ -1,12 +1,23 @@
 package elasticache
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage()
-	service.Register(New(storage))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the ElastiCache service.
@@ -53,3 +64,14 @@ func (s *Service) Actions() []string {
 
 // QueryProtocol is a marker method that indicates ElastiCache uses AWS Query protocol.
 func (s *Service) QueryProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/elasticache/storage.go
+++ b/internal/service/elasticache/storage.go
@@ -2,11 +2,14 @@ package elasticache
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -25,19 +28,97 @@ type Storage interface {
 	DescribeReplicationGroups(ctx context.Context, groupID string) ([]ReplicationGroup, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu                sync.RWMutex
-	cacheClusters     map[string]*CacheCluster
-	replicationGroups map[string]*ReplicationGroup
+	mu                sync.RWMutex                 `json:"-"`
+	CacheClusters     map[string]*CacheCluster     `json:"cacheClusters"`
+	ReplicationGroups map[string]*ReplicationGroup `json:"replicationGroups"`
+	dataDir           string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		cacheClusters:     make(map[string]*CacheCluster),
-		replicationGroups: make(map[string]*ReplicationGroup),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		CacheClusters:     make(map[string]*CacheCluster),
+		ReplicationGroups: make(map[string]*ReplicationGroup),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "elasticache", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.CacheClusters == nil {
+		m.CacheClusters = make(map[string]*CacheCluster)
+	}
+
+	if m.ReplicationGroups == nil {
+		m.ReplicationGroups = make(map[string]*ReplicationGroup)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "elasticache", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateCacheCluster creates a new cache cluster.
@@ -45,7 +126,7 @@ func (m *MemoryStorage) CreateCacheCluster(_ context.Context, input *CreateCache
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.cacheClusters[input.CacheClusterID]; exists {
+	if _, exists := m.CacheClusters[input.CacheClusterID]; exists {
 		return nil, &Error{
 			Code:    errCacheClusterAlreadyExists,
 			Message: fmt.Sprintf("Cache cluster already exists: %s", input.CacheClusterID),
@@ -53,7 +134,7 @@ func (m *MemoryStorage) CreateCacheCluster(_ context.Context, input *CreateCache
 	}
 
 	cluster := m.buildCacheCluster(input)
-	m.cacheClusters[input.CacheClusterID] = cluster
+	m.CacheClusters[input.CacheClusterID] = cluster
 
 	return cluster, nil
 }
@@ -128,7 +209,7 @@ func (m *MemoryStorage) DeleteCacheCluster(_ context.Context, clusterID string) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	cluster, exists := m.cacheClusters[clusterID]
+	cluster, exists := m.CacheClusters[clusterID]
 	if !exists {
 		return nil, &Error{
 			Code:    errCacheClusterNotFound,
@@ -138,7 +219,7 @@ func (m *MemoryStorage) DeleteCacheCluster(_ context.Context, clusterID string) 
 
 	cluster.CacheClusterStatus = CacheClusterStatusDeleting
 
-	delete(m.cacheClusters, clusterID)
+	delete(m.CacheClusters, clusterID)
 
 	return cluster, nil
 }
@@ -149,7 +230,7 @@ func (m *MemoryStorage) DescribeCacheClusters(_ context.Context, clusterID strin
 	defer m.mu.RUnlock()
 
 	if clusterID != "" {
-		cluster, exists := m.cacheClusters[clusterID]
+		cluster, exists := m.CacheClusters[clusterID]
 		if !exists {
 			return nil, &Error{
 				Code:    errCacheClusterNotFound,
@@ -165,9 +246,9 @@ func (m *MemoryStorage) DescribeCacheClusters(_ context.Context, clusterID strin
 		return []CacheCluster{result}, nil
 	}
 
-	clusters := make([]CacheCluster, 0, len(m.cacheClusters))
+	clusters := make([]CacheCluster, 0, len(m.CacheClusters))
 
-	for _, cluster := range m.cacheClusters {
+	for _, cluster := range m.CacheClusters {
 		result := *cluster
 		if !showNodeInfo {
 			result.CacheNodes = nil
@@ -184,7 +265,7 @@ func (m *MemoryStorage) ModifyCacheCluster(_ context.Context, input *ModifyCache
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	cluster, exists := m.cacheClusters[input.CacheClusterID]
+	cluster, exists := m.CacheClusters[input.CacheClusterID]
 	if !exists {
 		return nil, &Error{
 			Code:    errCacheClusterNotFound,
@@ -236,7 +317,7 @@ func (m *MemoryStorage) CreateReplicationGroup(_ context.Context, input *CreateR
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.replicationGroups[input.ReplicationGroupID]; exists {
+	if _, exists := m.ReplicationGroups[input.ReplicationGroupID]; exists {
 		return nil, &Error{
 			Code:    errReplicationGroupAlreadyExists,
 			Message: fmt.Sprintf("Replication group already exists: %s", input.ReplicationGroupID),
@@ -244,7 +325,7 @@ func (m *MemoryStorage) CreateReplicationGroup(_ context.Context, input *CreateR
 	}
 
 	group := m.buildReplicationGroup(input)
-	m.replicationGroups[input.ReplicationGroupID] = group
+	m.ReplicationGroups[input.ReplicationGroupID] = group
 
 	return group, nil
 }
@@ -348,7 +429,7 @@ func (m *MemoryStorage) DeleteReplicationGroup(_ context.Context, groupID string
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	group, exists := m.replicationGroups[groupID]
+	group, exists := m.ReplicationGroups[groupID]
 	if !exists {
 		return nil, &Error{
 			Code:    errReplicationGroupNotFound,
@@ -358,7 +439,7 @@ func (m *MemoryStorage) DeleteReplicationGroup(_ context.Context, groupID string
 
 	group.Status = ReplicationGroupStatusDeleting
 
-	delete(m.replicationGroups, groupID)
+	delete(m.ReplicationGroups, groupID)
 
 	return group, nil
 }
@@ -369,7 +450,7 @@ func (m *MemoryStorage) DescribeReplicationGroups(_ context.Context, groupID str
 	defer m.mu.RUnlock()
 
 	if groupID != "" {
-		group, exists := m.replicationGroups[groupID]
+		group, exists := m.ReplicationGroups[groupID]
 		if !exists {
 			return nil, &Error{
 				Code:    errReplicationGroupNotFound,
@@ -380,8 +461,8 @@ func (m *MemoryStorage) DescribeReplicationGroups(_ context.Context, groupID str
 		return []ReplicationGroup{*group}, nil
 	}
 
-	groups := make([]ReplicationGroup, 0, len(m.replicationGroups))
-	for _, group := range m.replicationGroups {
+	groups := make([]ReplicationGroup, 0, len(m.ReplicationGroups))
+	for _, group := range m.ReplicationGroups {
 		groups = append(groups, *group)
 	}
 

--- a/internal/service/elasticbeanstalk/service.go
+++ b/internal/service/elasticbeanstalk/service.go
@@ -1,8 +1,15 @@
 package elasticbeanstalk
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
 
 // Service implements the AWS Elastic Beanstalk service.
 type Service struct {
@@ -47,6 +54,22 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// Query protocol services use DispatchAction for routing.
 }
 
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }

--- a/internal/service/elasticbeanstalk/storage.go
+++ b/internal/service/elasticbeanstalk/storage.go
@@ -2,11 +2,14 @@ package elasticbeanstalk
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -40,19 +43,97 @@ type Storage interface {
 	TerminateEnvironment(ctx context.Context, envName string) (*EnvironmentDescription, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu           sync.RWMutex
-	applications map[string]*ApplicationDescription
-	environments map[string]*EnvironmentDescription
+	mu           sync.RWMutex                       `json:"-"`
+	Applications map[string]*ApplicationDescription `json:"applications"`
+	Environments map[string]*EnvironmentDescription `json:"environments"`
+	dataDir      string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		applications: make(map[string]*ApplicationDescription),
-		environments: make(map[string]*EnvironmentDescription),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Applications: make(map[string]*ApplicationDescription),
+		Environments: make(map[string]*EnvironmentDescription),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "elasticbeanstalk", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Applications == nil {
+		m.Applications = make(map[string]*ApplicationDescription)
+	}
+
+	if m.Environments == nil {
+		m.Environments = make(map[string]*EnvironmentDescription)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "elasticbeanstalk", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateApplication creates a new application.
@@ -60,7 +141,7 @@ func (m *MemoryStorage) CreateApplication(_ context.Context, req *CreateApplicat
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.applications[req.ApplicationName]; exists {
+	if _, exists := m.Applications[req.ApplicationName]; exists {
 		return nil, &ServiceError{
 			Code:    errAppExists,
 			Message: fmt.Sprintf("Application %s already exists.", req.ApplicationName),
@@ -76,7 +157,7 @@ func (m *MemoryStorage) CreateApplication(_ context.Context, req *CreateApplicat
 		ApplicationArn:  fmt.Sprintf("arn:aws:elasticbeanstalk:%s:%s:application/%s", defaultRegion, defaultAccountID, req.ApplicationName),
 	}
 
-	m.applications[req.ApplicationName] = app
+	m.Applications[req.ApplicationName] = app
 
 	return app, nil
 }
@@ -90,7 +171,7 @@ func (m *MemoryStorage) DescribeApplications(_ context.Context, names []string) 
 		apps := make([]ApplicationDescription, 0, len(names))
 
 		for _, name := range names {
-			if app, exists := m.applications[name]; exists {
+			if app, exists := m.Applications[name]; exists {
 				apps = append(apps, *app)
 			}
 		}
@@ -98,8 +179,8 @@ func (m *MemoryStorage) DescribeApplications(_ context.Context, names []string) 
 		return apps, nil
 	}
 
-	apps := make([]ApplicationDescription, 0, len(m.applications))
-	for _, app := range m.applications {
+	apps := make([]ApplicationDescription, 0, len(m.Applications))
+	for _, app := range m.Applications {
 		apps = append(apps, *app)
 	}
 
@@ -111,7 +192,7 @@ func (m *MemoryStorage) UpdateApplication(_ context.Context, req *UpdateApplicat
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	app, exists := m.applications[req.ApplicationName]
+	app, exists := m.Applications[req.ApplicationName]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errAppNotFound,
@@ -133,14 +214,14 @@ func (m *MemoryStorage) DeleteApplication(_ context.Context, name string) error 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.applications[name]; !exists {
+	if _, exists := m.Applications[name]; !exists {
 		return &ServiceError{
 			Code:    errAppNotFound,
 			Message: fmt.Sprintf("No Application named '%s' found.", name),
 		}
 	}
 
-	delete(m.applications, name)
+	delete(m.Applications, name)
 
 	return nil
 }
@@ -150,7 +231,7 @@ func (m *MemoryStorage) CreateEnvironment(_ context.Context, req *CreateEnvironm
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.environments[req.EnvironmentName]; exists {
+	if _, exists := m.Environments[req.EnvironmentName]; exists {
 		return nil, &ServiceError{
 			Code:    errEnvNotFound,
 			Message: fmt.Sprintf("Environment %s already exists.", req.EnvironmentName),
@@ -172,7 +253,7 @@ func (m *MemoryStorage) CreateEnvironment(_ context.Context, req *CreateEnvironm
 		EnvironmentArn:    fmt.Sprintf("arn:aws:elasticbeanstalk:%s:%s:environment/%s/%s", defaultRegion, defaultAccountID, req.ApplicationName, req.EnvironmentName),
 	}
 
-	m.environments[req.EnvironmentName] = env
+	m.Environments[req.EnvironmentName] = env
 
 	return env, nil
 }
@@ -186,7 +267,7 @@ func (m *MemoryStorage) DescribeEnvironments(_ context.Context, appName string, 
 		envs := make([]EnvironmentDescription, 0, len(envNames))
 
 		for _, name := range envNames {
-			if env, exists := m.environments[name]; exists {
+			if env, exists := m.Environments[name]; exists {
 				if appName == "" || env.ApplicationName == appName {
 					envs = append(envs, *env)
 				}
@@ -196,9 +277,9 @@ func (m *MemoryStorage) DescribeEnvironments(_ context.Context, appName string, 
 		return envs, nil
 	}
 
-	envs := make([]EnvironmentDescription, 0, len(m.environments))
+	envs := make([]EnvironmentDescription, 0, len(m.Environments))
 
-	for _, env := range m.environments {
+	for _, env := range m.Environments {
 		if appName == "" || env.ApplicationName == appName {
 			envs = append(envs, *env)
 		}
@@ -212,7 +293,7 @@ func (m *MemoryStorage) TerminateEnvironment(_ context.Context, envName string) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	env, exists := m.environments[envName]
+	env, exists := m.Environments[envName]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errEnvNotFound,
@@ -222,7 +303,7 @@ func (m *MemoryStorage) TerminateEnvironment(_ context.Context, envName string) 
 
 	env.Status = "Terminated"
 
-	delete(m.environments, envName)
+	delete(m.Environments, envName)
 
 	return env, nil
 }

--- a/internal/service/elbv2/service.go
+++ b/internal/service/elbv2/service.go
@@ -1,12 +1,23 @@
 package elbv2
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage()
-	service.Register(New(storage))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the ELB v2 service.
@@ -55,3 +66,14 @@ func (s *Service) Actions() []string {
 
 // QueryProtocol is a marker method that indicates ELB uses AWS Query protocol.
 func (s *Service) QueryProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/elbv2/storage.go
+++ b/internal/service/elbv2/storage.go
@@ -2,12 +2,15 @@ package elbv2
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -32,23 +35,109 @@ type Storage interface {
 	DeleteListener(ctx context.Context, listenerArn string) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage is an in-memory implementation of Storage.
 type MemoryStorage struct {
-	mu            sync.RWMutex
-	loadBalancers map[string]*LoadBalancer // keyed by ARN
-	targetGroups  map[string]*TargetGroup  // keyed by ARN
-	listeners     map[string]*Listener     // keyed by ARN
-	targets       map[string][]Target      // keyed by targetGroupArn
+	mu            sync.RWMutex             `json:"-"`
+	LoadBalancers map[string]*LoadBalancer `json:"loadBalancers"` // keyed by ARN
+	TargetGroups  map[string]*TargetGroup  `json:"targetGroups"`  // keyed by ARN
+	Listeners     map[string]*Listener     `json:"listeners"`     // keyed by ARN
+	Targets       map[string][]Target      `json:"targets"`       // keyed by targetGroupArn
+	dataDir       string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		loadBalancers: make(map[string]*LoadBalancer),
-		targetGroups:  make(map[string]*TargetGroup),
-		listeners:     make(map[string]*Listener),
-		targets:       make(map[string][]Target),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		LoadBalancers: make(map[string]*LoadBalancer),
+		TargetGroups:  make(map[string]*TargetGroup),
+		Listeners:     make(map[string]*Listener),
+		Targets:       make(map[string][]Target),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "elbv2", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.LoadBalancers == nil {
+		m.LoadBalancers = make(map[string]*LoadBalancer)
+	}
+
+	if m.TargetGroups == nil {
+		m.TargetGroups = make(map[string]*TargetGroup)
+	}
+
+	if m.Listeners == nil {
+		m.Listeners = make(map[string]*Listener)
+	}
+
+	if m.Targets == nil {
+		m.Targets = make(map[string][]Target)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "elbv2", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // loadBalancerDefaults holds default values for load balancer creation.
@@ -92,14 +181,14 @@ func (m *MemoryStorage) CreateLoadBalancer(_ context.Context, req *CreateLoadBal
 
 	defaults := getLoadBalancerDefaults(req)
 	lb := m.buildLoadBalancer(req, defaults)
-	m.loadBalancers[lb.LoadBalancerArn] = lb
+	m.LoadBalancers[lb.LoadBalancerArn] = lb
 
 	return lb, nil
 }
 
 // checkDuplicateLoadBalancerName checks if a load balancer with the given name already exists.
 func (m *MemoryStorage) checkDuplicateLoadBalancerName(name string) error {
-	for _, lb := range m.loadBalancers {
+	for _, lb := range m.LoadBalancers {
 		if lb.LoadBalancerName == name {
 			return &Error{
 				Code:    "DuplicateLoadBalancerName",
@@ -147,7 +236,7 @@ func (m *MemoryStorage) DeleteLoadBalancer(_ context.Context, loadBalancerArn st
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.loadBalancers[loadBalancerArn]; !ok {
+	if _, ok := m.LoadBalancers[loadBalancerArn]; !ok {
 		return &Error{
 			Code:    "LoadBalancerNotFound",
 			Message: fmt.Sprintf("Load balancer '%s' not found", loadBalancerArn),
@@ -155,13 +244,13 @@ func (m *MemoryStorage) DeleteLoadBalancer(_ context.Context, loadBalancerArn st
 	}
 
 	// Delete associated listeners.
-	for arn, listener := range m.listeners {
+	for arn, listener := range m.Listeners {
 		if listener.LoadBalancerArn == loadBalancerArn {
-			delete(m.listeners, arn)
+			delete(m.Listeners, arn)
 		}
 	}
 
-	delete(m.loadBalancers, loadBalancerArn)
+	delete(m.LoadBalancers, loadBalancerArn)
 
 	return nil
 }
@@ -175,7 +264,7 @@ func (m *MemoryStorage) DescribeLoadBalancers(_ context.Context, arns, names []s
 
 	if len(arns) == 0 && len(names) == 0 {
 		// Return all load balancers.
-		for _, lb := range m.loadBalancers {
+		for _, lb := range m.LoadBalancers {
 			result = append(result, lb)
 		}
 
@@ -194,7 +283,7 @@ func (m *MemoryStorage) DescribeLoadBalancers(_ context.Context, arns, names []s
 		nameSet[name] = true
 	}
 
-	for _, lb := range m.loadBalancers {
+	for _, lb := range m.LoadBalancers {
 		if len(arns) > 0 && arnSet[lb.LoadBalancerArn] {
 			result = append(result, lb)
 
@@ -283,15 +372,15 @@ func (m *MemoryStorage) CreateTargetGroup(_ context.Context, req *CreateTargetGr
 
 	defaults := getTargetGroupDefaults(req)
 	tg := m.buildTargetGroup(req, &defaults)
-	m.targetGroups[tg.TargetGroupArn] = tg
-	m.targets[tg.TargetGroupArn] = []Target{}
+	m.TargetGroups[tg.TargetGroupArn] = tg
+	m.Targets[tg.TargetGroupArn] = []Target{}
 
 	return tg, nil
 }
 
 // checkDuplicateTargetGroupName checks if a target group with the given name already exists.
 func (m *MemoryStorage) checkDuplicateTargetGroupName(name string) error {
-	for _, tg := range m.targetGroups {
+	for _, tg := range m.TargetGroups {
 		if tg.TargetGroupName == name {
 			return &Error{
 				Code:    "DuplicateTargetGroupName",
@@ -333,15 +422,15 @@ func (m *MemoryStorage) DeleteTargetGroup(_ context.Context, targetGroupArn stri
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.targetGroups[targetGroupArn]; !ok {
+	if _, ok := m.TargetGroups[targetGroupArn]; !ok {
 		return &Error{
 			Code:    "TargetGroupNotFound",
 			Message: fmt.Sprintf("Target group '%s' not found", targetGroupArn),
 		}
 	}
 
-	delete(m.targetGroups, targetGroupArn)
-	delete(m.targets, targetGroupArn)
+	delete(m.TargetGroups, targetGroupArn)
+	delete(m.Targets, targetGroupArn)
 
 	return nil
 }
@@ -355,7 +444,7 @@ func (m *MemoryStorage) DescribeTargetGroups(_ context.Context, arns, names []st
 
 	if len(arns) == 0 && len(names) == 0 && lbArn == "" {
 		// Return all target groups.
-		for _, tg := range m.targetGroups {
+		for _, tg := range m.TargetGroups {
 			result = append(result, tg)
 		}
 
@@ -374,7 +463,7 @@ func (m *MemoryStorage) DescribeTargetGroups(_ context.Context, arns, names []st
 		nameSet[name] = true
 	}
 
-	for _, tg := range m.targetGroups {
+	for _, tg := range m.TargetGroups {
 		if len(arns) > 0 && arnSet[tg.TargetGroupArn] {
 			result = append(result, tg)
 
@@ -400,14 +489,14 @@ func (m *MemoryStorage) RegisterTargets(_ context.Context, targetGroupArn string
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.targetGroups[targetGroupArn]; !ok {
+	if _, ok := m.TargetGroups[targetGroupArn]; !ok {
 		return &Error{
 			Code:    "TargetGroupNotFound",
 			Message: fmt.Sprintf("Target group '%s' not found", targetGroupArn),
 		}
 	}
 
-	existingTargets := m.targets[targetGroupArn]
+	existingTargets := m.Targets[targetGroupArn]
 	existingSet := make(map[string]bool)
 
 	for _, t := range existingTargets {
@@ -420,7 +509,7 @@ func (m *MemoryStorage) RegisterTargets(_ context.Context, targetGroupArn string
 		}
 	}
 
-	m.targets[targetGroupArn] = existingTargets
+	m.Targets[targetGroupArn] = existingTargets
 
 	return nil
 }
@@ -430,7 +519,7 @@ func (m *MemoryStorage) DeregisterTargets(_ context.Context, targetGroupArn stri
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.targetGroups[targetGroupArn]; !ok {
+	if _, ok := m.TargetGroups[targetGroupArn]; !ok {
 		return &Error{
 			Code:    "TargetGroupNotFound",
 			Message: fmt.Sprintf("Target group '%s' not found", targetGroupArn),
@@ -442,7 +531,7 @@ func (m *MemoryStorage) DeregisterTargets(_ context.Context, targetGroupArn stri
 		removeSet[t.ID] = true
 	}
 
-	existingTargets := m.targets[targetGroupArn]
+	existingTargets := m.Targets[targetGroupArn]
 	newTargets := make([]Target, 0, len(existingTargets))
 
 	for _, t := range existingTargets {
@@ -451,7 +540,7 @@ func (m *MemoryStorage) DeregisterTargets(_ context.Context, targetGroupArn stri
 		}
 	}
 
-	m.targets[targetGroupArn] = newTargets
+	m.Targets[targetGroupArn] = newTargets
 
 	return nil
 }
@@ -461,7 +550,7 @@ func (m *MemoryStorage) CreateListener(_ context.Context, req *CreateListenerReq
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	lb, ok := m.loadBalancers[req.LoadBalancerArn]
+	lb, ok := m.LoadBalancers[req.LoadBalancerArn]
 	if !ok {
 		return nil, &Error{
 			Code:    "LoadBalancerNotFound",
@@ -489,12 +578,12 @@ func (m *MemoryStorage) CreateListener(_ context.Context, req *CreateListenerReq
 		DefaultActions:  req.DefaultActions,
 	}
 
-	m.listeners[arn] = listener
+	m.Listeners[arn] = listener
 
 	// Update target group's load balancer ARNs.
 	for _, action := range req.DefaultActions {
 		if action.TargetGroupArn != "" {
-			if tg, exists := m.targetGroups[action.TargetGroupArn]; exists {
+			if tg, exists := m.TargetGroups[action.TargetGroupArn]; exists {
 				if !slices.Contains(tg.LoadBalancerArns, req.LoadBalancerArn) {
 					tg.LoadBalancerArns = append(tg.LoadBalancerArns, req.LoadBalancerArn)
 				}
@@ -510,14 +599,14 @@ func (m *MemoryStorage) DeleteListener(_ context.Context, listenerArn string) er
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.listeners[listenerArn]; !ok {
+	if _, ok := m.Listeners[listenerArn]; !ok {
 		return &Error{
 			Code:    "ListenerNotFound",
 			Message: fmt.Sprintf("Listener '%s' not found", listenerArn),
 		}
 	}
 
-	delete(m.listeners, listenerArn)
+	delete(m.Listeners, listenerArn)
 
 	return nil
 }

--- a/internal/service/emrserverless/service.go
+++ b/internal/service/emrserverless/service.go
@@ -1,8 +1,15 @@
 package emrserverless
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
 
 // Service implements the EMR Serverless service.
 type Service struct {
@@ -17,7 +24,23 @@ func New(storage Storage) *Service {
 }
 
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // Name returns the service name.

--- a/internal/service/emrserverless/storage.go
+++ b/internal/service/emrserverless/storage.go
@@ -2,12 +2,15 @@ package emrserverless
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the interface for EMR Serverless storage operations.
@@ -28,19 +31,97 @@ type Storage interface {
 	CancelJobRun(ctx context.Context, applicationID, jobRunID string) (*JobRun, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements the Storage interface using in-memory storage.
 type MemoryStorage struct {
-	mu           sync.RWMutex
-	applications map[string]*Application
-	jobRuns      map[string]map[string]*JobRun // applicationID -> jobRunID -> JobRun
+	mu           sync.RWMutex                  `json:"-"`
+	Applications map[string]*Application       `json:"applications"`
+	JobRuns      map[string]map[string]*JobRun `json:"jobRuns"`
+	dataDir      string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		applications: make(map[string]*Application),
-		jobRuns:      make(map[string]map[string]*JobRun),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Applications: make(map[string]*Application),
+		JobRuns:      make(map[string]map[string]*JobRun),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "emrserverless", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Applications == nil {
+		m.Applications = make(map[string]*Application)
+	}
+
+	if m.JobRuns == nil {
+		m.JobRuns = make(map[string]map[string]*JobRun)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "emrserverless", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 const (
@@ -135,8 +216,8 @@ func (m *MemoryStorage) CreateApplication(_ context.Context, req *CreateApplicat
 		UpdatedAt:               AWSTimestamp{Time: now},
 	}
 
-	m.applications[applicationID] = app
-	m.jobRuns[applicationID] = make(map[string]*JobRun)
+	m.Applications[applicationID] = app
+	m.JobRuns[applicationID] = make(map[string]*JobRun)
 
 	return app, nil
 }
@@ -146,7 +227,7 @@ func (m *MemoryStorage) GetApplication(_ context.Context, applicationID string) 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	app, exists := m.applications[applicationID]
+	app, exists := m.Applications[applicationID]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -174,7 +255,7 @@ func (m *MemoryStorage) ListApplications(_ context.Context, req *ListApplication
 
 	var summaries []*ApplicationSummary
 
-	for _, app := range m.applications {
+	for _, app := range m.Applications {
 		// Apply state filter.
 		if len(stateFilter) > 0 && !stateFilter[app.State] {
 			continue
@@ -210,7 +291,7 @@ func (m *MemoryStorage) UpdateApplication(_ context.Context, req *UpdateApplicat
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	app, exists := m.applications[req.ApplicationID]
+	app, exists := m.Applications[req.ApplicationID]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -269,7 +350,7 @@ func (m *MemoryStorage) DeleteApplication(_ context.Context, applicationID strin
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	app, exists := m.applications[applicationID]
+	app, exists := m.Applications[applicationID]
 	if !exists {
 		return &Error{
 			Code:    errResourceNotFound,
@@ -286,7 +367,7 @@ func (m *MemoryStorage) DeleteApplication(_ context.Context, applicationID strin
 	}
 
 	// Check for running job runs.
-	for _, jr := range m.jobRuns[applicationID] {
+	for _, jr := range m.JobRuns[applicationID] {
 		if jr.State == JobRunStateRunning || jr.State == JobRunStatePending || jr.State == JobRunStateScheduled {
 			return &Error{
 				Code:    errConflictException,
@@ -299,8 +380,8 @@ func (m *MemoryStorage) DeleteApplication(_ context.Context, applicationID strin
 	app.State = ApplicationStateTerminated
 	app.UpdatedAt = AWSTimestamp{Time: time.Now()}
 
-	delete(m.applications, applicationID)
-	delete(m.jobRuns, applicationID)
+	delete(m.Applications, applicationID)
+	delete(m.JobRuns, applicationID)
 
 	return nil
 }
@@ -310,7 +391,7 @@ func (m *MemoryStorage) StartApplication(_ context.Context, applicationID string
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	app, exists := m.applications[applicationID]
+	app, exists := m.Applications[applicationID]
 	if !exists {
 		return &Error{
 			Code:    errResourceNotFound,
@@ -338,7 +419,7 @@ func (m *MemoryStorage) StopApplication(_ context.Context, applicationID string)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	app, exists := m.applications[applicationID]
+	app, exists := m.Applications[applicationID]
 	if !exists {
 		return &Error{
 			Code:    errResourceNotFound,
@@ -368,7 +449,7 @@ func (m *MemoryStorage) StartJobRun(_ context.Context, req *StartJobRunInput) (*
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	app, exists := m.applications[req.ApplicationID]
+	app, exists := m.Applications[req.ApplicationID]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -434,7 +515,7 @@ func (m *MemoryStorage) StartJobRun(_ context.Context, req *StartJobRunInput) (*
 		CreatedBy:               fmt.Sprintf("arn:aws:iam::%s:user/test-user", accountID),
 	}
 
-	m.jobRuns[req.ApplicationID][jobRunID] = jobRun
+	m.JobRuns[req.ApplicationID][jobRunID] = jobRun
 
 	return jobRun, nil
 }
@@ -444,14 +525,14 @@ func (m *MemoryStorage) GetJobRun(_ context.Context, applicationID, jobRunID str
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.applications[applicationID]; !exists {
+	if _, exists := m.Applications[applicationID]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Application %s does not exist", applicationID),
 		}
 	}
 
-	jobRun, exists := m.jobRuns[applicationID][jobRunID]
+	jobRun, exists := m.JobRuns[applicationID][jobRunID]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -467,7 +548,7 @@ func (m *MemoryStorage) ListJobRuns(_ context.Context, req *ListJobRunsInput) (*
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if _, exists := m.applications[req.ApplicationID]; !exists {
+	if _, exists := m.Applications[req.ApplicationID]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Application %s does not exist", req.ApplicationID),
@@ -486,7 +567,7 @@ func (m *MemoryStorage) ListJobRuns(_ context.Context, req *ListJobRunsInput) (*
 
 	var summaries []*JobRunSummary
 
-	for _, jr := range m.jobRuns[req.ApplicationID] {
+	for _, jr := range m.JobRuns[req.ApplicationID] {
 		// Apply state filter.
 		if len(stateFilter) > 0 && !stateFilter[jr.State] {
 			continue
@@ -528,14 +609,14 @@ func (m *MemoryStorage) CancelJobRun(_ context.Context, applicationID, jobRunID 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.applications[applicationID]; !exists {
+	if _, exists := m.Applications[applicationID]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Application %s does not exist", applicationID),
 		}
 	}
 
-	jobRun, exists := m.jobRuns[applicationID][jobRunID]
+	jobRun, exists := m.JobRuns[applicationID][jobRunID]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,

--- a/internal/service/entityresolution/service.go
+++ b/internal/service/entityresolution/service.go
@@ -2,11 +2,23 @@
 package entityresolution
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the Entity Resolution service.
@@ -17,6 +29,17 @@ type Service struct {
 // New creates a new Entity Resolution service.
 func New(storage Storage) *Service {
 	return &Service{storage: storage}
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // Name returns the service name.

--- a/internal/service/entityresolution/storage.go
+++ b/internal/service/entityresolution/storage.go
@@ -2,9 +2,12 @@ package entityresolution
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -32,21 +35,103 @@ type Storage interface {
 	ListProviderServices(ctx context.Context) ([]ProviderService, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu                 sync.RWMutex
-	schemas            map[string]*SchemaMapping
-	matchingWorkflows  map[string]*MatchingWorkflow
-	idMappingWorkflows map[string]*IDMappingWorkflow
+	mu                 sync.RWMutex                  `json:"-"`
+	Schemas            map[string]*SchemaMapping     `json:"schemas"`
+	MatchingWorkflows  map[string]*MatchingWorkflow  `json:"matchingWorkflows"`
+	IDMappingWorkflows map[string]*IDMappingWorkflow `json:"idMappingWorkflows"`
+	dataDir            string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		schemas:            make(map[string]*SchemaMapping),
-		matchingWorkflows:  make(map[string]*MatchingWorkflow),
-		idMappingWorkflows: make(map[string]*IDMappingWorkflow),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Schemas:            make(map[string]*SchemaMapping),
+		MatchingWorkflows:  make(map[string]*MatchingWorkflow),
+		IDMappingWorkflows: make(map[string]*IDMappingWorkflow),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "entityresolution", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Schemas == nil {
+		m.Schemas = make(map[string]*SchemaMapping)
+	}
+
+	if m.MatchingWorkflows == nil {
+		m.MatchingWorkflows = make(map[string]*MatchingWorkflow)
+	}
+
+	if m.IDMappingWorkflows == nil {
+		m.IDMappingWorkflows = make(map[string]*IDMappingWorkflow)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "entityresolution", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateSchemaMapping creates a new schema mapping.
@@ -54,7 +139,7 @@ func (m *MemoryStorage) CreateSchemaMapping(_ context.Context, req *CreateSchema
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.schemas[req.SchemaName]; exists {
+	if _, exists := m.Schemas[req.SchemaName]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("Schema mapping %s already exists", req.SchemaName),
@@ -72,7 +157,7 @@ func (m *MemoryStorage) CreateSchemaMapping(_ context.Context, req *CreateSchema
 		Tags:              req.Tags,
 	}
 
-	m.schemas[req.SchemaName] = schema
+	m.Schemas[req.SchemaName] = schema
 
 	return schema, nil
 }
@@ -82,7 +167,7 @@ func (m *MemoryStorage) GetSchemaMapping(_ context.Context, schemaName string) (
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	schema, exists := m.schemas[schemaName]
+	schema, exists := m.Schemas[schemaName]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -98,14 +183,14 @@ func (m *MemoryStorage) DeleteSchemaMapping(_ context.Context, schemaName string
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.schemas[schemaName]; !exists {
+	if _, exists := m.Schemas[schemaName]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Schema mapping %s not found", schemaName),
 		}
 	}
 
-	delete(m.schemas, schemaName)
+	delete(m.Schemas, schemaName)
 
 	return nil
 }
@@ -115,8 +200,8 @@ func (m *MemoryStorage) ListSchemaMappings(_ context.Context) ([]SchemaMappingSu
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	summaries := make([]SchemaMappingSummary, 0, len(m.schemas))
-	for _, s := range m.schemas {
+	summaries := make([]SchemaMappingSummary, 0, len(m.Schemas))
+	for _, s := range m.Schemas {
 		summaries = append(summaries, SchemaMappingSummary{
 			SchemaName: s.SchemaName,
 			SchemaArn:  s.SchemaArn,
@@ -133,7 +218,7 @@ func (m *MemoryStorage) CreateMatchingWorkflow(_ context.Context, req *CreateMat
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.matchingWorkflows[req.WorkflowName]; exists {
+	if _, exists := m.MatchingWorkflows[req.WorkflowName]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("Matching workflow %s already exists", req.WorkflowName),
@@ -154,7 +239,7 @@ func (m *MemoryStorage) CreateMatchingWorkflow(_ context.Context, req *CreateMat
 		Tags:                 req.Tags,
 	}
 
-	m.matchingWorkflows[req.WorkflowName] = workflow
+	m.MatchingWorkflows[req.WorkflowName] = workflow
 
 	return workflow, nil
 }
@@ -164,7 +249,7 @@ func (m *MemoryStorage) GetMatchingWorkflow(_ context.Context, workflowName stri
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	workflow, exists := m.matchingWorkflows[workflowName]
+	workflow, exists := m.MatchingWorkflows[workflowName]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -180,14 +265,14 @@ func (m *MemoryStorage) DeleteMatchingWorkflow(_ context.Context, workflowName s
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.matchingWorkflows[workflowName]; !exists {
+	if _, exists := m.MatchingWorkflows[workflowName]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Matching workflow %s not found", workflowName),
 		}
 	}
 
-	delete(m.matchingWorkflows, workflowName)
+	delete(m.MatchingWorkflows, workflowName)
 
 	return nil
 }
@@ -197,8 +282,8 @@ func (m *MemoryStorage) ListMatchingWorkflows(_ context.Context) ([]MatchingWork
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	summaries := make([]MatchingWorkflowSummary, 0, len(m.matchingWorkflows))
-	for _, w := range m.matchingWorkflows {
+	summaries := make([]MatchingWorkflowSummary, 0, len(m.MatchingWorkflows))
+	for _, w := range m.MatchingWorkflows {
 		summaries = append(summaries, MatchingWorkflowSummary{
 			WorkflowName: w.WorkflowName,
 			WorkflowArn:  w.WorkflowArn,
@@ -215,7 +300,7 @@ func (m *MemoryStorage) CreateIDMappingWorkflow(_ context.Context, req *CreateID
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.idMappingWorkflows[req.WorkflowName]; exists {
+	if _, exists := m.IDMappingWorkflows[req.WorkflowName]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("ID mapping workflow %s already exists", req.WorkflowName),
@@ -236,7 +321,7 @@ func (m *MemoryStorage) CreateIDMappingWorkflow(_ context.Context, req *CreateID
 		Tags:                req.Tags,
 	}
 
-	m.idMappingWorkflows[req.WorkflowName] = workflow
+	m.IDMappingWorkflows[req.WorkflowName] = workflow
 
 	return workflow, nil
 }
@@ -246,7 +331,7 @@ func (m *MemoryStorage) GetIDMappingWorkflow(_ context.Context, workflowName str
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	workflow, exists := m.idMappingWorkflows[workflowName]
+	workflow, exists := m.IDMappingWorkflows[workflowName]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -262,14 +347,14 @@ func (m *MemoryStorage) DeleteIDMappingWorkflow(_ context.Context, workflowName 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.idMappingWorkflows[workflowName]; !exists {
+	if _, exists := m.IDMappingWorkflows[workflowName]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("ID mapping workflow %s not found", workflowName),
 		}
 	}
 
-	delete(m.idMappingWorkflows, workflowName)
+	delete(m.IDMappingWorkflows, workflowName)
 
 	return nil
 }
@@ -279,8 +364,8 @@ func (m *MemoryStorage) ListIDMappingWorkflows(_ context.Context) ([]IDMappingWo
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	summaries := make([]IDMappingWorkflowSummary, 0, len(m.idMappingWorkflows))
-	for _, w := range m.idMappingWorkflows {
+	summaries := make([]IDMappingWorkflowSummary, 0, len(m.IDMappingWorkflows))
+	for _, w := range m.IDMappingWorkflows {
 		summaries = append(summaries, IDMappingWorkflowSummary{
 			WorkflowName: w.WorkflowName,
 			WorkflowArn:  w.WorkflowArn,

--- a/internal/service/eventbridge/service.go
+++ b/internal/service/eventbridge/service.go
@@ -2,8 +2,15 @@
 package eventbridge
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
 
 // Service implements the EventBridge service.
 type Service struct {
@@ -34,5 +41,21 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 }
 
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -2,12 +2,15 @@ package eventbridge
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Default event bus name.
@@ -47,38 +50,119 @@ type Storage interface {
 	DispatchAction(action string) bool
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu         sync.RWMutex
-	eventBuses map[string]*EventBus
-	rules      map[string]map[string]*Rule     // eventBusName -> ruleName -> Rule
-	targets    map[string]map[string][]*Target // eventBusName:ruleName -> targets
+	mu         sync.RWMutex                    `json:"-"`
+	EventBuses map[string]*EventBus            `json:"eventBuses"`
+	Rules      map[string]map[string]*Rule     `json:"rules"`
+	Targets    map[string]map[string][]*Target `json:"targets"`
 	region     string
 	accountID  string
+	dataDir    string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	storage := &MemoryStorage{
-		eventBuses: make(map[string]*EventBus),
-		rules:      make(map[string]map[string]*Rule),
-		targets:    make(map[string]map[string][]*Target),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		EventBuses: make(map[string]*EventBus),
+		Rules:      make(map[string]map[string]*Rule),
+		Targets:    make(map[string]map[string][]*Target),
 		region:     "us-east-1",
 		accountID:  "000000000000",
 	}
-
-	// Create default event bus.
-	now := time.Now()
-	storage.eventBuses[defaultEventBusName] = &EventBus{
-		Name:         defaultEventBusName,
-		Arn:          fmt.Sprintf("arn:aws:events:%s:%s:event-bus/%s", storage.region, storage.accountID, defaultEventBusName),
-		CreationTime: now,
-		LastModified: now,
+	for _, o := range opts {
+		o(s)
 	}
 
-	storage.rules[defaultEventBusName] = make(map[string]*Rule)
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "eventbridge", s)
+	}
 
-	return storage
+	// Create default event bus if not present.
+	if _, exists := s.EventBuses[defaultEventBusName]; !exists {
+		now := time.Now()
+		s.EventBuses[defaultEventBusName] = &EventBus{
+			Name:         defaultEventBusName,
+			Arn:          fmt.Sprintf("arn:aws:events:%s:%s:event-bus/%s", s.region, s.accountID, defaultEventBusName),
+			CreationTime: now,
+			LastModified: now,
+		}
+		s.Rules[defaultEventBusName] = make(map[string]*Rule)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.EventBuses == nil {
+		s.EventBuses = make(map[string]*EventBus)
+	}
+
+	if s.Rules == nil {
+		s.Rules = make(map[string]map[string]*Rule)
+	}
+
+	if s.Targets == nil {
+		s.Targets = make(map[string]map[string][]*Target)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "eventbridge", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateEventBus creates a new event bus.
@@ -86,7 +170,7 @@ func (s *MemoryStorage) CreateEventBus(_ context.Context, req *CreateEventBusReq
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.eventBuses[req.Name]; exists {
+	if _, exists := s.EventBuses[req.Name]; exists {
 		return nil, &ServiceError{Code: errEventBusAlreadyExists, Message: "Event bus already exists"}
 	}
 
@@ -99,8 +183,8 @@ func (s *MemoryStorage) CreateEventBus(_ context.Context, req *CreateEventBusReq
 		LastModified: now,
 	}
 
-	s.eventBuses[req.Name] = eventBus
-	s.rules[req.Name] = make(map[string]*Rule)
+	s.EventBuses[req.Name] = eventBus
+	s.Rules[req.Name] = make(map[string]*Rule)
 
 	return eventBus, nil
 }
@@ -114,17 +198,17 @@ func (s *MemoryStorage) DeleteEventBus(_ context.Context, name string) error {
 		return &ServiceError{Code: errInvalidParameter, Message: "Cannot delete the default event bus"}
 	}
 
-	if _, exists := s.eventBuses[name]; !exists {
+	if _, exists := s.EventBuses[name]; !exists {
 		return &ServiceError{Code: errEventBusNotFound, Message: "Event bus not found"}
 	}
 
-	delete(s.eventBuses, name)
-	delete(s.rules, name)
+	delete(s.EventBuses, name)
+	delete(s.Rules, name)
 
 	// Delete all targets for rules on this event bus.
-	for key := range s.targets {
+	for key := range s.Targets {
 		if strings.HasPrefix(key, name+":") {
-			delete(s.targets, key)
+			delete(s.Targets, key)
 		}
 	}
 
@@ -140,7 +224,7 @@ func (s *MemoryStorage) DescribeEventBus(_ context.Context, name string) (*Event
 		name = defaultEventBusName
 	}
 
-	eventBus, exists := s.eventBuses[name]
+	eventBus, exists := s.EventBuses[name]
 	if !exists {
 		return nil, &ServiceError{Code: errEventBusNotFound, Message: "Event bus not found"}
 	}
@@ -159,7 +243,7 @@ func (s *MemoryStorage) ListEventBuses(_ context.Context, namePrefix string, lim
 
 	var eventBuses []*EventBus
 
-	for _, eb := range s.eventBuses {
+	for _, eb := range s.EventBuses {
 		if namePrefix == "" || strings.HasPrefix(eb.Name, namePrefix) {
 			eventBuses = append(eventBuses, eb)
 		}
@@ -182,7 +266,7 @@ func (s *MemoryStorage) PutRule(_ context.Context, req *PutRuleRequest) (*Rule, 
 		eventBusName = defaultEventBusName
 	}
 
-	if _, exists := s.eventBuses[eventBusName]; !exists {
+	if _, exists := s.EventBuses[eventBusName]; !exists {
 		return nil, &ServiceError{Code: errEventBusNotFound, Message: "Event bus not found"}
 	}
 
@@ -206,11 +290,11 @@ func (s *MemoryStorage) PutRule(_ context.Context, req *PutRuleRequest) (*Rule, 
 		LastModified:       now,
 	}
 
-	if s.rules[eventBusName] == nil {
-		s.rules[eventBusName] = make(map[string]*Rule)
+	if s.Rules[eventBusName] == nil {
+		s.Rules[eventBusName] = make(map[string]*Rule)
 	}
 
-	s.rules[eventBusName][req.Name] = rule
+	s.Rules[eventBusName][req.Name] = rule
 
 	return rule, nil
 }
@@ -224,7 +308,7 @@ func (s *MemoryStorage) DeleteRule(_ context.Context, eventBusName, ruleName str
 		eventBusName = defaultEventBusName
 	}
 
-	rules, exists := s.rules[eventBusName]
+	rules, exists := s.Rules[eventBusName]
 	if !exists {
 		return &ServiceError{Code: errRuleNotFound, Message: "Rule not found"}
 	}
@@ -237,7 +321,7 @@ func (s *MemoryStorage) DeleteRule(_ context.Context, eventBusName, ruleName str
 
 	// Delete targets for this rule.
 	targetKey := eventBusName + ":" + ruleName
-	delete(s.targets, targetKey)
+	delete(s.Targets, targetKey)
 
 	return nil
 }
@@ -251,7 +335,7 @@ func (s *MemoryStorage) DescribeRule(_ context.Context, eventBusName, ruleName s
 		eventBusName = defaultEventBusName
 	}
 
-	rules, exists := s.rules[eventBusName]
+	rules, exists := s.Rules[eventBusName]
 	if !exists {
 		return nil, &ServiceError{Code: errRuleNotFound, Message: "Rule not found"}
 	}
@@ -277,7 +361,7 @@ func (s *MemoryStorage) ListRules(_ context.Context, eventBusName, namePrefix st
 		limit = 10
 	}
 
-	rules, exists := s.rules[eventBusName]
+	rules, exists := s.Rules[eventBusName]
 	if !exists {
 		return nil, "", nil
 	}
@@ -306,7 +390,7 @@ func (s *MemoryStorage) PutTargets(_ context.Context, eventBusName, ruleName str
 		eventBusName = defaultEventBusName
 	}
 
-	rules, exists := s.rules[eventBusName]
+	rules, exists := s.Rules[eventBusName]
 	if !exists {
 		return nil, &ServiceError{Code: errRuleNotFound, Message: "Rule not found"}
 	}
@@ -317,8 +401,8 @@ func (s *MemoryStorage) PutTargets(_ context.Context, eventBusName, ruleName str
 
 	targetKey := eventBusName + ":" + ruleName
 
-	if s.targets[targetKey] == nil {
-		s.targets[targetKey] = make(map[string][]*Target)
+	if s.Targets[targetKey] == nil {
+		s.Targets[targetKey] = make(map[string][]*Target)
 	}
 
 	var failedEntries []PutTargetsResultEntry
@@ -334,7 +418,7 @@ func (s *MemoryStorage) PutTargets(_ context.Context, eventBusName, ruleName str
 
 		// Find and update existing target or add new one.
 		found := false
-		existingTargets := s.targets[targetKey][ruleName]
+		existingTargets := s.Targets[targetKey][ruleName]
 
 		for i, existing := range existingTargets {
 			if existing.ID == t.ID {
@@ -346,7 +430,7 @@ func (s *MemoryStorage) PutTargets(_ context.Context, eventBusName, ruleName str
 		}
 
 		if !found {
-			s.targets[targetKey][ruleName] = append(s.targets[targetKey][ruleName], target)
+			s.Targets[targetKey][ruleName] = append(s.Targets[targetKey][ruleName], target)
 		}
 	}
 
@@ -366,11 +450,11 @@ func (s *MemoryStorage) RemoveTargets(_ context.Context, eventBusName, ruleName 
 
 	var failedEntries []RemoveTargetsResultEntry
 
-	if s.targets[targetKey] == nil {
+	if s.Targets[targetKey] == nil {
 		return failedEntries, nil
 	}
 
-	existingTargets := s.targets[targetKey][ruleName]
+	existingTargets := s.Targets[targetKey][ruleName]
 
 	var newTargets []*Target
 
@@ -385,7 +469,7 @@ func (s *MemoryStorage) RemoveTargets(_ context.Context, eventBusName, ruleName 
 		}
 	}
 
-	s.targets[targetKey][ruleName] = newTargets
+	s.Targets[targetKey][ruleName] = newTargets
 
 	return failedEntries, nil
 }
@@ -405,11 +489,11 @@ func (s *MemoryStorage) ListTargetsByRule(_ context.Context, eventBusName, ruleN
 
 	targetKey := eventBusName + ":" + ruleName
 
-	if s.targets[targetKey] == nil {
+	if s.Targets[targetKey] == nil {
 		return nil, "", nil
 	}
 
-	targets := s.targets[targetKey][ruleName]
+	targets := s.Targets[targetKey][ruleName]
 
 	if int32(len(targets)) > limit { //nolint:gosec // slice length bounded by limit parameter
 		targets = targets[:limit]

--- a/internal/service/eventbridge/types.go
+++ b/internal/service/eventbridge/types.go
@@ -24,35 +24,35 @@ const (
 
 // EventBus represents an event bus.
 type EventBus struct {
-	Name         string
-	Arn          string
-	Description  string
-	ManagedBy    string
-	CreationTime time.Time
-	LastModified time.Time
+	Name         string    `json:"name"`
+	Arn          string    `json:"arn"`
+	Description  string    `json:"description,omitempty"`
+	ManagedBy    string    `json:"managedBy,omitempty"`
+	CreationTime time.Time `json:"creationTime"`
+	LastModified time.Time `json:"lastModified"`
 }
 
 // Rule represents an EventBridge rule.
 type Rule struct {
-	Name               string
-	Arn                string
-	EventBusName       string
-	EventPattern       string
-	ScheduleExpression string
-	State              RuleState
-	Description        string
-	RoleArn            string
-	CreationTime       time.Time
-	LastModified       time.Time
+	Name               string    `json:"name"`
+	Arn                string    `json:"arn"`
+	EventBusName       string    `json:"eventBusName"`
+	EventPattern       string    `json:"eventPattern,omitempty"`
+	ScheduleExpression string    `json:"scheduleExpression,omitempty"`
+	State              RuleState `json:"state"`
+	Description        string    `json:"description,omitempty"`
+	RoleArn            string    `json:"roleArn,omitempty"`
+	CreationTime       time.Time `json:"creationTime"`
+	LastModified       time.Time `json:"lastModified"`
 }
 
 // Target represents a rule target.
 type Target struct {
-	ID        string
-	Arn       string
-	RoleArn   string
-	Input     string
-	InputPath string
+	ID        string `json:"id"`
+	Arn       string `json:"arn"`
+	RoleArn   string `json:"roleArn,omitempty"`
+	Input     string `json:"input,omitempty"`
+	InputPath string `json:"inputPath,omitempty"`
 }
 
 // PutEventsRequestEntry represents an entry in PutEvents request.

--- a/internal/service/finspace/service.go
+++ b/internal/service/finspace/service.go
@@ -1,12 +1,26 @@
 package finspace
 
-import "github.com/sivchari/kumo/internal/service"
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // Compile-time check to ensure Service implements service.Service.
-var _ service.Service = (*Service)(nil)
+var (
+	_ service.Service = (*Service)(nil)
+	_ io.Closer       = (*Service)(nil)
+)
 
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the FinSpace service.
@@ -53,6 +67,17 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("POST", "/tags", s.TagResource)
 	r.Handle("DELETE", "/tags", s.UntagResource)
 	r.Handle("GET", "/tags", s.ListTagsForResource)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // Prefix returns the URL prefix for FinSpace.

--- a/internal/service/finspace/storage.go
+++ b/internal/service/finspace/storage.go
@@ -2,12 +2,15 @@ package finspace
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -47,27 +50,113 @@ type Storage interface {
 	ListTagsForResource(ctx context.Context, resourceARN string) (map[string]string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements in-memory storage for FinSpace.
 type MemoryStorage struct {
-	mu           sync.RWMutex
-	environments map[string]*KxEnvironment
-	databases    map[string]*KxDatabase // key: environmentID/databaseName
-	users        map[string]*KxUser     // key: environmentID/userName
-	tags         map[string]map[string]string
+	mu           sync.RWMutex                 `json:"-"`
+	Environments map[string]*KxEnvironment    `json:"environments"`
+	Databases    map[string]*KxDatabase       `json:"databases"`
+	Users        map[string]*KxUser           `json:"users"`
+	Tags         map[string]map[string]string `json:"tags"`
 	accountID    string
 	region       string
+	dataDir      string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		environments: make(map[string]*KxEnvironment),
-		databases:    make(map[string]*KxDatabase),
-		users:        make(map[string]*KxUser),
-		tags:         make(map[string]map[string]string),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Environments: make(map[string]*KxEnvironment),
+		Databases:    make(map[string]*KxDatabase),
+		Users:        make(map[string]*KxUser),
+		Tags:         make(map[string]map[string]string),
 		accountID:    "123456789012",
 		region:       "us-east-1",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "finspace", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Environments == nil {
+		s.Environments = make(map[string]*KxEnvironment)
+	}
+
+	if s.Databases == nil {
+		s.Databases = make(map[string]*KxDatabase)
+	}
+
+	if s.Users == nil {
+		s.Users = make(map[string]*KxUser)
+	}
+
+	if s.Tags == nil {
+		s.Tags = make(map[string]map[string]string)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "finspace", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateKxEnvironment creates a new kdb environment.
@@ -76,7 +165,7 @@ func (s *MemoryStorage) CreateKxEnvironment(_ context.Context, req *CreateKxEnvi
 	defer s.mu.Unlock()
 
 	// Check for duplicate name
-	for _, env := range s.environments {
+	for _, env := range s.Environments {
 		if env.Name == req.Name {
 			return nil, &Error{
 				Code:    errConflict,
@@ -101,10 +190,10 @@ func (s *MemoryStorage) CreateKxEnvironment(_ context.Context, req *CreateKxEnvi
 		UpdateTimestamp:   now,
 	}
 
-	s.environments[environmentID] = env
+	s.Environments[environmentID] = env
 
 	if len(req.Tags) > 0 {
-		s.tags[arn] = req.Tags
+		s.Tags[arn] = req.Tags
 	}
 
 	return &CreateKxEnvironmentResponse{
@@ -123,7 +212,7 @@ func (s *MemoryStorage) GetKxEnvironment(_ context.Context, environmentID string
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	env, exists := s.environments[environmentID]
+	env, exists := s.Environments[environmentID]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -156,7 +245,7 @@ func (s *MemoryStorage) DeleteKxEnvironment(_ context.Context, environmentID str
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	env, exists := s.environments[environmentID]
+	env, exists := s.Environments[environmentID]
 	if !exists {
 		return &Error{
 			Code:    errResourceNotFound,
@@ -164,8 +253,8 @@ func (s *MemoryStorage) DeleteKxEnvironment(_ context.Context, environmentID str
 		}
 	}
 
-	delete(s.tags, env.EnvironmentARN)
-	delete(s.environments, environmentID)
+	delete(s.Tags, env.EnvironmentARN)
+	delete(s.Environments, environmentID)
 
 	return nil
 }
@@ -179,9 +268,9 @@ func (s *MemoryStorage) ListKxEnvironments(_ context.Context, maxResults int, _ 
 		maxResults = 10
 	}
 
-	environments := make([]*KxEnvironment, 0, len(s.environments))
+	environments := make([]*KxEnvironment, 0, len(s.Environments))
 
-	for _, env := range s.environments {
+	for _, env := range s.Environments {
 		environments = append(environments, env)
 
 		if len(environments) >= maxResults {
@@ -199,7 +288,7 @@ func (s *MemoryStorage) UpdateKxEnvironment(_ context.Context, req *UpdateKxEnvi
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	env, exists := s.environments[req.EnvironmentID]
+	env, exists := s.Environments[req.EnvironmentID]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -240,7 +329,7 @@ func (s *MemoryStorage) CreateKxDatabase(_ context.Context, req *CreateKxDatabas
 	defer s.mu.Unlock()
 
 	// Check if environment exists
-	if _, exists := s.environments[req.EnvironmentID]; !exists {
+	if _, exists := s.Environments[req.EnvironmentID]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Environment with ID %s not found", req.EnvironmentID),
@@ -250,7 +339,7 @@ func (s *MemoryStorage) CreateKxDatabase(_ context.Context, req *CreateKxDatabas
 	key := fmt.Sprintf("%s/%s", req.EnvironmentID, req.DatabaseName)
 
 	// Check for duplicate
-	if _, exists := s.databases[key]; exists {
+	if _, exists := s.Databases[key]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("Database with name %s already exists in environment %s", req.DatabaseName, req.EnvironmentID),
@@ -269,10 +358,10 @@ func (s *MemoryStorage) CreateKxDatabase(_ context.Context, req *CreateKxDatabas
 		LastModifiedTimestamp: now,
 	}
 
-	s.databases[key] = db
+	s.Databases[key] = db
 
 	if len(req.Tags) > 0 {
-		s.tags[arn] = req.Tags
+		s.Tags[arn] = req.Tags
 	}
 
 	return &CreateKxDatabaseResponse{
@@ -291,7 +380,7 @@ func (s *MemoryStorage) GetKxDatabase(_ context.Context, environmentID, database
 
 	key := fmt.Sprintf("%s/%s", environmentID, databaseName)
 
-	db, exists := s.databases[key]
+	db, exists := s.Databases[key]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -320,7 +409,7 @@ func (s *MemoryStorage) DeleteKxDatabase(_ context.Context, environmentID, datab
 
 	key := fmt.Sprintf("%s/%s", environmentID, databaseName)
 
-	db, exists := s.databases[key]
+	db, exists := s.Databases[key]
 	if !exists {
 		return &Error{
 			Code:    errResourceNotFound,
@@ -328,8 +417,8 @@ func (s *MemoryStorage) DeleteKxDatabase(_ context.Context, environmentID, datab
 		}
 	}
 
-	delete(s.tags, db.DatabaseARN)
-	delete(s.databases, key)
+	delete(s.Tags, db.DatabaseARN)
+	delete(s.Databases, key)
 
 	return nil
 }
@@ -345,7 +434,7 @@ func (s *MemoryStorage) ListKxDatabases(_ context.Context, environmentID string,
 
 	databases := make([]*KxDatabase, 0)
 
-	for key, db := range s.databases {
+	for key, db := range s.Databases {
 		if db.EnvironmentID == environmentID {
 			databases = append(databases, db)
 
@@ -369,7 +458,7 @@ func (s *MemoryStorage) UpdateKxDatabase(_ context.Context, req *UpdateKxDatabas
 
 	key := fmt.Sprintf("%s/%s", req.EnvironmentID, req.DatabaseName)
 
-	db, exists := s.databases[key]
+	db, exists := s.Databases[key]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -398,7 +487,7 @@ func (s *MemoryStorage) CreateKxUser(_ context.Context, req *CreateKxUserRequest
 	defer s.mu.Unlock()
 
 	// Check if environment exists
-	if _, exists := s.environments[req.EnvironmentID]; !exists {
+	if _, exists := s.Environments[req.EnvironmentID]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Environment with ID %s not found", req.EnvironmentID),
@@ -408,7 +497,7 @@ func (s *MemoryStorage) CreateKxUser(_ context.Context, req *CreateKxUserRequest
 	key := fmt.Sprintf("%s/%s", req.EnvironmentID, req.UserName)
 
 	// Check for duplicate
-	if _, exists := s.users[key]; exists {
+	if _, exists := s.Users[key]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("User with name %s already exists in environment %s", req.UserName, req.EnvironmentID),
@@ -426,10 +515,10 @@ func (s *MemoryStorage) CreateKxUser(_ context.Context, req *CreateKxUserRequest
 		UserName:        req.UserName,
 	}
 
-	s.users[key] = user
+	s.Users[key] = user
 
 	if len(req.Tags) > 0 {
-		s.tags[arn] = req.Tags
+		s.Tags[arn] = req.Tags
 	}
 
 	return &CreateKxUserResponse{
@@ -447,7 +536,7 @@ func (s *MemoryStorage) GetKxUser(_ context.Context, environmentID, userName str
 
 	key := fmt.Sprintf("%s/%s", environmentID, userName)
 
-	user, exists := s.users[key]
+	user, exists := s.Users[key]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -470,7 +559,7 @@ func (s *MemoryStorage) DeleteKxUser(_ context.Context, environmentID, userName 
 
 	key := fmt.Sprintf("%s/%s", environmentID, userName)
 
-	user, exists := s.users[key]
+	user, exists := s.Users[key]
 	if !exists {
 		return &Error{
 			Code:    errResourceNotFound,
@@ -478,8 +567,8 @@ func (s *MemoryStorage) DeleteKxUser(_ context.Context, environmentID, userName 
 		}
 	}
 
-	delete(s.tags, user.UserARN)
-	delete(s.users, key)
+	delete(s.Tags, user.UserARN)
+	delete(s.Users, key)
 
 	return nil
 }
@@ -495,7 +584,7 @@ func (s *MemoryStorage) ListKxUsers(_ context.Context, environmentID string, max
 
 	users := make([]*KxUser, 0)
 
-	for key, user := range s.users {
+	for key, user := range s.Users {
 		// Check if the key starts with the environmentID
 		if len(key) > len(environmentID) && key[:len(environmentID)] == environmentID && key[len(environmentID)] == '/' {
 			users = append(users, user)
@@ -518,7 +607,7 @@ func (s *MemoryStorage) UpdateKxUser(_ context.Context, req *UpdateKxUserRequest
 
 	key := fmt.Sprintf("%s/%s", req.EnvironmentID, req.UserName)
 
-	user, exists := s.users[key]
+	user, exists := s.Users[key]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -545,11 +634,11 @@ func (s *MemoryStorage) TagResource(_ context.Context, resourceARN string, tags 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.tags[resourceARN] == nil {
-		s.tags[resourceARN] = make(map[string]string)
+	if s.Tags[resourceARN] == nil {
+		s.Tags[resourceARN] = make(map[string]string)
 	}
 
-	maps.Copy(s.tags[resourceARN], tags)
+	maps.Copy(s.Tags[resourceARN], tags)
 
 	return nil
 }
@@ -559,12 +648,12 @@ func (s *MemoryStorage) UntagResource(_ context.Context, resourceARN string, tag
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.tags[resourceARN] == nil {
+	if s.Tags[resourceARN] == nil {
 		return nil
 	}
 
 	for _, key := range tagKeys {
-		delete(s.tags[resourceARN], key)
+		delete(s.Tags[resourceARN], key)
 	}
 
 	return nil
@@ -575,7 +664,7 @@ func (s *MemoryStorage) ListTagsForResource(_ context.Context, resourceARN strin
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	tags := s.tags[resourceARN]
+	tags := s.Tags[resourceARN]
 	if tags == nil {
 		tags = make(map[string]string)
 	}

--- a/internal/service/firehose/service.go
+++ b/internal/service/firehose/service.go
@@ -2,8 +2,15 @@
 package firehose
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// Compile-time interface checks.
+var _ io.Closer = (*Service)(nil)
 
 // Service is the Firehose service.
 type Service struct {
@@ -36,6 +43,22 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// Routes are dispatched by the server based on X-Amz-Target.
 }
 
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }

--- a/internal/service/firehose/storage.go
+++ b/internal/service/firehose/storage.go
@@ -2,6 +2,7 @@ package firehose
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the interface for Firehose storage operations.
@@ -22,28 +25,104 @@ type Storage interface {
 	UpdateDestination(ctx context.Context, input *UpdateDestinationInput) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu      sync.RWMutex
-	streams map[string]*streamData
+	mu      sync.RWMutex           `json:"-"`
+	Streams map[string]*StreamData `json:"streams"`
+	dataDir string
 }
 
-type streamData struct {
-	stream  *DeliveryStream
-	records []storedRecord
+// StreamData holds a delivery stream and its records.
+type StreamData struct {
+	Stream  *DeliveryStream `json:"stream"`
+	Records []StoredRecord  `json:"records"`
 }
 
-type storedRecord struct {
-	recordID string
-	data     []byte
-	received time.Time
+// StoredRecord holds a stored record.
+type StoredRecord struct {
+	RecordID string    `json:"recordId"`
+	Data     []byte    `json:"data"`
+	Received time.Time `json:"received"`
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		streams: make(map[string]*streamData),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Streams: make(map[string]*StreamData),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "firehose", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Streams == nil {
+		s.Streams = make(map[string]*StreamData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "firehose", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateDeliveryStream creates a new delivery stream.
@@ -51,7 +130,7 @@ func (s *MemoryStorage) CreateDeliveryStream(_ context.Context, input *CreateDel
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.streams[input.DeliveryStreamName]; exists {
+	if _, exists := s.Streams[input.DeliveryStreamName]; exists {
 		return nil, &Error{
 			Code:    errResourceInUse,
 			Message: fmt.Sprintf("Delivery stream %s already exists", input.DeliveryStreamName),
@@ -59,9 +138,9 @@ func (s *MemoryStorage) CreateDeliveryStream(_ context.Context, input *CreateDel
 	}
 
 	stream := s.buildDeliveryStream(input)
-	s.streams[input.DeliveryStreamName] = &streamData{
-		stream:  stream,
-		records: make([]storedRecord, 0),
+	s.Streams[input.DeliveryStreamName] = &StreamData{
+		Stream:  stream,
+		Records: make([]StoredRecord, 0),
 	}
 
 	return stream, nil
@@ -158,14 +237,14 @@ func (s *MemoryStorage) DeleteDeliveryStream(_ context.Context, name string, _ b
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.streams[name]; !exists {
+	if _, exists := s.Streams[name]; !exists {
 		return &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Delivery stream %s not found", name),
 		}
 	}
 
-	delete(s.streams, name)
+	delete(s.Streams, name)
 
 	return nil
 }
@@ -175,7 +254,7 @@ func (s *MemoryStorage) DescribeDeliveryStream(_ context.Context, name string, _
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	data, exists := s.streams[name]
+	data, exists := s.Streams[name]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -183,7 +262,7 @@ func (s *MemoryStorage) DescribeDeliveryStream(_ context.Context, name string, _
 		}
 	}
 
-	return data.stream, nil
+	return data.Stream, nil
 }
 
 // ListDeliveryStreams lists delivery streams.
@@ -221,10 +300,10 @@ func (s *MemoryStorage) ListDeliveryStreams(_ context.Context, streamType, exclu
 }
 
 func (s *MemoryStorage) collectStreamNames(streamType string) []string {
-	names := make([]string, 0, len(s.streams))
+	names := make([]string, 0, len(s.Streams))
 
-	for name, data := range s.streams {
-		if streamType != "" && string(data.stream.DeliveryStreamType) != streamType {
+	for name, data := range s.Streams {
+		if streamType != "" && string(data.Stream.DeliveryStreamType) != streamType {
 			continue
 		}
 
@@ -253,7 +332,7 @@ func (s *MemoryStorage) PutRecord(_ context.Context, streamName string, record R
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.streams[streamName]
+	data, exists := s.Streams[streamName]
 	if !exists {
 		return "", &Error{
 			Code:    errResourceNotFound,
@@ -263,10 +342,10 @@ func (s *MemoryStorage) PutRecord(_ context.Context, streamName string, record R
 
 	recordID := uuid.New().String()
 
-	data.records = append(data.records, storedRecord{
-		recordID: recordID,
-		data:     record.Data,
-		received: time.Now(),
+	data.Records = append(data.Records, StoredRecord{
+		RecordID: recordID,
+		Data:     record.Data,
+		Received: time.Now(),
 	})
 
 	return recordID, nil
@@ -277,7 +356,7 @@ func (s *MemoryStorage) PutRecordBatch(_ context.Context, streamName string, rec
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.streams[streamName]
+	data, exists := s.Streams[streamName]
 	if !exists {
 		return nil, 0, &Error{
 			Code:    errResourceNotFound,
@@ -291,10 +370,10 @@ func (s *MemoryStorage) PutRecordBatch(_ context.Context, streamName string, rec
 	for i, record := range records {
 		recordID := uuid.New().String()
 
-		data.records = append(data.records, storedRecord{
-			recordID: recordID,
-			data:     record.Data,
-			received: now,
+		data.Records = append(data.Records, StoredRecord{
+			RecordID: recordID,
+			Data:     record.Data,
+			Received: now,
 		})
 
 		responses[i] = PutRecordBatchResponseEntry{
@@ -310,7 +389,7 @@ func (s *MemoryStorage) UpdateDestination(_ context.Context, input *UpdateDestin
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, exists := s.streams[input.DeliveryStreamName]
+	data, exists := s.Streams[input.DeliveryStreamName]
 	if !exists {
 		return &Error{
 			Code:    errResourceNotFound,
@@ -318,7 +397,7 @@ func (s *MemoryStorage) UpdateDestination(_ context.Context, input *UpdateDestin
 		}
 	}
 
-	if data.stream.VersionID != input.CurrentDeliveryStreamVersionID {
+	if data.Stream.VersionID != input.CurrentDeliveryStreamVersionID {
 		return &Error{
 			Code:    errInvalidArgument,
 			Message: "Invalid version ID",
@@ -327,7 +406,7 @@ func (s *MemoryStorage) UpdateDestination(_ context.Context, input *UpdateDestin
 
 	found := false
 
-	for i, dest := range data.stream.Destinations {
+	for i, dest := range data.Stream.Destinations {
 		if dest.DestinationID != input.DestinationID {
 			continue
 		}
@@ -350,7 +429,7 @@ func (s *MemoryStorage) UpdateDestination(_ context.Context, input *UpdateDestin
 			s.applyExtendedS3Update(dest.ExtendedS3DestinationDescription, input.ExtendedS3DestinationUpdate)
 		}
 
-		data.stream.Destinations[i] = dest
+		data.Stream.Destinations[i] = dest
 
 		break
 	}
@@ -362,9 +441,9 @@ func (s *MemoryStorage) UpdateDestination(_ context.Context, input *UpdateDestin
 		}
 	}
 
-	versionNum, _ := strconv.Atoi(data.stream.VersionID)
-	data.stream.VersionID = strconv.Itoa(versionNum + 1)
-	data.stream.LastUpdateTimestamp = time.Now()
+	versionNum, _ := strconv.Atoi(data.Stream.VersionID)
+	data.Stream.VersionID = strconv.Itoa(versionNum + 1)
+	data.Stream.LastUpdateTimestamp = time.Now()
 
 	return nil
 }

--- a/internal/service/forecast/service.go
+++ b/internal/service/forecast/service.go
@@ -1,7 +1,13 @@
 // Package forecast provides Amazon Forecast service emulation.
 package forecast
 
-import "github.com/sivchari/kumo/internal/service"
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // Service implements the Forecast service.
 type Service struct {
@@ -29,11 +35,28 @@ func (s *Service) JSONProtocol() {}
 // RegisterRoutes registers HTTP routes for the service.
 func (s *Service) RegisterRoutes(_ service.Router) {}
 
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 var (
 	_ service.Service             = (*Service)(nil)
 	_ service.JSONProtocolService = (*Service)(nil)
+	_ io.Closer                   = (*Service)(nil)
 )

--- a/internal/service/forecast/storage.go
+++ b/internal/service/forecast/storage.go
@@ -2,12 +2,15 @@ package forecast
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the interface for Forecast storage operations.
@@ -38,27 +41,113 @@ type Storage interface {
 	DeleteForecast(ctx context.Context, forecastArn string) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage using in-memory storage.
 type MemoryStorage struct {
-	mu            sync.RWMutex
-	datasets      map[string]*Dataset
-	datasetGroups map[string]*DatasetGroup
-	predictors    map[string]*Predictor
-	forecasts     map[string]*Forecast
+	mu            sync.RWMutex             `json:"-"`
+	Datasets      map[string]*Dataset      `json:"datasets"`
+	DatasetGroups map[string]*DatasetGroup `json:"datasetGroups"`
+	Predictors    map[string]*Predictor    `json:"predictors"`
+	Forecasts     map[string]*Forecast     `json:"forecasts"`
 	accountID     string
 	region        string
+	dataDir       string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		datasets:      make(map[string]*Dataset),
-		datasetGroups: make(map[string]*DatasetGroup),
-		predictors:    make(map[string]*Predictor),
-		forecasts:     make(map[string]*Forecast),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Datasets:      make(map[string]*Dataset),
+		DatasetGroups: make(map[string]*DatasetGroup),
+		Predictors:    make(map[string]*Predictor),
+		Forecasts:     make(map[string]*Forecast),
 		accountID:     "123456789012",
 		region:        "us-east-1",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "forecast", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Datasets == nil {
+		m.Datasets = make(map[string]*Dataset)
+	}
+
+	if m.DatasetGroups == nil {
+		m.DatasetGroups = make(map[string]*DatasetGroup)
+	}
+
+	if m.Predictors == nil {
+		m.Predictors = make(map[string]*Predictor)
+	}
+
+	if m.Forecasts == nil {
+		m.Forecasts = make(map[string]*Forecast)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "forecast", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // Dataset operations.
@@ -69,7 +158,7 @@ func (m *MemoryStorage) CreateDataset(_ context.Context, req *CreateDatasetInput
 	defer m.mu.Unlock()
 
 	// Check for duplicate name.
-	for _, ds := range m.datasets {
+	for _, ds := range m.Datasets {
 		if ds.DatasetName == req.DatasetName {
 			return "", &Error{
 				Code:    errResourceAlreadyExistsException,
@@ -110,7 +199,7 @@ func (m *MemoryStorage) CreateDataset(_ context.Context, req *CreateDatasetInput
 		EncryptionConfig:     req.EncryptionConfig,
 	}
 
-	m.datasets[datasetArn] = dataset
+	m.Datasets[datasetArn] = dataset
 
 	return datasetArn, nil
 }
@@ -120,7 +209,7 @@ func (m *MemoryStorage) DescribeDataset(_ context.Context, datasetArn string) (*
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	dataset, exists := m.datasets[datasetArn]
+	dataset, exists := m.Datasets[datasetArn]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -141,9 +230,9 @@ func (m *MemoryStorage) ListDatasets(_ context.Context, maxResults *int32, _ str
 		limit = *maxResults
 	}
 
-	summaries := make([]*DatasetSummary, 0, len(m.datasets))
+	summaries := make([]*DatasetSummary, 0, len(m.Datasets))
 
-	for _, ds := range m.datasets {
+	for _, ds := range m.Datasets {
 		if int32(len(summaries)) >= limit { //nolint:gosec // G115: len(summaries) is bounded by limit which is int32
 			break
 		}
@@ -166,7 +255,7 @@ func (m *MemoryStorage) DeleteDataset(_ context.Context, datasetArn string) erro
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.datasets[datasetArn]; !exists {
+	if _, exists := m.Datasets[datasetArn]; !exists {
 		return &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Dataset %s not found", datasetArn),
@@ -174,7 +263,7 @@ func (m *MemoryStorage) DeleteDataset(_ context.Context, datasetArn string) erro
 	}
 
 	// Check if dataset is in use by any dataset group.
-	for _, dg := range m.datasetGroups {
+	for _, dg := range m.DatasetGroups {
 		if slices.Contains(dg.DatasetArns, datasetArn) {
 			return &Error{
 				Code:    errResourceInUseException,
@@ -183,7 +272,7 @@ func (m *MemoryStorage) DeleteDataset(_ context.Context, datasetArn string) erro
 		}
 	}
 
-	delete(m.datasets, datasetArn)
+	delete(m.Datasets, datasetArn)
 
 	return nil
 }
@@ -196,7 +285,7 @@ func (m *MemoryStorage) CreateDatasetGroup(_ context.Context, req *CreateDataset
 	defer m.mu.Unlock()
 
 	// Check for duplicate name.
-	for _, dg := range m.datasetGroups {
+	for _, dg := range m.DatasetGroups {
 		if dg.DatasetGroupName == req.DatasetGroupName {
 			return "", &Error{
 				Code:    errResourceAlreadyExistsException,
@@ -215,7 +304,7 @@ func (m *MemoryStorage) CreateDatasetGroup(_ context.Context, req *CreateDataset
 
 	// Validate dataset ARNs exist and have matching domain.
 	for _, dsArn := range req.DatasetArns {
-		ds, exists := m.datasets[dsArn]
+		ds, exists := m.Datasets[dsArn]
 		if !exists {
 			return "", &Error{
 				Code:    errResourceNotFoundException,
@@ -244,7 +333,7 @@ func (m *MemoryStorage) CreateDatasetGroup(_ context.Context, req *CreateDataset
 		LastModificationTime: ToAWSTimestamp(now),
 	}
 
-	m.datasetGroups[datasetGroupArn] = datasetGroup
+	m.DatasetGroups[datasetGroupArn] = datasetGroup
 
 	return datasetGroupArn, nil
 }
@@ -254,7 +343,7 @@ func (m *MemoryStorage) DescribeDatasetGroup(_ context.Context, datasetGroupArn 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	datasetGroup, exists := m.datasetGroups[datasetGroupArn]
+	datasetGroup, exists := m.DatasetGroups[datasetGroupArn]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -275,9 +364,9 @@ func (m *MemoryStorage) ListDatasetGroups(_ context.Context, maxResults *int32, 
 		limit = *maxResults
 	}
 
-	summaries := make([]*DatasetGroupSummary, 0, len(m.datasetGroups))
+	summaries := make([]*DatasetGroupSummary, 0, len(m.DatasetGroups))
 
-	for _, dg := range m.datasetGroups {
+	for _, dg := range m.DatasetGroups {
 		if int32(len(summaries)) >= limit { //nolint:gosec // G115: len(summaries) is bounded by limit which is int32
 			break
 		}
@@ -298,7 +387,7 @@ func (m *MemoryStorage) DeleteDatasetGroup(_ context.Context, datasetGroupArn st
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.datasetGroups[datasetGroupArn]; !exists {
+	if _, exists := m.DatasetGroups[datasetGroupArn]; !exists {
 		return &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Dataset group %s not found", datasetGroupArn),
@@ -306,7 +395,7 @@ func (m *MemoryStorage) DeleteDatasetGroup(_ context.Context, datasetGroupArn st
 	}
 
 	// Check if dataset group is in use by any predictor.
-	for _, p := range m.predictors {
+	for _, p := range m.Predictors {
 		if p.InputDataConfig != nil && p.InputDataConfig.DatasetGroupArn == datasetGroupArn {
 			return &Error{
 				Code:    errResourceInUseException,
@@ -315,7 +404,7 @@ func (m *MemoryStorage) DeleteDatasetGroup(_ context.Context, datasetGroupArn st
 		}
 	}
 
-	delete(m.datasetGroups, datasetGroupArn)
+	delete(m.DatasetGroups, datasetGroupArn)
 
 	return nil
 }
@@ -325,7 +414,7 @@ func (m *MemoryStorage) UpdateDatasetGroup(_ context.Context, datasetGroupArn st
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	dg, exists := m.datasetGroups[datasetGroupArn]
+	dg, exists := m.DatasetGroups[datasetGroupArn]
 	if !exists {
 		return &Error{
 			Code:    errResourceNotFoundException,
@@ -335,7 +424,7 @@ func (m *MemoryStorage) UpdateDatasetGroup(_ context.Context, datasetGroupArn st
 
 	// Validate dataset ARNs exist and have matching domain.
 	for _, dsArn := range datasetArns {
-		ds, dsExists := m.datasets[dsArn]
+		ds, dsExists := m.Datasets[dsArn]
 		if !dsExists {
 			return &Error{
 				Code:    errResourceNotFoundException,
@@ -367,7 +456,7 @@ func (m *MemoryStorage) CreatePredictor(_ context.Context, req *CreatePredictorI
 	defer m.mu.Unlock()
 
 	// Check for duplicate name.
-	for _, p := range m.predictors {
+	for _, p := range m.Predictors {
 		if p.PredictorName == req.PredictorName {
 			return "", &Error{
 				Code:    errResourceAlreadyExistsException,
@@ -384,7 +473,7 @@ func (m *MemoryStorage) CreatePredictor(_ context.Context, req *CreatePredictorI
 		}
 	}
 
-	dg, exists := m.datasetGroups[req.InputDataConfig.DatasetGroupArn]
+	dg, exists := m.DatasetGroups[req.InputDataConfig.DatasetGroupArn]
 	if !exists {
 		return "", &Error{
 			Code:    errResourceNotFoundException,
@@ -424,7 +513,7 @@ func (m *MemoryStorage) CreatePredictor(_ context.Context, req *CreatePredictorI
 		LastModificationTime: ToAWSTimestamp(now),
 	}
 
-	m.predictors[predictorArn] = predictor
+	m.Predictors[predictorArn] = predictor
 
 	return predictorArn, nil
 }
@@ -434,7 +523,7 @@ func (m *MemoryStorage) DescribePredictor(_ context.Context, predictorArn string
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	predictor, exists := m.predictors[predictorArn]
+	predictor, exists := m.Predictors[predictorArn]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -455,9 +544,9 @@ func (m *MemoryStorage) ListPredictors(_ context.Context, maxResults *int32, _ s
 		limit = *maxResults
 	}
 
-	summaries := make([]*PredictorSummary, 0, len(m.predictors))
+	summaries := make([]*PredictorSummary, 0, len(m.Predictors))
 
-	for _, p := range m.predictors {
+	for _, p := range m.Predictors {
 		if int32(len(summaries)) >= limit { //nolint:gosec // G115: len(summaries) is bounded by limit which is int32
 			break
 		}
@@ -491,7 +580,7 @@ func (m *MemoryStorage) DeletePredictor(_ context.Context, predictorArn string) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.predictors[predictorArn]; !exists {
+	if _, exists := m.Predictors[predictorArn]; !exists {
 		return &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Predictor %s not found", predictorArn),
@@ -499,7 +588,7 @@ func (m *MemoryStorage) DeletePredictor(_ context.Context, predictorArn string) 
 	}
 
 	// Check if predictor is in use by any forecast.
-	for _, f := range m.forecasts {
+	for _, f := range m.Forecasts {
 		if f.PredictorArn == predictorArn {
 			return &Error{
 				Code:    errResourceInUseException,
@@ -508,7 +597,7 @@ func (m *MemoryStorage) DeletePredictor(_ context.Context, predictorArn string) 
 		}
 	}
 
-	delete(m.predictors, predictorArn)
+	delete(m.Predictors, predictorArn)
 
 	return nil
 }
@@ -521,7 +610,7 @@ func (m *MemoryStorage) CreateForecast(_ context.Context, req *CreateForecastInp
 	defer m.mu.Unlock()
 
 	// Check for duplicate name.
-	for _, f := range m.forecasts {
+	for _, f := range m.Forecasts {
 		if f.ForecastName == req.ForecastName {
 			return "", &Error{
 				Code:    errResourceAlreadyExistsException,
@@ -531,7 +620,7 @@ func (m *MemoryStorage) CreateForecast(_ context.Context, req *CreateForecastInp
 	}
 
 	// Validate predictor exists.
-	predictor, exists := m.predictors[req.PredictorArn]
+	predictor, exists := m.Predictors[req.PredictorArn]
 	if !exists {
 		return "", &Error{
 			Code:    errResourceNotFoundException,
@@ -564,7 +653,7 @@ func (m *MemoryStorage) CreateForecast(_ context.Context, req *CreateForecastInp
 		LastModificationTime: ToAWSTimestamp(now),
 	}
 
-	m.forecasts[forecastArn] = forecast
+	m.Forecasts[forecastArn] = forecast
 
 	return forecastArn, nil
 }
@@ -574,7 +663,7 @@ func (m *MemoryStorage) DescribeForecast(_ context.Context, forecastArn string) 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	forecast, exists := m.forecasts[forecastArn]
+	forecast, exists := m.Forecasts[forecastArn]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFoundException,
@@ -595,9 +684,9 @@ func (m *MemoryStorage) ListForecasts(_ context.Context, maxResults *int32, _ st
 		limit = *maxResults
 	}
 
-	summaries := make([]*ForecastSummary, 0, len(m.forecasts))
+	summaries := make([]*ForecastSummary, 0, len(m.Forecasts))
 
-	for _, f := range m.forecasts {
+	for _, f := range m.Forecasts {
 		if int32(len(summaries)) >= limit { //nolint:gosec // G115: len(summaries) is bounded by limit which is int32
 			break
 		}
@@ -627,14 +716,14 @@ func (m *MemoryStorage) DeleteForecast(_ context.Context, forecastArn string) er
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.forecasts[forecastArn]; !exists {
+	if _, exists := m.Forecasts[forecastArn]; !exists {
 		return &Error{
 			Code:    errResourceNotFoundException,
 			Message: fmt.Sprintf("Forecast %s not found", forecastArn),
 		}
 	}
 
-	delete(m.forecasts, forecastArn)
+	delete(m.Forecasts, forecastArn)
 
 	return nil
 }

--- a/internal/service/gamelift/service.go
+++ b/internal/service/gamelift/service.go
@@ -2,6 +2,10 @@
 package gamelift
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
@@ -36,12 +40,29 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// Routes are dispatched by the server based on X-Amz-Target.
 }
 
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Ensure Service implements required interfaces.
 var (
 	_ service.Service             = (*Service)(nil)
 	_ service.JSONProtocolService = (*Service)(nil)
+	_ io.Closer                   = (*Service)(nil)
 )

--- a/internal/service/gamelift/storage.go
+++ b/internal/service/gamelift/storage.go
@@ -2,11 +2,14 @@ package gamelift
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -75,27 +78,113 @@ type Storage interface {
 	DescribePlayerSessions(ctx context.Context, gameSessionID, playerSessionID, playerID string) ([]*PlayerSession, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu             sync.RWMutex
-	builds         map[string]*Build
-	fleets         map[string]*Fleet
-	gameSessions   map[string]*GameSession
-	playerSessions map[string]*PlayerSession
+	mu             sync.RWMutex              `json:"-"`
+	Builds         map[string]*Build         `json:"builds"`
+	Fleets         map[string]*Fleet         `json:"fleets"`
+	GameSessions   map[string]*GameSession   `json:"gameSessions"`
+	PlayerSessions map[string]*PlayerSession `json:"playerSessions"`
 	region         string
 	accountID      string
+	dataDir        string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		builds:         make(map[string]*Build),
-		fleets:         make(map[string]*Fleet),
-		gameSessions:   make(map[string]*GameSession),
-		playerSessions: make(map[string]*PlayerSession),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Builds:         make(map[string]*Build),
+		Fleets:         make(map[string]*Fleet),
+		GameSessions:   make(map[string]*GameSession),
+		PlayerSessions: make(map[string]*PlayerSession),
 		region:         defaultRegion,
 		accountID:      defaultAccountID,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "gamelift", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Builds == nil {
+		m.Builds = make(map[string]*Build)
+	}
+
+	if m.Fleets == nil {
+		m.Fleets = make(map[string]*Fleet)
+	}
+
+	if m.GameSessions == nil {
+		m.GameSessions = make(map[string]*GameSession)
+	}
+
+	if m.PlayerSessions == nil {
+		m.PlayerSessions = make(map[string]*PlayerSession)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "gamelift", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateBuild creates a new build.
@@ -117,7 +206,7 @@ func (m *MemoryStorage) CreateBuild(_ context.Context, req *CreateBuildRequest) 
 		CreationTime:    time.Now(),
 	}
 
-	m.builds[buildID] = build
+	m.Builds[buildID] = build
 
 	return build, nil
 }
@@ -127,7 +216,7 @@ func (m *MemoryStorage) DescribeBuild(_ context.Context, buildID string) (*Build
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	build, exists := m.builds[buildID]
+	build, exists := m.Builds[buildID]
 	if !exists {
 		return nil, &Error{Code: errNotFoundException, Message: "Build not found: " + buildID}
 	}
@@ -140,9 +229,9 @@ func (m *MemoryStorage) ListBuilds(_ context.Context, status string, limit int32
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]*Build, 0, len(m.builds))
+	result := make([]*Build, 0, len(m.Builds))
 
-	for _, build := range m.builds {
+	for _, build := range m.Builds {
 		if status != "" && build.Status != status {
 			continue
 		}
@@ -163,11 +252,11 @@ func (m *MemoryStorage) DeleteBuild(_ context.Context, buildID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.builds[buildID]; !exists {
+	if _, exists := m.Builds[buildID]; !exists {
 		return &Error{Code: errNotFoundException, Message: "Build not found: " + buildID}
 	}
 
-	delete(m.builds, buildID)
+	delete(m.Builds, buildID)
 
 	return nil
 }
@@ -198,7 +287,7 @@ func (m *MemoryStorage) CreateFleet(_ context.Context, req *CreateFleetRequest) 
 		CreationTime:                   time.Now(),
 	}
 
-	m.fleets[fleetID] = fleet
+	m.Fleets[fleetID] = fleet
 
 	return fleet, nil
 }
@@ -210,8 +299,8 @@ func (m *MemoryStorage) DescribeFleetAttributes(_ context.Context, fleetIDs []st
 
 	if len(fleetIDs) == 0 {
 		// Return all fleets
-		result := make([]*Fleet, 0, len(m.fleets))
-		for _, fleet := range m.fleets {
+		result := make([]*Fleet, 0, len(m.Fleets))
+		for _, fleet := range m.Fleets {
 			result = append(result, fleet)
 		}
 
@@ -222,7 +311,7 @@ func (m *MemoryStorage) DescribeFleetAttributes(_ context.Context, fleetIDs []st
 	result := make([]*Fleet, 0, len(fleetIDs))
 
 	for _, fleetID := range fleetIDs {
-		if fleet, exists := m.fleets[fleetID]; exists {
+		if fleet, exists := m.Fleets[fleetID]; exists {
 			result = append(result, fleet)
 		}
 	}
@@ -235,9 +324,9 @@ func (m *MemoryStorage) ListFleets(_ context.Context, buildID string, limit int3
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]string, 0, len(m.fleets))
+	result := make([]string, 0, len(m.Fleets))
 
-	for _, fleet := range m.fleets {
+	for _, fleet := range m.Fleets {
 		if buildID != "" && fleet.BuildID != buildID {
 			continue
 		}
@@ -258,11 +347,11 @@ func (m *MemoryStorage) DeleteFleet(_ context.Context, fleetID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.fleets[fleetID]; !exists {
+	if _, exists := m.Fleets[fleetID]; !exists {
 		return &Error{Code: errNotFoundException, Message: "Fleet not found: " + fleetID}
 	}
 
-	delete(m.fleets, fleetID)
+	delete(m.Fleets, fleetID)
 
 	return nil
 }
@@ -276,7 +365,7 @@ func (m *MemoryStorage) CreateGameSession(_ context.Context, req *CreateGameSess
 		return nil, &Error{Code: errInvalidRequestException, Message: "FleetId is required"}
 	}
 
-	fleet, exists := m.fleets[req.FleetID]
+	fleet, exists := m.Fleets[req.FleetID]
 	if !exists {
 		return nil, &Error{Code: errNotFoundException, Message: "Fleet not found: " + req.FleetID}
 	}
@@ -298,7 +387,7 @@ func (m *MemoryStorage) CreateGameSession(_ context.Context, req *CreateGameSess
 		CreationTime:              time.Now(),
 	}
 
-	m.gameSessions[gameSessionID] = gameSession
+	m.GameSessions[gameSessionID] = gameSession
 
 	return gameSession, nil
 }
@@ -309,7 +398,7 @@ func (m *MemoryStorage) DescribeGameSessions(_ context.Context, fleetID, gameSes
 	defer m.mu.RUnlock()
 
 	if gameSessionID != "" {
-		session, exists := m.gameSessions[gameSessionID]
+		session, exists := m.GameSessions[gameSessionID]
 		if !exists {
 			return []*GameSession{}, nil
 		}
@@ -317,9 +406,9 @@ func (m *MemoryStorage) DescribeGameSessions(_ context.Context, fleetID, gameSes
 		return []*GameSession{session}, nil
 	}
 
-	result := make([]*GameSession, 0, len(m.gameSessions))
+	result := make([]*GameSession, 0, len(m.GameSessions))
 
-	for _, session := range m.gameSessions {
+	for _, session := range m.GameSessions {
 		if fleetID != "" && session.FleetID != fleetID {
 			continue
 		}
@@ -335,7 +424,7 @@ func (m *MemoryStorage) UpdateGameSession(_ context.Context, req *UpdateGameSess
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	session, exists := m.gameSessions[req.GameSessionID]
+	session, exists := m.GameSessions[req.GameSessionID]
 	if !exists {
 		return nil, &Error{Code: errNotFoundException, Message: "Game session not found: " + req.GameSessionID}
 	}
@@ -356,7 +445,7 @@ func (m *MemoryStorage) CreatePlayerSession(_ context.Context, gameSessionID, pl
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	gameSession, exists := m.gameSessions[gameSessionID]
+	gameSession, exists := m.GameSessions[gameSessionID]
 	if !exists {
 		return nil, &Error{Code: errNotFoundException, Message: "Game session not found: " + gameSessionID}
 	}
@@ -379,7 +468,7 @@ func (m *MemoryStorage) CreatePlayerSession(_ context.Context, gameSessionID, pl
 		CreationTime:    time.Now(),
 	}
 
-	m.playerSessions[playerSessionID] = playerSession
+	m.PlayerSessions[playerSessionID] = playerSession
 	gameSession.CurrentPlayerSessionCount++
 
 	return playerSession, nil
@@ -390,7 +479,7 @@ func (m *MemoryStorage) CreatePlayerSessions(_ context.Context, gameSessionID st
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	gameSession, exists := m.gameSessions[gameSessionID]
+	gameSession, exists := m.GameSessions[gameSessionID]
 	if !exists {
 		return nil, &Error{Code: errNotFoundException, Message: "Game session not found: " + gameSessionID}
 	}
@@ -417,7 +506,7 @@ func (m *MemoryStorage) CreatePlayerSessions(_ context.Context, gameSessionID st
 			CreationTime:    time.Now(),
 		}
 
-		m.playerSessions[playerSessionID] = playerSession
+		m.PlayerSessions[playerSessionID] = playerSession
 		result = append(result, playerSession)
 	}
 
@@ -433,7 +522,7 @@ func (m *MemoryStorage) DescribePlayerSessions(_ context.Context, gameSessionID,
 	defer m.mu.RUnlock()
 
 	if playerSessionID != "" {
-		session, exists := m.playerSessions[playerSessionID]
+		session, exists := m.PlayerSessions[playerSessionID]
 		if !exists {
 			return []*PlayerSession{}, nil
 		}
@@ -441,9 +530,9 @@ func (m *MemoryStorage) DescribePlayerSessions(_ context.Context, gameSessionID,
 		return []*PlayerSession{session}, nil
 	}
 
-	result := make([]*PlayerSession, 0, len(m.playerSessions))
+	result := make([]*PlayerSession, 0, len(m.PlayerSessions))
 
-	for _, session := range m.playerSessions {
+	for _, session := range m.PlayerSessions {
 		if gameSessionID != "" && session.GameSessionID != gameSessionID {
 			continue
 		}

--- a/internal/service/glacier/service.go
+++ b/internal/service/glacier/service.go
@@ -1,8 +1,15 @@
 package glacier
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
 
 // Service implements the AWS Glacier service.
 type Service struct {
@@ -31,5 +38,21 @@ func (s *Service) RegisterRoutes(r service.Router) {
 }
 
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/glacier/storage.go
+++ b/internal/service/glacier/storage.go
@@ -2,9 +2,12 @@ package glacier
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -32,17 +35,91 @@ type Storage interface {
 	ListVaults(ctx context.Context) ([]Vault, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu     sync.RWMutex
-	vaults map[string]*Vault
+	mu      sync.RWMutex      `json:"-"`
+	Vaults  map[string]*Vault `json:"vaults"`
+	dataDir string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		vaults: make(map[string]*Vault),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Vaults: make(map[string]*Vault),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "glacier", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Vaults == nil {
+		m.Vaults = make(map[string]*Vault)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "glacier", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateVault creates a new vault.
@@ -51,7 +128,7 @@ func (m *MemoryStorage) CreateVault(_ context.Context, vaultName string) (*Vault
 	defer m.mu.Unlock()
 
 	// CreateVault is idempotent - no error if vault already exists
-	if v, exists := m.vaults[vaultName]; exists {
+	if v, exists := m.Vaults[vaultName]; exists {
 		return v, nil
 	}
 
@@ -63,7 +140,7 @@ func (m *MemoryStorage) CreateVault(_ context.Context, vaultName string) (*Vault
 		VaultName:        vaultName,
 	}
 
-	m.vaults[vaultName] = vault
+	m.Vaults[vaultName] = vault
 
 	return vault, nil
 }
@@ -73,7 +150,7 @@ func (m *MemoryStorage) DescribeVault(_ context.Context, vaultName string) (*Vau
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	vault, exists := m.vaults[vaultName]
+	vault, exists := m.Vaults[vaultName]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errVaultNotFound,
@@ -89,14 +166,14 @@ func (m *MemoryStorage) DeleteVault(_ context.Context, vaultName string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.vaults[vaultName]; !exists {
+	if _, exists := m.Vaults[vaultName]; !exists {
 		return &ServiceError{
 			Code:    errVaultNotFound,
 			Message: fmt.Sprintf("Vault not found: arn:aws:glacier:%s:%s:vaults/%s", defaultRegion, defaultAccountID, vaultName),
 		}
 	}
 
-	delete(m.vaults, vaultName)
+	delete(m.Vaults, vaultName)
 
 	return nil
 }
@@ -106,8 +183,8 @@ func (m *MemoryStorage) ListVaults(_ context.Context) ([]Vault, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	vaults := make([]Vault, 0, len(m.vaults))
-	for _, v := range m.vaults {
+	vaults := make([]Vault, 0, len(m.Vaults))
+	for _, v := range m.Vaults {
 		vaults = append(vaults, *v)
 	}
 

--- a/internal/service/globalaccelerator/service.go
+++ b/internal/service/globalaccelerator/service.go
@@ -2,8 +2,15 @@
 package globalaccelerator
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
 
 // Service implements the Global Accelerator service.
 type Service struct {
@@ -35,5 +42,21 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 }
 
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/globalaccelerator/storage.go
+++ b/internal/service/globalaccelerator/storage.go
@@ -2,12 +2,15 @@ package globalaccelerator
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -44,21 +47,103 @@ type Storage interface {
 	DeleteEndpointGroup(ctx context.Context, arn string) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu             sync.RWMutex
-	accelerators   map[string]*Accelerator
-	listeners      map[string]*Listener
-	endpointGroups map[string]*EndpointGroup
+	mu             sync.RWMutex              `json:"-"`
+	Accelerators   map[string]*Accelerator   `json:"accelerators"`
+	Listeners      map[string]*Listener      `json:"listeners"`
+	EndpointGroups map[string]*EndpointGroup `json:"endpointGroups"`
+	dataDir        string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		accelerators:   make(map[string]*Accelerator),
-		listeners:      make(map[string]*Listener),
-		endpointGroups: make(map[string]*EndpointGroup),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Accelerators:   make(map[string]*Accelerator),
+		Listeners:      make(map[string]*Listener),
+		EndpointGroups: make(map[string]*EndpointGroup),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "globalaccelerator", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Accelerators == nil {
+		s.Accelerators = make(map[string]*Accelerator)
+	}
+
+	if s.Listeners == nil {
+		s.Listeners = make(map[string]*Listener)
+	}
+
+	if s.EndpointGroups == nil {
+		s.EndpointGroups = make(map[string]*EndpointGroup)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "globalaccelerator", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateAccelerator creates a new accelerator.
@@ -113,7 +198,7 @@ func (s *MemoryStorage) CreateAccelerator(_ context.Context, req *CreateAccelera
 		accelerator.DualStackDNS = fmt.Sprintf("%s.dualstack.awsglobalaccelerator.com", acceleratorID[:8])
 	}
 
-	s.accelerators[arn] = accelerator
+	s.Accelerators[arn] = accelerator
 
 	return accelerator, nil
 }
@@ -123,7 +208,7 @@ func (s *MemoryStorage) GetAccelerator(_ context.Context, arn string) (*Accelera
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	accelerator, ok := s.accelerators[arn]
+	accelerator, ok := s.Accelerators[arn]
 	if !ok {
 		return nil, &ServiceError{Code: errNotFound, Message: "Accelerator not found"}
 	}
@@ -142,8 +227,8 @@ func (s *MemoryStorage) ListAccelerators(_ context.Context, maxResults int32, ne
 	}
 
 	// Collect all ARNs and sort for consistent pagination.
-	arns := make([]string, 0, len(s.accelerators))
-	for arn := range s.accelerators {
+	arns := make([]string, 0, len(s.Accelerators))
+	for arn := range s.Accelerators {
 		arns = append(arns, arn)
 	}
 
@@ -165,7 +250,7 @@ func (s *MemoryStorage) ListAccelerators(_ context.Context, maxResults int32, ne
 	// Collect accelerators from startIdx up to maxResults.
 	accelerators := make([]*Accelerator, 0, maxResults)
 	for i := startIdx; i < len(arns) && len(accelerators) < int(maxResults); i++ {
-		accelerators = append(accelerators, s.accelerators[arns[i]])
+		accelerators = append(accelerators, s.Accelerators[arns[i]])
 	}
 
 	// Determine next token.
@@ -182,7 +267,7 @@ func (s *MemoryStorage) UpdateAccelerator(_ context.Context, arn, name, ipAddres
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	accelerator, ok := s.accelerators[arn]
+	accelerator, ok := s.Accelerators[arn]
 	if !ok {
 		return nil, &ServiceError{Code: errNotFound, Message: "Accelerator not found"}
 	}
@@ -209,7 +294,7 @@ func (s *MemoryStorage) DeleteAccelerator(_ context.Context, arn string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	accelerator, ok := s.accelerators[arn]
+	accelerator, ok := s.Accelerators[arn]
 	if !ok {
 		return &ServiceError{Code: errNotFound, Message: "Accelerator not found"}
 	}
@@ -219,20 +304,20 @@ func (s *MemoryStorage) DeleteAccelerator(_ context.Context, arn string) error {
 	}
 
 	// Delete associated listeners and endpoint groups.
-	for listenerArn, listener := range s.listeners {
+	for listenerArn, listener := range s.Listeners {
 		if listener.AcceleratorArn == arn {
 			// Delete endpoint groups for this listener.
-			for egArn, eg := range s.endpointGroups {
+			for egArn, eg := range s.EndpointGroups {
 				if eg.ListenerArn == listenerArn {
-					delete(s.endpointGroups, egArn)
+					delete(s.EndpointGroups, egArn)
 				}
 			}
 
-			delete(s.listeners, listenerArn)
+			delete(s.Listeners, listenerArn)
 		}
 	}
 
-	delete(s.accelerators, arn)
+	delete(s.Accelerators, arn)
 
 	return nil
 }
@@ -243,7 +328,7 @@ func (s *MemoryStorage) CreateListener(_ context.Context, req *CreateListenerReq
 	defer s.mu.Unlock()
 
 	// Verify accelerator exists.
-	if _, ok := s.accelerators[req.AcceleratorArn]; !ok {
+	if _, ok := s.Accelerators[req.AcceleratorArn]; !ok {
 		return nil, &ServiceError{Code: errNotFound, Message: "Accelerator not found"}
 	}
 
@@ -268,7 +353,7 @@ func (s *MemoryStorage) CreateListener(_ context.Context, req *CreateListenerReq
 		ClientAffinity: clientAffinity,
 	}
 
-	s.listeners[arn] = listener
+	s.Listeners[arn] = listener
 
 	return listener, nil
 }
@@ -278,7 +363,7 @@ func (s *MemoryStorage) GetListener(_ context.Context, arn string) (*Listener, e
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	listener, ok := s.listeners[arn]
+	listener, ok := s.Listeners[arn]
 	if !ok {
 		return nil, &ServiceError{Code: errListenerNotFound, Message: "Listener not found"}
 	}
@@ -296,7 +381,8 @@ func (s *MemoryStorage) ListListeners(_ context.Context, acceleratorArn string, 
 	}
 
 	listeners := make([]*Listener, 0)
-	for _, listener := range s.listeners {
+
+	for _, listener := range s.Listeners {
 		if listener.AcceleratorArn == acceleratorArn {
 			listeners = append(listeners, listener)
 			if len(listeners) >= int(maxResults) {
@@ -313,7 +399,7 @@ func (s *MemoryStorage) UpdateListener(_ context.Context, req *UpdateListenerReq
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	listener, ok := s.listeners[req.ListenerArn]
+	listener, ok := s.Listeners[req.ListenerArn]
 	if !ok {
 		return nil, &ServiceError{Code: errListenerNotFound, Message: "Listener not found"}
 	}
@@ -343,18 +429,18 @@ func (s *MemoryStorage) DeleteListener(_ context.Context, arn string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.listeners[arn]; !ok {
+	if _, ok := s.Listeners[arn]; !ok {
 		return &ServiceError{Code: errListenerNotFound, Message: "Listener not found"}
 	}
 
 	// Delete associated endpoint groups.
-	for egArn, eg := range s.endpointGroups {
+	for egArn, eg := range s.EndpointGroups {
 		if eg.ListenerArn == arn {
-			delete(s.endpointGroups, egArn)
+			delete(s.EndpointGroups, egArn)
 		}
 	}
 
-	delete(s.listeners, arn)
+	delete(s.Listeners, arn)
 
 	return nil
 }
@@ -365,7 +451,7 @@ func (s *MemoryStorage) CreateEndpointGroup(_ context.Context, req *CreateEndpoi
 	defer s.mu.Unlock()
 
 	// Verify listener exists.
-	if _, ok := s.listeners[req.ListenerArn]; !ok {
+	if _, ok := s.Listeners[req.ListenerArn]; !ok {
 		return nil, &ServiceError{Code: errListenerNotFound, Message: "Listener not found"}
 	}
 
@@ -406,7 +492,7 @@ func (s *MemoryStorage) CreateEndpointGroup(_ context.Context, req *CreateEndpoi
 		PortOverrides:              convertPortOverrides(req.PortOverrides),
 	}
 
-	s.endpointGroups[arn] = endpointGroup
+	s.EndpointGroups[arn] = endpointGroup
 
 	return endpointGroup, nil
 }
@@ -416,7 +502,7 @@ func (s *MemoryStorage) GetEndpointGroup(_ context.Context, arn string) (*Endpoi
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	endpointGroup, ok := s.endpointGroups[arn]
+	endpointGroup, ok := s.EndpointGroups[arn]
 	if !ok {
 		return nil, &ServiceError{Code: errEndpointNotFound, Message: "Endpoint group not found"}
 	}
@@ -434,7 +520,8 @@ func (s *MemoryStorage) ListEndpointGroups(_ context.Context, listenerArn string
 	}
 
 	endpointGroups := make([]*EndpointGroup, 0)
-	for _, eg := range s.endpointGroups {
+
+	for _, eg := range s.EndpointGroups {
 		if eg.ListenerArn == listenerArn {
 			endpointGroups = append(endpointGroups, eg)
 			if len(endpointGroups) >= int(maxResults) {
@@ -451,7 +538,7 @@ func (s *MemoryStorage) UpdateEndpointGroup(_ context.Context, req *UpdateEndpoi
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	eg, ok := s.endpointGroups[req.EndpointGroupArn]
+	eg, ok := s.EndpointGroups[req.EndpointGroupArn]
 	if !ok {
 		return nil, &ServiceError{Code: errEndpointNotFound, Message: "Endpoint group not found"}
 	}
@@ -496,11 +583,11 @@ func (s *MemoryStorage) DeleteEndpointGroup(_ context.Context, arn string) error
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.endpointGroups[arn]; !ok {
+	if _, ok := s.EndpointGroups[arn]; !ok {
 		return &ServiceError{Code: errEndpointNotFound, Message: "Endpoint group not found"}
 	}
 
-	delete(s.endpointGroups, arn)
+	delete(s.EndpointGroups, arn)
 
 	return nil
 }

--- a/internal/service/glue/service.go
+++ b/internal/service/glue/service.go
@@ -1,11 +1,23 @@
 package glue
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the Glue service.
@@ -39,3 +51,14 @@ func (s *Service) TargetPrefix() string {
 
 // JSONProtocol is a marker method that indicates Glue uses AWS JSON 1.1 protocol.
 func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/glue/storage.go
+++ b/internal/service/glue/storage.go
@@ -2,11 +2,14 @@ package glue
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -35,23 +38,109 @@ type Storage interface {
 	StartJobRun(ctx context.Context, input *StartJobRunInput) (*JobRun, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data structures.
 type MemoryStorage struct {
-	mu        sync.RWMutex
-	databases map[string]*Database // key: catalogID/databaseName
-	tables    map[string]*Table    // key: catalogID/databaseName/tableName
-	jobs      map[string]*Job      // key: jobName
-	jobRuns   map[string]*JobRun   // key: jobRunID
+	mu        sync.RWMutex         `json:"-"`
+	Databases map[string]*Database `json:"databases"` // key: catalogID/databaseName
+	Tables    map[string]*Table    `json:"tables"`    // key: catalogID/databaseName/tableName
+	Jobs      map[string]*Job      `json:"jobs"`      // key: jobName
+	JobRuns   map[string]*JobRun   `json:"jobRuns"`   // key: jobRunID
+	dataDir   string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		databases: make(map[string]*Database),
-		tables:    make(map[string]*Table),
-		jobs:      make(map[string]*Job),
-		jobRuns:   make(map[string]*JobRun),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Databases: make(map[string]*Database),
+		Tables:    make(map[string]*Table),
+		Jobs:      make(map[string]*Job),
+		JobRuns:   make(map[string]*JobRun),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "glue", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Databases == nil {
+		s.Databases = make(map[string]*Database)
+	}
+
+	if s.Tables == nil {
+		s.Tables = make(map[string]*Table)
+	}
+
+	if s.Jobs == nil {
+		s.Jobs = make(map[string]*Job)
+	}
+
+	if s.JobRuns == nil {
+		s.JobRuns = make(map[string]*JobRun)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "glue", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 func databaseKey(catalogID, name string) string {
@@ -84,7 +173,7 @@ func (s *MemoryStorage) CreateDatabase(_ context.Context, catalogID string, inpu
 
 	key := databaseKey(catalogID, input.Name)
 
-	if _, exists := s.databases[key]; exists {
+	if _, exists := s.Databases[key]; exists {
 		return &Error{
 			Code:    errAlreadyExists,
 			Message: fmt.Sprintf("Database %s already exists", input.Name),
@@ -101,7 +190,7 @@ func (s *MemoryStorage) CreateDatabase(_ context.Context, catalogID string, inpu
 		CreateTableMode: input.CreateTableMode,
 	}
 
-	s.databases[key] = db
+	s.Databases[key] = db
 
 	return nil
 }
@@ -112,7 +201,7 @@ func (s *MemoryStorage) GetDatabase(_ context.Context, catalogID, name string) (
 	defer s.mu.RUnlock()
 
 	key := databaseKey(catalogID, name)
-	db, exists := s.databases[key]
+	db, exists := s.Databases[key]
 
 	if !exists {
 		return nil, &Error{
@@ -140,7 +229,7 @@ func (s *MemoryStorage) GetDatabases(_ context.Context, catalogID string, maxRes
 	prefix := catalogID + "/"
 	databases := make([]*Database, 0)
 
-	for key, db := range s.databases {
+	for key, db := range s.Databases {
 		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
 			databases = append(databases, db)
 
@@ -160,14 +249,14 @@ func (s *MemoryStorage) DeleteDatabase(_ context.Context, catalogID, name string
 
 	key := databaseKey(catalogID, name)
 
-	if _, exists := s.databases[key]; !exists {
+	if _, exists := s.Databases[key]; !exists {
 		return &Error{
 			Code:    errEntityNotFound,
 			Message: fmt.Sprintf("Database %s not found", name),
 		}
 	}
 
-	delete(s.databases, key)
+	delete(s.Databases, key)
 
 	return nil
 }
@@ -186,7 +275,7 @@ func (s *MemoryStorage) CreateTable(_ context.Context, catalogID, databaseName s
 
 	// Check if database exists.
 	dbKey := databaseKey(catalogID, databaseName)
-	if _, exists := s.databases[dbKey]; !exists {
+	if _, exists := s.Databases[dbKey]; !exists {
 		return &Error{
 			Code:    errEntityNotFound,
 			Message: fmt.Sprintf("Database %s not found", databaseName),
@@ -195,7 +284,7 @@ func (s *MemoryStorage) CreateTable(_ context.Context, catalogID, databaseName s
 
 	key := tableKey(catalogID, databaseName, input.Name)
 
-	if _, exists := s.tables[key]; exists {
+	if _, exists := s.Tables[key]; exists {
 		return &Error{
 			Code:    errAlreadyExists,
 			Message: fmt.Sprintf("Table %s already exists", input.Name),
@@ -220,7 +309,7 @@ func (s *MemoryStorage) CreateTable(_ context.Context, catalogID, databaseName s
 		CatalogID:         catalogID,
 	}
 
-	s.tables[key] = table
+	s.Tables[key] = table
 
 	return nil
 }
@@ -231,7 +320,7 @@ func (s *MemoryStorage) GetTable(_ context.Context, catalogID, databaseName, nam
 	defer s.mu.RUnlock()
 
 	key := tableKey(catalogID, databaseName, name)
-	table, exists := s.tables[key]
+	table, exists := s.Tables[key]
 
 	if !exists {
 		return nil, &Error{
@@ -259,7 +348,7 @@ func (s *MemoryStorage) GetTables(_ context.Context, catalogID, databaseName str
 	prefix := catalogID + "/" + databaseName + "/"
 	tables := make([]*Table, 0)
 
-	for key, table := range s.tables {
+	for key, table := range s.Tables {
 		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
 			tables = append(tables, table)
 
@@ -279,14 +368,14 @@ func (s *MemoryStorage) DeleteTable(_ context.Context, catalogID, databaseName, 
 
 	key := tableKey(catalogID, databaseName, name)
 
-	if _, exists := s.tables[key]; !exists {
+	if _, exists := s.Tables[key]; !exists {
 		return &Error{
 			Code:    errEntityNotFound,
 			Message: fmt.Sprintf("Table %s not found", name),
 		}
 	}
 
-	delete(s.tables, key)
+	delete(s.Tables, key)
 
 	return nil
 }
@@ -310,7 +399,7 @@ func (s *MemoryStorage) CreateJob(_ context.Context, input *CreateJobInput) (*Jo
 		}
 	}
 
-	if _, exists := s.jobs[input.Name]; exists {
+	if _, exists := s.Jobs[input.Name]; exists {
 		return nil, &Error{
 			Code:    errAlreadyExists,
 			Message: fmt.Sprintf("Job %s already exists", input.Name),
@@ -337,7 +426,7 @@ func (s *MemoryStorage) CreateJob(_ context.Context, input *CreateJobInput) (*Jo
 		ExecutionProperty:       input.ExecutionProperty,
 	}
 
-	s.jobs[input.Name] = job
+	s.Jobs[input.Name] = job
 
 	return job, nil
 }
@@ -347,14 +436,14 @@ func (s *MemoryStorage) DeleteJob(_ context.Context, jobName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.jobs[jobName]; !exists {
+	if _, exists := s.Jobs[jobName]; !exists {
 		return &Error{
 			Code:    errEntityNotFound,
 			Message: fmt.Sprintf("Job %s not found", jobName),
 		}
 	}
 
-	delete(s.jobs, jobName)
+	delete(s.Jobs, jobName)
 
 	return nil
 }
@@ -364,7 +453,7 @@ func (s *MemoryStorage) StartJobRun(_ context.Context, input *StartJobRunInput) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	job, exists := s.jobs[input.JobName]
+	job, exists := s.Jobs[input.JobName]
 	if !exists {
 		return nil, &Error{
 			Code:    errEntityNotFound,
@@ -394,7 +483,7 @@ func (s *MemoryStorage) StartJobRun(_ context.Context, input *StartJobRunInput) 
 		GlueVersion:       job.GlueVersion,
 	}
 
-	s.jobRuns[runID] = jobRun
+	s.JobRuns[runID] = jobRun
 
 	return jobRun, nil
 }

--- a/internal/service/iam/service.go
+++ b/internal/service/iam/service.go
@@ -2,13 +2,24 @@
 package iam
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the IAM service.
@@ -70,4 +81,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.HandleFunc("GET", "/iam/", s.DispatchAction)
 	r.HandleFunc("POST", "/iam", s.DispatchAction)
 	r.HandleFunc("GET", "/iam", s.DispatchAction)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/iam/storage.go
+++ b/internal/service/iam/storage.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -53,25 +56,111 @@ type Storage interface {
 	ListAccessKeys(ctx context.Context, userName string, maxItems int) ([]AccessKeyMetadata, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu         sync.RWMutex
-	users      map[string]*User
-	roles      map[string]*Role
-	policies   map[string]*Policy               // key is ARN
-	accessKeys map[string]map[string]*AccessKey // userName -> accessKeyID -> AccessKey
+	mu         sync.RWMutex                     `json:"-"`
+	Users      map[string]*User                 `json:"users"`
+	Roles      map[string]*Role                 `json:"roles"`
+	Policies   map[string]*Policy               `json:"policies"`   // key is ARN
+	AccessKeys map[string]map[string]*AccessKey `json:"accessKeys"` // userName -> accessKeyID -> AccessKey
 	accountID  string
+	dataDir    string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		users:      make(map[string]*User),
-		roles:      make(map[string]*Role),
-		policies:   make(map[string]*Policy),
-		accessKeys: make(map[string]map[string]*AccessKey),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Users:      make(map[string]*User),
+		Roles:      make(map[string]*Role),
+		Policies:   make(map[string]*Policy),
+		AccessKeys: make(map[string]map[string]*AccessKey),
 		accountID:  "123456789012",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "iam", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Users == nil {
+		s.Users = make(map[string]*User)
+	}
+
+	if s.Roles == nil {
+		s.Roles = make(map[string]*Role)
+	}
+
+	if s.Policies == nil {
+		s.Policies = make(map[string]*Policy)
+	}
+
+	if s.AccessKeys == nil {
+		s.AccessKeys = make(map[string]map[string]*AccessKey)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "iam", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateUser creates a new IAM user.
@@ -79,7 +168,7 @@ func (s *MemoryStorage) CreateUser(_ context.Context, req *CreateUserRequest) (*
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.users[req.UserName]; exists {
+	if _, exists := s.Users[req.UserName]; exists {
 		return nil, &Error{
 			Code:    errEntityAlreadyExists,
 			Message: fmt.Sprintf("User with name %s already exists.", req.UserName),
@@ -101,8 +190,8 @@ func (s *MemoryStorage) CreateUser(_ context.Context, req *CreateUserRequest) (*
 		AttachedPolicies: []AttachedPolicy{},
 	}
 
-	s.users[req.UserName] = user
-	s.accessKeys[req.UserName] = make(map[string]*AccessKey)
+	s.Users[req.UserName] = user
+	s.AccessKeys[req.UserName] = make(map[string]*AccessKey)
 
 	return user, nil
 }
@@ -112,7 +201,7 @@ func (s *MemoryStorage) DeleteUser(_ context.Context, userName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	user, exists := s.users[userName]
+	user, exists := s.Users[userName]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -127,15 +216,15 @@ func (s *MemoryStorage) DeleteUser(_ context.Context, userName string) error {
 		}
 	}
 
-	if keys, ok := s.accessKeys[userName]; ok && len(keys) > 0 {
+	if keys, ok := s.AccessKeys[userName]; ok && len(keys) > 0 {
 		return &Error{
 			Code:    errDeleteConflict,
 			Message: "Cannot delete entity, must delete access keys first.",
 		}
 	}
 
-	delete(s.users, userName)
-	delete(s.accessKeys, userName)
+	delete(s.Users, userName)
+	delete(s.AccessKeys, userName)
 
 	return nil
 }
@@ -145,7 +234,7 @@ func (s *MemoryStorage) GetUser(_ context.Context, userName string) (*User, erro
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	user, exists := s.users[userName]
+	user, exists := s.Users[userName]
 	if !exists {
 		return nil, &Error{
 			Code:    errNoSuchEntity,
@@ -171,7 +260,7 @@ func (s *MemoryStorage) ListUsers(_ context.Context, pathPrefix string, maxItems
 
 	users := make([]User, 0)
 
-	for _, user := range s.users {
+	for _, user := range s.Users {
 		if strings.HasPrefix(user.Path, pathPrefix) {
 			users = append(users, *user)
 			if len(users) >= maxItems {
@@ -188,7 +277,7 @@ func (s *MemoryStorage) CreateRole(_ context.Context, req *CreateRoleRequest) (*
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.roles[req.RoleName]; exists {
+	if _, exists := s.Roles[req.RoleName]; exists {
 		return nil, &Error{
 			Code:    errEntityAlreadyExists,
 			Message: fmt.Sprintf("Role with name %s already exists.", req.RoleName),
@@ -218,7 +307,7 @@ func (s *MemoryStorage) CreateRole(_ context.Context, req *CreateRoleRequest) (*
 		AttachedPolicies:         []AttachedPolicy{},
 	}
 
-	s.roles[req.RoleName] = role
+	s.Roles[req.RoleName] = role
 
 	return role, nil
 }
@@ -228,7 +317,7 @@ func (s *MemoryStorage) DeleteRole(_ context.Context, roleName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	role, exists := s.roles[roleName]
+	role, exists := s.Roles[roleName]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -243,7 +332,7 @@ func (s *MemoryStorage) DeleteRole(_ context.Context, roleName string) error {
 		}
 	}
 
-	delete(s.roles, roleName)
+	delete(s.Roles, roleName)
 
 	return nil
 }
@@ -253,7 +342,7 @@ func (s *MemoryStorage) GetRole(_ context.Context, roleName string) (*Role, erro
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	role, exists := s.roles[roleName]
+	role, exists := s.Roles[roleName]
 	if !exists {
 		return nil, &Error{
 			Code:    errNoSuchEntity,
@@ -279,7 +368,7 @@ func (s *MemoryStorage) ListRoles(_ context.Context, pathPrefix string, maxItems
 
 	roles := make([]Role, 0)
 
-	for _, role := range s.roles {
+	for _, role := range s.Roles {
 		if strings.HasPrefix(role.Path, pathPrefix) {
 			roles = append(roles, *role)
 			if len(roles) >= maxItems {
@@ -303,7 +392,7 @@ func (s *MemoryStorage) CreatePolicy(_ context.Context, req *CreatePolicyRequest
 
 	arn := fmt.Sprintf("arn:aws:iam::%s:policy%s%s", s.accountID, path, req.PolicyName)
 
-	if _, exists := s.policies[arn]; exists {
+	if _, exists := s.Policies[arn]; exists {
 		return nil, &Error{
 			Code:    errEntityAlreadyExists,
 			Message: fmt.Sprintf("A policy called %s already exists. Duplicate names are not allowed.", req.PolicyName),
@@ -327,7 +416,7 @@ func (s *MemoryStorage) CreatePolicy(_ context.Context, req *CreatePolicyRequest
 		PolicyDocument:   req.PolicyDocument,
 	}
 
-	s.policies[arn] = policy
+	s.Policies[arn] = policy
 
 	return policy, nil
 }
@@ -337,7 +426,7 @@ func (s *MemoryStorage) DeletePolicy(_ context.Context, policyArn string) error 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	policy, exists := s.policies[policyArn]
+	policy, exists := s.Policies[policyArn]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -352,7 +441,7 @@ func (s *MemoryStorage) DeletePolicy(_ context.Context, policyArn string) error 
 		}
 	}
 
-	delete(s.policies, policyArn)
+	delete(s.Policies, policyArn)
 
 	return nil
 }
@@ -362,7 +451,7 @@ func (s *MemoryStorage) GetPolicy(_ context.Context, policyArn string) (*Policy,
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	policy, exists := s.policies[policyArn]
+	policy, exists := s.Policies[policyArn]
 	if !exists {
 		return nil, &Error{
 			Code:    errNoSuchEntity,
@@ -388,7 +477,7 @@ func (s *MemoryStorage) ListPolicies(_ context.Context, pathPrefix string, maxIt
 
 	policies := make([]Policy, 0)
 
-	for _, policy := range s.policies {
+	for _, policy := range s.Policies {
 		if !strings.HasPrefix(policy.Path, pathPrefix) {
 			continue
 		}
@@ -412,7 +501,7 @@ func (s *MemoryStorage) AttachUserPolicy(_ context.Context, userName, policyArn 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	user, exists := s.users[userName]
+	user, exists := s.Users[userName]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -420,7 +509,7 @@ func (s *MemoryStorage) AttachUserPolicy(_ context.Context, userName, policyArn 
 		}
 	}
 
-	policy, exists := s.policies[policyArn]
+	policy, exists := s.Policies[policyArn]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -448,7 +537,7 @@ func (s *MemoryStorage) DetachUserPolicy(_ context.Context, userName, policyArn 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	user, exists := s.users[userName]
+	user, exists := s.Users[userName]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -456,7 +545,7 @@ func (s *MemoryStorage) DetachUserPolicy(_ context.Context, userName, policyArn 
 		}
 	}
 
-	policy, exists := s.policies[policyArn]
+	policy, exists := s.Policies[policyArn]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -492,7 +581,7 @@ func (s *MemoryStorage) AttachRolePolicy(_ context.Context, roleName, policyArn 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	role, exists := s.roles[roleName]
+	role, exists := s.Roles[roleName]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -500,7 +589,7 @@ func (s *MemoryStorage) AttachRolePolicy(_ context.Context, roleName, policyArn 
 		}
 	}
 
-	policy, exists := s.policies[policyArn]
+	policy, exists := s.Policies[policyArn]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -528,7 +617,7 @@ func (s *MemoryStorage) DetachRolePolicy(_ context.Context, roleName, policyArn 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	role, exists := s.roles[roleName]
+	role, exists := s.Roles[roleName]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -536,7 +625,7 @@ func (s *MemoryStorage) DetachRolePolicy(_ context.Context, roleName, policyArn 
 		}
 	}
 
-	policy, exists := s.policies[policyArn]
+	policy, exists := s.Policies[policyArn]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -572,14 +661,14 @@ func (s *MemoryStorage) CreateAccessKey(_ context.Context, userName string) (*Ac
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.users[userName]; !exists {
+	if _, exists := s.Users[userName]; !exists {
 		return nil, &Error{
 			Code:    errNoSuchEntity,
 			Message: fmt.Sprintf("The user with name %s cannot be found.", userName),
 		}
 	}
 
-	keys := s.accessKeys[userName]
+	keys := s.AccessKeys[userName]
 	if len(keys) >= 2 {
 		return nil, &Error{
 			Code:    errLimitExceeded,
@@ -595,7 +684,7 @@ func (s *MemoryStorage) CreateAccessKey(_ context.Context, userName string) (*Ac
 		CreateDate:      time.Now().UTC(),
 	}
 
-	s.accessKeys[userName][accessKey.AccessKeyID] = accessKey
+	s.AccessKeys[userName][accessKey.AccessKeyID] = accessKey
 
 	return accessKey, nil
 }
@@ -605,14 +694,14 @@ func (s *MemoryStorage) DeleteAccessKey(_ context.Context, userName, accessKeyID
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.users[userName]; !exists {
+	if _, exists := s.Users[userName]; !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
 			Message: fmt.Sprintf("The user with name %s cannot be found.", userName),
 		}
 	}
 
-	keys, exists := s.accessKeys[userName]
+	keys, exists := s.AccessKeys[userName]
 	if !exists {
 		return &Error{
 			Code:    errNoSuchEntity,
@@ -627,7 +716,7 @@ func (s *MemoryStorage) DeleteAccessKey(_ context.Context, userName, accessKeyID
 		}
 	}
 
-	delete(s.accessKeys[userName], accessKeyID)
+	delete(s.AccessKeys[userName], accessKeyID)
 
 	return nil
 }
@@ -637,7 +726,7 @@ func (s *MemoryStorage) ListAccessKeys(_ context.Context, userName string, maxIt
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if _, exists := s.users[userName]; !exists {
+	if _, exists := s.Users[userName]; !exists {
 		return nil, &Error{
 			Code:    errNoSuchEntity,
 			Message: fmt.Sprintf("The user with name %s cannot be found.", userName),
@@ -650,7 +739,7 @@ func (s *MemoryStorage) ListAccessKeys(_ context.Context, userName string, maxIt
 
 	keys := make([]AccessKeyMetadata, 0)
 
-	for _, key := range s.accessKeys[userName] {
+	for _, key := range s.AccessKeys[userName] {
 		keys = append(keys, AccessKeyMetadata{
 			AccessKeyID: key.AccessKeyID,
 			Status:      key.Status,

--- a/internal/service/kafka/service.go
+++ b/internal/service/kafka/service.go
@@ -2,14 +2,25 @@
 package kafka
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the MSK service.
@@ -47,4 +58,15 @@ func (s *Service) handleGetCluster(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.DescribeCluster(w, r)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/kafka/storage.go
+++ b/internal/service/kafka/storage.go
@@ -2,12 +2,15 @@ package kafka
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -37,21 +40,95 @@ type Storage interface {
 	UpdateClusterConfiguration(ctx context.Context, clusterArn string, req *UpdateClusterConfigurationRequest) (*UpdateClusterConfigurationResponse, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu        sync.RWMutex
-	clusters  map[string]*ClusterInfo // keyed by clusterArn
+	mu        sync.RWMutex            `json:"-"`
+	Clusters  map[string]*ClusterInfo `json:"clusters"` // keyed by clusterArn
 	region    string
 	accountID string
+	dataDir   string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		clusters:  make(map[string]*ClusterInfo),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Clusters:  make(map[string]*ClusterInfo),
 		region:    "us-east-1",
 		accountID: "123456789012",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "kafka", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Clusters == nil {
+		s.Clusters = make(map[string]*ClusterInfo)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "kafka", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateCluster creates a new MSK cluster.
@@ -60,7 +137,7 @@ func (s *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 	defer s.mu.Unlock()
 
 	// Check for duplicate cluster name.
-	for _, c := range s.clusters {
+	for _, c := range s.Clusters {
 		if c.ClusterName == req.ClusterName {
 			return nil, &Error{
 				Code:    errConflict,
@@ -110,7 +187,7 @@ func (s *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 		Tags:                req.Tags,
 	}
 
-	s.clusters[clusterArn] = cluster
+	s.Clusters[clusterArn] = cluster
 
 	return &CreateClusterResponse{
 		ClusterArn:  clusterArn,
@@ -124,7 +201,7 @@ func (s *MemoryStorage) DescribeCluster(_ context.Context, clusterArn string) (*
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	cluster, exists := s.clusters[clusterArn]
+	cluster, exists := s.Clusters[clusterArn]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -140,7 +217,7 @@ func (s *MemoryStorage) DeleteCluster(_ context.Context, clusterArn string) (*De
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cluster, exists := s.clusters[clusterArn]
+	cluster, exists := s.Clusters[clusterArn]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -150,7 +227,7 @@ func (s *MemoryStorage) DeleteCluster(_ context.Context, clusterArn string) (*De
 
 	cluster.State = statusDeleting
 
-	delete(s.clusters, clusterArn)
+	delete(s.Clusters, clusterArn)
 
 	return &DeleteClusterResponse{
 		ClusterArn: clusterArn,
@@ -163,8 +240,8 @@ func (s *MemoryStorage) ListClusters(_ context.Context, _ int, _ string) ([]Clus
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	clusters := make([]ClusterInfo, 0, len(s.clusters))
-	for _, c := range s.clusters {
+	clusters := make([]ClusterInfo, 0, len(s.Clusters))
+	for _, c := range s.Clusters {
 		clusters = append(clusters, *c)
 	}
 
@@ -176,7 +253,7 @@ func (s *MemoryStorage) GetBootstrapBrokers(_ context.Context, clusterArn string
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	cluster, exists := s.clusters[clusterArn]
+	cluster, exists := s.Clusters[clusterArn]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -205,7 +282,7 @@ func (s *MemoryStorage) UpdateClusterConfiguration(_ context.Context, clusterArn
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cluster, exists := s.clusters[clusterArn]
+	cluster, exists := s.Clusters[clusterArn]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,

--- a/internal/service/kinesis/service.go
+++ b/internal/service/kinesis/service.go
@@ -2,8 +2,15 @@
 package kinesis
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
 
 // Service is the Kinesis service.
 type Service struct {
@@ -36,6 +43,22 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// Routes are dispatched by the server based on X-Amz-Target.
 }
 
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }

--- a/internal/service/kinesis/storage.go
+++ b/internal/service/kinesis/storage.go
@@ -5,12 +5,15 @@ import (
 	"crypto/md5" //nolint:gosec // MD5 used for partition key hashing, not security
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -48,26 +51,43 @@ type Storage interface {
 	DispatchAction(action string) bool
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu              sync.RWMutex
-	streams         map[string]*streamData
-	shardIterators  map[string]*shardIteratorData
+	mu              sync.RWMutex                  `json:"-"`
+	Streams         map[string]*StreamData        `json:"streams"`
+	shardIterators  map[string]*shardIteratorData `json:"-"`
 	region          string
 	accountID       string
-	sequenceCounter uint64
+	SequenceCounter uint64 `json:"sequenceCounter"`
+	dataDir         string
 }
 
-// streamData holds stream information and its shards.
-type streamData struct {
-	stream *Stream
-	shards map[string]*shardData
+// StreamData holds stream information and its shards.
+type StreamData struct {
+	Stream *Stream               `json:"stream"`
+	Shards map[string]*ShardData `json:"shards"`
 }
 
-// shardData holds shard information and its records.
-type shardData struct {
-	shard   *Shard
-	records []*Record
+// ShardData holds shard information and its records.
+type ShardData struct {
+	Shard   *Shard    `json:"shard"`
+	Records []*Record `json:"records"`
 }
 
 // shardIteratorData holds shard iterator state.
@@ -79,13 +99,74 @@ type shardIteratorData struct {
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		streams:        make(map[string]*streamData),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Streams:        make(map[string]*StreamData),
 		shardIterators: make(map[string]*shardIteratorData),
 		region:         "us-east-1",
 		accountID:      "000000000000",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "kinesis", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Streams == nil {
+		s.Streams = make(map[string]*StreamData)
+	}
+
+	if s.shardIterators == nil {
+		s.shardIterators = make(map[string]*shardIteratorData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "kinesis", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateStream creates a new stream.
@@ -93,7 +174,7 @@ func (s *MemoryStorage) CreateStream(_ context.Context, req *CreateStreamRequest
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.streams[req.StreamName]; exists {
+	if _, exists := s.Streams[req.StreamName]; exists {
 		return &ServiceError{Code: errResourceInUse, Message: "Stream already exists"}
 	}
 
@@ -120,7 +201,7 @@ func (s *MemoryStorage) CreateStream(_ context.Context, req *CreateStreamRequest
 	}
 
 	// Create shards.
-	shards := make(map[string]*shardData)
+	shards := make(map[string]*ShardData)
 	hashKeyRange := calculateHashKeyRanges(shardCount)
 
 	for i := int32(0); i < shardCount; i++ {
@@ -135,15 +216,15 @@ func (s *MemoryStorage) CreateStream(_ context.Context, req *CreateStreamRequest
 			},
 		}
 
-		shards[shardID] = &shardData{
-			shard:   shard,
-			records: make([]*Record, 0),
+		shards[shardID] = &ShardData{
+			Shard:   shard,
+			Records: make([]*Record, 0),
 		}
 	}
 
-	s.streams[req.StreamName] = &streamData{
-		stream: stream,
-		shards: shards,
+	s.Streams[req.StreamName] = &StreamData{
+		Stream: stream,
+		Shards: shards,
 	}
 
 	return nil
@@ -154,11 +235,11 @@ func (s *MemoryStorage) DeleteStream(_ context.Context, streamName string) error
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.streams[streamName]; !exists {
+	if _, exists := s.Streams[streamName]; !exists {
 		return &ServiceError{Code: errResourceNotFound, Message: "Stream not found"}
 	}
 
-	delete(s.streams, streamName)
+	delete(s.Streams, streamName)
 
 	return nil
 }
@@ -168,15 +249,15 @@ func (s *MemoryStorage) DescribeStream(_ context.Context, streamName string, lim
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	sd, exists := s.streams[streamName]
+	sd, exists := s.Streams[streamName]
 	if !exists {
 		return nil, nil, false, &ServiceError{Code: errResourceNotFound, Message: "Stream not found"}
 	}
 
 	// Collect and sort shards.
-	shards := make([]*Shard, 0, len(sd.shards))
-	for _, shardData := range sd.shards {
-		shards = append(shards, shardData.shard)
+	shards := make([]*Shard, 0, len(sd.Shards))
+	for _, shardData := range sd.Shards {
+		shards = append(shards, shardData.Shard)
 	}
 
 	sort.Slice(shards, func(i, j int) bool {
@@ -209,7 +290,7 @@ func (s *MemoryStorage) DescribeStream(_ context.Context, streamName string, lim
 		hasMoreShards = true
 	}
 
-	return sd.stream, shards[startIndex:endIndex], hasMoreShards, nil
+	return sd.Stream, shards[startIndex:endIndex], hasMoreShards, nil
 }
 
 // ListStreams lists all streams.
@@ -222,8 +303,8 @@ func (s *MemoryStorage) ListStreams(_ context.Context, exclusiveStartStreamName 
 	}
 
 	// Collect and sort stream names.
-	names := make([]string, 0, len(s.streams))
-	for name := range s.streams {
+	names := make([]string, 0, len(s.Streams))
+	for name := range s.Streams {
 		names = append(names, name)
 	}
 
@@ -253,7 +334,7 @@ func (s *MemoryStorage) ListStreams(_ context.Context, exclusiveStartStreamName 
 
 	streams := make([]*Stream, endIndex-startIndex)
 	for i, name := range names[startIndex:endIndex] {
-		streams[i] = s.streams[name].stream
+		streams[i] = s.Streams[name].Stream
 	}
 
 	return streams, hasMoreStreams, nil
@@ -264,7 +345,7 @@ func (s *MemoryStorage) ListShards(_ context.Context, streamName, _ string, maxR
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	sd, exists := s.streams[streamName]
+	sd, exists := s.Streams[streamName]
 	if !exists {
 		return nil, "", &ServiceError{Code: errResourceNotFound, Message: "Stream not found"}
 	}
@@ -274,9 +355,9 @@ func (s *MemoryStorage) ListShards(_ context.Context, streamName, _ string, maxR
 	}
 
 	// Collect and sort shards.
-	shards := make([]*Shard, 0, len(sd.shards))
-	for _, shardData := range sd.shards {
-		shards = append(shards, shardData.shard)
+	shards := make([]*Shard, 0, len(sd.Shards))
+	for _, shardData := range sd.Shards {
+		shards = append(shards, shardData.Shard)
 	}
 
 	sort.Slice(shards, func(i, j int) bool {
@@ -295,7 +376,7 @@ func (s *MemoryStorage) PutRecord(_ context.Context, streamName string, data []b
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	sd, exists := s.streams[streamName]
+	sd, exists := s.Streams[streamName]
 	if !exists {
 		return "", "", &ServiceError{Code: errResourceNotFound, Message: "Stream not found"}
 	}
@@ -319,7 +400,7 @@ func (s *MemoryStorage) PutRecord(_ context.Context, streamName string, data []b
 		ApproximateArrivalTimestamp: time.Now(),
 	}
 
-	sd.shards[shardID].records = append(sd.shards[shardID].records, record)
+	sd.Shards[shardID].Records = append(sd.Shards[shardID].Records, record)
 
 	return shardID, seqNum, nil
 }
@@ -329,7 +410,7 @@ func (s *MemoryStorage) PutRecords(_ context.Context, streamName string, records
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	sd, exists := s.streams[streamName]
+	sd, exists := s.Streams[streamName]
 	if !exists {
 		return nil, 0, &ServiceError{Code: errResourceNotFound, Message: "Stream not found"}
 	}
@@ -360,7 +441,7 @@ func (s *MemoryStorage) PutRecords(_ context.Context, streamName string, records
 			ApproximateArrivalTimestamp: time.Now(),
 		}
 
-		sd.shards[shardID].records = append(sd.shards[shardID].records, record)
+		sd.Shards[shardID].Records = append(sd.Shards[shardID].Records, record)
 
 		results[i] = PutRecordsResultEntry{
 			ShardID:        shardID,
@@ -384,12 +465,12 @@ func (s *MemoryStorage) GetShardIterator(_ context.Context, streamName, shardID,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	sd, exists := s.streams[streamName]
+	sd, exists := s.Streams[streamName]
 	if !exists {
 		return "", &ServiceError{Code: errResourceNotFound, Message: "Stream not found"}
 	}
 
-	shardData, exists := sd.shards[shardID]
+	shardData, exists := sd.Shards[shardID]
 	if !exists {
 		return "", &ServiceError{Code: errResourceNotFound, Message: "Shard not found"}
 	}
@@ -400,11 +481,11 @@ func (s *MemoryStorage) GetShardIterator(_ context.Context, streamName, shardID,
 	case string(ShardIteratorTypeTrimHorizon):
 		position = 0
 	case string(ShardIteratorTypeLatest):
-		position = len(shardData.records)
+		position = len(shardData.Records)
 	case string(ShardIteratorTypeAtSequenceNumber):
-		position = s.findPositionAtSequenceNumber(shardData.records, startingSeqNum)
+		position = s.findPositionAtSequenceNumber(shardData.Records, startingSeqNum)
 	case string(ShardIteratorTypeAfterSequenceNumber):
-		position = s.findPositionAtSequenceNumber(shardData.records, startingSeqNum) + 1
+		position = s.findPositionAtSequenceNumber(shardData.Records, startingSeqNum) + 1
 	default:
 		return "", &ServiceError{Code: errInvalidArgument, Message: "Invalid ShardIteratorType"}
 	}
@@ -438,12 +519,12 @@ func (s *MemoryStorage) GetRecords(_ context.Context, shardIterator string, limi
 		return nil, "", 0, &ServiceError{Code: errExpiredIterator, Message: "Shard iterator has expired"}
 	}
 
-	sd, exists := s.streams[iterData.streamName]
+	sd, exists := s.Streams[iterData.streamName]
 	if !exists {
 		return nil, "", 0, &ServiceError{Code: errResourceNotFound, Message: "Stream not found"}
 	}
 
-	shardData, exists := sd.shards[iterData.shardID]
+	shardData, exists := sd.Shards[iterData.shardID]
 	if !exists {
 		return nil, "", 0, &ServiceError{Code: errResourceNotFound, Message: "Shard not found"}
 	}
@@ -453,10 +534,10 @@ func (s *MemoryStorage) GetRecords(_ context.Context, shardIterator string, limi
 	}
 
 	startPos := iterData.position
-	endPos := min(startPos+int(limit), len(shardData.records))
+	endPos := min(startPos+int(limit), len(shardData.Records))
 
 	records := make([]*Record, endPos-startPos)
-	copy(records, shardData.records[startPos:endPos])
+	copy(records, shardData.Records[startPos:endPos])
 
 	// Create next iterator.
 	delete(s.shardIterators, shardIterator)
@@ -482,21 +563,21 @@ func (s *MemoryStorage) DispatchAction(_ string) bool {
 // Helper functions.
 
 func (s *MemoryStorage) nextSequenceNumber() string {
-	seq := atomic.AddUint64(&s.sequenceCounter, 1)
+	seq := atomic.AddUint64(&s.SequenceCounter, 1)
 
 	return fmt.Sprintf("%021d", seq)
 }
 
-func (s *MemoryStorage) findShardForHashKey(sd *streamData, hashKey string) string {
+func (s *MemoryStorage) findShardForHashKey(sd *StreamData, hashKey string) string {
 	hashKeyBig := new(big.Int)
 	hashKeyBig.SetString(hashKey, 10)
 
-	for shardID, shardData := range sd.shards {
+	for shardID, shardData := range sd.Shards {
 		startKey := new(big.Int)
 		endKey := new(big.Int)
 
-		startKey.SetString(shardData.shard.HashKeyRange.StartingHashKey, 10)
-		endKey.SetString(shardData.shard.HashKeyRange.EndingHashKey, 10)
+		startKey.SetString(shardData.Shard.HashKeyRange.StartingHashKey, 10)
+		endKey.SetString(shardData.Shard.HashKeyRange.EndingHashKey, 10)
 
 		if hashKeyBig.Cmp(startKey) >= 0 && hashKeyBig.Cmp(endKey) <= 0 {
 			return shardID

--- a/internal/service/kms/service.go
+++ b/internal/service/kms/service.go
@@ -1,6 +1,10 @@
 package kms
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
@@ -34,6 +38,25 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// JSON protocol services use DispatchAction for routing
 }
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/kms/storage.go
+++ b/internal/service/kms/storage.go
@@ -5,12 +5,15 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -69,21 +72,99 @@ type Storage interface {
 	GetAlias(ctx context.Context, aliasName string) (*Alias, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu      sync.RWMutex
-	keys    map[string]*Key   // keyID -> Key
-	aliases map[string]*Alias // aliasName -> Alias
+	mu      sync.RWMutex      `json:"-"`
+	Keys    map[string]*Key   `json:"keys"`    // keyID -> Key
+	Aliases map[string]*Alias `json:"aliases"` // aliasName -> Alias
 	region  string
+	dataDir string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		keys:    make(map[string]*Key),
-		aliases: make(map[string]*Alias),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Keys:    make(map[string]*Key),
+		Aliases: make(map[string]*Alias),
 		region:  defaultRegion,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "kms", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type MemStorageAlias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *MemStorageAlias }{MemStorageAlias: (*MemStorageAlias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type MemStorageAlias MemoryStorage
+
+	aux := &struct{ *MemStorageAlias }{MemStorageAlias: (*MemStorageAlias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Keys == nil {
+		s.Keys = make(map[string]*Key)
+	}
+
+	if s.Aliases == nil {
+		s.Aliases = make(map[string]*Alias)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "kms", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateKey creates a new KMS key.
@@ -136,7 +217,7 @@ func (s *MemoryStorage) CreateKey(_ context.Context, req *CreateKeyRequest) (*Ke
 		KeyMaterial:  keyMaterial,
 	}
 
-	s.keys[keyID] = key
+	s.Keys[keyID] = key
 
 	return key, nil
 }
@@ -153,7 +234,7 @@ func (s *MemoryStorage) GetKey(_ context.Context, keyID string) (*Key, error) {
 func (s *MemoryStorage) getKeyLocked(keyID string) (*Key, error) {
 	// Check if it's an alias.
 	if len(keyID) > 6 && keyID[:6] == "alias/" {
-		alias, ok := s.aliases[keyID]
+		alias, ok := s.Aliases[keyID]
 		if !ok {
 			return nil, &ServiceError{Code: errNotFound, Message: "Alias " + keyID + " is not found."}
 		}
@@ -164,7 +245,7 @@ func (s *MemoryStorage) getKeyLocked(keyID string) (*Key, error) {
 	// Check if it's an ARN.
 	if len(keyID) > 8 && keyID[:8] == "arn:aws:" {
 		// Extract key ID from ARN.
-		for _, key := range s.keys {
+		for _, key := range s.Keys {
 			if key.Arn == keyID {
 				return key, nil
 			}
@@ -174,7 +255,7 @@ func (s *MemoryStorage) getKeyLocked(keyID string) (*Key, error) {
 	}
 
 	// Look up by key ID.
-	key, ok := s.keys[keyID]
+	key, ok := s.Keys[keyID]
 	if !ok {
 		return nil, &ServiceError{Code: errNotFound, Message: "Key " + keyID + " is not found."}
 	}
@@ -191,10 +272,10 @@ func (s *MemoryStorage) ListKeys(_ context.Context, limit int32, _ string) ([]*K
 		limit = 100
 	}
 
-	keys := make([]*Key, 0, len(s.keys))
+	keys := make([]*Key, 0, len(s.Keys))
 	maxKeys := int(limit)
 
-	for _, key := range s.keys {
+	for _, key := range s.Keys {
 		keys = append(keys, key)
 
 		if len(keys) >= maxKeys {
@@ -462,7 +543,7 @@ func (s *MemoryStorage) CreateAlias(_ context.Context, aliasName, targetKeyID st
 	}
 
 	// Check if alias already exists.
-	if _, ok := s.aliases[aliasName]; ok {
+	if _, ok := s.Aliases[aliasName]; ok {
 		return &ServiceError{Code: errAlreadyExists, Message: "Alias " + aliasName + " already exists."}
 	}
 
@@ -475,7 +556,7 @@ func (s *MemoryStorage) CreateAlias(_ context.Context, aliasName, targetKeyID st
 	aliasArn := fmt.Sprintf("arn:aws:kms:%s:%s:%s", s.region, defaultAccountID, aliasName)
 	now := time.Now()
 
-	s.aliases[aliasName] = &Alias{
+	s.Aliases[aliasName] = &Alias{
 		AliasName:       aliasName,
 		AliasArn:        aliasArn,
 		TargetKeyID:     key.KeyID,
@@ -491,11 +572,11 @@ func (s *MemoryStorage) DeleteAlias(_ context.Context, aliasName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.aliases[aliasName]; !ok {
+	if _, ok := s.Aliases[aliasName]; !ok {
 		return &ServiceError{Code: errNotFound, Message: "Alias " + aliasName + " is not found."}
 	}
 
-	delete(s.aliases, aliasName)
+	delete(s.Aliases, aliasName)
 
 	return nil
 }
@@ -512,7 +593,7 @@ func (s *MemoryStorage) ListAliases(_ context.Context, keyID string, limit int32
 	aliases := make([]*Alias, 0)
 	maxAliases := int(limit)
 
-	for _, alias := range s.aliases {
+	for _, alias := range s.Aliases {
 		if keyID != "" && alias.TargetKeyID != keyID {
 			// If keyID is specified, filter by it.
 			// Also need to resolve keyID if it's an alias or ARN.
@@ -541,7 +622,7 @@ func (s *MemoryStorage) GetAlias(_ context.Context, aliasName string) (*Alias, e
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	alias, ok := s.aliases[aliasName]
+	alias, ok := s.Aliases[aliasName]
 	if !ok {
 		return nil, &ServiceError{Code: errNotFound, Message: "Alias " + aliasName + " is not found."}
 	}

--- a/internal/service/lambda/service.go
+++ b/internal/service/lambda/service.go
@@ -1,13 +1,25 @@
 package lambda
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
 const defaultBaseURL = "http://localhost:4566"
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage(defaultBaseURL), defaultBaseURL))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(defaultBaseURL, opts...), defaultBaseURL))
 }
 
 // Service implements the Lambda service.
@@ -68,4 +80,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 
 	// DeleteEventSourceMapping: DELETE /lambda/2015-03-31/event-source-mappings/{UUID}
 	r.Handle("DELETE", "/lambda/2015-03-31/event-source-mappings/{uuid}", s.DeleteEventSourceMapping)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/lambda/storage.go
+++ b/internal/service/lambda/storage.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the Lambda storage interface.
@@ -26,25 +29,103 @@ type Storage interface {
 	UpdateEventSourceMapping(ctx context.Context, uuid string, req *UpdateEventSourceMappingRequest) (*EventSourceMapping, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu                  sync.RWMutex
-	functions           map[string]*Function
-	eventSourceMappings map[string]*EventSourceMapping
+	mu                  sync.RWMutex                   `json:"-"`
+	Functions           map[string]*Function           `json:"functions"`
+	EventSourceMappings map[string]*EventSourceMapping `json:"eventSourceMappings"`
 	baseURL             string
 	region              string
 	accountID           string
+	dataDir             string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage(baseURL string) *MemoryStorage {
-	return &MemoryStorage{
-		functions:           make(map[string]*Function),
-		eventSourceMappings: make(map[string]*EventSourceMapping),
+func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Functions:           make(map[string]*Function),
+		EventSourceMappings: make(map[string]*EventSourceMapping),
 		baseURL:             baseURL,
 		region:              "us-east-1",
 		accountID:           "000000000000",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "lambda", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Functions == nil {
+		s.Functions = make(map[string]*Function)
+	}
+
+	if s.EventSourceMappings == nil {
+		s.EventSourceMappings = make(map[string]*EventSourceMapping)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "lambda", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateFunction creates a new Lambda function.
@@ -52,7 +133,7 @@ func (s *MemoryStorage) CreateFunction(_ context.Context, req *CreateFunctionReq
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.functions[req.FunctionName]; exists {
+	if _, exists := s.Functions[req.FunctionName]; exists {
 		return nil, &FunctionError{
 			Type:    ErrResourceConflict,
 			Message: fmt.Sprintf("Function already exist: %s", req.FunctionName),
@@ -60,7 +141,7 @@ func (s *MemoryStorage) CreateFunction(_ context.Context, req *CreateFunctionReq
 	}
 
 	fn := s.buildFunction(req)
-	s.functions[req.FunctionName] = fn
+	s.Functions[req.FunctionName] = fn
 
 	return fn, nil
 }
@@ -123,7 +204,7 @@ func (s *MemoryStorage) GetFunction(_ context.Context, name string) (*Function, 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	fn, exists := s.functions[name]
+	fn, exists := s.Functions[name]
 	if !exists {
 		return nil, &FunctionError{
 			Type:    ErrResourceNotFound,
@@ -139,14 +220,14 @@ func (s *MemoryStorage) DeleteFunction(_ context.Context, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.functions[name]; !exists {
+	if _, exists := s.Functions[name]; !exists {
 		return &FunctionError{
 			Type:    ErrResourceNotFound,
 			Message: fmt.Sprintf("Function not found: %s", name),
 		}
 	}
 
-	delete(s.functions, name)
+	delete(s.Functions, name)
 
 	return nil
 }
@@ -160,8 +241,8 @@ func (s *MemoryStorage) ListFunctions(_ context.Context, marker string, maxItems
 		maxItems = 50
 	}
 
-	functions := make([]*Function, 0, len(s.functions))
-	for _, fn := range s.functions {
+	functions := make([]*Function, 0, len(s.Functions))
+	for _, fn := range s.Functions {
 		functions = append(functions, fn)
 	}
 
@@ -198,7 +279,7 @@ func (s *MemoryStorage) UpdateFunctionCode(_ context.Context, name string, req *
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	fn, exists := s.functions[name]
+	fn, exists := s.Functions[name]
 	if !exists {
 		return nil, &FunctionError{
 			Type:    ErrResourceNotFound,
@@ -244,7 +325,7 @@ func (s *MemoryStorage) UpdateFunctionConfiguration(_ context.Context, name stri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	fn, exists := s.functions[name]
+	fn, exists := s.Functions[name]
 	if !exists {
 		return nil, &FunctionError{
 			Type:    ErrResourceNotFound,
@@ -295,7 +376,7 @@ func (s *MemoryStorage) CreateEventSourceMapping(_ context.Context, req *CreateE
 	defer s.mu.Unlock()
 
 	// Validate function exists
-	fn, exists := s.functions[req.FunctionName]
+	fn, exists := s.Functions[req.FunctionName]
 	if !exists {
 		return nil, &FunctionError{
 			Type:    ErrResourceNotFound,
@@ -334,7 +415,7 @@ func (s *MemoryStorage) CreateEventSourceMapping(_ context.Context, req *CreateE
 		LastProcessingResult:           "No records processed",
 	}
 
-	s.eventSourceMappings[mappingUUID] = mapping
+	s.EventSourceMappings[mappingUUID] = mapping
 
 	return mapping, nil
 }
@@ -344,7 +425,7 @@ func (s *MemoryStorage) GetEventSourceMapping(_ context.Context, uuid string) (*
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	mapping, exists := s.eventSourceMappings[uuid]
+	mapping, exists := s.EventSourceMappings[uuid]
 	if !exists {
 		return nil, &FunctionError{
 			Type:    ErrResourceNotFound,
@@ -360,7 +441,7 @@ func (s *MemoryStorage) DeleteEventSourceMapping(_ context.Context, uuid string)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	mapping, exists := s.eventSourceMappings[uuid]
+	mapping, exists := s.EventSourceMappings[uuid]
 	if !exists {
 		return &FunctionError{
 			Type:    ErrResourceNotFound,
@@ -371,7 +452,7 @@ func (s *MemoryStorage) DeleteEventSourceMapping(_ context.Context, uuid string)
 	// Mark as deleting state before removing
 	mapping.State = "Deleting"
 
-	delete(s.eventSourceMappings, uuid)
+	delete(s.EventSourceMappings, uuid)
 
 	return nil
 }
@@ -388,7 +469,7 @@ func (s *MemoryStorage) ListEventSourceMappings(_ context.Context, functionName,
 	// Collect matching mappings
 	var mappings []*EventSourceMapping
 
-	for _, m := range s.eventSourceMappings {
+	for _, m := range s.EventSourceMappings {
 		// Filter by function name if specified
 		if functionName != "" && !matchesFunctionName(m.FunctionArn, functionName) {
 			continue
@@ -435,7 +516,7 @@ func (s *MemoryStorage) UpdateEventSourceMapping(_ context.Context, uuid string,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	mapping, exists := s.eventSourceMappings[uuid]
+	mapping, exists := s.EventSourceMappings[uuid]
 	if !exists {
 		return nil, &FunctionError{
 			Type:    ErrResourceNotFound,
@@ -445,7 +526,7 @@ func (s *MemoryStorage) UpdateEventSourceMapping(_ context.Context, uuid string,
 
 	// Update function ARN if function name is specified
 	if req.FunctionName != "" {
-		fn, fnExists := s.functions[req.FunctionName]
+		fn, fnExists := s.Functions[req.FunctionName]
 		if !fnExists {
 			return nil, &FunctionError{
 				Type:    ErrResourceNotFound,

--- a/internal/service/memorydb/service.go
+++ b/internal/service/memorydb/service.go
@@ -1,6 +1,10 @@
 package memorydb
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
@@ -34,6 +38,25 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// JSON protocol services use DispatchAction for routing
 }
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/memorydb/storage.go
+++ b/internal/service/memorydb/storage.go
@@ -2,8 +2,11 @@ package memorydb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -48,21 +51,103 @@ type Storage interface {
 	DeleteACL(ctx context.Context, aclName string) (*ACL, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu       sync.RWMutex
-	clusters map[string]*Cluster
-	users    map[string]*User
-	acls     map[string]*ACL
+	mu       sync.RWMutex        `json:"-"`
+	Clusters map[string]*Cluster `json:"clusters"`
+	Users    map[string]*User    `json:"users"`
+	Acls     map[string]*ACL     `json:"acls"`
+	dataDir  string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		clusters: make(map[string]*Cluster),
-		users:    make(map[string]*User),
-		acls:     make(map[string]*ACL),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Clusters: make(map[string]*Cluster),
+		Users:    make(map[string]*User),
+		Acls:     make(map[string]*ACL),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "memorydb", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Clusters == nil {
+		m.Clusters = make(map[string]*Cluster)
+	}
+
+	if m.Users == nil {
+		m.Users = make(map[string]*User)
+	}
+
+	if m.Acls == nil {
+		m.Acls = make(map[string]*ACL)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "memorydb", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // buildClusterBase creates a Cluster with core fields from a CreateClusterRequest.
@@ -150,7 +235,7 @@ func (m *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.clusters[req.ClusterName]; exists {
+	if _, exists := m.Clusters[req.ClusterName]; exists {
 		return nil, &ServiceError{
 			Code:    errClusterExists,
 			Message: fmt.Sprintf("Cluster %s already exists", req.ClusterName),
@@ -158,7 +243,7 @@ func (m *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 	}
 
 	cluster := buildCluster(req)
-	m.clusters[req.ClusterName] = cluster
+	m.Clusters[req.ClusterName] = cluster
 
 	return cluster, nil
 }
@@ -169,7 +254,7 @@ func (m *MemoryStorage) DescribeClusters(_ context.Context, clusterName string) 
 	defer m.mu.RUnlock()
 
 	if clusterName != "" {
-		cluster, exists := m.clusters[clusterName]
+		cluster, exists := m.Clusters[clusterName]
 		if !exists {
 			return nil, &ServiceError{
 				Code:    errClusterNotFound,
@@ -180,8 +265,8 @@ func (m *MemoryStorage) DescribeClusters(_ context.Context, clusterName string) 
 		return []Cluster{*cluster}, nil
 	}
 
-	clusters := make([]Cluster, 0, len(m.clusters))
-	for _, c := range m.clusters {
+	clusters := make([]Cluster, 0, len(m.Clusters))
+	for _, c := range m.Clusters {
 		clusters = append(clusters, *c)
 	}
 
@@ -193,7 +278,7 @@ func (m *MemoryStorage) UpdateCluster(_ context.Context, req *UpdateClusterReque
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	cluster, exists := m.clusters[req.ClusterName]
+	cluster, exists := m.Clusters[req.ClusterName]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errClusterNotFound,
@@ -257,7 +342,7 @@ func (m *MemoryStorage) DeleteCluster(_ context.Context, clusterName string) (*C
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	cluster, exists := m.clusters[clusterName]
+	cluster, exists := m.Clusters[clusterName]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errClusterNotFound,
@@ -267,7 +352,7 @@ func (m *MemoryStorage) DeleteCluster(_ context.Context, clusterName string) (*C
 
 	cluster.Status = statusDeleting
 
-	delete(m.clusters, clusterName)
+	delete(m.Clusters, clusterName)
 
 	return cluster, nil
 }
@@ -277,7 +362,7 @@ func (m *MemoryStorage) CreateUser(_ context.Context, req *CreateUserRequest) (*
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.users[req.UserName]; exists {
+	if _, exists := m.Users[req.UserName]; exists {
 		return nil, &ServiceError{
 			Code:    errUserExists,
 			Message: fmt.Sprintf("User %s already exists", req.UserName),
@@ -307,7 +392,7 @@ func (m *MemoryStorage) CreateUser(_ context.Context, req *CreateUserRequest) (*
 		ACLNames: []string{},
 	}
 
-	m.users[req.UserName] = user
+	m.Users[req.UserName] = user
 
 	return user, nil
 }
@@ -318,7 +403,7 @@ func (m *MemoryStorage) DescribeUsers(_ context.Context, userName string) ([]Use
 	defer m.mu.RUnlock()
 
 	if userName != "" {
-		user, exists := m.users[userName]
+		user, exists := m.Users[userName]
 		if !exists {
 			return nil, &ServiceError{
 				Code:    errUserNotFound,
@@ -329,8 +414,8 @@ func (m *MemoryStorage) DescribeUsers(_ context.Context, userName string) ([]Use
 		return []User{*user}, nil
 	}
 
-	users := make([]User, 0, len(m.users))
-	for _, u := range m.users {
+	users := make([]User, 0, len(m.Users))
+	for _, u := range m.Users {
 		users = append(users, *u)
 	}
 
@@ -342,7 +427,7 @@ func (m *MemoryStorage) DeleteUser(_ context.Context, userName string) (*User, e
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	user, exists := m.users[userName]
+	user, exists := m.Users[userName]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errUserNotFound,
@@ -352,7 +437,7 @@ func (m *MemoryStorage) DeleteUser(_ context.Context, userName string) (*User, e
 
 	user.Status = statusDeleting
 
-	delete(m.users, userName)
+	delete(m.Users, userName)
 
 	return user, nil
 }
@@ -362,7 +447,7 @@ func (m *MemoryStorage) CreateACL(_ context.Context, req *CreateACLRequest) (*AC
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.acls[req.ACLName]; exists {
+	if _, exists := m.Acls[req.ACLName]; exists {
 		return nil, &ServiceError{
 			Code:    errACLExists,
 			Message: fmt.Sprintf("ACL %s already exists", req.ACLName),
@@ -383,7 +468,7 @@ func (m *MemoryStorage) CreateACL(_ context.Context, req *CreateACLRequest) (*AC
 		UserNames:            userNames,
 	}
 
-	m.acls[req.ACLName] = acl
+	m.Acls[req.ACLName] = acl
 
 	return acl, nil
 }
@@ -394,7 +479,7 @@ func (m *MemoryStorage) DescribeACLs(_ context.Context, aclName string) ([]ACL, 
 	defer m.mu.RUnlock()
 
 	if aclName != "" {
-		acl, exists := m.acls[aclName]
+		acl, exists := m.Acls[aclName]
 		if !exists {
 			return nil, &ServiceError{
 				Code:    errACLNotFound,
@@ -405,8 +490,8 @@ func (m *MemoryStorage) DescribeACLs(_ context.Context, aclName string) ([]ACL, 
 		return []ACL{*acl}, nil
 	}
 
-	acls := make([]ACL, 0, len(m.acls))
-	for _, a := range m.acls {
+	acls := make([]ACL, 0, len(m.Acls))
+	for _, a := range m.Acls {
 		acls = append(acls, *a)
 	}
 
@@ -418,7 +503,7 @@ func (m *MemoryStorage) DeleteACL(_ context.Context, aclName string) (*ACL, erro
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	acl, exists := m.acls[aclName]
+	acl, exists := m.Acls[aclName]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errACLNotFound,
@@ -428,7 +513,7 @@ func (m *MemoryStorage) DeleteACL(_ context.Context, aclName string) (*ACL, erro
 
 	acl.Status = statusDeleting
 
-	delete(m.acls, aclName)
+	delete(m.Acls, aclName)
 
 	return acl, nil
 }

--- a/internal/service/mq/service.go
+++ b/internal/service/mq/service.go
@@ -1,13 +1,24 @@
 package mq
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the Amazon MQ service.
@@ -71,4 +82,15 @@ func (s *Service) handleUpdateBroker(w http.ResponseWriter, r *http.Request) {
 // handleCreateConfiguration handles POST /v1/configurations.
 func (s *Service) handleCreateConfiguration(w http.ResponseWriter, r *http.Request) {
 	s.CreateConfiguration(w, r)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/mq/storage.go
+++ b/internal/service/mq/storage.go
@@ -2,12 +2,15 @@ package mq
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the MQ storage interface.
@@ -21,23 +24,101 @@ type Storage interface {
 	GetConfiguration(ctx context.Context, configID string) (*Configuration, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu             sync.RWMutex
-	brokers        map[string]*Broker
-	configurations map[string]*Configuration
+	mu             sync.RWMutex              `json:"-"`
+	Brokers        map[string]*Broker        `json:"brokers"`
+	Configurations map[string]*Configuration `json:"configurations"`
 	region         string
 	accountID      string
+	dataDir        string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		brokers:        make(map[string]*Broker),
-		configurations: make(map[string]*Configuration),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Brokers:        make(map[string]*Broker),
+		Configurations: make(map[string]*Configuration),
 		region:         "us-east-1",
 		accountID:      "123456789012",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "mq", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Brokers == nil {
+		s.Brokers = make(map[string]*Broker)
+	}
+
+	if s.Configurations == nil {
+		s.Configurations = make(map[string]*Configuration)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "mq", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateBroker creates a new broker.
@@ -46,7 +127,7 @@ func (s *MemoryStorage) CreateBroker(_ context.Context, req *CreateBrokerRequest
 	defer s.mu.Unlock()
 
 	// Check for duplicate broker name
-	for _, b := range s.brokers {
+	for _, b := range s.Brokers {
 		if b.BrokerName == req.BrokerName {
 			return nil, &Error{
 				Type:    ErrConflict,
@@ -84,7 +165,7 @@ func (s *MemoryStorage) CreateBroker(_ context.Context, req *CreateBrokerRequest
 		Configuration:        req.Configuration,
 	}
 
-	s.brokers[brokerID] = broker
+	s.Brokers[brokerID] = broker
 
 	return broker, nil
 }
@@ -94,14 +175,14 @@ func (s *MemoryStorage) DeleteBroker(_ context.Context, brokerID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.brokers[brokerID]; !exists {
+	if _, exists := s.Brokers[brokerID]; !exists {
 		return &Error{
 			Type:    ErrNotFound,
 			Message: fmt.Sprintf("Broker %s not found", brokerID),
 		}
 	}
 
-	delete(s.brokers, brokerID)
+	delete(s.Brokers, brokerID)
 
 	return nil
 }
@@ -111,7 +192,7 @@ func (s *MemoryStorage) DescribeBroker(_ context.Context, brokerID string) (*Bro
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	broker, exists := s.brokers[brokerID]
+	broker, exists := s.Brokers[brokerID]
 	if !exists {
 		return nil, &Error{
 			Type:    ErrNotFound,
@@ -132,8 +213,8 @@ func (s *MemoryStorage) ListBrokers(_ context.Context, maxResults int, nextToken
 	}
 
 	// Collect all brokers
-	brokers := make([]*Broker, 0, len(s.brokers))
-	for _, b := range s.brokers {
+	brokers := make([]*Broker, 0, len(s.Brokers))
+	for _, b := range s.Brokers {
 		brokers = append(brokers, b)
 	}
 
@@ -172,7 +253,7 @@ func (s *MemoryStorage) UpdateBroker(_ context.Context, brokerID string, req *Up
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	broker, exists := s.brokers[brokerID]
+	broker, exists := s.Brokers[brokerID]
 	if !exists {
 		return nil, &Error{
 			Type:    ErrNotFound,
@@ -205,7 +286,7 @@ func (s *MemoryStorage) CreateConfiguration(_ context.Context, req *CreateConfig
 	defer s.mu.Unlock()
 
 	// Check for duplicate configuration name
-	for _, c := range s.configurations {
+	for _, c := range s.Configurations {
 		if c.Name == req.Name {
 			return nil, &Error{
 				Type:    ErrConflict,
@@ -236,7 +317,7 @@ func (s *MemoryStorage) CreateConfiguration(_ context.Context, req *CreateConfig
 		Revisions:      []*ConfigurationRevision{revision},
 	}
 
-	s.configurations[configID] = config
+	s.Configurations[configID] = config
 
 	return config, nil
 }
@@ -246,7 +327,7 @@ func (s *MemoryStorage) GetConfiguration(_ context.Context, configID string) (*C
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	config, exists := s.configurations[configID]
+	config, exists := s.Configurations[configID]
 	if !exists {
 		return nil, &Error{
 			Type:    ErrNotFound,

--- a/internal/service/organizations/service.go
+++ b/internal/service/organizations/service.go
@@ -1,7 +1,13 @@
 // Package organizations provides AWS Organizations service emulation.
 package organizations
 
-import "github.com/sivchari/kumo/internal/service"
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // Service implements the Organizations service.
 type Service struct {
@@ -29,11 +35,30 @@ func (s *Service) JSONProtocol() {}
 // RegisterRoutes registers HTTP routes for the service.
 func (s *Service) RegisterRoutes(_ service.Router) {}
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 var (
 	_ service.Service             = (*Service)(nil)
 	_ service.JSONProtocolService = (*Service)(nil)
 )
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/organizations/storage.go
+++ b/internal/service/organizations/storage.go
@@ -2,11 +2,14 @@ package organizations
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -88,41 +91,130 @@ type Storage interface {
 	ListRoots(ctx context.Context, maxResults int32, nextToken string) ([]*Root, string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu                  sync.RWMutex
-	organization        *Organization
-	root                *Root
-	accounts            map[string]*Account            // accountID -> account
-	organizationalUnits map[string]*OrganizationalUnit // ouID -> OU
-	ouParents           map[string]string              // ouID -> parentID
-	policies            map[string]*Policy             // policyID -> policy
-	policyAttachments   map[string]map[string]bool     // targetID -> policyID -> attached
+	mu                  sync.RWMutex                   `json:"-"`
+	Organization        *Organization                  `json:"organization"`
+	Root                *Root                          `json:"root"`
+	Accounts            map[string]*Account            `json:"accounts"`            // accountID -> account
+	OrganizationalUnits map[string]*OrganizationalUnit `json:"organizationalUnits"` // ouID -> OU
+	OuParents           map[string]string              `json:"ouParents"`           // ouID -> parentID
+	Policies            map[string]*Policy             `json:"policies"`            // policyID -> policy
+	PolicyAttachments   map[string]map[string]bool     `json:"policyAttachments"`   // targetID -> policyID -> attached
 	region              string
 	accountID           string
+	dataDir             string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	storage := &MemoryStorage{
-		accounts:            make(map[string]*Account),
-		organizationalUnits: make(map[string]*OrganizationalUnit),
-		ouParents:           make(map[string]string),
-		policies:            make(map[string]*Policy),
-		policyAttachments:   make(map[string]map[string]bool),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Accounts:            make(map[string]*Account),
+		OrganizationalUnits: make(map[string]*OrganizationalUnit),
+		OuParents:           make(map[string]string),
+		Policies:            make(map[string]*Policy),
+		PolicyAttachments:   make(map[string]map[string]bool),
 		region:              defaultRegion,
 		accountID:           defaultAccountID,
 	}
 
-	storage.initializeDefaultPolicy()
+	for _, o := range opts {
+		o(s)
+	}
 
-	return storage
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "organizations", s)
+	}
+
+	s.initializeDefaultPolicy()
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Accounts == nil {
+		m.Accounts = make(map[string]*Account)
+	}
+
+	if m.OrganizationalUnits == nil {
+		m.OrganizationalUnits = make(map[string]*OrganizationalUnit)
+	}
+
+	if m.OuParents == nil {
+		m.OuParents = make(map[string]string)
+	}
+
+	if m.Policies == nil {
+		m.Policies = make(map[string]*Policy)
+	}
+
+	if m.PolicyAttachments == nil {
+		m.PolicyAttachments = make(map[string]map[string]bool)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "organizations", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 func (m *MemoryStorage) initializeDefaultPolicy() {
 	// Create a default full access SCP.
 	defaultSCPID := "p-FullAWSAccess"
-	m.policies[defaultSCPID] = &Policy{
+	m.Policies[defaultSCPID] = &Policy{
 		Content: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`,
 		PolicySummary: &PolicySummary{
 			ARN:         fmt.Sprintf("arn:aws:organizations::%s:policy/o-example/service_control_policy/%s", defaultAccountID, defaultSCPID),
@@ -140,7 +232,7 @@ func (m *MemoryStorage) CreateOrganization(_ context.Context, featureSet string)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.organization != nil {
+	if m.Organization != nil {
 		return nil, &Error{Code: errAlreadyInOrganizationException, Message: "You are already a member of an organization"}
 	}
 
@@ -151,7 +243,7 @@ func (m *MemoryStorage) CreateOrganization(_ context.Context, featureSet string)
 	orgID := "o-" + generateShortID()
 	rootID := "r-" + generateShortID()[:4]
 
-	m.organization = &Organization{
+	m.Organization = &Organization{
 		ARN:                fmt.Sprintf("arn:aws:organizations::%s:organization/%s", m.accountID, orgID),
 		FeatureSet:         featureSet,
 		ID:                 orgID,
@@ -161,28 +253,28 @@ func (m *MemoryStorage) CreateOrganization(_ context.Context, featureSet string)
 	}
 
 	if featureSet == featureSetAll {
-		m.organization.AvailablePolicyTypes = []PolicyTypeSummary{
+		m.Organization.AvailablePolicyTypes = []PolicyTypeSummary{
 			{Status: policyStatusEnabled, Type: policyTypeServiceControlPolicy},
 		}
 	}
 
 	// Create the root.
-	m.root = &Root{
+	m.Root = &Root{
 		ARN:  fmt.Sprintf("arn:aws:organizations::%s:root/%s/%s", m.accountID, orgID, rootID),
 		ID:   rootID,
 		Name: "Root",
 	}
 
 	if featureSet == featureSetAll {
-		m.root.PolicyTypes = []PolicyTypeSummary{
+		m.Root.PolicyTypes = []PolicyTypeSummary{
 			{Status: policyStatusEnabled, Type: policyTypeServiceControlPolicy},
 		}
 	}
 
 	// Add the management account.
-	m.accounts[m.accountID] = &Account{
-		ARN:             m.organization.MasterAccountARN,
-		Email:           m.organization.MasterAccountEmail,
+	m.Accounts[m.accountID] = &Account{
+		ARN:             m.Organization.MasterAccountARN,
+		Email:           m.Organization.MasterAccountEmail,
 		ID:              m.accountID,
 		JoinedMethod:    joinedMethodCreated,
 		JoinedTimestamp: ToAWSTimestamp(time.Now()),
@@ -192,11 +284,11 @@ func (m *MemoryStorage) CreateOrganization(_ context.Context, featureSet string)
 	}
 
 	// Attach the default SCP to the root.
-	m.policyAttachments[rootID] = map[string]bool{
+	m.PolicyAttachments[rootID] = map[string]bool{
 		"p-FullAWSAccess": true,
 	}
 
-	return m.organization, nil
+	return m.Organization, nil
 }
 
 // DeleteOrganization deletes the organization.
@@ -204,25 +296,25 @@ func (m *MemoryStorage) DeleteOrganization(_ context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.organization == nil {
+	if m.Organization == nil {
 		return &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
 	// Check if there are any member accounts (besides the management account).
-	if len(m.accounts) > 1 {
+	if len(m.Accounts) > 1 {
 		return &Error{Code: errOrganizationNotEmptyException, Message: "Organization still has member accounts"}
 	}
 
 	// Check if there are any OUs.
-	if len(m.organizationalUnits) > 0 {
+	if len(m.OrganizationalUnits) > 0 {
 		return &Error{Code: errOrganizationNotEmptyException, Message: "Organization still has organizational units"}
 	}
 
 	// Delete the organization.
-	m.organization = nil
-	m.root = nil
-	m.accounts = make(map[string]*Account)
-	m.policyAttachments = make(map[string]map[string]bool)
+	m.Organization = nil
+	m.Root = nil
+	m.Accounts = make(map[string]*Account)
+	m.PolicyAttachments = make(map[string]map[string]bool)
 
 	return nil
 }
@@ -232,11 +324,11 @@ func (m *MemoryStorage) DescribeOrganization(_ context.Context) (*Organization, 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if m.organization == nil {
+	if m.Organization == nil {
 		return nil, &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
-	return m.organization, nil
+	return m.Organization, nil
 }
 
 // CreateAccount creates a new account.
@@ -244,7 +336,7 @@ func (m *MemoryStorage) CreateAccount(_ context.Context, req *CreateAccountInput
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.organization == nil {
+	if m.Organization == nil {
 		return nil, &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
@@ -259,7 +351,7 @@ func (m *MemoryStorage) CreateAccount(_ context.Context, req *CreateAccountInput
 
 	// Create the account.
 	account := &Account{
-		ARN:             fmt.Sprintf("arn:aws:organizations::%s:account/%s/%s", m.accountID, m.organization.ID, accountID),
+		ARN:             fmt.Sprintf("arn:aws:organizations::%s:account/%s/%s", m.accountID, m.Organization.ID, accountID),
 		Email:           req.Email,
 		ID:              accountID,
 		JoinedMethod:    joinedMethodCreated,
@@ -269,10 +361,10 @@ func (m *MemoryStorage) CreateAccount(_ context.Context, req *CreateAccountInput
 		Status:          accountStatusActive,
 	}
 
-	m.accounts[accountID] = account
+	m.Accounts[accountID] = account
 
 	// Attach the default SCP to the new account.
-	m.policyAttachments[accountID] = map[string]bool{
+	m.PolicyAttachments[accountID] = map[string]bool{
 		"p-FullAWSAccess": true,
 	}
 
@@ -294,11 +386,11 @@ func (m *MemoryStorage) DescribeAccount(_ context.Context, accountID string) (*A
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if m.organization == nil {
+	if m.Organization == nil {
 		return nil, &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
-	account, exists := m.accounts[accountID]
+	account, exists := m.Accounts[accountID]
 	if !exists {
 		return nil, &Error{Code: errAccountNotFoundException, Message: "Account not found: " + accountID}
 	}
@@ -311,13 +403,13 @@ func (m *MemoryStorage) ListAccounts(_ context.Context, maxResults int32, _ stri
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if m.organization == nil {
+	if m.Organization == nil {
 		return nil, "", &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
-	result := make([]*Account, 0, len(m.accounts))
+	result := make([]*Account, 0, len(m.Accounts))
 
-	for _, account := range m.accounts {
+	for _, account := range m.Accounts {
 		result = append(result, account)
 
 		//nolint:gosec // len(result) is bounded by the number of accounts which is limited.
@@ -334,7 +426,7 @@ func (m *MemoryStorage) CreateOrganizationalUnit(_ context.Context, name, parent
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.organization == nil {
+	if m.Organization == nil {
 		return nil, &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
@@ -344,8 +436,8 @@ func (m *MemoryStorage) CreateOrganizationalUnit(_ context.Context, name, parent
 	}
 
 	// Check for duplicate OU name under the same parent.
-	for ouID, ou := range m.organizationalUnits {
-		if m.ouParents[ouID] == parentID && ou.Name == name {
+	for ouID, ou := range m.OrganizationalUnits {
+		if m.OuParents[ouID] == parentID && ou.Name == name {
 			return nil, &Error{Code: errDuplicateOrganizationalUnitException, Message: "OU with this name already exists under the parent"}
 		}
 	}
@@ -354,16 +446,16 @@ func (m *MemoryStorage) CreateOrganizationalUnit(_ context.Context, name, parent
 	ouID := fmt.Sprintf("ou-%s-%s", generateShortID()[:4], generateShortID()[:8])
 
 	ou := &OrganizationalUnit{
-		ARN:  fmt.Sprintf("arn:aws:organizations::%s:ou/%s/%s", m.accountID, m.organization.ID, ouID),
+		ARN:  fmt.Sprintf("arn:aws:organizations::%s:ou/%s/%s", m.accountID, m.Organization.ID, ouID),
 		ID:   ouID,
 		Name: name,
 	}
 
-	m.organizationalUnits[ouID] = ou
-	m.ouParents[ouID] = parentID
+	m.OrganizationalUnits[ouID] = ou
+	m.OuParents[ouID] = parentID
 
 	// Attach the default SCP to the new OU.
-	m.policyAttachments[ouID] = map[string]bool{
+	m.PolicyAttachments[ouID] = map[string]bool{
 		"p-FullAWSAccess": true,
 	}
 
@@ -375,7 +467,7 @@ func (m *MemoryStorage) ListOrganizationalUnitsForParent(_ context.Context, pare
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if m.organization == nil {
+	if m.Organization == nil {
 		return nil, "", &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
@@ -386,8 +478,8 @@ func (m *MemoryStorage) ListOrganizationalUnitsForParent(_ context.Context, pare
 
 	result := make([]*OrganizationalUnit, 0)
 
-	for ouID, ou := range m.organizationalUnits {
-		if m.ouParents[ouID] == parentID {
+	for ouID, ou := range m.OrganizationalUnits {
+		if m.OuParents[ouID] == parentID {
 			result = append(result, ou)
 
 			//nolint:gosec // len(result) is bounded by the number of OUs which is limited.
@@ -405,12 +497,12 @@ func (m *MemoryStorage) AttachPolicy(_ context.Context, policyID, targetID strin
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.organization == nil {
+	if m.Organization == nil {
 		return &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
 	// Validate policy ID.
-	if _, exists := m.policies[policyID]; !exists {
+	if _, exists := m.Policies[policyID]; !exists {
 		return &Error{Code: errPolicyNotFoundException, Message: "Policy not found: " + policyID}
 	}
 
@@ -420,18 +512,18 @@ func (m *MemoryStorage) AttachPolicy(_ context.Context, policyID, targetID strin
 	}
 
 	// Check if already attached.
-	if attachments, exists := m.policyAttachments[targetID]; exists {
+	if attachments, exists := m.PolicyAttachments[targetID]; exists {
 		if attachments[policyID] {
 			return &Error{Code: errDuplicatePolicyAttachmentException, Message: "Policy is already attached to the target"}
 		}
 	}
 
 	// Attach the policy.
-	if m.policyAttachments[targetID] == nil {
-		m.policyAttachments[targetID] = make(map[string]bool)
+	if m.PolicyAttachments[targetID] == nil {
+		m.PolicyAttachments[targetID] = make(map[string]bool)
 	}
 
-	m.policyAttachments[targetID][policyID] = true
+	m.PolicyAttachments[targetID][policyID] = true
 
 	return nil
 }
@@ -441,12 +533,12 @@ func (m *MemoryStorage) DetachPolicy(_ context.Context, policyID, targetID strin
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.organization == nil {
+	if m.Organization == nil {
 		return &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
 	// Validate policy ID.
-	if _, exists := m.policies[policyID]; !exists {
+	if _, exists := m.Policies[policyID]; !exists {
 		return &Error{Code: errPolicyNotFoundException, Message: "Policy not found: " + policyID}
 	}
 
@@ -456,13 +548,13 @@ func (m *MemoryStorage) DetachPolicy(_ context.Context, policyID, targetID strin
 	}
 
 	// Check if attached.
-	attachments, exists := m.policyAttachments[targetID]
+	attachments, exists := m.PolicyAttachments[targetID]
 	if !exists || !attachments[policyID] {
 		return &Error{Code: errPolicyNotAttachedException, Message: "Policy is not attached to the target"}
 	}
 
 	// Detach the policy.
-	delete(m.policyAttachments[targetID], policyID)
+	delete(m.PolicyAttachments[targetID], policyID)
 
 	return nil
 }
@@ -472,26 +564,26 @@ func (m *MemoryStorage) ListRoots(_ context.Context, _ int32, _ string) ([]*Root
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	if m.organization == nil {
+	if m.Organization == nil {
 		return nil, "", &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
-	if m.root == nil {
+	if m.Root == nil {
 		return []*Root{}, "", nil
 	}
 
-	return []*Root{m.root}, "", nil
+	return []*Root{m.Root}, "", nil
 }
 
 // isValidParentID checks if a parent ID is valid (root or OU).
 func (m *MemoryStorage) isValidParentID(parentID string) bool {
 	// Check if it's the root.
-	if m.root != nil && m.root.ID == parentID {
+	if m.Root != nil && m.Root.ID == parentID {
 		return true
 	}
 
 	// Check if it's an OU.
-	_, exists := m.organizationalUnits[parentID]
+	_, exists := m.OrganizationalUnits[parentID]
 
 	return exists
 }
@@ -499,17 +591,17 @@ func (m *MemoryStorage) isValidParentID(parentID string) bool {
 // isValidTargetID checks if a target ID is valid (root, OU, or account).
 func (m *MemoryStorage) isValidTargetID(targetID string) bool {
 	// Check if it's the root.
-	if m.root != nil && m.root.ID == targetID {
+	if m.Root != nil && m.Root.ID == targetID {
 		return true
 	}
 
 	// Check if it's an OU.
-	if _, exists := m.organizationalUnits[targetID]; exists {
+	if _, exists := m.OrganizationalUnits[targetID]; exists {
 		return true
 	}
 
 	// Check if it's an account.
-	_, exists := m.accounts[targetID]
+	_, exists := m.Accounts[targetID]
 
 	return exists
 }

--- a/internal/service/pipes/service.go
+++ b/internal/service/pipes/service.go
@@ -1,11 +1,23 @@
 package pipes
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the EventBridge Pipes service.
@@ -47,3 +59,14 @@ func (s *Service) RegisterRoutes(r service.Router) {
 }
 
 var _ service.Service = (*Service)(nil)
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/pipes/storage.go
+++ b/internal/service/pipes/storage.go
@@ -2,11 +2,14 @@ package pipes
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the interface for pipe storage operations.
@@ -42,17 +45,91 @@ type Storage interface {
 	ListTagsForResource(ctx context.Context, arn string) (map[string]string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements the Storage interface using in-memory storage.
 type MemoryStorage struct {
-	mu    sync.RWMutex
-	pipes map[string]*Pipe // keyed by name
+	mu      sync.RWMutex     `json:"-"`
+	Pipes   map[string]*Pipe `json:"pipes"` // keyed by name
+	dataDir string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		pipes: make(map[string]*Pipe),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Pipes: make(map[string]*Pipe),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "pipes", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Pipes == nil {
+		m.Pipes = make(map[string]*Pipe)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "pipes", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 const (
@@ -73,7 +150,7 @@ func (m *MemoryStorage) CreatePipe(_ context.Context, req *CreatePipeInput) (*Pi
 	defer m.mu.Unlock()
 
 	// Check if pipe already exists.
-	if _, exists := m.pipes[req.Name]; exists {
+	if _, exists := m.Pipes[req.Name]; exists {
 		return nil, &Error{
 			Code:    errConflictException,
 			Message: fmt.Sprintf("Pipe with name %s already exists", req.Name),
@@ -135,7 +212,7 @@ func (m *MemoryStorage) CreatePipe(_ context.Context, req *CreatePipeInput) (*Pi
 		LastModifiedTime:     AWSTimestamp{Time: now},
 	}
 
-	m.pipes[req.Name] = pipe
+	m.Pipes[req.Name] = pipe
 
 	return pipe, nil
 }
@@ -145,7 +222,7 @@ func (m *MemoryStorage) DescribePipe(_ context.Context, name string) (*Pipe, err
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	pipe, exists := m.pipes[name]
+	pipe, exists := m.Pipes[name]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFoundException,
@@ -163,7 +240,7 @@ func (m *MemoryStorage) UpdatePipe(_ context.Context, req *UpdatePipeInput) (*Pi
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	pipe, exists := m.pipes[req.Name]
+	pipe, exists := m.Pipes[req.Name]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFoundException,
@@ -231,7 +308,7 @@ func (m *MemoryStorage) DeletePipe(_ context.Context, name string) (*Pipe, error
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	pipe, exists := m.pipes[name]
+	pipe, exists := m.Pipes[name]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFoundException,
@@ -254,7 +331,7 @@ func (m *MemoryStorage) DeletePipe(_ context.Context, name string) (*Pipe, error
 		LastModifiedTime: pipe.LastModifiedTime,
 	}
 
-	delete(m.pipes, name)
+	delete(m.Pipes, name)
 
 	return result, nil
 }
@@ -271,7 +348,7 @@ func (m *MemoryStorage) ListPipes(_ context.Context, req *ListPipesInput) (*List
 
 	var pipes []*PipeSummary
 
-	for _, pipe := range m.pipes {
+	for _, pipe := range m.Pipes {
 		// Apply filters.
 		if req.NamePrefix != "" && !strings.HasPrefix(pipe.Name, req.NamePrefix) {
 			continue
@@ -323,7 +400,7 @@ func (m *MemoryStorage) StartPipe(_ context.Context, name string) (*Pipe, error)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	pipe, exists := m.pipes[name]
+	pipe, exists := m.Pipes[name]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFoundException,
@@ -351,7 +428,7 @@ func (m *MemoryStorage) StopPipe(_ context.Context, name string) (*Pipe, error) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	pipe, exists := m.pipes[name]
+	pipe, exists := m.Pipes[name]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFoundException,
@@ -382,7 +459,7 @@ func (m *MemoryStorage) TagResource(_ context.Context, arn string, tags map[stri
 	// Find pipe by ARN.
 	var pipe *Pipe
 
-	for _, p := range m.pipes {
+	for _, p := range m.Pipes {
 		if p.Arn == arn {
 			pipe = p
 
@@ -414,7 +491,7 @@ func (m *MemoryStorage) UntagResource(_ context.Context, arn string, tagKeys []s
 	// Find pipe by ARN.
 	var pipe *Pipe
 
-	for _, p := range m.pipes {
+	for _, p := range m.Pipes {
 		if p.Arn == arn {
 			pipe = p
 
@@ -448,7 +525,7 @@ func (m *MemoryStorage) ListTagsForResource(_ context.Context, arn string) (map[
 	// Find pipe by ARN.
 	var pipe *Pipe
 
-	for _, p := range m.pipes {
+	for _, p := range m.Pipes {
 		if p.Arn == arn {
 			pipe = p
 

--- a/internal/service/rds/service.go
+++ b/internal/service/rds/service.go
@@ -1,11 +1,23 @@
 package rds
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage()
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	storage := NewMemoryStorage(opts...)
 	service.Register(New(storage))
 }
 
@@ -58,3 +70,14 @@ func (s *Service) Actions() []string {
 
 // QueryProtocol is a marker method that indicates RDS uses AWS Query protocol.
 func (s *Service) QueryProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/rds/storage.go
+++ b/internal/service/rds/storage.go
@@ -2,11 +2,14 @@ package rds
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -30,21 +33,103 @@ type Storage interface {
 	DeleteDBSnapshot(ctx context.Context, identifier string) (*DBSnapshot, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu        sync.RWMutex
-	instances map[string]*DBInstance
-	clusters  map[string]*DBCluster
-	snapshots map[string]*DBSnapshot
+	mu        sync.RWMutex           `json:"-"`
+	Instances map[string]*DBInstance `json:"instances"`
+	Clusters  map[string]*DBCluster  `json:"clusters"`
+	Snapshots map[string]*DBSnapshot `json:"snapshots"`
+	dataDir   string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		instances: make(map[string]*DBInstance),
-		clusters:  make(map[string]*DBCluster),
-		snapshots: make(map[string]*DBSnapshot),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Instances: make(map[string]*DBInstance),
+		Clusters:  make(map[string]*DBCluster),
+		Snapshots: make(map[string]*DBSnapshot),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "rds", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Instances == nil {
+		m.Instances = make(map[string]*DBInstance)
+	}
+
+	if m.Clusters == nil {
+		m.Clusters = make(map[string]*DBCluster)
+	}
+
+	if m.Snapshots == nil {
+		m.Snapshots = make(map[string]*DBSnapshot)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "rds", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateDBInstance creates a new DB instance.
@@ -52,7 +137,7 @@ func (m *MemoryStorage) CreateDBInstance(_ context.Context, input *CreateDBInsta
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.instances[input.DBInstanceIdentifier]; exists {
+	if _, exists := m.Instances[input.DBInstanceIdentifier]; exists {
 		return nil, &Error{
 			Code:    errDBInstanceAlreadyExists,
 			Message: fmt.Sprintf("DB instance already exists: %s", input.DBInstanceIdentifier),
@@ -60,7 +145,7 @@ func (m *MemoryStorage) CreateDBInstance(_ context.Context, input *CreateDBInsta
 	}
 
 	instance := m.buildDBInstance(input)
-	m.instances[input.DBInstanceIdentifier] = instance
+	m.Instances[input.DBInstanceIdentifier] = instance
 
 	return instance, nil
 }
@@ -117,7 +202,7 @@ func (m *MemoryStorage) DeleteDBInstance(_ context.Context, identifier string, _
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	instance, exists := m.instances[identifier]
+	instance, exists := m.Instances[identifier]
 	if !exists {
 		return nil, &Error{
 			Code:    errDBInstanceNotFound,
@@ -127,7 +212,7 @@ func (m *MemoryStorage) DeleteDBInstance(_ context.Context, identifier string, _
 
 	instance.DBInstanceStatus = DBInstanceStatusDeleting
 
-	delete(m.instances, identifier)
+	delete(m.Instances, identifier)
 
 	return instance, nil
 }
@@ -138,7 +223,7 @@ func (m *MemoryStorage) DescribeDBInstances(_ context.Context, identifier string
 	defer m.mu.RUnlock()
 
 	if identifier != "" {
-		instance, exists := m.instances[identifier]
+		instance, exists := m.Instances[identifier]
 		if !exists {
 			return nil, &Error{
 				Code:    errDBInstanceNotFound,
@@ -149,8 +234,8 @@ func (m *MemoryStorage) DescribeDBInstances(_ context.Context, identifier string
 		return []DBInstance{*instance}, nil
 	}
 
-	instances := make([]DBInstance, 0, len(m.instances))
-	for _, instance := range m.instances {
+	instances := make([]DBInstance, 0, len(m.Instances))
+	for _, instance := range m.Instances {
 		instances = append(instances, *instance)
 	}
 
@@ -162,7 +247,7 @@ func (m *MemoryStorage) ModifyDBInstance(_ context.Context, input *ModifyDBInsta
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	instance, exists := m.instances[input.DBInstanceIdentifier]
+	instance, exists := m.Instances[input.DBInstanceIdentifier]
 	if !exists {
 		return nil, &Error{
 			Code:    errDBInstanceNotFound,
@@ -226,7 +311,7 @@ func (m *MemoryStorage) StartDBInstance(_ context.Context, identifier string) (*
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	instance, exists := m.instances[identifier]
+	instance, exists := m.Instances[identifier]
 	if !exists {
 		return nil, &Error{
 			Code:    errDBInstanceNotFound,
@@ -251,7 +336,7 @@ func (m *MemoryStorage) StopDBInstance(_ context.Context, identifier string) (*D
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	instance, exists := m.instances[identifier]
+	instance, exists := m.Instances[identifier]
 	if !exists {
 		return nil, &Error{
 			Code:    errDBInstanceNotFound,
@@ -276,7 +361,7 @@ func (m *MemoryStorage) CreateDBCluster(_ context.Context, input *CreateDBCluste
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.clusters[input.DBClusterIdentifier]; exists {
+	if _, exists := m.Clusters[input.DBClusterIdentifier]; exists {
 		return nil, &Error{
 			Code:    errDBClusterAlreadyExists,
 			Message: fmt.Sprintf("DB cluster already exists: %s", input.DBClusterIdentifier),
@@ -322,7 +407,7 @@ func (m *MemoryStorage) CreateDBCluster(_ context.Context, input *CreateDBCluste
 		}
 	}
 
-	m.clusters[input.DBClusterIdentifier] = cluster
+	m.Clusters[input.DBClusterIdentifier] = cluster
 
 	return cluster, nil
 }
@@ -332,7 +417,7 @@ func (m *MemoryStorage) DeleteDBCluster(_ context.Context, identifier string, _ 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	cluster, exists := m.clusters[identifier]
+	cluster, exists := m.Clusters[identifier]
 	if !exists {
 		return nil, &Error{
 			Code:    errDBClusterNotFound,
@@ -342,7 +427,7 @@ func (m *MemoryStorage) DeleteDBCluster(_ context.Context, identifier string, _ 
 
 	cluster.Status = DBClusterStatusDeleting
 
-	delete(m.clusters, identifier)
+	delete(m.Clusters, identifier)
 
 	return cluster, nil
 }
@@ -353,7 +438,7 @@ func (m *MemoryStorage) DescribeDBClusters(_ context.Context, identifier string)
 	defer m.mu.RUnlock()
 
 	if identifier != "" {
-		cluster, exists := m.clusters[identifier]
+		cluster, exists := m.Clusters[identifier]
 		if !exists {
 			return nil, &Error{
 				Code:    errDBClusterNotFound,
@@ -364,8 +449,8 @@ func (m *MemoryStorage) DescribeDBClusters(_ context.Context, identifier string)
 		return []DBCluster{*cluster}, nil
 	}
 
-	clusters := make([]DBCluster, 0, len(m.clusters))
-	for _, cluster := range m.clusters {
+	clusters := make([]DBCluster, 0, len(m.Clusters))
+	for _, cluster := range m.Clusters {
 		clusters = append(clusters, *cluster)
 	}
 
@@ -377,7 +462,7 @@ func (m *MemoryStorage) ModifyDBCluster(_ context.Context, input *ModifyDBCluste
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	cluster, exists := m.clusters[input.DBClusterIdentifier]
+	cluster, exists := m.Clusters[input.DBClusterIdentifier]
 	if !exists {
 		return nil, &Error{
 			Code:    errDBClusterNotFound,
@@ -409,14 +494,14 @@ func (m *MemoryStorage) CreateDBSnapshot(_ context.Context, input *CreateDBSnaps
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.snapshots[input.DBSnapshotIdentifier]; exists {
+	if _, exists := m.Snapshots[input.DBSnapshotIdentifier]; exists {
 		return nil, &Error{
 			Code:    errDBSnapshotAlreadyExists,
 			Message: fmt.Sprintf("DB snapshot already exists: %s", input.DBSnapshotIdentifier),
 		}
 	}
 
-	instance, exists := m.instances[input.DBInstanceIdentifier]
+	instance, exists := m.Instances[input.DBInstanceIdentifier]
 	if !exists {
 		return nil, &Error{
 			Code:    errDBInstanceNotFound,
@@ -443,7 +528,7 @@ func (m *MemoryStorage) CreateDBSnapshot(_ context.Context, input *CreateDBSnaps
 		Tags:                 input.Tags,
 	}
 
-	m.snapshots[input.DBSnapshotIdentifier] = snapshot
+	m.Snapshots[input.DBSnapshotIdentifier] = snapshot
 
 	return snapshot, nil
 }
@@ -453,7 +538,7 @@ func (m *MemoryStorage) DeleteDBSnapshot(_ context.Context, identifier string) (
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	snapshot, exists := m.snapshots[identifier]
+	snapshot, exists := m.Snapshots[identifier]
 	if !exists {
 		return nil, &Error{
 			Code:    errDBSnapshotNotFound,
@@ -461,7 +546,7 @@ func (m *MemoryStorage) DeleteDBSnapshot(_ context.Context, identifier string) (
 		}
 	}
 
-	delete(m.snapshots, identifier)
+	delete(m.Snapshots, identifier)
 
 	return snapshot, nil
 }

--- a/internal/service/rekognition/service.go
+++ b/internal/service/rekognition/service.go
@@ -1,14 +1,26 @@
 package rekognition
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
 // Compile-time check to ensure Service implements service.Service.
 var _ service.Service = (*Service)(nil)
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the AWS Rekognition service.
@@ -39,4 +51,15 @@ func (s *Service) JSONProtocol() {}
 // RegisterRoutes registers the routes for this service.
 func (s *Service) RegisterRoutes(_ service.Router) {
 	// JSON protocol services use DispatchAction for routing
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/rekognition/storage.go
+++ b/internal/service/rekognition/storage.go
@@ -2,11 +2,14 @@ package rekognition
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -52,17 +55,91 @@ type Storage interface {
 	DetectModerationLabels(ctx context.Context, req *DetectModerationLabelsRequest) (*DetectModerationLabelsResponse, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements in-memory storage for Rekognition.
 type MemoryStorage struct {
-	mu          sync.RWMutex
-	collections map[string]*Collection
+	mu          sync.RWMutex           `json:"-"`
+	Collections map[string]*Collection `json:"collections"`
+	dataDir     string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		collections: make(map[string]*Collection),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Collections: make(map[string]*Collection),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "rekognition", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Collections == nil {
+		s.Collections = make(map[string]*Collection)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "rekognition", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateCollection creates a new collection.
@@ -77,7 +154,7 @@ func (s *MemoryStorage) CreateCollection(_ context.Context, req *CreateCollectio
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.collections[req.CollectionID]; exists {
+	if _, exists := s.Collections[req.CollectionID]; exists {
 		return nil, &ServiceError{
 			Code:    errResourceExists,
 			Message: fmt.Sprintf("Collection with id %s already exists", req.CollectionID),
@@ -97,7 +174,7 @@ func (s *MemoryStorage) CreateCollection(_ context.Context, req *CreateCollectio
 		Faces:             make(map[string]*Face),
 	}
 
-	s.collections[req.CollectionID] = collection
+	s.Collections[req.CollectionID] = collection
 
 	return &CreateCollectionResponse{
 		CollectionArn:    arn,
@@ -111,14 +188,14 @@ func (s *MemoryStorage) DeleteCollection(_ context.Context, collectionID string)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.collections[collectionID]; !exists {
+	if _, exists := s.Collections[collectionID]; !exists {
 		return nil, &ServiceError{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Collection with id %s not found", collectionID),
 		}
 	}
 
-	delete(s.collections, collectionID)
+	delete(s.Collections, collectionID)
 
 	return &DeleteCollectionResponse{
 		StatusCode: 200,
@@ -130,10 +207,10 @@ func (s *MemoryStorage) ListCollections(_ context.Context, _ *ListCollectionsReq
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	collectionIDs := make([]string, 0, len(s.collections))
-	faceModelVersions := make([]string, 0, len(s.collections))
+	collectionIDs := make([]string, 0, len(s.Collections))
+	faceModelVersions := make([]string, 0, len(s.Collections))
 
-	for _, c := range s.collections {
+	for _, c := range s.Collections {
 		collectionIDs = append(collectionIDs, c.CollectionID)
 		faceModelVersions = append(faceModelVersions, c.FaceModelVersion)
 	}
@@ -149,7 +226,7 @@ func (s *MemoryStorage) DescribeCollection(_ context.Context, collectionID strin
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	collection, exists := s.collections[collectionID]
+	collection, exists := s.Collections[collectionID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errResourceNotFound,
@@ -178,7 +255,7 @@ func (s *MemoryStorage) IndexFaces(_ context.Context, req *IndexFacesRequest) (*
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	collection, exists := s.collections[req.CollectionID]
+	collection, exists := s.Collections[req.CollectionID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errResourceNotFound,
@@ -239,7 +316,7 @@ func (s *MemoryStorage) ListFaces(_ context.Context, req *ListFacesRequest) (*Li
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	collection, exists := s.collections[req.CollectionID]
+	collection, exists := s.Collections[req.CollectionID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errResourceNotFound,
@@ -278,7 +355,7 @@ func (s *MemoryStorage) SearchFaces(_ context.Context, req *SearchFacesRequest) 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	collection, exists := s.collections[req.CollectionID]
+	collection, exists := s.Collections[req.CollectionID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errResourceNotFound,
@@ -324,7 +401,7 @@ func (s *MemoryStorage) DeleteFaces(_ context.Context, req *DeleteFacesRequest) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	collection, exists := s.collections[req.CollectionID]
+	collection, exists := s.Collections[req.CollectionID]
 	if !exists {
 		return nil, &ServiceError{
 			Code:    errResourceNotFound,

--- a/internal/service/resiliencehub/service.go
+++ b/internal/service/resiliencehub/service.go
@@ -1,12 +1,26 @@
 package resiliencehub
 
-import "github.com/sivchari/kumo/internal/service"
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // Compile-time check to ensure Service implements service.Service.
 var _ service.Service = (*Service)(nil)
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the Resilience Hub service.
@@ -58,4 +72,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("POST", "/untag-resource", s.UntagResource)
 	r.Handle("POST", "/list-tags-for-resource", s.ListTagsForResource)
 	r.Handle("GET", "/list-tags-for-resource", s.ListTagsForResource)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/resiliencehub/storage.go
+++ b/internal/service/resiliencehub/storage.go
@@ -1,12 +1,15 @@
 package resiliencehub
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -42,23 +45,109 @@ type Storage interface {
 	ListTagsForResource(resourceARN string) (map[string]string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage provides an in-memory implementation of Storage.
 type MemoryStorage struct {
-	mu          sync.RWMutex
-	apps        map[string]*App
-	policies    map[string]*ResiliencyPolicy
-	assessments map[string]*AppAssessment
-	tags        map[string]map[string]string
+	mu          sync.RWMutex                 `json:"-"`
+	Apps        map[string]*App              `json:"apps"`
+	Policies    map[string]*ResiliencyPolicy `json:"policies"`
+	Assessments map[string]*AppAssessment    `json:"assessments"`
+	Tags        map[string]map[string]string `json:"tags"`
+	dataDir     string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		apps:        make(map[string]*App),
-		policies:    make(map[string]*ResiliencyPolicy),
-		assessments: make(map[string]*AppAssessment),
-		tags:        make(map[string]map[string]string),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Apps:        make(map[string]*App),
+		Policies:    make(map[string]*ResiliencyPolicy),
+		Assessments: make(map[string]*AppAssessment),
+		Tags:        make(map[string]map[string]string),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "resiliencehub", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Apps == nil {
+		s.Apps = make(map[string]*App)
+	}
+
+	if s.Policies == nil {
+		s.Policies = make(map[string]*ResiliencyPolicy)
+	}
+
+	if s.Assessments == nil {
+		s.Assessments = make(map[string]*AppAssessment)
+	}
+
+	if s.Tags == nil {
+		s.Tags = make(map[string]map[string]string)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "resiliencehub", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateApp creates a new application.
@@ -67,7 +156,7 @@ func (s *MemoryStorage) CreateApp(req *CreateAppRequest) (*App, error) {
 	defer s.mu.Unlock()
 
 	// Check for duplicate name
-	for _, app := range s.apps {
+	for _, app := range s.Apps {
 		if app.Name == req.Name {
 			return nil, &Error{
 				Code:    errConflict,
@@ -95,10 +184,10 @@ func (s *MemoryStorage) CreateApp(req *CreateAppRequest) (*App, error) {
 		Tags:               req.Tags,
 	}
 
-	s.apps[appARN] = app
+	s.Apps[appARN] = app
 
 	if req.Tags != nil {
-		s.tags[appARN] = req.Tags
+		s.Tags[appARN] = req.Tags
 	}
 
 	return app, nil
@@ -109,7 +198,7 @@ func (s *MemoryStorage) DescribeApp(appARN string) (*App, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	app, ok := s.apps[appARN]
+	app, ok := s.Apps[appARN]
 	if !ok {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -125,7 +214,7 @@ func (s *MemoryStorage) UpdateApp(req *UpdateAppRequest) (*App, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	app, ok := s.apps[req.AppARN]
+	app, ok := s.Apps[req.AppARN]
 	if !ok {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -165,15 +254,15 @@ func (s *MemoryStorage) DeleteApp(appARN string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.apps[appARN]; !ok {
+	if _, ok := s.Apps[appARN]; !ok {
 		return &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("App not found: %s", appARN),
 		}
 	}
 
-	delete(s.apps, appARN)
-	delete(s.tags, appARN)
+	delete(s.Apps, appARN)
+	delete(s.Tags, appARN)
 
 	return nil
 }
@@ -183,9 +272,9 @@ func (s *MemoryStorage) ListApps(req *ListAppsRequest) ([]*AppSummary, string, e
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	summaries := make([]*AppSummary, 0, len(s.apps))
+	summaries := make([]*AppSummary, 0, len(s.Apps))
 
-	for _, app := range s.apps {
+	for _, app := range s.Apps {
 		// Apply filters
 		if req.Name != "" && app.Name != req.Name {
 			continue
@@ -221,7 +310,7 @@ func (s *MemoryStorage) CreateResiliencyPolicy(req *CreateResiliencyPolicyReques
 	defer s.mu.Unlock()
 
 	// Check for duplicate name
-	for _, policy := range s.policies {
+	for _, policy := range s.Policies {
 		if policy.PolicyName == req.PolicyName {
 			return nil, &Error{
 				Code:    errConflict,
@@ -245,10 +334,10 @@ func (s *MemoryStorage) CreateResiliencyPolicy(req *CreateResiliencyPolicyReques
 		Tier:                   req.Tier,
 	}
 
-	s.policies[policyARN] = policy
+	s.Policies[policyARN] = policy
 
 	if req.Tags != nil {
-		s.tags[policyARN] = req.Tags
+		s.Tags[policyARN] = req.Tags
 	}
 
 	return policy, nil
@@ -259,7 +348,7 @@ func (s *MemoryStorage) DescribeResiliencyPolicy(policyARN string) (*ResiliencyP
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	policy, ok := s.policies[policyARN]
+	policy, ok := s.Policies[policyARN]
 	if !ok {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -275,7 +364,7 @@ func (s *MemoryStorage) UpdateResiliencyPolicy(req *UpdateResiliencyPolicyReques
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	policy, ok := s.policies[req.PolicyARN]
+	policy, ok := s.Policies[req.PolicyARN]
 	if !ok {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -311,15 +400,15 @@ func (s *MemoryStorage) DeleteResiliencyPolicy(policyARN string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.policies[policyARN]; !ok {
+	if _, ok := s.Policies[policyARN]; !ok {
 		return &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Policy not found: %s", policyARN),
 		}
 	}
 
-	delete(s.policies, policyARN)
-	delete(s.tags, policyARN)
+	delete(s.Policies, policyARN)
+	delete(s.Tags, policyARN)
 
 	return nil
 }
@@ -329,9 +418,9 @@ func (s *MemoryStorage) ListResiliencyPolicies(req *ListResiliencyPoliciesReques
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	policies := make([]*ResiliencyPolicy, 0, len(s.policies))
+	policies := make([]*ResiliencyPolicy, 0, len(s.Policies))
 
-	for _, policy := range s.policies {
+	for _, policy := range s.Policies {
 		// Apply filters
 		if req.PolicyName != "" && policy.PolicyName != req.PolicyName {
 			continue
@@ -348,7 +437,7 @@ func (s *MemoryStorage) StartAppAssessment(req *StartAppAssessmentRequest) (*App
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	app, ok := s.apps[req.AppARN]
+	app, ok := s.Apps[req.AppARN]
 	if !ok {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -361,7 +450,7 @@ func (s *MemoryStorage) StartAppAssessment(req *StartAppAssessmentRequest) (*App
 
 	var policy *ResiliencyPolicy
 	if app.PolicyARN != "" {
-		policy = s.policies[app.PolicyARN]
+		policy = s.Policies[app.PolicyARN]
 	}
 
 	assessment := &AppAssessment{
@@ -377,10 +466,10 @@ func (s *MemoryStorage) StartAppAssessment(req *StartAppAssessmentRequest) (*App
 		ResiliencyScore: defaultResiliencyScore(),
 	}
 
-	s.assessments[assessmentARN] = assessment
+	s.Assessments[assessmentARN] = assessment
 
 	if req.Tags != nil {
-		s.tags[assessmentARN] = req.Tags
+		s.Tags[assessmentARN] = req.Tags
 	}
 
 	return assessment, nil
@@ -404,7 +493,7 @@ func (s *MemoryStorage) DescribeAppAssessment(assessmentARN string) (*AppAssessm
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	assessment, ok := s.assessments[assessmentARN]
+	assessment, ok := s.Assessments[assessmentARN]
 	if !ok {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -420,15 +509,15 @@ func (s *MemoryStorage) DeleteAppAssessment(assessmentARN string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.assessments[assessmentARN]; !ok {
+	if _, ok := s.Assessments[assessmentARN]; !ok {
 		return &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Assessment not found: %s", assessmentARN),
 		}
 	}
 
-	delete(s.assessments, assessmentARN)
-	delete(s.tags, assessmentARN)
+	delete(s.Assessments, assessmentARN)
+	delete(s.Tags, assessmentARN)
 
 	return nil
 }
@@ -438,9 +527,9 @@ func (s *MemoryStorage) ListAppAssessments(req *ListAppAssessmentsRequest) ([]*A
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	summaries := make([]*AppAssessmentSummary, 0, len(s.assessments))
+	summaries := make([]*AppAssessmentSummary, 0, len(s.Assessments))
 
-	for _, assessment := range s.assessments {
+	for _, assessment := range s.Assessments {
 		// Apply filters
 		if req.AppARN != "" && assessment.AppARN != req.AppARN {
 			continue
@@ -495,9 +584,9 @@ func (s *MemoryStorage) TagResource(resourceARN string, tags map[string]string) 
 	defer s.mu.Unlock()
 
 	// Check if resource exists
-	_, appOK := s.apps[resourceARN]
-	_, policyOK := s.policies[resourceARN]
-	_, assessmentOK := s.assessments[resourceARN]
+	_, appOK := s.Apps[resourceARN]
+	_, policyOK := s.Policies[resourceARN]
+	_, assessmentOK := s.Assessments[resourceARN]
 
 	if !appOK && !policyOK && !assessmentOK {
 		return &Error{
@@ -506,11 +595,11 @@ func (s *MemoryStorage) TagResource(resourceARN string, tags map[string]string) 
 		}
 	}
 
-	if s.tags[resourceARN] == nil {
-		s.tags[resourceARN] = make(map[string]string)
+	if s.Tags[resourceARN] == nil {
+		s.Tags[resourceARN] = make(map[string]string)
 	}
 
-	maps.Copy(s.tags[resourceARN], tags)
+	maps.Copy(s.Tags[resourceARN], tags)
 
 	return nil
 }
@@ -521,9 +610,9 @@ func (s *MemoryStorage) UntagResource(resourceARN string, tagKeys []string) erro
 	defer s.mu.Unlock()
 
 	// Check if resource exists
-	_, appOK := s.apps[resourceARN]
-	_, policyOK := s.policies[resourceARN]
-	_, assessmentOK := s.assessments[resourceARN]
+	_, appOK := s.Apps[resourceARN]
+	_, policyOK := s.Policies[resourceARN]
+	_, assessmentOK := s.Assessments[resourceARN]
 
 	if !appOK && !policyOK && !assessmentOK {
 		return &Error{
@@ -532,9 +621,9 @@ func (s *MemoryStorage) UntagResource(resourceARN string, tagKeys []string) erro
 		}
 	}
 
-	if s.tags[resourceARN] != nil {
+	if s.Tags[resourceARN] != nil {
 		for _, key := range tagKeys {
-			delete(s.tags[resourceARN], key)
+			delete(s.Tags[resourceARN], key)
 		}
 	}
 
@@ -547,9 +636,9 @@ func (s *MemoryStorage) ListTagsForResource(resourceARN string) (map[string]stri
 	defer s.mu.RUnlock()
 
 	// Check if resource exists
-	_, appOK := s.apps[resourceARN]
-	_, policyOK := s.policies[resourceARN]
-	_, assessmentOK := s.assessments[resourceARN]
+	_, appOK := s.Apps[resourceARN]
+	_, policyOK := s.Policies[resourceARN]
+	_, assessmentOK := s.Assessments[resourceARN]
 
 	if !appOK && !policyOK && !assessmentOK {
 		return nil, &Error{
@@ -558,7 +647,7 @@ func (s *MemoryStorage) ListTagsForResource(resourceARN string) (map[string]stri
 		}
 	}
 
-	tags := s.tags[resourceARN]
+	tags := s.Tags[resourceARN]
 	if tags == nil {
 		return make(map[string]string), nil
 	}

--- a/internal/service/route53/service.go
+++ b/internal/service/route53/service.go
@@ -1,9 +1,23 @@
 package route53
 
-import "github.com/sivchari/kumo/internal/service"
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
 
 func init() {
-	storage := NewMemoryStorage()
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	storage := NewMemoryStorage(opts...)
 	service.Register(New(storage))
 }
 
@@ -33,4 +47,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	// Resource Record Sets
 	r.Handle("POST", "/2013-04-01/hostedzone/{id}/rrset", s.ChangeResourceRecordSets)
 	r.Handle("GET", "/2013-04-01/hostedzone/{id}/rrset", s.ListResourceRecordSets)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/route53/storage.go
+++ b/internal/service/route53/storage.go
@@ -1,8 +1,12 @@
 package route53
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 var (
@@ -30,19 +34,97 @@ type Storage interface {
 	ChangeRecordSets(hostedZoneID string, changes []Change) error
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage is an in-memory implementation of Storage.
 type MemoryStorage struct {
-	mu          sync.RWMutex
-	hostedZones map[string]*HostedZone
-	recordSets  map[string][]ResourceRecordSet // key: hostedZoneID
+	mu          sync.RWMutex                   `json:"-"`
+	HostedZones map[string]*HostedZone         `json:"hostedZones"`
+	RecordSets  map[string][]ResourceRecordSet `json:"recordSets"` // key: hostedZoneID
+	dataDir     string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		hostedZones: make(map[string]*HostedZone),
-		recordSets:  make(map[string][]ResourceRecordSet),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		HostedZones: make(map[string]*HostedZone),
+		RecordSets:  make(map[string][]ResourceRecordSet),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "route53", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.HostedZones == nil {
+		s.HostedZones = make(map[string]*HostedZone)
+	}
+
+	if s.RecordSets == nil {
+		s.RecordSets = make(map[string][]ResourceRecordSet)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "route53", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateHostedZone creates a new hosted zone.
@@ -50,12 +132,12 @@ func (s *MemoryStorage) CreateHostedZone(zone *HostedZone) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.hostedZones[zone.ID]; exists {
+	if _, exists := s.HostedZones[zone.ID]; exists {
 		return ErrHostedZoneAlreadyExists
 	}
 
-	s.hostedZones[zone.ID] = zone
-	s.recordSets[zone.ID] = []ResourceRecordSet{}
+	s.HostedZones[zone.ID] = zone
+	s.RecordSets[zone.ID] = []ResourceRecordSet{}
 
 	return nil
 }
@@ -65,7 +147,7 @@ func (s *MemoryStorage) GetHostedZone(id string) (*HostedZone, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	zone, exists := s.hostedZones[id]
+	zone, exists := s.HostedZones[id]
 	if !exists {
 		return nil, ErrHostedZoneNotFound
 	}
@@ -78,8 +160,8 @@ func (s *MemoryStorage) ListHostedZones() ([]*HostedZone, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	zones := make([]*HostedZone, 0, len(s.hostedZones))
-	for _, zone := range s.hostedZones {
+	zones := make([]*HostedZone, 0, len(s.HostedZones))
+	for _, zone := range s.HostedZones {
 		zones = append(zones, zone)
 	}
 
@@ -91,12 +173,12 @@ func (s *MemoryStorage) DeleteHostedZone(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.hostedZones[id]; !exists {
+	if _, exists := s.HostedZones[id]; !exists {
 		return ErrHostedZoneNotFound
 	}
 
 	// Check if hosted zone has record sets (other than NS and SOA)
-	if records, ok := s.recordSets[id]; ok {
+	if records, ok := s.RecordSets[id]; ok {
 		for i := range records {
 			if records[i].Type != "NS" && records[i].Type != "SOA" {
 				return ErrHostedZoneNotEmpty
@@ -104,8 +186,8 @@ func (s *MemoryStorage) DeleteHostedZone(id string) error {
 		}
 	}
 
-	delete(s.hostedZones, id)
-	delete(s.recordSets, id)
+	delete(s.HostedZones, id)
+	delete(s.RecordSets, id)
 
 	return nil
 }
@@ -115,11 +197,11 @@ func (s *MemoryStorage) GetRecordSets(hostedZoneID string) ([]ResourceRecordSet,
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if _, exists := s.hostedZones[hostedZoneID]; !exists {
+	if _, exists := s.HostedZones[hostedZoneID]; !exists {
 		return nil, ErrHostedZoneNotFound
 	}
 
-	records, ok := s.recordSets[hostedZoneID]
+	records, ok := s.RecordSets[hostedZoneID]
 	if !ok {
 		return []ResourceRecordSet{}, nil
 	}
@@ -132,11 +214,11 @@ func (s *MemoryStorage) ChangeRecordSets(hostedZoneID string, changes []Change) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.hostedZones[hostedZoneID]; !exists {
+	if _, exists := s.HostedZones[hostedZoneID]; !exists {
 		return ErrHostedZoneNotFound
 	}
 
-	records := s.recordSets[hostedZoneID]
+	records := s.RecordSets[hostedZoneID]
 
 	for i := range changes {
 		switch changes[i].Action {
@@ -165,10 +247,10 @@ func (s *MemoryStorage) ChangeRecordSets(hostedZoneID string, changes []Change) 
 		}
 	}
 
-	s.recordSets[hostedZoneID] = records
+	s.RecordSets[hostedZoneID] = records
 
 	// Update record count
-	if zone, exists := s.hostedZones[hostedZoneID]; exists {
+	if zone, exists := s.HostedZones[hostedZoneID]; exists {
 		zone.ResourceRecordSetCount = int64(len(records))
 	}
 

--- a/internal/service/route53resolver/service.go
+++ b/internal/service/route53resolver/service.go
@@ -1,12 +1,26 @@
 package route53resolver
 
-import "github.com/sivchari/kumo/internal/service"
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // Compile-time check to ensure Service implements JSONProtocolService.
 var _ service.JSONProtocolService = (*Service)(nil)
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the Route 53 Resolver service.
@@ -39,3 +53,14 @@ func (s *Service) TargetPrefix() string {
 
 // JSONProtocol is a marker method that indicates Route 53 Resolver uses AWS JSON 1.1 protocol.
 func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/route53resolver/storage.go
+++ b/internal/service/route53resolver/storage.go
@@ -2,11 +2,14 @@ package route53resolver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -38,25 +41,107 @@ type Storage interface {
 	ListResolverRuleAssociations(ctx context.Context, maxResults int, nextToken string) ([]*ResolverRuleAssociation, string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements in-memory storage for Route 53 Resolver.
 type MemoryStorage struct {
-	mu           sync.RWMutex
-	endpoints    map[string]*ResolverEndpoint
-	rules        map[string]*ResolverRule
-	associations map[string]*ResolverRuleAssociation
+	mu           sync.RWMutex                        `json:"-"`
+	Endpoints    map[string]*ResolverEndpoint        `json:"endpoints"`
+	Rules        map[string]*ResolverRule            `json:"rules"`
+	Associations map[string]*ResolverRuleAssociation `json:"associations"`
 	accountID    string
 	region       string
+	dataDir      string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		endpoints:    make(map[string]*ResolverEndpoint),
-		rules:        make(map[string]*ResolverRule),
-		associations: make(map[string]*ResolverRuleAssociation),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Endpoints:    make(map[string]*ResolverEndpoint),
+		Rules:        make(map[string]*ResolverRule),
+		Associations: make(map[string]*ResolverRuleAssociation),
 		accountID:    "123456789012",
 		region:       "us-east-1",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "route53resolver", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Endpoints == nil {
+		s.Endpoints = make(map[string]*ResolverEndpoint)
+	}
+
+	if s.Rules == nil {
+		s.Rules = make(map[string]*ResolverRule)
+	}
+
+	if s.Associations == nil {
+		s.Associations = make(map[string]*ResolverRuleAssociation)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "route53resolver", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateResolverEndpoint creates a new resolver endpoint.
@@ -117,7 +202,7 @@ func (s *MemoryStorage) CreateResolverEndpoint(_ context.Context, req *CreateRes
 		endpoint.Protocols = []string{"Do53"}
 	}
 
-	s.endpoints[id] = endpoint
+	s.Endpoints[id] = endpoint
 
 	return endpoint, nil
 }
@@ -127,7 +212,7 @@ func (s *MemoryStorage) GetResolverEndpoint(_ context.Context, id string) (*Reso
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	endpoint, exists := s.endpoints[id]
+	endpoint, exists := s.Endpoints[id]
 	if !exists {
 		return nil, &ResolverError{
 			Code:    errResourceNotFound,
@@ -143,7 +228,7 @@ func (s *MemoryStorage) DeleteResolverEndpoint(_ context.Context, id string) (*R
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	endpoint, exists := s.endpoints[id]
+	endpoint, exists := s.Endpoints[id]
 	if !exists {
 		return nil, &ResolverError{
 			Code:    errResourceNotFound,
@@ -153,7 +238,7 @@ func (s *MemoryStorage) DeleteResolverEndpoint(_ context.Context, id string) (*R
 
 	endpoint.Status = statusDeleting
 
-	delete(s.endpoints, id)
+	delete(s.Endpoints, id)
 
 	return endpoint, nil
 }
@@ -167,8 +252,8 @@ func (s *MemoryStorage) ListResolverEndpoints(_ context.Context, maxResults int,
 		maxResults = 10
 	}
 
-	endpoints := make([]*ResolverEndpoint, 0, len(s.endpoints))
-	for _, endpoint := range s.endpoints {
+	endpoints := make([]*ResolverEndpoint, 0, len(s.Endpoints))
+	for _, endpoint := range s.Endpoints {
 		endpoints = append(endpoints, endpoint)
 		if len(endpoints) >= maxResults {
 			break
@@ -212,7 +297,7 @@ func (s *MemoryStorage) CreateResolverRule(_ context.Context, req *CreateResolve
 		ModificationTime:   now,
 	}
 
-	s.rules[id] = rule
+	s.Rules[id] = rule
 
 	return rule, nil
 }
@@ -222,7 +307,7 @@ func (s *MemoryStorage) GetResolverRule(_ context.Context, id string) (*Resolver
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	rule, exists := s.rules[id]
+	rule, exists := s.Rules[id]
 	if !exists {
 		return nil, &ResolverError{
 			Code:    errResourceNotFound,
@@ -238,7 +323,7 @@ func (s *MemoryStorage) DeleteResolverRule(_ context.Context, id string) (*Resol
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	rule, exists := s.rules[id]
+	rule, exists := s.Rules[id]
 	if !exists {
 		return nil, &ResolverError{
 			Code:    errResourceNotFound,
@@ -247,7 +332,7 @@ func (s *MemoryStorage) DeleteResolverRule(_ context.Context, id string) (*Resol
 	}
 
 	// Check if rule is associated with any VPC
-	for _, assoc := range s.associations {
+	for _, assoc := range s.Associations {
 		if assoc.ResolverRuleID == id {
 			return nil, &ResolverError{
 				Code:    errResourceInUse,
@@ -258,7 +343,7 @@ func (s *MemoryStorage) DeleteResolverRule(_ context.Context, id string) (*Resol
 
 	rule.Status = statusDeleting
 
-	delete(s.rules, id)
+	delete(s.Rules, id)
 
 	return rule, nil
 }
@@ -272,8 +357,8 @@ func (s *MemoryStorage) ListResolverRules(_ context.Context, maxResults int, _ s
 		maxResults = 10
 	}
 
-	rules := make([]*ResolverRule, 0, len(s.rules))
-	for _, rule := range s.rules {
+	rules := make([]*ResolverRule, 0, len(s.Rules))
+	for _, rule := range s.Rules {
 		rules = append(rules, rule)
 		if len(rules) >= maxResults {
 			break
@@ -289,7 +374,7 @@ func (s *MemoryStorage) AssociateResolverRule(_ context.Context, req *AssociateR
 	defer s.mu.Unlock()
 
 	// Check if rule exists
-	if _, exists := s.rules[req.ResolverRuleID]; !exists {
+	if _, exists := s.Rules[req.ResolverRuleID]; !exists {
 		return nil, &ResolverError{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Resolver rule with ID '%s' does not exist", req.ResolverRuleID),
@@ -297,7 +382,7 @@ func (s *MemoryStorage) AssociateResolverRule(_ context.Context, req *AssociateR
 	}
 
 	// Check if association already exists
-	for _, assoc := range s.associations {
+	for _, assoc := range s.Associations {
 		if assoc.ResolverRuleID == req.ResolverRuleID && assoc.VPCID == req.VPCID {
 			return nil, &ResolverError{
 				Code:    errResourceExists,
@@ -316,7 +401,7 @@ func (s *MemoryStorage) AssociateResolverRule(_ context.Context, req *AssociateR
 		Status:         "COMPLETE",
 	}
 
-	s.associations[id] = assoc
+	s.Associations[id] = assoc
 
 	return assoc, nil
 }
@@ -326,11 +411,11 @@ func (s *MemoryStorage) DisassociateResolverRule(_ context.Context, ruleID, vpcI
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for id, assoc := range s.associations {
+	for id, assoc := range s.Associations {
 		if assoc.ResolverRuleID == ruleID && assoc.VPCID == vpcID {
 			assoc.Status = statusDeleting
 
-			delete(s.associations, id)
+			delete(s.Associations, id)
 
 			return assoc, nil
 		}
@@ -351,8 +436,8 @@ func (s *MemoryStorage) ListResolverRuleAssociations(_ context.Context, maxResul
 		maxResults = 10
 	}
 
-	associations := make([]*ResolverRuleAssociation, 0, len(s.associations))
-	for _, assoc := range s.associations {
+	associations := make([]*ResolverRuleAssociation, 0, len(s.Associations))
+	for _, assoc := range s.Associations {
 		associations = append(associations, assoc)
 		if len(associations) >= maxResults {
 			break

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -1,11 +1,23 @@
 package s3
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the S3 service.
@@ -42,4 +54,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("DELETE", "/{bucket}/{key...}", s.handleObjectDelete)
 	r.Handle("HEAD", "/{bucket}/{key...}", s.HeadObject)
 	r.Handle("POST", "/{bucket}/{key...}", s.handleObjectPost)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"crypto/md5" //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Versioning status constants.
@@ -50,27 +53,102 @@ type Storage interface {
 	ListParts(ctx context.Context, bucket, key, uploadID string, maxParts int) ([]*Part, error)
 }
 
-// MemoryStorage implements Storage with in-memory data.
-type MemoryStorage struct {
-	mu      sync.RWMutex
-	buckets map[string]*memoryBucket
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
 }
 
-type memoryBucket struct {
-	name             string
-	creationDate     time.Time
-	objects          map[string]*Object          // current/latest version per key
-	versions         map[string][]*Object        // all versions per key (newest first)
-	versioningStatus string                      // "", "Enabled", "Suspended"
-	versionIDCounter uint64                      // counter for generating version IDs
-	multipartUploads map[string]*MultipartUpload // uploadID -> MultipartUpload
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
+// MemoryStorage implements Storage with in-memory data.
+type MemoryStorage struct {
+	mu      sync.RWMutex             `json:"-"`
+	Buckets map[string]*MemoryBucket `json:"buckets"`
+	dataDir string
+}
+
+// MemoryBucket holds the data for a single S3 bucket.
+type MemoryBucket struct {
+	Name             string                      `json:"name"`
+	CreationDate     time.Time                   `json:"creationDate"`
+	Objects          map[string]*Object          `json:"objects"`          // current/latest version per key
+	Versions         map[string][]*Object        `json:"versions"`         // all versions per key (newest first)
+	VersioningStatus string                      `json:"versioningStatus"` // "", "Enabled", "Suspended"
+	VersionIDCounter uint64                      `json:"versionIdcounter"` // counter for generating version IDs
+	MultipartUploads map[string]*MultipartUpload `json:"-"`                // uploadID -> MultipartUpload
 }
 
 // NewMemoryStorage creates a new in-memory S3 storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		buckets: make(map[string]*memoryBucket),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Buckets: make(map[string]*MemoryBucket),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "s3", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Buckets == nil {
+		s.Buckets = make(map[string]*MemoryBucket)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "s3", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateBucket creates a new bucket.
@@ -78,17 +156,17 @@ func (s *MemoryStorage) CreateBucket(_ context.Context, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.buckets[name]; exists {
+	if _, exists := s.Buckets[name]; exists {
 		return &BucketError{Code: "BucketAlreadyOwnedByYou", Message: "Your previous request to create the named bucket succeeded and you already own it.", BucketName: name}
 	}
 
-	s.buckets[name] = &memoryBucket{
-		name:             name,
-		creationDate:     time.Now(),
-		objects:          make(map[string]*Object),
-		versions:         make(map[string][]*Object),
-		versioningStatus: "",
-		multipartUploads: make(map[string]*MultipartUpload),
+	s.Buckets[name] = &MemoryBucket{
+		Name:             name,
+		CreationDate:     time.Now(),
+		Objects:          make(map[string]*Object),
+		Versions:         make(map[string][]*Object),
+		VersioningStatus: "",
+		MultipartUploads: make(map[string]*MultipartUpload),
 	}
 
 	return nil
@@ -99,16 +177,16 @@ func (s *MemoryStorage) DeleteBucket(_ context.Context, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	bucket, exists := s.buckets[name]
+	bucket, exists := s.Buckets[name]
 	if !exists {
 		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: name}
 	}
 
-	if len(bucket.objects) > 0 {
+	if len(bucket.Objects) > 0 {
 		return &BucketError{Code: "BucketNotEmpty", Message: "The bucket you tried to delete is not empty", BucketName: name}
 	}
 
-	delete(s.buckets, name)
+	delete(s.Buckets, name)
 
 	return nil
 }
@@ -118,11 +196,11 @@ func (s *MemoryStorage) ListBuckets(_ context.Context) ([]Bucket, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	buckets := make([]Bucket, 0, len(s.buckets))
-	for _, b := range s.buckets {
+	buckets := make([]Bucket, 0, len(s.Buckets))
+	for _, b := range s.Buckets {
 		buckets = append(buckets, Bucket{
-			Name:         b.name,
-			CreationDate: b.creationDate,
+			Name:         b.Name,
+			CreationDate: b.CreationDate,
 		})
 	}
 
@@ -139,7 +217,7 @@ func (s *MemoryStorage) BucketExists(_ context.Context, name string) (bool, erro
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	_, exists := s.buckets[name]
+	_, exists := s.Buckets[name]
 
 	return exists, nil
 }
@@ -149,7 +227,7 @@ func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
@@ -181,20 +259,20 @@ func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io
 	}
 
 	// Handle versioning
-	switch b.versioningStatus {
+	switch b.VersioningStatus {
 	case VersioningEnabled:
 		// Generate version ID
-		b.versionIDCounter++
-		obj.VersionID = fmt.Sprintf("v%d", b.versionIDCounter)
+		b.VersionIDCounter++
+		obj.VersionID = fmt.Sprintf("v%d", b.VersionIDCounter)
 
 		// Prepend to versions list (newest first)
-		b.versions[key] = append([]*Object{obj}, b.versions[key]...)
+		b.Versions[key] = append([]*Object{obj}, b.Versions[key]...)
 	case VersioningSuspended:
 		// For suspended versioning, use "null" version ID
 		obj.VersionID = VersionIDNull
 
 		// Remove any existing "null" version
-		versions := b.versions[key]
+		versions := b.Versions[key]
 		newVersions := make([]*Object, 0, len(versions))
 
 		for _, v := range versions {
@@ -203,11 +281,11 @@ func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io
 			}
 		}
 
-		b.versions[key] = append([]*Object{obj}, newVersions...)
+		b.Versions[key] = append([]*Object{obj}, newVersions...)
 	}
 
 	// Always update current object
-	b.objects[key] = obj
+	b.Objects[key] = obj
 
 	return obj, nil
 }
@@ -217,12 +295,12 @@ func (s *MemoryStorage) GetObject(_ context.Context, bucket, key string) (*Objec
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
-	obj, exists := b.objects[key]
+	obj, exists := b.Objects[key]
 	if !exists {
 		return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
 	}
@@ -240,12 +318,12 @@ func (s *MemoryStorage) GetObjectVersion(_ context.Context, bucket, key, version
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
-	versions := b.versions[key]
+	versions := b.Versions[key]
 	for _, obj := range versions {
 		if obj.VersionID == versionID {
 			if obj.IsDeleteMarker {
@@ -265,34 +343,34 @@ func (s *MemoryStorage) DeleteObject(_ context.Context, bucket, key string) (*Ob
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
 	// Handle versioning - create delete marker for enabled buckets
-	if b.versioningStatus == VersioningEnabled {
-		b.versionIDCounter++
+	if b.VersioningStatus == VersioningEnabled {
+		b.VersionIDCounter++
 		deleteMarker := &Object{
 			Key:            key,
-			VersionID:      fmt.Sprintf("v%d", b.versionIDCounter),
+			VersionID:      fmt.Sprintf("v%d", b.VersionIDCounter),
 			IsDeleteMarker: true,
 			LastModified:   time.Now(),
 		}
 
 		// Prepend delete marker to versions
-		b.versions[key] = append([]*Object{deleteMarker}, b.versions[key]...)
-		b.objects[key] = deleteMarker
+		b.Versions[key] = append([]*Object{deleteMarker}, b.Versions[key]...)
+		b.Objects[key] = deleteMarker
 
 		return deleteMarker, nil
 	}
 
 	// For non-versioned or suspended buckets, just delete
-	delete(b.objects, key)
+	delete(b.Objects, key)
 
 	// For suspended buckets, also remove "null" version
-	if b.versioningStatus == VersioningSuspended {
-		versions := b.versions[key]
+	if b.VersioningStatus == VersioningSuspended {
+		versions := b.Versions[key]
 		newVersions := make([]*Object, 0, len(versions))
 
 		for _, v := range versions {
@@ -302,9 +380,9 @@ func (s *MemoryStorage) DeleteObject(_ context.Context, bucket, key string) (*Ob
 		}
 
 		if len(newVersions) == 0 {
-			delete(b.versions, key)
+			delete(b.Versions, key)
 		} else {
-			b.versions[key] = newVersions
+			b.Versions[key] = newVersions
 		}
 	}
 
@@ -317,12 +395,12 @@ func (s *MemoryStorage) DeleteObjectVersion(_ context.Context, bucket, key, vers
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
-	versions := b.versions[key]
+	versions := b.Versions[key]
 	deletedObj, newVersions := filterOutVersion(versions, versionID)
 
 	// S3 doesn't return error if version doesn't exist, returns empty object
@@ -331,12 +409,12 @@ func (s *MemoryStorage) DeleteObjectVersion(_ context.Context, bucket, key, vers
 	}
 
 	if len(newVersions) == 0 {
-		delete(b.versions, key)
-		delete(b.objects, key)
+		delete(b.Versions, key)
+		delete(b.Objects, key)
 	} else {
-		b.versions[key] = newVersions
+		b.Versions[key] = newVersions
 		// Update current object to the newest version
-		b.objects[key] = newVersions[0]
+		b.Objects[key] = newVersions[0]
 	}
 
 	return deletedObj, nil
@@ -364,12 +442,12 @@ func (s *MemoryStorage) HeadObject(_ context.Context, bucket, key string) (*Obje
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
-	obj, exists := b.objects[key]
+	obj, exists := b.Objects[key]
 	if !exists {
 		return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
 	}
@@ -390,7 +468,7 @@ func (s *MemoryStorage) ListObjects(_ context.Context, bucket, prefix, delimiter
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
@@ -403,9 +481,9 @@ func (s *MemoryStorage) ListObjects(_ context.Context, bucket, prefix, delimiter
 	commonPrefixes := make(map[string]bool)
 
 	// Collect all matching keys.
-	keys := make([]string, 0, len(b.objects))
+	keys := make([]string, 0, len(b.Objects))
 
-	for key := range b.objects {
+	for key := range b.Objects {
 		if prefix == "" || strings.HasPrefix(key, prefix) {
 			keys = append(keys, key)
 		}
@@ -415,7 +493,7 @@ func (s *MemoryStorage) ListObjects(_ context.Context, bucket, prefix, delimiter
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		obj := b.objects[key]
+		obj := b.Objects[key]
 
 		// Handle delimiter
 		if delimiter != "" {
@@ -458,7 +536,7 @@ func (s *MemoryStorage) PutBucketVersioning(_ context.Context, bucket, status st
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
@@ -467,7 +545,7 @@ func (s *MemoryStorage) PutBucketVersioning(_ context.Context, bucket, status st
 		return &BucketError{Code: "MalformedXML", Message: "Invalid versioning status", BucketName: bucket}
 	}
 
-	b.versioningStatus = status
+	b.VersioningStatus = status
 
 	return nil
 }
@@ -477,12 +555,12 @@ func (s *MemoryStorage) GetBucketVersioning(_ context.Context, bucket string) (s
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return "", &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
-	return b.versioningStatus, nil
+	return b.VersioningStatus, nil
 }
 
 // ListObjectVersions lists all versions of objects in a bucket.
@@ -490,7 +568,7 @@ func (s *MemoryStorage) ListObjectVersions(_ context.Context, bucket, prefix, de
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
@@ -509,16 +587,16 @@ func (s *MemoryStorage) ListObjectVersions(_ context.Context, bucket, prefix, de
 }
 
 // collectVersionKeys collects all keys that match the prefix from both versions and objects maps.
-func collectVersionKeys(b *memoryBucket, prefix string) []string {
+func collectVersionKeys(b *MemoryBucket, prefix string) []string {
 	keySet := make(map[string]bool)
 
-	for key := range b.versions {
+	for key := range b.Versions {
 		if prefix == "" || strings.HasPrefix(key, prefix) {
 			keySet[key] = true
 		}
 	}
 
-	for key := range b.objects {
+	for key := range b.Objects {
 		if prefix == "" || strings.HasPrefix(key, prefix) {
 			keySet[key] = true
 		}
@@ -533,7 +611,7 @@ func collectVersionKeys(b *memoryBucket, prefix string) []string {
 }
 
 // processVersionKeys processes keys and returns objects and common prefixes.
-func processVersionKeys(b *memoryBucket, keys []string, prefix, delimiter string, maxKeys int) ([]Object, map[string]bool) {
+func processVersionKeys(b *MemoryBucket, keys []string, prefix, delimiter string, maxKeys int) ([]Object, map[string]bool) {
 	objects := make([]Object, 0)
 	commonPrefixes := make(map[string]bool)
 	count := 0
@@ -571,11 +649,11 @@ func extractCommonPrefix(key, prefix, delimiter string) string {
 }
 
 // addKeyVersions adds all versions of a key to the objects slice.
-func addKeyVersions(b *memoryBucket, key string, objects *[]Object, limit int) int {
-	versions := b.versions[key]
+func addKeyVersions(b *MemoryBucket, key string, objects *[]Object, limit int) int {
+	versions := b.Versions[key]
 	if len(versions) == 0 {
 		// No versioning history, include current object if exists
-		if obj, exists := b.objects[key]; exists {
+		if obj, exists := b.Objects[key]; exists {
 			*objects = append(*objects, objectToVersionInfo(obj))
 
 			return 1
@@ -660,7 +738,7 @@ func (s *MemoryStorage) CreateMultipartUpload(_ context.Context, bucket, key str
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
@@ -674,7 +752,7 @@ func (s *MemoryStorage) CreateMultipartUpload(_ context.Context, bucket, key str
 		Parts:     make(map[int]*Part),
 	}
 
-	b.multipartUploads[uploadID] = upload
+	b.MultipartUploads[uploadID] = upload
 
 	return upload, nil
 }
@@ -684,12 +762,12 @@ func (s *MemoryStorage) UploadPart(_ context.Context, bucket, key, uploadID stri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
-	upload, exists := b.multipartUploads[uploadID]
+	upload, exists := b.MultipartUploads[uploadID]
 	if !exists {
 		return nil, &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
 	}
@@ -724,12 +802,12 @@ func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
-	upload, exists := b.multipartUploads[uploadID]
+	upload, exists := b.MultipartUploads[uploadID]
 	if !exists {
 		return nil, &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
 	}
@@ -767,8 +845,8 @@ func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, 
 		ContentType:  "application/octet-stream",
 	}
 
-	b.objects[key] = obj
-	delete(b.multipartUploads, uploadID)
+	b.Objects[key] = obj
+	delete(b.MultipartUploads, uploadID)
 
 	return obj, nil
 }
@@ -778,12 +856,12 @@ func (s *MemoryStorage) AbortMultipartUpload(_ context.Context, bucket, key, upl
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
-	upload, exists := b.multipartUploads[uploadID]
+	upload, exists := b.MultipartUploads[uploadID]
 	if !exists {
 		return &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
 	}
@@ -792,7 +870,7 @@ func (s *MemoryStorage) AbortMultipartUpload(_ context.Context, bucket, key, upl
 		return &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
 	}
 
-	delete(b.multipartUploads, uploadID)
+	delete(b.MultipartUploads, uploadID)
 
 	return nil
 }
@@ -802,7 +880,7 @@ func (s *MemoryStorage) ListMultipartUploads(_ context.Context, bucket, prefix s
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
@@ -813,7 +891,7 @@ func (s *MemoryStorage) ListMultipartUploads(_ context.Context, bucket, prefix s
 
 	uploads := make([]*MultipartUpload, 0)
 
-	for _, upload := range b.multipartUploads {
+	for _, upload := range b.MultipartUploads {
 		if prefix == "" || strings.HasPrefix(upload.Key, prefix) {
 			uploads = append(uploads, upload)
 		}
@@ -840,12 +918,12 @@ func (s *MemoryStorage) ListParts(_ context.Context, bucket, key, uploadID strin
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	b, exists := s.buckets[bucket]
+	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
-	upload, exists := b.multipartUploads[uploadID]
+	upload, exists := b.MultipartUploads[uploadID]
 	if !exists {
 		return nil, &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
 	}

--- a/internal/service/s3control/service.go
+++ b/internal/service/s3control/service.go
@@ -1,11 +1,23 @@
 package s3control
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the S3 Control service.
@@ -37,4 +49,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("GET", "/v20180820/accesspoint/{name}", s.GetAccessPoint)
 	r.Handle("DELETE", "/v20180820/accesspoint/{name}", s.DeleteAccessPoint)
 	r.Handle("GET", "/v20180820/accesspoint", s.ListAccessPoints)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/s3control/storage.go
+++ b/internal/service/s3control/storage.go
@@ -2,8 +2,11 @@ package s3control
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage is the interface for S3 Control storage operations.
@@ -20,19 +23,97 @@ type Storage interface {
 	ListAccessPoints(ctx context.Context, accountID, bucket string, maxResults int, nextToken string) ([]*AccessPoint, string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements in-memory storage for S3 Control.
 type MemoryStorage struct {
-	mu                 sync.RWMutex
-	publicAccessBlocks map[string]*PublicAccessBlockConfiguration // key: accountID
-	accessPoints       map[string]map[string]*AccessPoint         // key: accountID -> name -> AccessPoint
+	mu                 sync.RWMutex                               `json:"-"`
+	PublicAccessBlocks map[string]*PublicAccessBlockConfiguration `json:"publicAccessBlocks"` // key: accountID
+	AccessPoints       map[string]map[string]*AccessPoint         `json:"accessPoints"`       // key: accountID -> name -> AccessPoint
+	dataDir            string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		publicAccessBlocks: make(map[string]*PublicAccessBlockConfiguration),
-		accessPoints:       make(map[string]map[string]*AccessPoint),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		PublicAccessBlocks: make(map[string]*PublicAccessBlockConfiguration),
+		AccessPoints:       make(map[string]map[string]*AccessPoint),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "s3control", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.PublicAccessBlocks == nil {
+		s.PublicAccessBlocks = make(map[string]*PublicAccessBlockConfiguration)
+	}
+
+	if s.AccessPoints == nil {
+		s.AccessPoints = make(map[string]map[string]*AccessPoint)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "s3control", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // GetPublicAccessBlock retrieves the public access block configuration for an account.
@@ -40,7 +121,7 @@ func (s *MemoryStorage) GetPublicAccessBlock(_ context.Context, accountID string
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	config, exists := s.publicAccessBlocks[accountID]
+	config, exists := s.PublicAccessBlocks[accountID]
 	if !exists {
 		return nil, &Error{
 			Code:    ErrNoSuchPublicAccessBlockConfiguration,
@@ -56,7 +137,7 @@ func (s *MemoryStorage) PutPublicAccessBlock(_ context.Context, accountID string
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.publicAccessBlocks[accountID] = config
+	s.PublicAccessBlocks[accountID] = config
 
 	return nil
 }
@@ -66,7 +147,7 @@ func (s *MemoryStorage) DeletePublicAccessBlock(_ context.Context, accountID str
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	delete(s.publicAccessBlocks, accountID)
+	delete(s.PublicAccessBlocks, accountID)
 
 	return nil
 }
@@ -76,11 +157,11 @@ func (s *MemoryStorage) CreateAccessPoint(_ context.Context, accountID string, a
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.accessPoints[accountID]; !exists {
-		s.accessPoints[accountID] = make(map[string]*AccessPoint)
+	if _, exists := s.AccessPoints[accountID]; !exists {
+		s.AccessPoints[accountID] = make(map[string]*AccessPoint)
 	}
 
-	if _, exists := s.accessPoints[accountID][ap.Name]; exists {
+	if _, exists := s.AccessPoints[accountID][ap.Name]; exists {
 		return nil, &Error{
 			Code:    ErrAccessPointAlreadyOwnedByYou,
 			Message: fmt.Sprintf("Access point %s already exists", ap.Name),
@@ -102,7 +183,7 @@ func (s *MemoryStorage) CreateAccessPoint(_ context.Context, accountID string, a
 		"https": fmt.Sprintf("https://%s-%s.s3-accesspoint.us-east-1.amazonaws.com", ap.Name, accountID),
 	}
 
-	s.accessPoints[accountID][ap.Name] = ap
+	s.AccessPoints[accountID][ap.Name] = ap
 
 	return ap, nil
 }
@@ -112,7 +193,7 @@ func (s *MemoryStorage) GetAccessPoint(_ context.Context, accountID, name string
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	accountAPs, exists := s.accessPoints[accountID]
+	accountAPs, exists := s.AccessPoints[accountID]
 	if !exists {
 		return nil, &Error{
 			Code:    ErrNoSuchAccessPoint,
@@ -136,7 +217,7 @@ func (s *MemoryStorage) DeleteAccessPoint(_ context.Context, accountID, name str
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	accountAPs, exists := s.accessPoints[accountID]
+	accountAPs, exists := s.AccessPoints[accountID]
 	if !exists {
 		return &Error{
 			Code:    ErrNoSuchAccessPoint,
@@ -165,7 +246,7 @@ func (s *MemoryStorage) ListAccessPoints(_ context.Context, accountID, bucket st
 		maxResults = 1000
 	}
 
-	accountAPs, exists := s.accessPoints[accountID]
+	accountAPs, exists := s.AccessPoints[accountID]
 	if !exists {
 		return []*AccessPoint{}, "", nil
 	}

--- a/internal/service/s3tables/service.go
+++ b/internal/service/s3tables/service.go
@@ -2,11 +2,23 @@
 package s3tables
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the S3 Tables service.
@@ -45,4 +57,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.HandleFunc("GET", "/get-table", s.GetTable)
 	r.HandleFunc("GET", "/tables/{tableBucketARN}/{namespace}", s.ListTables)
 	r.HandleFunc("GET", "/tables/{tableBucketARN}", s.ListTables)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/s3tables/storage.go
+++ b/internal/service/s3tables/storage.go
@@ -2,12 +2,15 @@ package s3tables
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -37,21 +40,103 @@ type Storage interface {
 	ListTables(ctx context.Context, tableBucketArn, namespace, prefix string, maxTables int) ([]TableSummary, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu           sync.RWMutex
-	tableBuckets map[string]*TableBucket          // ARN -> TableBucket
-	namespaces   map[string]map[string]*Namespace // TableBucketARN -> namespace -> Namespace
-	tables       map[string]map[string]*Table     // TableBucketARN/namespace -> tableName -> Table
+	mu           sync.RWMutex                     `json:"-"`
+	TableBuckets map[string]*TableBucket          `json:"tableBuckets"` // ARN -> TableBucket
+	Namespaces   map[string]map[string]*Namespace `json:"namespaces"`   // TableBucketARN -> namespace -> Namespace
+	Tables       map[string]map[string]*Table     `json:"tables"`       // TableBucketARN/namespace -> tableName -> Table
+	dataDir      string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		tableBuckets: make(map[string]*TableBucket),
-		namespaces:   make(map[string]map[string]*Namespace),
-		tables:       make(map[string]map[string]*Table),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		TableBuckets: make(map[string]*TableBucket),
+		Namespaces:   make(map[string]map[string]*Namespace),
+		Tables:       make(map[string]map[string]*Table),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "s3tables", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.TableBuckets == nil {
+		s.TableBuckets = make(map[string]*TableBucket)
+	}
+
+	if s.Namespaces == nil {
+		s.Namespaces = make(map[string]map[string]*Namespace)
+	}
+
+	if s.Tables == nil {
+		s.Tables = make(map[string]map[string]*Table)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "s3tables", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateTableBucket creates a new table bucket.
@@ -60,7 +145,7 @@ func (s *MemoryStorage) CreateTableBucket(_ context.Context, name string) (*Tabl
 	defer s.mu.Unlock()
 
 	// Check if bucket with same name already exists
-	for _, bucket := range s.tableBuckets {
+	for _, bucket := range s.TableBuckets {
 		if bucket.Name == name {
 			return nil, &Error{
 				Code:    errConflict,
@@ -81,8 +166,8 @@ func (s *MemoryStorage) CreateTableBucket(_ context.Context, name string) (*Tabl
 		CreatedAt: time.Now().UTC(),
 	}
 
-	s.tableBuckets[arn] = bucket
-	s.namespaces[arn] = make(map[string]*Namespace)
+	s.TableBuckets[arn] = bucket
+	s.Namespaces[arn] = make(map[string]*Namespace)
 
 	return bucket, nil
 }
@@ -92,7 +177,7 @@ func (s *MemoryStorage) DeleteTableBucket(_ context.Context, arn string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.tableBuckets[arn]; !exists {
+	if _, exists := s.TableBuckets[arn]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Table bucket '%s' not found", arn),
@@ -100,15 +185,15 @@ func (s *MemoryStorage) DeleteTableBucket(_ context.Context, arn string) error {
 	}
 
 	// Check if bucket has namespaces
-	if namespaces, exists := s.namespaces[arn]; exists && len(namespaces) > 0 {
+	if namespaces, exists := s.Namespaces[arn]; exists && len(namespaces) > 0 {
 		return &Error{
 			Code:    errConflict,
 			Message: "Table bucket contains namespaces and cannot be deleted",
 		}
 	}
 
-	delete(s.tableBuckets, arn)
-	delete(s.namespaces, arn)
+	delete(s.TableBuckets, arn)
+	delete(s.Namespaces, arn)
 
 	return nil
 }
@@ -118,7 +203,7 @@ func (s *MemoryStorage) GetTableBucket(_ context.Context, arn string) (*TableBuc
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	bucket, exists := s.tableBuckets[arn]
+	bucket, exists := s.TableBuckets[arn]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -141,7 +226,7 @@ func (s *MemoryStorage) ListTableBuckets(_ context.Context, prefix, continuation
 	// Collect all matching buckets sorted by name for consistent pagination
 	allBuckets := make([]TableBucketSummary, 0)
 
-	for _, bucket := range s.tableBuckets {
+	for _, bucket := range s.TableBuckets {
 		if prefix != "" && !strings.HasPrefix(bucket.Name, prefix) {
 			continue
 		}
@@ -199,7 +284,7 @@ func (s *MemoryStorage) CreateNamespace(_ context.Context, tableBucketArn string
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.tableBuckets[tableBucketArn]; !exists {
+	if _, exists := s.TableBuckets[tableBucketArn]; !exists {
 		return nil, &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Table bucket '%s' not found", tableBucketArn),
@@ -208,11 +293,11 @@ func (s *MemoryStorage) CreateNamespace(_ context.Context, tableBucketArn string
 
 	namespaceKey := strings.Join(namespace, ".")
 
-	if s.namespaces[tableBucketArn] == nil {
-		s.namespaces[tableBucketArn] = make(map[string]*Namespace)
+	if s.Namespaces[tableBucketArn] == nil {
+		s.Namespaces[tableBucketArn] = make(map[string]*Namespace)
 	}
 
-	if _, exists := s.namespaces[tableBucketArn][namespaceKey]; exists {
+	if _, exists := s.Namespaces[tableBucketArn][namespaceKey]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("Namespace '%s' already exists", namespaceKey),
@@ -227,7 +312,7 @@ func (s *MemoryStorage) CreateNamespace(_ context.Context, tableBucketArn string
 		CreatedBy:      defaultAccountID,
 	}
 
-	s.namespaces[tableBucketArn][namespaceKey] = ns
+	s.Namespaces[tableBucketArn][namespaceKey] = ns
 
 	return ns, nil
 }
@@ -237,14 +322,14 @@ func (s *MemoryStorage) DeleteNamespace(_ context.Context, tableBucketArn, names
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.tableBuckets[tableBucketArn]; !exists {
+	if _, exists := s.TableBuckets[tableBucketArn]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Table bucket '%s' not found", tableBucketArn),
 		}
 	}
 
-	if _, exists := s.namespaces[tableBucketArn][namespace]; !exists {
+	if _, exists := s.Namespaces[tableBucketArn][namespace]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Namespace '%s' not found", namespace),
@@ -253,14 +338,14 @@ func (s *MemoryStorage) DeleteNamespace(_ context.Context, tableBucketArn, names
 
 	// Check if namespace has tables
 	tableKey := tableBucketArn + "/" + namespace
-	if tables, exists := s.tables[tableKey]; exists && len(tables) > 0 {
+	if tables, exists := s.Tables[tableKey]; exists && len(tables) > 0 {
 		return &Error{
 			Code:    errConflict,
 			Message: "Namespace contains tables and cannot be deleted",
 		}
 	}
 
-	delete(s.namespaces[tableBucketArn], namespace)
+	delete(s.Namespaces[tableBucketArn], namespace)
 
 	return nil
 }
@@ -270,14 +355,14 @@ func (s *MemoryStorage) GetNamespace(_ context.Context, tableBucketArn, namespac
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if _, exists := s.tableBuckets[tableBucketArn]; !exists {
+	if _, exists := s.TableBuckets[tableBucketArn]; !exists {
 		return nil, &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Table bucket '%s' not found", tableBucketArn),
 		}
 	}
 
-	ns, exists := s.namespaces[tableBucketArn][namespace]
+	ns, exists := s.Namespaces[tableBucketArn][namespace]
 	if !exists {
 		return nil, &Error{
 			Code:    errNotFound,
@@ -293,7 +378,7 @@ func (s *MemoryStorage) ListNamespaces(_ context.Context, tableBucketArn, prefix
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if _, exists := s.tableBuckets[tableBucketArn]; !exists {
+	if _, exists := s.TableBuckets[tableBucketArn]; !exists {
 		return nil, &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Table bucket '%s' not found", tableBucketArn),
@@ -306,7 +391,7 @@ func (s *MemoryStorage) ListNamespaces(_ context.Context, tableBucketArn, prefix
 
 	namespaces := make([]NamespaceSummary, 0)
 
-	for _, ns := range s.namespaces[tableBucketArn] {
+	for _, ns := range s.Namespaces[tableBucketArn] {
 		nsName := strings.Join(ns.Namespace, ".")
 		if prefix != "" && !strings.HasPrefix(nsName, prefix) {
 			continue
@@ -332,14 +417,14 @@ func (s *MemoryStorage) CreateTable(_ context.Context, tableBucketArn, namespace
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.tableBuckets[tableBucketArn]; !exists {
+	if _, exists := s.TableBuckets[tableBucketArn]; !exists {
 		return nil, &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Table bucket '%s' not found", tableBucketArn),
 		}
 	}
 
-	if _, exists := s.namespaces[tableBucketArn][namespace]; !exists {
+	if _, exists := s.Namespaces[tableBucketArn][namespace]; !exists {
 		return nil, &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Namespace '%s' not found", namespace),
@@ -347,11 +432,11 @@ func (s *MemoryStorage) CreateTable(_ context.Context, tableBucketArn, namespace
 	}
 
 	tableKey := tableBucketArn + "/" + namespace
-	if s.tables[tableKey] == nil {
-		s.tables[tableKey] = make(map[string]*Table)
+	if s.Tables[tableKey] == nil {
+		s.Tables[tableKey] = make(map[string]*Table)
 	}
 
-	if _, exists := s.tables[tableKey][name]; exists {
+	if _, exists := s.Tables[tableKey][name]; exists {
 		return nil, &Error{
 			Code:    errConflict,
 			Message: fmt.Sprintf("Table '%s' already exists in namespace '%s'", name, namespace),
@@ -381,7 +466,7 @@ func (s *MemoryStorage) CreateTable(_ context.Context, tableBucketArn, namespace
 		OwnerID:        defaultAccountID,
 	}
 
-	s.tables[tableKey][name] = table
+	s.Tables[tableKey][name] = table
 
 	return table, nil
 }
@@ -391,7 +476,7 @@ func (s *MemoryStorage) DeleteTable(_ context.Context, tableBucketArn, namespace
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.tableBuckets[tableBucketArn]; !exists {
+	if _, exists := s.TableBuckets[tableBucketArn]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Table bucket '%s' not found", tableBucketArn),
@@ -399,14 +484,14 @@ func (s *MemoryStorage) DeleteTable(_ context.Context, tableBucketArn, namespace
 	}
 
 	tableKey := tableBucketArn + "/" + namespace
-	if _, exists := s.tables[tableKey][name]; !exists {
+	if _, exists := s.Tables[tableKey][name]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Table '%s' not found in namespace '%s'", name, namespace),
 		}
 	}
 
-	delete(s.tables[tableKey], name)
+	delete(s.Tables[tableKey], name)
 
 	return nil
 }
@@ -416,7 +501,7 @@ func (s *MemoryStorage) GetTable(_ context.Context, tableBucketArn, namespace, n
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if _, exists := s.tableBuckets[tableBucketArn]; !exists {
+	if _, exists := s.TableBuckets[tableBucketArn]; !exists {
 		return nil, &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Table bucket '%s' not found", tableBucketArn),
@@ -424,7 +509,7 @@ func (s *MemoryStorage) GetTable(_ context.Context, tableBucketArn, namespace, n
 	}
 
 	tableKey := tableBucketArn + "/" + namespace
-	table, exists := s.tables[tableKey][name]
+	table, exists := s.Tables[tableKey][name]
 
 	if !exists {
 		return nil, &Error{
@@ -441,7 +526,7 @@ func (s *MemoryStorage) ListTables(_ context.Context, tableBucketArn, namespace,
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if _, exists := s.tableBuckets[tableBucketArn]; !exists {
+	if _, exists := s.TableBuckets[tableBucketArn]; !exists {
 		return nil, &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Table bucket '%s' not found", tableBucketArn),
@@ -464,7 +549,7 @@ func (s *MemoryStorage) listTablesInNamespace(tableBucketArn, namespace, prefix 
 	tables := make([]TableSummary, 0)
 	tableKey := tableBucketArn + "/" + namespace
 
-	for _, table := range s.tables[tableKey] {
+	for _, table := range s.Tables[tableKey] {
 		if prefix != "" && !strings.HasPrefix(table.Name, prefix) {
 			continue
 		}
@@ -483,7 +568,7 @@ func (s *MemoryStorage) listTablesInNamespace(tableBucketArn, namespace, prefix 
 func (s *MemoryStorage) listTablesAcrossNamespaces(tableBucketArn, prefix string, maxTables int) []TableSummary {
 	tables := make([]TableSummary, 0)
 
-	for key, tablemap := range s.tables {
+	for key, tablemap := range s.Tables {
 		if !strings.HasPrefix(key, tableBucketArn+"/") {
 			continue
 		}

--- a/internal/service/sagemaker/service.go
+++ b/internal/service/sagemaker/service.go
@@ -2,11 +2,23 @@
 package sagemaker
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the SageMaker service.
@@ -46,3 +58,14 @@ var (
 	_ service.Service             = (*Service)(nil)
 	_ service.JSONProtocolService = (*Service)(nil)
 )
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/sagemaker/storage.go
+++ b/internal/service/sagemaker/storage.go
@@ -2,9 +2,12 @@ package sagemaker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -52,27 +55,113 @@ type Storage interface {
 	DescribeEndpoint(ctx context.Context, name string) (*Endpoint, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu                sync.RWMutex
-	notebookInstances map[string]*NotebookInstance
-	trainingJobs      map[string]*TrainingJob
-	models            map[string]*Model
-	endpoints         map[string]*Endpoint
+	mu                sync.RWMutex                 `json:"-"`
+	NotebookInstances map[string]*NotebookInstance `json:"notebookInstances"`
+	TrainingJobs      map[string]*TrainingJob      `json:"trainingJobs"`
+	Models            map[string]*Model            `json:"models"`
+	Endpoints         map[string]*Endpoint         `json:"endpoints"`
 	region            string
 	accountID         string
+	dataDir           string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		notebookInstances: make(map[string]*NotebookInstance),
-		trainingJobs:      make(map[string]*TrainingJob),
-		models:            make(map[string]*Model),
-		endpoints:         make(map[string]*Endpoint),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		NotebookInstances: make(map[string]*NotebookInstance),
+		TrainingJobs:      make(map[string]*TrainingJob),
+		Models:            make(map[string]*Model),
+		Endpoints:         make(map[string]*Endpoint),
 		region:            defaultRegion,
 		accountID:         defaultAccountID,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "sagemaker", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.NotebookInstances == nil {
+		m.NotebookInstances = make(map[string]*NotebookInstance)
+	}
+
+	if m.TrainingJobs == nil {
+		m.TrainingJobs = make(map[string]*TrainingJob)
+	}
+
+	if m.Models == nil {
+		m.Models = make(map[string]*Model)
+	}
+
+	if m.Endpoints == nil {
+		m.Endpoints = make(map[string]*Endpoint)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "sagemaker", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateNotebookInstance creates a new notebook instance.
@@ -80,7 +169,7 @@ func (m *MemoryStorage) CreateNotebookInstance(_ context.Context, req *CreateNot
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.notebookInstances[req.NotebookInstanceName]; exists {
+	if _, exists := m.NotebookInstances[req.NotebookInstanceName]; exists {
 		return nil, &Error{
 			Code:    errResourceInUse,
 			Message: fmt.Sprintf("Notebook instance %s already exists", req.NotebookInstanceName),
@@ -126,7 +215,7 @@ func (m *MemoryStorage) CreateNotebookInstance(_ context.Context, req *CreateNot
 		instance.RootAccess = "Enabled"
 	}
 
-	m.notebookInstances[req.NotebookInstanceName] = instance
+	m.NotebookInstances[req.NotebookInstanceName] = instance
 
 	return instance, nil
 }
@@ -136,14 +225,14 @@ func (m *MemoryStorage) DeleteNotebookInstance(_ context.Context, name string) e
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.notebookInstances[name]; !exists {
+	if _, exists := m.NotebookInstances[name]; !exists {
 		return &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Notebook instance %s not found", name),
 		}
 	}
 
-	delete(m.notebookInstances, name)
+	delete(m.NotebookInstances, name)
 
 	return nil
 }
@@ -153,7 +242,7 @@ func (m *MemoryStorage) DescribeNotebookInstance(_ context.Context, name string)
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	instance, exists := m.notebookInstances[name]
+	instance, exists := m.NotebookInstances[name]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -173,9 +262,9 @@ func (m *MemoryStorage) ListNotebookInstances(_ context.Context, maxResults int3
 		maxResults = 100
 	}
 
-	result := make([]*NotebookInstance, 0, len(m.notebookInstances))
+	result := make([]*NotebookInstance, 0, len(m.NotebookInstances))
 
-	for _, instance := range m.notebookInstances {
+	for _, instance := range m.NotebookInstances {
 		result = append(result, instance)
 
 		if len(result) >= int(maxResults) {
@@ -191,7 +280,7 @@ func (m *MemoryStorage) CreateTrainingJob(_ context.Context, req *CreateTraining
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.trainingJobs[req.TrainingJobName]; exists {
+	if _, exists := m.TrainingJobs[req.TrainingJobName]; exists {
 		return nil, &Error{
 			Code:    errResourceInUse,
 			Message: fmt.Sprintf("Training job %s already exists", req.TrainingJobName),
@@ -217,7 +306,7 @@ func (m *MemoryStorage) CreateTrainingJob(_ context.Context, req *CreateTraining
 		TrainingEndTime:   &now,
 	}
 
-	m.trainingJobs[req.TrainingJobName] = job
+	m.TrainingJobs[req.TrainingJobName] = job
 
 	return job, nil
 }
@@ -227,7 +316,7 @@ func (m *MemoryStorage) DescribeTrainingJob(_ context.Context, name string) (*Tr
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	job, exists := m.trainingJobs[name]
+	job, exists := m.TrainingJobs[name]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -243,7 +332,7 @@ func (m *MemoryStorage) CreateModel(_ context.Context, req *CreateModelRequest) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.models[req.ModelName]; exists {
+	if _, exists := m.Models[req.ModelName]; exists {
 		return nil, &Error{
 			Code:    errResourceInUse,
 			Message: fmt.Sprintf("Model %s already exists", req.ModelName),
@@ -262,7 +351,7 @@ func (m *MemoryStorage) CreateModel(_ context.Context, req *CreateModelRequest) 
 		CreationTime:           now,
 	}
 
-	m.models[req.ModelName] = model
+	m.Models[req.ModelName] = model
 
 	return model, nil
 }
@@ -272,14 +361,14 @@ func (m *MemoryStorage) DeleteModel(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.models[name]; !exists {
+	if _, exists := m.Models[name]; !exists {
 		return &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Model %s not found", name),
 		}
 	}
 
-	delete(m.models, name)
+	delete(m.Models, name)
 
 	return nil
 }
@@ -289,7 +378,7 @@ func (m *MemoryStorage) CreateEndpoint(_ context.Context, req *CreateEndpointReq
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.endpoints[req.EndpointName]; exists {
+	if _, exists := m.Endpoints[req.EndpointName]; exists {
 		return nil, &Error{
 			Code:    errResourceInUse,
 			Message: fmt.Sprintf("Endpoint %s already exists", req.EndpointName),
@@ -308,7 +397,7 @@ func (m *MemoryStorage) CreateEndpoint(_ context.Context, req *CreateEndpointReq
 		LastModifiedTime:   now,
 	}
 
-	m.endpoints[req.EndpointName] = endpoint
+	m.Endpoints[req.EndpointName] = endpoint
 
 	return endpoint, nil
 }
@@ -318,14 +407,14 @@ func (m *MemoryStorage) DeleteEndpoint(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.endpoints[name]; !exists {
+	if _, exists := m.Endpoints[name]; !exists {
 		return &Error{
 			Code:    errResourceNotFound,
 			Message: fmt.Sprintf("Endpoint %s not found", name),
 		}
 	}
 
-	delete(m.endpoints, name)
+	delete(m.Endpoints, name)
 
 	return nil
 }
@@ -335,7 +424,7 @@ func (m *MemoryStorage) DescribeEndpoint(_ context.Context, name string) (*Endpo
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	endpoint, exists := m.endpoints[name]
+	endpoint, exists := m.Endpoints[name]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,

--- a/internal/service/scheduler/service.go
+++ b/internal/service/scheduler/service.go
@@ -2,11 +2,23 @@
 package scheduler
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the EventBridge Scheduler service.
@@ -42,3 +54,14 @@ func (s *Service) RegisterRoutes(r service.Router) {
 
 // Ensure Service implements service.Service.
 var _ service.Service = (*Service)(nil)
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/scheduler/storage.go
+++ b/internal/service/scheduler/storage.go
@@ -2,9 +2,12 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -38,26 +41,51 @@ type Storage interface {
 	ListScheduleGroups(ctx context.Context, limit int32) ([]*ScheduleGroup, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu             sync.RWMutex
-	schedules      map[string]*Schedule      // key: groupName/scheduleName
-	scheduleGroups map[string]*ScheduleGroup // key: groupName
+	mu             sync.RWMutex              `json:"-"`
+	Schedules      map[string]*Schedule      `json:"schedules"`      // key: groupName/scheduleName
+	ScheduleGroups map[string]*ScheduleGroup `json:"scheduleGroups"` // key: groupName
 	region         string
 	accountID      string
+	dataDir        string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	ms := &MemoryStorage{
-		schedules:      make(map[string]*Schedule),
-		scheduleGroups: make(map[string]*ScheduleGroup),
+		Schedules:      make(map[string]*Schedule),
+		ScheduleGroups: make(map[string]*ScheduleGroup),
 		region:         defaultRegion,
 		accountID:      defaultAccountID,
 	}
 
+	for _, o := range opts {
+		o(ms)
+	}
+
+	if ms.dataDir != "" {
+		_ = storage.Load(ms.dataDir, "scheduler", ms)
+	}
+
 	// Create default schedule group.
-	ms.scheduleGroups[defaultGroupName] = &ScheduleGroup{
+	ms.ScheduleGroups[defaultGroupName] = &ScheduleGroup{
 		Name:         defaultGroupName,
 		ARN:          generateScheduleGroupARN(defaultRegion, defaultAccountID, defaultGroupName),
 		State:        ScheduleGroupStateActive,
@@ -65,6 +93,58 @@ func NewMemoryStorage() *MemoryStorage {
 	}
 
 	return ms
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Schedules == nil {
+		m.Schedules = make(map[string]*Schedule)
+	}
+
+	if m.ScheduleGroups == nil {
+		m.ScheduleGroups = make(map[string]*ScheduleGroup)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "scheduler", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateSchedule creates a new schedule.
@@ -75,12 +155,12 @@ func (m *MemoryStorage) CreateSchedule(_ context.Context, name string, req *Crea
 	groupName := defaultString(req.GroupName, defaultGroupName)
 	key := scheduleKey(groupName, name)
 
-	if _, exists := m.schedules[key]; exists {
+	if _, exists := m.Schedules[key]; exists {
 		return nil, &Error{Code: errConflictException, Message: "Schedule already exists: " + name}
 	}
 
 	// Check if group exists.
-	if _, exists := m.scheduleGroups[groupName]; !exists {
+	if _, exists := m.ScheduleGroups[groupName]; !exists {
 		return nil, &Error{Code: errResourceNotFound, Message: "ScheduleGroup not found: " + groupName}
 	}
 
@@ -117,7 +197,7 @@ func (m *MemoryStorage) CreateSchedule(_ context.Context, name string, req *Crea
 		}
 	}
 
-	m.schedules[key] = schedule
+	m.Schedules[key] = schedule
 
 	return schedule, nil
 }
@@ -130,7 +210,7 @@ func (m *MemoryStorage) GetSchedule(_ context.Context, name, groupName string) (
 	groupName = defaultString(groupName, defaultGroupName)
 	key := scheduleKey(groupName, name)
 
-	schedule, exists := m.schedules[key]
+	schedule, exists := m.Schedules[key]
 	if !exists {
 		return nil, &Error{Code: errResourceNotFound, Message: "Schedule not found: " + name}
 	}
@@ -146,7 +226,7 @@ func (m *MemoryStorage) UpdateSchedule(_ context.Context, name string, req *Upda
 	groupName := defaultString(req.GroupName, defaultGroupName)
 	key := scheduleKey(groupName, name)
 
-	schedule, exists := m.schedules[key]
+	schedule, exists := m.Schedules[key]
 	if !exists {
 		return nil, &Error{Code: errResourceNotFound, Message: "Schedule not found: " + name}
 	}
@@ -191,11 +271,11 @@ func (m *MemoryStorage) DeleteSchedule(_ context.Context, name, groupName string
 	groupName = defaultString(groupName, defaultGroupName)
 	key := scheduleKey(groupName, name)
 
-	if _, exists := m.schedules[key]; !exists {
+	if _, exists := m.Schedules[key]; !exists {
 		return &Error{Code: errResourceNotFound, Message: "Schedule not found: " + name}
 	}
 
-	delete(m.schedules, key)
+	delete(m.Schedules, key)
 
 	return nil
 }
@@ -205,9 +285,9 @@ func (m *MemoryStorage) ListSchedules(_ context.Context, groupName string, limit
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]*Schedule, 0, len(m.schedules))
+	result := make([]*Schedule, 0, len(m.Schedules))
 
-	for _, schedule := range m.schedules {
+	for _, schedule := range m.Schedules {
 		if groupName != "" && schedule.GroupName != groupName {
 			continue
 		}
@@ -227,7 +307,7 @@ func (m *MemoryStorage) CreateScheduleGroup(_ context.Context, name string, _ *C
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.scheduleGroups[name]; exists {
+	if _, exists := m.ScheduleGroups[name]; exists {
 		return nil, &Error{Code: errConflictException, Message: "ScheduleGroup already exists: " + name}
 	}
 
@@ -241,7 +321,7 @@ func (m *MemoryStorage) CreateScheduleGroup(_ context.Context, name string, _ *C
 		CreationDate: now,
 	}
 
-	m.scheduleGroups[name] = group
+	m.ScheduleGroups[name] = group
 
 	return group, nil
 }
@@ -251,7 +331,7 @@ func (m *MemoryStorage) GetScheduleGroup(_ context.Context, name string) (*Sched
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	group, exists := m.scheduleGroups[name]
+	group, exists := m.ScheduleGroups[name]
 	if !exists {
 		return nil, &Error{Code: errResourceNotFound, Message: "ScheduleGroup not found: " + name}
 	}
@@ -268,18 +348,18 @@ func (m *MemoryStorage) DeleteScheduleGroup(_ context.Context, name string) erro
 		return &Error{Code: errValidationException, Message: "Cannot delete default schedule group"}
 	}
 
-	if _, exists := m.scheduleGroups[name]; !exists {
+	if _, exists := m.ScheduleGroups[name]; !exists {
 		return &Error{Code: errResourceNotFound, Message: "ScheduleGroup not found: " + name}
 	}
 
 	// Check if any schedules use this group.
-	for _, schedule := range m.schedules {
+	for _, schedule := range m.Schedules {
 		if schedule.GroupName == name {
 			return &Error{Code: errConflictException, Message: "ScheduleGroup has schedules: " + name}
 		}
 	}
 
-	delete(m.scheduleGroups, name)
+	delete(m.ScheduleGroups, name)
 
 	return nil
 }
@@ -289,9 +369,9 @@ func (m *MemoryStorage) ListScheduleGroups(_ context.Context, limit int32) ([]*S
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]*ScheduleGroup, 0, len(m.scheduleGroups))
+	result := make([]*ScheduleGroup, 0, len(m.ScheduleGroups))
 
-	for _, group := range m.scheduleGroups {
+	for _, group := range m.ScheduleGroups {
 		result = append(result, group)
 
 		if limit > 0 && len(result) >= int(limit) {

--- a/internal/service/secretsmanager/service.go
+++ b/internal/service/secretsmanager/service.go
@@ -1,13 +1,25 @@
 package secretsmanager
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
 const defaultBaseURL = "http://localhost:4566"
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage(defaultBaseURL), defaultBaseURL))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(defaultBaseURL, opts...), defaultBaseURL))
 }
 
 // Service implements the Secrets Manager service.
@@ -43,3 +55,14 @@ func (s *Service) TargetPrefix() string {
 
 // JSONProtocol is a marker method that indicates Secrets Manager uses AWS JSON 1.1 protocol.
 func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/secretsmanager/storage.go
+++ b/internal/service/secretsmanager/storage.go
@@ -2,6 +2,7 @@ package secretsmanager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
@@ -10,6 +11,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -31,19 +34,93 @@ type Storage interface {
 	UpdateSecret(ctx context.Context, req *UpdateSecretRequest) (*Secret, *SecretVersion, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu      sync.RWMutex
-	secrets map[string]*Secret // keyed by name
+	mu      sync.RWMutex       `json:"-"`
+	Secrets map[string]*Secret `json:"secrets"` // keyed by name
 	baseURL string
+	dataDir string
 }
 
 // NewMemoryStorage creates a new in-memory Secrets Manager storage.
-func NewMemoryStorage(baseURL string) *MemoryStorage {
-	return &MemoryStorage{
-		secrets: make(map[string]*Secret),
+func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Secrets: make(map[string]*Secret),
 		baseURL: baseURL,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "secretsmanager", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Secrets == nil {
+		m.Secrets = make(map[string]*Secret)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "secretsmanager", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateSecret creates a new secret.
@@ -51,7 +128,7 @@ func (m *MemoryStorage) CreateSecret(_ context.Context, req *CreateSecretRequest
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, exists := m.secrets[req.Name]; exists {
+	if _, exists := m.Secrets[req.Name]; exists {
 		return nil, &SecretError{
 			Code:    "ResourceExistsException",
 			Message: fmt.Sprintf("The operation failed because the secret %s already exists.", req.Name),
@@ -88,7 +165,7 @@ func (m *MemoryStorage) CreateSecret(_ context.Context, req *CreateSecretRequest
 		secret.VersionIDs[versionID] = version
 	}
 
-	m.secrets[req.Name] = secret
+	m.Secrets[req.Name] = secret
 
 	return secret, nil
 }
@@ -230,7 +307,7 @@ func (m *MemoryStorage) DeleteSecret(_ context.Context, secretID string, recover
 
 	if forceDelete {
 		// Immediately delete.
-		delete(m.secrets, secret.Name)
+		delete(m.Secrets, secret.Name)
 		secret.DeletedDate = &now
 
 		return secret, nil
@@ -258,9 +335,9 @@ func (m *MemoryStorage) ListSecrets(_ context.Context, maxResults int, nextToken
 	}
 
 	// Collect all secrets.
-	allSecrets := make([]*Secret, 0, len(m.secrets))
+	allSecrets := make([]*Secret, 0, len(m.Secrets))
 
-	for _, secret := range m.secrets {
+	for _, secret := range m.Secrets {
 		// Skip deleted secrets unless requested.
 		if secret.DeletedDate != nil && !includePlannedDeletion {
 			continue
@@ -400,12 +477,12 @@ func (m *MemoryStorage) rotateVersionStages(secret *Secret) {
 // findSecret finds a secret by name or ARN.
 func (m *MemoryStorage) findSecret(secretID string) *Secret {
 	// Try by name first.
-	if secret, exists := m.secrets[secretID]; exists {
+	if secret, exists := m.Secrets[secretID]; exists {
 		return secret
 	}
 
 	// Try by ARN.
-	for _, secret := range m.secrets {
+	for _, secret := range m.Secrets {
 		if secret.ARN == secretID {
 			return secret
 		}

--- a/internal/service/securitylake/service.go
+++ b/internal/service/securitylake/service.go
@@ -1,12 +1,26 @@
 package securitylake
 
-import "github.com/sivchari/kumo/internal/service"
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // Compile-time check to ensure Service implements service.Service.
 var _ service.Service = (*Service)(nil)
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the Security Lake service.
@@ -55,4 +69,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 // Prefix returns the URL prefix for Security Lake.
 func (s *Service) Prefix() string {
 	return "/securitylake"
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/securitylake/storage.go
+++ b/internal/service/securitylake/storage.go
@@ -2,12 +2,15 @@ package securitylake
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -45,27 +48,113 @@ type Storage interface {
 	ListTagsForResource(ctx context.Context, resourceARN string) ([]*Tag, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements in-memory storage for Security Lake.
 type MemoryStorage struct {
-	mu          sync.RWMutex
-	dataLakes   map[string]*DataLake
-	subscribers map[string]*Subscriber
-	logSources  map[string]*LogSource
-	tags        map[string][]*Tag
+	mu          sync.RWMutex           `json:"-"`
+	DataLakes   map[string]*DataLake   `json:"dataLakes"`
+	Subscribers map[string]*Subscriber `json:"subscribers"`
+	LogSources  map[string]*LogSource  `json:"logSources"`
+	Tags        map[string][]*Tag      `json:"tags"`
 	accountID   string
 	region      string
+	dataDir     string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		dataLakes:   make(map[string]*DataLake),
-		subscribers: make(map[string]*Subscriber),
-		logSources:  make(map[string]*LogSource),
-		tags:        make(map[string][]*Tag),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		DataLakes:   make(map[string]*DataLake),
+		Subscribers: make(map[string]*Subscriber),
+		LogSources:  make(map[string]*LogSource),
+		Tags:        make(map[string][]*Tag),
 		accountID:   "123456789012",
 		region:      "us-east-1",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "securitylake", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.DataLakes == nil {
+		s.DataLakes = make(map[string]*DataLake)
+	}
+
+	if s.Subscribers == nil {
+		s.Subscribers = make(map[string]*Subscriber)
+	}
+
+	if s.LogSources == nil {
+		s.LogSources = make(map[string]*LogSource)
+	}
+
+	if s.Tags == nil {
+		s.Tags = make(map[string][]*Tag)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "securitylake", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateDataLake creates new data lakes.
@@ -82,7 +171,7 @@ func (s *MemoryStorage) CreateDataLake(_ context.Context, req *CreateDataLakeReq
 		}
 
 		// Check if data lake already exists for this region
-		if _, exists := s.dataLakes[region]; exists {
+		if _, exists := s.DataLakes[region]; exists {
 			return nil, &Error{
 				Code:    errConflict,
 				Message: fmt.Sprintf("Data lake already exists in region %s", region),
@@ -102,10 +191,10 @@ func (s *MemoryStorage) CreateDataLake(_ context.Context, req *CreateDataLakeReq
 			S3BucketARN:              fmt.Sprintf("arn:aws:s3:::%s", bucketName),
 		}
 
-		s.dataLakes[region] = dataLake
+		s.DataLakes[region] = dataLake
 
 		if len(req.Tags) > 0 {
-			s.tags[arn] = req.Tags
+			s.Tags[arn] = req.Tags
 		}
 
 		dataLakes = append(dataLakes, dataLake)
@@ -120,7 +209,7 @@ func (s *MemoryStorage) DeleteDataLake(_ context.Context, regions []string) erro
 	defer s.mu.Unlock()
 
 	for _, region := range regions {
-		dataLake, exists := s.dataLakes[region]
+		dataLake, exists := s.DataLakes[region]
 		if !exists {
 			return &Error{
 				Code:    errResourceNotFound,
@@ -128,8 +217,8 @@ func (s *MemoryStorage) DeleteDataLake(_ context.Context, regions []string) erro
 			}
 		}
 
-		delete(s.tags, dataLake.ARN)
-		delete(s.dataLakes, region)
+		delete(s.Tags, dataLake.ARN)
+		delete(s.DataLakes, region)
 	}
 
 	return nil
@@ -143,12 +232,12 @@ func (s *MemoryStorage) ListDataLakes(_ context.Context, regions []string) ([]*D
 	dataLakes := make([]*DataLake, 0)
 
 	if len(regions) == 0 {
-		for _, dataLake := range s.dataLakes {
+		for _, dataLake := range s.DataLakes {
 			dataLakes = append(dataLakes, dataLake)
 		}
 	} else {
 		for _, region := range regions {
-			if dataLake, exists := s.dataLakes[region]; exists {
+			if dataLake, exists := s.DataLakes[region]; exists {
 				dataLakes = append(dataLakes, dataLake)
 			}
 		}
@@ -170,7 +259,7 @@ func (s *MemoryStorage) UpdateDataLake(_ context.Context, req *UpdateDataLakeReq
 			region = s.region
 		}
 
-		dataLake, exists := s.dataLakes[region]
+		dataLake, exists := s.DataLakes[region]
 		if !exists {
 			return nil, &Error{
 				Code:    errResourceNotFound,
@@ -202,7 +291,7 @@ func (s *MemoryStorage) CreateSubscriber(_ context.Context, req *CreateSubscribe
 	defer s.mu.Unlock()
 
 	// Check for duplicate subscriber name
-	for _, sub := range s.subscribers {
+	for _, sub := range s.Subscribers {
 		if sub.SubscriberName == req.SubscriberName {
 			return nil, &Error{
 				Code:    errConflict,
@@ -228,10 +317,10 @@ func (s *MemoryStorage) CreateSubscriber(_ context.Context, req *CreateSubscribe
 		UpdatedAt:             now,
 	}
 
-	s.subscribers[subscriberID] = subscriber
+	s.Subscribers[subscriberID] = subscriber
 
 	if len(req.Tags) > 0 {
-		s.tags[arn] = req.Tags
+		s.Tags[arn] = req.Tags
 	}
 
 	return subscriber, nil
@@ -242,7 +331,7 @@ func (s *MemoryStorage) GetSubscriber(_ context.Context, subscriberID string) (*
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	subscriber, exists := s.subscribers[subscriberID]
+	subscriber, exists := s.Subscribers[subscriberID]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -258,7 +347,7 @@ func (s *MemoryStorage) DeleteSubscriber(_ context.Context, subscriberID string)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	subscriber, exists := s.subscribers[subscriberID]
+	subscriber, exists := s.Subscribers[subscriberID]
 	if !exists {
 		return &Error{
 			Code:    errResourceNotFound,
@@ -266,8 +355,8 @@ func (s *MemoryStorage) DeleteSubscriber(_ context.Context, subscriberID string)
 		}
 	}
 
-	delete(s.tags, subscriber.SubscriberARN)
-	delete(s.subscribers, subscriberID)
+	delete(s.Tags, subscriber.SubscriberARN)
+	delete(s.Subscribers, subscriberID)
 
 	return nil
 }
@@ -277,7 +366,7 @@ func (s *MemoryStorage) UpdateSubscriber(_ context.Context, req *UpdateSubscribe
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	subscriber, exists := s.subscribers[req.SubscriberID]
+	subscriber, exists := s.Subscribers[req.SubscriberID]
 	if !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -315,9 +404,9 @@ func (s *MemoryStorage) ListSubscribers(_ context.Context, maxResults int, _ str
 		maxResults = 10
 	}
 
-	subscribers := make([]*Subscriber, 0, len(s.subscribers))
+	subscribers := make([]*Subscriber, 0, len(s.Subscribers))
 
-	for _, subscriber := range s.subscribers {
+	for _, subscriber := range s.Subscribers {
 		subscribers = append(subscribers, subscriber)
 
 		if len(subscribers) >= maxResults {
@@ -352,7 +441,7 @@ func (s *MemoryStorage) CreateAwsLogSource(_ context.Context, req *CreateAwsLogS
 				},
 			}
 
-			s.logSources[key] = logSource
+			s.LogSources[key] = logSource
 		}
 	}
 
@@ -370,7 +459,7 @@ func (s *MemoryStorage) DeleteAwsLogSource(_ context.Context, req *DeleteAwsLogS
 		for _, region := range source.Regions {
 			key := fmt.Sprintf("%s-%s-%s", source.SourceName, region, s.accountID)
 
-			delete(s.logSources, key)
+			delete(s.LogSources, key)
 		}
 	}
 
@@ -387,9 +476,9 @@ func (s *MemoryStorage) ListLogSources(_ context.Context, req *ListLogSourcesReq
 		maxResults = 10
 	}
 
-	sources := make([]*LogSource, 0, len(s.logSources))
+	sources := make([]*LogSource, 0, len(s.LogSources))
 
-	for _, source := range s.logSources {
+	for _, source := range s.LogSources {
 		// Filter by regions if specified
 		if len(req.Regions) > 0 && !slices.Contains(req.Regions, source.Region) {
 			continue
@@ -415,7 +504,7 @@ func (s *MemoryStorage) TagResource(_ context.Context, resourceARN string, tags 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	existingTags := s.tags[resourceARN]
+	existingTags := s.Tags[resourceARN]
 	tagMap := make(map[string]string)
 
 	for _, tag := range existingTags {
@@ -432,7 +521,7 @@ func (s *MemoryStorage) TagResource(_ context.Context, resourceARN string, tags 
 		newTags = append(newTags, &Tag{Key: k, Value: v})
 	}
 
-	s.tags[resourceARN] = newTags
+	s.Tags[resourceARN] = newTags
 
 	return nil
 }
@@ -442,7 +531,7 @@ func (s *MemoryStorage) UntagResource(_ context.Context, resourceARN string, tag
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	existingTags := s.tags[resourceARN]
+	existingTags := s.Tags[resourceARN]
 	keySet := make(map[string]bool)
 
 	for _, key := range tagKeys {
@@ -457,7 +546,7 @@ func (s *MemoryStorage) UntagResource(_ context.Context, resourceARN string, tag
 		}
 	}
 
-	s.tags[resourceARN] = newTags
+	s.Tags[resourceARN] = newTags
 
 	return nil
 }
@@ -467,7 +556,7 @@ func (s *MemoryStorage) ListTagsForResource(_ context.Context, resourceARN strin
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	tags := s.tags[resourceARN]
+	tags := s.Tags[resourceARN]
 	if tags == nil {
 		tags = make([]*Tag, 0)
 	}

--- a/internal/service/servicequotas/service.go
+++ b/internal/service/servicequotas/service.go
@@ -1,7 +1,13 @@
 // Package servicequotas provides AWS Service Quotas service emulation.
 package servicequotas
 
-import "github.com/sivchari/kumo/internal/service"
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // Service implements the Service Quotas service.
 type Service struct {
@@ -29,11 +35,30 @@ func (s *Service) JSONProtocol() {}
 // RegisterRoutes registers HTTP routes for the service.
 func (s *Service) RegisterRoutes(_ service.Router) {}
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 var (
 	_ service.Service             = (*Service)(nil)
 	_ service.JSONProtocolService = (*Service)(nil)
 )
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/servicequotas/storage.go
+++ b/internal/service/servicequotas/storage.go
@@ -2,11 +2,14 @@ package servicequotas
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -32,14 +35,14 @@ const (
 	quotaAppliedAtLevelAccount = "ACCOUNT"
 )
 
-// quotaDefinition represents a quota definition for initialization.
-type quotaDefinition struct {
-	code        string
-	name        string
-	value       float64
-	unit        string
-	adjustable  bool
-	description string
+// QuotaDefinition represents a quota definition for initialization.
+type QuotaDefinition struct {
+	Code        string  `json:"code"`
+	Name        string  `json:"name"`
+	Value       float64 `json:"value"`
+	Unit        string  `json:"unit"`
+	Adjustable  bool    `json:"adjustable"`
+	Description string  `json:"description"`
 }
 
 // Storage defines the Service Quotas storage interface.
@@ -59,31 +62,116 @@ type Storage interface {
 	ListRequestedServiceQuotaChangeHistory(ctx context.Context, serviceCode, quotaCode, status string, maxResults int32, nextToken string) ([]*QuotaChangeRequest, string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu            sync.RWMutex
-	services      map[string]*ServiceInfo
-	quotas        map[string]map[string]*ServiceQuota // serviceCode -> quotaCode -> quota
-	defaultQuotas map[string]map[string]*ServiceQuota // serviceCode -> quotaCode -> quota
-	requests      map[string]*QuotaChangeRequest
+	mu            sync.RWMutex                        `json:"-"`
+	Services      map[string]*ServiceInfo             `json:"services"`
+	Quotas        map[string]map[string]*ServiceQuota `json:"quotas"`        // serviceCode -> quotaCode -> quota
+	DefaultQuotas map[string]map[string]*ServiceQuota `json:"defaultQuotas"` // serviceCode -> quotaCode -> quota
+	Requests      map[string]*QuotaChangeRequest      `json:"requests"`
 	region        string
 	accountID     string
+	dataDir       string
 }
 
 // NewMemoryStorage creates a new MemoryStorage with predefined services and quotas.
-func NewMemoryStorage() *MemoryStorage {
-	storage := &MemoryStorage{
-		services:      make(map[string]*ServiceInfo),
-		quotas:        make(map[string]map[string]*ServiceQuota),
-		defaultQuotas: make(map[string]map[string]*ServiceQuota),
-		requests:      make(map[string]*QuotaChangeRequest),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Services:      make(map[string]*ServiceInfo),
+		Quotas:        make(map[string]map[string]*ServiceQuota),
+		DefaultQuotas: make(map[string]map[string]*ServiceQuota),
+		Requests:      make(map[string]*QuotaChangeRequest),
 		region:        defaultRegion,
 		accountID:     defaultAccountID,
 	}
 
-	storage.initializeDefaultData()
+	for _, o := range opts {
+		o(s)
+	}
 
-	return storage
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "service-quotas", s)
+	}
+
+	s.initializeDefaultData()
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Services == nil {
+		m.Services = make(map[string]*ServiceInfo)
+	}
+
+	if m.Quotas == nil {
+		m.Quotas = make(map[string]map[string]*ServiceQuota)
+	}
+
+	if m.DefaultQuotas == nil {
+		m.DefaultQuotas = make(map[string]map[string]*ServiceQuota)
+	}
+
+	if m.Requests == nil {
+		m.Requests = make(map[string]*QuotaChangeRequest)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "service-quotas", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // initializeDefaultData sets up predefined services and quotas.
@@ -111,12 +199,12 @@ func (m *MemoryStorage) initializeServices() {
 	}
 
 	for i := range services {
-		m.services[services[i].ServiceCode] = &services[i]
+		m.Services[services[i].ServiceCode] = &services[i]
 	}
 }
 
 func (m *MemoryStorage) initializeEC2Quotas() {
-	m.addServiceQuotas("ec2", "Amazon Elastic Compute Cloud (Amazon EC2)", []quotaDefinition{
+	m.addServiceQuotas("ec2", "Amazon Elastic Compute Cloud (Amazon EC2)", []QuotaDefinition{
 		{"L-1216C47A", "Running On-Demand Standard instances", 1920, "None", true, "Max vCPUs for On-Demand Standard instances"},
 		{"L-34B43A08", "All Standard Spot Instance Requests", 1920, "None", true, "Max vCPUs for Standard Spot Requests"},
 		{"L-0E3CBAB9", "EC2-VPC Elastic IPs", 5, "None", true, "Max Elastic IP addresses for EC2-VPC"},
@@ -125,61 +213,61 @@ func (m *MemoryStorage) initializeEC2Quotas() {
 }
 
 func (m *MemoryStorage) initializeS3Quotas() {
-	m.addServiceQuotas("s3", "Amazon Simple Storage Service (Amazon S3)", []quotaDefinition{
+	m.addServiceQuotas("s3", "Amazon Simple Storage Service (Amazon S3)", []QuotaDefinition{
 		{"L-DC2B2D3D", "Buckets", 100, "None", true, "Maximum number of buckets per account"},
 	})
 }
 
 func (m *MemoryStorage) initializeLambdaQuotas() {
-	m.addServiceQuotas("lambda", "AWS Lambda", []quotaDefinition{
+	m.addServiceQuotas("lambda", "AWS Lambda", []QuotaDefinition{
 		{"L-B99A9384", "Concurrent executions", 1000, "None", true, "Maximum number of concurrent executions"},
 		{"L-2ACBD22F", "Function and layer storage", 75, "Gigabytes", true, "Max total storage for functions and layers"},
 	})
 }
 
 func (m *MemoryStorage) initializeDynamoDBQuotas() {
-	m.addServiceQuotas("dynamodb", "Amazon DynamoDB", []quotaDefinition{
+	m.addServiceQuotas("dynamodb", "Amazon DynamoDB", []QuotaDefinition{
 		{"L-F98FE922", "Table-level read throughput", 40000, "None", true, "Max read capacity units per table"},
 		{"L-82ACEF56", "Table-level write throughput", 40000, "None", true, "Max write capacity units per table"},
 	})
 }
 
 func (m *MemoryStorage) initializeSQSQuotas() {
-	m.addServiceQuotas("sqs", "Amazon Simple Queue Service (Amazon SQS)", []quotaDefinition{
+	m.addServiceQuotas("sqs", "Amazon Simple Queue Service (Amazon SQS)", []QuotaDefinition{
 		{"L-06F64E4A", "Messages per queue (backlog)", 120000, "None", false, "Max inflight messages per queue"},
 	})
 }
 
 // addServiceQuotas adds quotas for a service.
-func (m *MemoryStorage) addServiceQuotas(serviceCode, serviceName string, quotas []quotaDefinition) {
-	if m.quotas[serviceCode] == nil {
-		m.quotas[serviceCode] = make(map[string]*ServiceQuota)
+func (m *MemoryStorage) addServiceQuotas(serviceCode, serviceName string, quotas []QuotaDefinition) {
+	if m.Quotas[serviceCode] == nil {
+		m.Quotas[serviceCode] = make(map[string]*ServiceQuota)
 	}
 
-	if m.defaultQuotas[serviceCode] == nil {
-		m.defaultQuotas[serviceCode] = make(map[string]*ServiceQuota)
+	if m.DefaultQuotas[serviceCode] == nil {
+		m.DefaultQuotas[serviceCode] = make(map[string]*ServiceQuota)
 	}
 
 	for _, q := range quotas {
 		quota := &ServiceQuota{
-			QuotaARN:            generateQuotaARN(m.region, serviceCode, q.code),
-			QuotaCode:           q.code,
-			QuotaName:           q.name,
+			QuotaARN:            generateQuotaARN(m.region, serviceCode, q.Code),
+			QuotaCode:           q.Code,
+			QuotaName:           q.Name,
 			ServiceCode:         serviceCode,
 			ServiceName:         serviceName,
-			Value:               q.value,
-			Unit:                q.unit,
-			Adjustable:          q.adjustable,
+			Value:               q.Value,
+			Unit:                q.Unit,
+			Adjustable:          q.Adjustable,
 			GlobalQuota:         false,
-			Description:         q.description,
+			Description:         q.Description,
 			QuotaAppliedAtLevel: quotaAppliedAtLevelAccount,
 		}
 
-		m.quotas[serviceCode][q.code] = quota
+		m.Quotas[serviceCode][q.Code] = quota
 
 		// Default quotas are the same initially
 		defaultQuota := *quota
-		m.defaultQuotas[serviceCode][q.code] = &defaultQuota
+		m.DefaultQuotas[serviceCode][q.Code] = &defaultQuota
 	}
 }
 
@@ -188,9 +276,9 @@ func (m *MemoryStorage) ListServices(_ context.Context, maxResults int32, _ stri
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]*ServiceInfo, 0, len(m.services))
+	result := make([]*ServiceInfo, 0, len(m.Services))
 
-	for _, svc := range m.services {
+	for _, svc := range m.Services {
 		result = append(result, svc)
 
 		//nolint:gosec // len(result) is bounded by the number of services which is limited.
@@ -207,7 +295,7 @@ func (m *MemoryStorage) GetServiceQuota(_ context.Context, serviceCode, quotaCod
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	serviceQuotas, exists := m.quotas[serviceCode]
+	serviceQuotas, exists := m.Quotas[serviceCode]
 	if !exists {
 		return nil, &Error{Code: errNoSuchResourceException, Message: "Service not found: " + serviceCode}
 	}
@@ -225,7 +313,7 @@ func (m *MemoryStorage) ListServiceQuotas(_ context.Context, serviceCode string,
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	serviceQuotas, exists := m.quotas[serviceCode]
+	serviceQuotas, exists := m.Quotas[serviceCode]
 	if !exists {
 		return nil, "", &Error{Code: errNoSuchResourceException, Message: "Service not found: " + serviceCode}
 	}
@@ -249,7 +337,7 @@ func (m *MemoryStorage) GetAWSDefaultServiceQuota(_ context.Context, serviceCode
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	serviceQuotas, exists := m.defaultQuotas[serviceCode]
+	serviceQuotas, exists := m.DefaultQuotas[serviceCode]
 	if !exists {
 		return nil, &Error{Code: errNoSuchResourceException, Message: "Service not found: " + serviceCode}
 	}
@@ -267,7 +355,7 @@ func (m *MemoryStorage) ListAWSDefaultServiceQuotas(_ context.Context, serviceCo
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	serviceQuotas, exists := m.defaultQuotas[serviceCode]
+	serviceQuotas, exists := m.DefaultQuotas[serviceCode]
 	if !exists {
 		return nil, "", &Error{Code: errNoSuchResourceException, Message: "Service not found: " + serviceCode}
 	}
@@ -292,7 +380,7 @@ func (m *MemoryStorage) RequestServiceQuotaIncrease(_ context.Context, serviceCo
 	defer m.mu.Unlock()
 
 	// Check if the service exists
-	serviceQuotas, exists := m.quotas[serviceCode]
+	serviceQuotas, exists := m.Quotas[serviceCode]
 	if !exists {
 		return nil, &Error{Code: errNoSuchResourceException, Message: "Service not found: " + serviceCode}
 	}
@@ -327,7 +415,7 @@ func (m *MemoryStorage) RequestServiceQuotaIncrease(_ context.Context, serviceCo
 		QuotaRequestedAtLevel: quotaAppliedAtLevelAccount,
 	}
 
-	m.requests[requestID] = request
+	m.Requests[requestID] = request
 
 	return request, nil
 }
@@ -337,7 +425,7 @@ func (m *MemoryStorage) GetRequestedServiceQuotaChange(_ context.Context, reques
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	request, exists := m.requests[requestID]
+	request, exists := m.Requests[requestID]
 	if !exists {
 		return nil, &Error{Code: errNoSuchResourceException, Message: "Request not found: " + requestID}
 	}
@@ -350,9 +438,9 @@ func (m *MemoryStorage) ListRequestedServiceQuotaChangeHistory(_ context.Context
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	result := make([]*QuotaChangeRequest, 0, len(m.requests))
+	result := make([]*QuotaChangeRequest, 0, len(m.Requests))
 
-	for _, request := range m.requests {
+	for _, request := range m.Requests {
 		if serviceCode != "" && request.ServiceCode != serviceCode {
 			continue
 		}

--- a/internal/service/sesv2/service.go
+++ b/internal/service/sesv2/service.go
@@ -1,11 +1,23 @@
 package sesv2
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the SES v2 service.
@@ -42,4 +54,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 
 	// Send Email route.
 	r.HandleFunc("POST", "/ses/v2/email/outbound-emails", s.SendEmail)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/sesv2/storage.go
+++ b/internal/service/sesv2/storage.go
@@ -2,11 +2,15 @@ package sesv2
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -38,21 +42,99 @@ type Storage interface {
 	GetSentEmails(ctx context.Context) ([]*SentEmail, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data structures.
 type MemoryStorage struct {
-	mu                sync.RWMutex
-	emailIdentities   map[string]*EmailIdentity
-	configurationSets map[string]*ConfigurationSet
-	sentEmails        []*SentEmail
+	mu                sync.RWMutex                 `json:"-"`
+	EmailIdentities   map[string]*EmailIdentity    `json:"emailIdentities"`
+	ConfigurationSets map[string]*ConfigurationSet `json:"configurationSets"`
+	SentEmails        []*SentEmail                 `json:"sentEmails"`
+	dataDir           string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		emailIdentities:   make(map[string]*EmailIdentity),
-		configurationSets: make(map[string]*ConfigurationSet),
-		sentEmails:        make([]*SentEmail, 0),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		EmailIdentities:   make(map[string]*EmailIdentity),
+		ConfigurationSets: make(map[string]*ConfigurationSet),
+		SentEmails:        make([]*SentEmail, 0),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "sesv2", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.EmailIdentities == nil {
+		s.EmailIdentities = make(map[string]*EmailIdentity)
+	}
+
+	if s.ConfigurationSets == nil {
+		s.ConfigurationSets = make(map[string]*ConfigurationSet)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "sesv2", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateEmailIdentity creates a new email identity.
@@ -67,7 +149,7 @@ func (s *MemoryStorage) CreateEmailIdentity(_ context.Context, req *CreateEmailI
 		}
 	}
 
-	if _, exists := s.emailIdentities[req.EmailIdentity]; exists {
+	if _, exists := s.EmailIdentities[req.EmailIdentity]; exists {
 		return nil, &IdentityError{
 			Code:    errAlreadyExists,
 			Message: "The email identity already exists",
@@ -92,7 +174,7 @@ func (s *MemoryStorage) CreateEmailIdentity(_ context.Context, req *CreateEmailI
 		CreatedAt: time.Now(),
 	}
 
-	s.emailIdentities[req.EmailIdentity] = identity
+	s.EmailIdentities[req.EmailIdentity] = identity
 
 	return identity, nil
 }
@@ -102,7 +184,7 @@ func (s *MemoryStorage) GetEmailIdentity(_ context.Context, emailIdentity string
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	identity, exists := s.emailIdentities[emailIdentity]
+	identity, exists := s.EmailIdentities[emailIdentity]
 	if !exists {
 		return nil, &IdentityError{
 			Code:    errNotFound,
@@ -122,8 +204,8 @@ func (s *MemoryStorage) ListEmailIdentities(_ context.Context, _ string, pageSiz
 		pageSize = 100
 	}
 
-	identities := make([]*EmailIdentity, 0, len(s.emailIdentities))
-	for _, identity := range s.emailIdentities {
+	identities := make([]*EmailIdentity, 0, len(s.EmailIdentities))
+	for _, identity := range s.EmailIdentities {
 		identities = append(identities, identity)
 	}
 
@@ -140,14 +222,14 @@ func (s *MemoryStorage) DeleteEmailIdentity(_ context.Context, emailIdentity str
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.emailIdentities[emailIdentity]; !exists {
+	if _, exists := s.EmailIdentities[emailIdentity]; !exists {
 		return &IdentityError{
 			Code:    errNotFound,
 			Message: "The email identity does not exist",
 		}
 	}
 
-	delete(s.emailIdentities, emailIdentity)
+	delete(s.EmailIdentities, emailIdentity)
 
 	return nil
 }
@@ -164,7 +246,7 @@ func (s *MemoryStorage) CreateConfigurationSet(_ context.Context, req *CreateCon
 		}
 	}
 
-	if _, exists := s.configurationSets[req.ConfigurationSetName]; exists {
+	if _, exists := s.ConfigurationSets[req.ConfigurationSetName]; exists {
 		return nil, &IdentityError{
 			Code:    errAlreadyExists,
 			Message: "The configuration set already exists",
@@ -185,7 +267,7 @@ func (s *MemoryStorage) CreateConfigurationSet(_ context.Context, req *CreateCon
 		configSet.SendingOptions = &SendingOptions{SendingEnabled: true}
 	}
 
-	s.configurationSets[req.ConfigurationSetName] = configSet
+	s.ConfigurationSets[req.ConfigurationSetName] = configSet
 
 	return configSet, nil
 }
@@ -195,7 +277,7 @@ func (s *MemoryStorage) GetConfigurationSet(_ context.Context, name string) (*Co
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	configSet, exists := s.configurationSets[name]
+	configSet, exists := s.ConfigurationSets[name]
 	if !exists {
 		return nil, &IdentityError{
 			Code:    errNotFound,
@@ -215,8 +297,8 @@ func (s *MemoryStorage) ListConfigurationSets(_ context.Context, _ string, pageS
 		pageSize = 100
 	}
 
-	names := make([]string, 0, len(s.configurationSets))
-	for name := range s.configurationSets {
+	names := make([]string, 0, len(s.ConfigurationSets))
+	for name := range s.ConfigurationSets {
 		names = append(names, name)
 	}
 
@@ -232,14 +314,14 @@ func (s *MemoryStorage) DeleteConfigurationSet(_ context.Context, name string) e
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.configurationSets[name]; !exists {
+	if _, exists := s.ConfigurationSets[name]; !exists {
 		return &IdentityError{
 			Code:    errNotFound,
 			Message: "The configuration set does not exist",
 		}
 	}
 
-	delete(s.configurationSets, name)
+	delete(s.ConfigurationSets, name)
 
 	return nil
 }
@@ -284,7 +366,7 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 		SentAt:               time.Now(),
 	}
 
-	s.sentEmails = append(s.sentEmails, sentEmail)
+	s.SentEmails = append(s.SentEmails, sentEmail)
 
 	return messageID, nil
 }
@@ -294,7 +376,7 @@ func (s *MemoryStorage) GetSentEmails(_ context.Context) ([]*SentEmail, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.sentEmails, nil
+	return s.SentEmails, nil
 }
 
 // extractSimpleEmailContent extracts subject and body from a SimpleEmail.

--- a/internal/service/sfn/service.go
+++ b/internal/service/sfn/service.go
@@ -2,6 +2,10 @@
 package sfn
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
@@ -36,6 +40,25 @@ func (s *Service) RegisterRoutes(_ service.Router) {
 	// Routes are dispatched by the server based on X-Amz-Target.
 }
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/sfn/storage.go
+++ b/internal/service/sfn/storage.go
@@ -2,6 +2,7 @@ package sfn
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -40,30 +43,108 @@ type Storage interface {
 	DispatchAction(action string) bool
 }
 
-// MemoryStorage implements Storage with in-memory data.
-type MemoryStorage struct {
-	mu            sync.RWMutex
-	stateMachines map[string]*StateMachine
-	executions    map[string]*executionData
-	region        string
-	accountID     string
-	eventCounter  int64
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
 }
 
-// executionData holds execution information and its history.
-type executionData struct {
-	execution *Execution
-	history   []*HistoryEvent
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
+// MemoryStorage implements Storage with in-memory data.
+type MemoryStorage struct {
+	mu            sync.RWMutex              `json:"-"`
+	StateMachines map[string]*StateMachine  `json:"stateMachines"`
+	Executions    map[string]*ExecutionData `json:"executions"`
+	region        string
+	accountID     string
+	EventCounter  int64 `json:"eventCounter"`
+	dataDir       string
+}
+
+// ExecutionData holds execution information and its history.
+type ExecutionData struct {
+	Execution *Execution      `json:"execution"`
+	History   []*HistoryEvent `json:"history"`
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		stateMachines: make(map[string]*StateMachine),
-		executions:    make(map[string]*executionData),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		StateMachines: make(map[string]*StateMachine),
+		Executions:    make(map[string]*ExecutionData),
 		region:        "us-east-1",
 		accountID:     "000000000000",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "states", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.StateMachines == nil {
+		s.StateMachines = make(map[string]*StateMachine)
+	}
+
+	if s.Executions == nil {
+		s.Executions = make(map[string]*ExecutionData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "states", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateStateMachine creates a new state machine.
@@ -73,7 +154,7 @@ func (s *MemoryStorage) CreateStateMachine(_ context.Context, req *CreateStateMa
 
 	arn := fmt.Sprintf("arn:aws:states:%s:%s:stateMachine:%s", s.region, s.accountID, req.Name)
 
-	if _, exists := s.stateMachines[arn]; exists {
+	if _, exists := s.StateMachines[arn]; exists {
 		return nil, &ServiceError{Code: errStateMachineAlreadyExists, Message: "State machine already exists"}
 	}
 
@@ -96,7 +177,7 @@ func (s *MemoryStorage) CreateStateMachine(_ context.Context, req *CreateStateMa
 		RevisionID:           uuid.New().String(),
 	}
 
-	s.stateMachines[arn] = sm
+	s.StateMachines[arn] = sm
 
 	return sm, nil
 }
@@ -106,11 +187,11 @@ func (s *MemoryStorage) DeleteStateMachine(_ context.Context, arn string) error 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.stateMachines[arn]; !exists {
+	if _, exists := s.StateMachines[arn]; !exists {
 		return &ServiceError{Code: errStateMachineDoesNotExist, Message: "State machine does not exist"}
 	}
 
-	delete(s.stateMachines, arn)
+	delete(s.StateMachines, arn)
 
 	return nil
 }
@@ -120,7 +201,7 @@ func (s *MemoryStorage) DescribeStateMachine(_ context.Context, arn string) (*St
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	sm, exists := s.stateMachines[arn]
+	sm, exists := s.StateMachines[arn]
 	if !exists {
 		return nil, &ServiceError{Code: errStateMachineDoesNotExist, Message: "State machine does not exist"}
 	}
@@ -137,8 +218,8 @@ func (s *MemoryStorage) ListStateMachines(_ context.Context, maxResults int32, _
 		maxResults = 100
 	}
 
-	stateMachines := make([]*StateMachine, 0, len(s.stateMachines))
-	for _, sm := range s.stateMachines {
+	stateMachines := make([]*StateMachine, 0, len(s.StateMachines))
+	for _, sm := range s.StateMachines {
 		stateMachines = append(stateMachines, sm)
 	}
 
@@ -159,7 +240,7 @@ func (s *MemoryStorage) StartExecution(_ context.Context, stateMachineArn, name,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	sm, exists := s.stateMachines[stateMachineArn]
+	sm, exists := s.StateMachines[stateMachineArn]
 	if !exists {
 		return nil, &ServiceError{Code: errStateMachineDoesNotExist, Message: "State machine does not exist"}
 	}
@@ -169,9 +250,9 @@ func (s *MemoryStorage) StartExecution(_ context.Context, stateMachineArn, name,
 		execName = uuid.New().String()
 	}
 
-	executionArn := fmt.Sprintf("arn:aws:states:%s:%s:execution:%s:%s", s.region, s.accountID, sm.Name, execName)
+	executionArn := fmt.Sprintf("arn:aws:states:%s:%s:Execution:%s:%s", s.region, s.accountID, sm.Name, execName)
 
-	if _, exists := s.executions[executionArn]; exists {
+	if _, exists := s.Executions[executionArn]; exists {
 		return nil, &ServiceError{Code: errExecutionAlreadyExists, Message: "Execution already exists"}
 	}
 
@@ -184,7 +265,7 @@ func (s *MemoryStorage) StartExecution(_ context.Context, stateMachineArn, name,
 	exec.Output = input
 	exec.OutputDetails = &CloudWatchEventsExecutionDataDetails{Included: true}
 
-	s.executions[executionArn] = &executionData{execution: exec, history: history}
+	s.Executions[executionArn] = &ExecutionData{Execution: exec, History: history}
 
 	return exec, nil
 }
@@ -205,8 +286,8 @@ func (s *MemoryStorage) createExecution(arn, smArn, name, input, traceHeader str
 
 // createExecutionHistory creates execution history events for a pass-through execution.
 func (s *MemoryStorage) createExecutionHistory(roleArn, input string, now time.Time) []*HistoryEvent {
-	startID := atomic.AddInt64(&s.eventCounter, 1)
-	endID := atomic.AddInt64(&s.eventCounter, 1)
+	startID := atomic.AddInt64(&s.EventCounter, 1)
+	endID := atomic.AddInt64(&s.EventCounter, 1)
 
 	return []*HistoryEvent{
 		{
@@ -229,38 +310,38 @@ func (s *MemoryStorage) StopExecution(_ context.Context, executionArn, errorCode
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	ed, exists := s.executions[executionArn]
+	ed, exists := s.Executions[executionArn]
 	if !exists {
 		return nil, &ServiceError{Code: errExecutionDoesNotExist, Message: "Execution does not exist"}
 	}
 
-	if ed.execution.Status != ExecutionStatusRunning {
+	if ed.Execution.Status != ExecutionStatusRunning {
 		// Already stopped.
-		return ed.execution, nil
+		return ed.Execution, nil
 	}
 
 	now := time.Now()
-	ed.execution.Status = ExecutionStatusAborted
-	ed.execution.StopDate = &now
-	ed.execution.Error = errorCode
-	ed.execution.Cause = cause
+	ed.Execution.Status = ExecutionStatusAborted
+	ed.Execution.StopDate = &now
+	ed.Execution.Error = errorCode
+	ed.Execution.Cause = cause
 
 	// Add abort event.
-	eventID := atomic.AddInt64(&s.eventCounter, 1)
+	eventID := atomic.AddInt64(&s.EventCounter, 1)
 	abortEvent := &HistoryEvent{
 		Timestamp:       now,
 		Type:            HistoryEventTypeExecutionAborted,
 		ID:              eventID,
-		PreviousEventID: int64(len(ed.history)),
+		PreviousEventID: int64(len(ed.History)),
 		ExecutionAbortedEventDetails: &ExecutionAbortedEventDetails{
 			Error: errorCode,
 			Cause: cause,
 		},
 	}
 
-	ed.history = append(ed.history, abortEvent)
+	ed.History = append(ed.History, abortEvent)
 
-	return ed.execution, nil
+	return ed.Execution, nil
 }
 
 // DescribeExecution describes an execution.
@@ -268,12 +349,12 @@ func (s *MemoryStorage) DescribeExecution(_ context.Context, executionArn string
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	ed, exists := s.executions[executionArn]
+	ed, exists := s.Executions[executionArn]
 	if !exists {
 		return nil, &ServiceError{Code: errExecutionDoesNotExist, Message: "Execution does not exist"}
 	}
 
-	return ed.execution, nil
+	return ed.Execution, nil
 }
 
 // ListExecutions lists executions for a state machine.
@@ -287,16 +368,16 @@ func (s *MemoryStorage) ListExecutions(_ context.Context, stateMachineArn, statu
 
 	var executions []*Execution
 
-	for _, ed := range s.executions {
-		if ed.execution.StateMachineArn != stateMachineArn {
+	for _, ed := range s.Executions {
+		if ed.Execution.StateMachineArn != stateMachineArn {
 			continue
 		}
 
-		if statusFilter != "" && string(ed.execution.Status) != statusFilter {
+		if statusFilter != "" && string(ed.Execution.Status) != statusFilter {
 			continue
 		}
 
-		executions = append(executions, ed.execution)
+		executions = append(executions, ed.Execution)
 	}
 
 	// Sort by start date (most recent first).
@@ -316,7 +397,7 @@ func (s *MemoryStorage) GetExecutionHistory(_ context.Context, executionArn stri
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	ed, exists := s.executions[executionArn]
+	ed, exists := s.Executions[executionArn]
 	if !exists {
 		return nil, "", &ServiceError{Code: errExecutionDoesNotExist, Message: "Execution does not exist"}
 	}
@@ -326,8 +407,8 @@ func (s *MemoryStorage) GetExecutionHistory(_ context.Context, executionArn stri
 	}
 
 	// Copy events.
-	events := make([]*HistoryEvent, len(ed.history))
-	copy(events, ed.history)
+	events := make([]*HistoryEvent, len(ed.History))
+	copy(events, ed.History)
 
 	if reverseOrder {
 		for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {

--- a/internal/service/sns/service.go
+++ b/internal/service/sns/service.go
@@ -1,11 +1,23 @@
 package sns
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage("")
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	storage := NewMemoryStorage("", opts...)
 	service.Register(New(storage))
 }
 
@@ -58,4 +70,15 @@ func (s *Service) QueryProtocol() {}
 // This can be used to set up cross-service integration (e.g., SNS to SQS).
 func (s *Service) Storage() Storage {
 	return s.storage
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -2,6 +2,7 @@ package sns
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -33,27 +36,105 @@ type Storage interface {
 	ListSubscriptionsByTopic(ctx context.Context, topicARN, nextToken string) ([]*Subscription, string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu            sync.RWMutex
-	topics        map[string]*Topic        // keyed by ARN
-	subscriptions map[string]*Subscription // keyed by ARN
+	mu            sync.RWMutex             `json:"-"`
+	Topics        map[string]*Topic        `json:"topics"`        // keyed by ARN
+	Subscriptions map[string]*Subscription `json:"subscriptions"` // keyed by ARN
 	baseURL       string
-	sqsPublisher  SQSPublisher
+	SqsPublisher  SQSPublisher `json:"-"`
+	dataDir       string
 }
 
 // NewMemoryStorage creates a new in-memory SNS storage.
-func NewMemoryStorage(baseURL string) *MemoryStorage {
-	return &MemoryStorage{
-		topics:        make(map[string]*Topic),
-		subscriptions: make(map[string]*Subscription),
+func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Topics:        make(map[string]*Topic),
+		Subscriptions: make(map[string]*Subscription),
 		baseURL:       baseURL,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "sns", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(m)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(m)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if m.Topics == nil {
+		m.Topics = make(map[string]*Topic)
+	}
+
+	if m.Subscriptions == nil {
+		m.Subscriptions = make(map[string]*Subscription)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "sns", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // SetSQSPublisher sets the SQS publisher for SNS to SQS integration.
 func (m *MemoryStorage) SetSQSPublisher(publisher SQSPublisher) {
-	m.sqsPublisher = publisher
+	m.SqsPublisher = publisher
 }
 
 // CreateTopic creates a new topic.
@@ -64,7 +145,7 @@ func (m *MemoryStorage) CreateTopic(_ context.Context, name string, attributes m
 	arn := m.buildTopicARN(name)
 
 	// Return existing topic if it exists.
-	if topic, exists := m.topics[arn]; exists {
+	if topic, exists := m.Topics[arn]; exists {
 		return topic, nil
 	}
 
@@ -82,7 +163,7 @@ func (m *MemoryStorage) CreateTopic(_ context.Context, name string, attributes m
 		}
 	}
 
-	m.topics[arn] = topic
+	m.Topics[arn] = topic
 
 	return topic, nil
 }
@@ -92,7 +173,7 @@ func (m *MemoryStorage) DeleteTopic(_ context.Context, topicARN string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	topic, exists := m.topics[topicARN]
+	topic, exists := m.Topics[topicARN]
 	if !exists {
 		return &TopicError{
 			Code:    "NotFound",
@@ -102,10 +183,10 @@ func (m *MemoryStorage) DeleteTopic(_ context.Context, topicARN string) error {
 
 	// Delete all subscriptions for this topic.
 	for subARN := range topic.Subscriptions {
-		delete(m.subscriptions, subARN)
+		delete(m.Subscriptions, subARN)
 	}
 
-	delete(m.topics, topicARN)
+	delete(m.Topics, topicARN)
 
 	return nil
 }
@@ -116,8 +197,8 @@ func (m *MemoryStorage) ListTopics(_ context.Context, nextToken string) ([]*Topi
 	defer m.mu.RUnlock()
 
 	// Collect all topics.
-	allTopics := make([]*Topic, 0, len(m.topics))
-	for _, topic := range m.topics {
+	allTopics := make([]*Topic, 0, len(m.Topics))
+	for _, topic := range m.Topics {
 		allTopics = append(allTopics, topic)
 	}
 
@@ -156,7 +237,7 @@ func (m *MemoryStorage) Subscribe(_ context.Context, topicARN, protocol, endpoin
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	topic, exists := m.topics[topicARN]
+	topic, exists := m.Topics[topicARN]
 	if !exists {
 		return nil, &TopicError{
 			Code:    "NotFound",
@@ -194,7 +275,7 @@ func (m *MemoryStorage) Subscribe(_ context.Context, topicARN, protocol, endpoin
 		subscription.ConfirmationWasAuthenticated = true
 	}
 
-	m.subscriptions[subscriptionARN] = subscription
+	m.Subscriptions[subscriptionARN] = subscription
 	topic.Subscriptions[subscriptionARN] = subscription
 
 	return subscription, nil
@@ -205,7 +286,7 @@ func (m *MemoryStorage) Unsubscribe(_ context.Context, subscriptionARN string) e
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	subscription, exists := m.subscriptions[subscriptionARN]
+	subscription, exists := m.Subscriptions[subscriptionARN]
 	if !exists {
 		return &TopicError{
 			Code:    "NotFound",
@@ -214,11 +295,11 @@ func (m *MemoryStorage) Unsubscribe(_ context.Context, subscriptionARN string) e
 	}
 
 	// Remove from topic's subscriptions.
-	if topic, exists := m.topics[subscription.TopicARN]; exists {
+	if topic, exists := m.Topics[subscription.TopicARN]; exists {
 		delete(topic.Subscriptions, subscriptionARN)
 	}
 
-	delete(m.subscriptions, subscriptionARN)
+	delete(m.Subscriptions, subscriptionARN)
 
 	return nil
 }
@@ -227,7 +308,7 @@ func (m *MemoryStorage) Unsubscribe(_ context.Context, subscriptionARN string) e
 func (m *MemoryStorage) Publish(ctx context.Context, topicARN, message, subject string, attributes map[string]MessageAttribute) (string, error) {
 	m.mu.RLock()
 
-	topic, exists := m.topics[topicARN]
+	topic, exists := m.Topics[topicARN]
 	if !exists {
 		m.mu.RUnlock()
 
@@ -261,7 +342,7 @@ func (m *MemoryStorage) Publish(ctx context.Context, topicARN, message, subject 
 func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, message, subject, messageID string, _ map[string]MessageAttribute) error {
 	switch sub.Protocol {
 	case "sqs":
-		if m.sqsPublisher != nil {
+		if m.SqsPublisher != nil {
 			attrs := map[string]string{
 				"MessageId": messageID,
 			}
@@ -269,7 +350,7 @@ func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, m
 				attrs["Subject"] = subject
 			}
 
-			if err := m.sqsPublisher.PublishToSQS(ctx, sub.Endpoint, message, attrs); err != nil {
+			if err := m.SqsPublisher.PublishToSQS(ctx, sub.Endpoint, message, attrs); err != nil {
 				return fmt.Errorf("failed to publish to SQS: %w", err)
 			}
 
@@ -292,8 +373,8 @@ func (m *MemoryStorage) ListSubscriptions(_ context.Context, nextToken string) (
 	defer m.mu.RUnlock()
 
 	// Collect all subscriptions.
-	allSubs := make([]*Subscription, 0, len(m.subscriptions))
-	for _, sub := range m.subscriptions {
+	allSubs := make([]*Subscription, 0, len(m.Subscriptions))
+	for _, sub := range m.Subscriptions {
 		allSubs = append(allSubs, sub)
 	}
 
@@ -332,7 +413,7 @@ func (m *MemoryStorage) ListSubscriptionsByTopic(_ context.Context, topicARN, ne
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	topic, exists := m.topics[topicARN]
+	topic, exists := m.Topics[topicARN]
 	if !exists {
 		return nil, "", &TopicError{
 			Code:    "NotFound",

--- a/internal/service/sqs/service.go
+++ b/internal/service/sqs/service.go
@@ -1,13 +1,25 @@
 package sqs
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
 const defaultBaseURL = "http://localhost:4566"
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage(defaultBaseURL), defaultBaseURL))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(defaultBaseURL, opts...), defaultBaseURL))
 }
 
 // Service implements the SQS service.
@@ -43,3 +55,14 @@ func (s *Service) TargetPrefix() string {
 
 // JSONProtocol is a marker method that indicates SQS uses AWS JSON 1.0 protocol.
 func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/sqs/storage.go
+++ b/internal/service/sqs/storage.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5" //nolint:gosec // MD5 is required by SQS spec for message body hash
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -12,12 +13,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
-// deduplicationEntry holds deduplication information for FIFO queues.
-type deduplicationEntry struct {
-	messageID string
-	expiresAt time.Time
+// DeduplicationEntry holds deduplication information for FIFO queues.
+type DeduplicationEntry struct {
+	MessageID string    `json:"messageId"`
+	ExpiresAt time.Time `json:"expiresAt"`
 }
 
 // Storage defines the interface for SQS storage operations.
@@ -56,27 +59,102 @@ var (
 	ErrMessageNotInflight   = &QueueError{Code: "MessageNotInflight", Message: "The message is not in flight"}
 )
 
-// MemoryStorage implements Storage using in-memory maps.
-type MemoryStorage struct {
-	mu      sync.RWMutex
-	queues  map[string]*queueData
-	baseURL string
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
 }
 
-type queueData struct {
-	queue              *Queue
-	messages           []*Message
-	inflight           map[string]*Message           // receiptHandle -> message
-	deduplicationCache map[string]deduplicationEntry // deduplicationID -> entry (FIFO only)
-	sequenceCounter    uint64                        // Per-queue sequence number (FIFO only)
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
+// MemoryStorage implements Storage using in-memory maps.
+type MemoryStorage struct {
+	mu      sync.RWMutex          `json:"-"`
+	Queues  map[string]*QueueData `json:"queues"`
+	baseURL string
+	dataDir string
+}
+
+// QueueData holds all data associated with a single SQS queue.
+type QueueData struct {
+	Queue              *Queue                        `json:"queue"`
+	Messages           []*Message                    `json:"messages"`
+	Inflight           map[string]*Message           `json:"-"`               // receiptHandle -> message
+	DeduplicationCache map[string]DeduplicationEntry `json:"-"`               // deduplicationID -> entry (FIFO only)
+	SequenceCounter    uint64                        `json:"sequenceCounter"` // Per-queue sequence number (FIFO only)
 }
 
 // NewMemoryStorage creates a new in-memory SQS storage.
-func NewMemoryStorage(baseURL string) *MemoryStorage {
-	return &MemoryStorage{
-		queues:  make(map[string]*queueData),
+func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Queues:  make(map[string]*QueueData),
 		baseURL: baseURL,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "sqs", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Queues == nil {
+		s.Queues = make(map[string]*QueueData)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "sqs", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // CreateQueue creates a new queue.
@@ -86,8 +164,8 @@ func (s *MemoryStorage) CreateQueue(_ context.Context, name string, attributes m
 
 	queueURL := fmt.Sprintf("%s/000000000000/%s", s.baseURL, name)
 
-	if qd, exists := s.queues[queueURL]; exists {
-		return qd.queue, nil
+	if qd, exists := s.Queues[queueURL]; exists {
+		return qd.Queue, nil
 	}
 
 	// Check FIFO queue requirements.
@@ -118,17 +196,17 @@ func (s *MemoryStorage) CreateQueue(_ context.Context, name string, attributes m
 	// Apply attributes.
 	applyQueueAttributes(queue, attributes)
 
-	qd := &queueData{
-		queue:    queue,
-		messages: make([]*Message, 0),
-		inflight: make(map[string]*Message),
+	qd := &QueueData{
+		Queue:    queue,
+		Messages: make([]*Message, 0),
+		Inflight: make(map[string]*Message),
 	}
 
 	if isFifo {
-		qd.deduplicationCache = make(map[string]deduplicationEntry)
+		qd.DeduplicationCache = make(map[string]DeduplicationEntry)
 	}
 
-	s.queues[queueURL] = qd
+	s.Queues[queueURL] = qd
 
 	return queue, nil
 }
@@ -138,11 +216,11 @@ func (s *MemoryStorage) DeleteQueue(_ context.Context, queueURL string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.queues[queueURL]; !exists {
+	if _, exists := s.Queues[queueURL]; !exists {
 		return ErrQueueDoesNotExist
 	}
 
-	delete(s.queues, queueURL)
+	delete(s.Queues, queueURL)
 
 	return nil
 }
@@ -152,10 +230,10 @@ func (s *MemoryStorage) ListQueues(_ context.Context, prefix string) ([]string, 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	urls := make([]string, 0, len(s.queues))
+	urls := make([]string, 0, len(s.Queues))
 
-	for url, qd := range s.queues {
-		if prefix == "" || len(qd.queue.Name) >= len(prefix) && qd.queue.Name[:len(prefix)] == prefix {
+	for url, qd := range s.Queues {
+		if prefix == "" || len(qd.Queue.Name) >= len(prefix) && qd.Queue.Name[:len(prefix)] == prefix {
 			urls = append(urls, url)
 		}
 	}
@@ -168,8 +246,8 @@ func (s *MemoryStorage) GetQueueURL(_ context.Context, name string) (string, err
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	for url, qd := range s.queues {
-		if qd.queue.Name == name {
+	for url, qd := range s.Queues {
+		if qd.Queue.Name == name {
 			return url, nil
 		}
 	}
@@ -182,23 +260,23 @@ func (s *MemoryStorage) GetQueue(_ context.Context, queueURL string) (*Queue, er
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	qd, exists := s.queues[queueURL]
+	qd, exists := s.Queues[queueURL]
 	if !exists {
 		return nil, ErrQueueDoesNotExist
 	}
 
-	return qd.queue, nil
+	return qd.Queue, nil
 }
 
-// fifoResult holds the result of FIFO validation and deduplication.
-type fifoResult struct {
-	sequenceNumber string
-	dedupID        string
-	existingMsg    *Message
+// FifoResult holds the result of FIFO validation and deduplication.
+type FifoResult struct {
+	SequenceNumber string   `json:"sequenceNumber"`
+	DedupID        string   `json:"dedupId"`
+	ExistingMsg    *Message `json:"existingMsg"`
 }
 
 // validateFIFO validates FIFO queue requirements and handles deduplication.
-func (qd *queueData) validateFIFO(body, messageGroupID, messageDeduplicationID string, now time.Time) (*fifoResult, error) {
+func (qd *QueueData) validateFIFO(body, messageGroupID, messageDeduplicationID string, now time.Time) (*FifoResult, error) {
 	if messageGroupID == "" {
 		return nil, &QueueError{
 			Code:    "MissingParameter",
@@ -208,7 +286,7 @@ func (qd *queueData) validateFIFO(body, messageGroupID, messageDeduplicationID s
 
 	dedupID := messageDeduplicationID
 	if dedupID == "" {
-		if qd.queue.ContentBasedDeduplication {
+		if qd.Queue.ContentBasedDeduplication {
 			hash := sha256.Sum256([]byte(body))
 			dedupID = hex.EncodeToString(hash[:])
 		} else {
@@ -220,41 +298,41 @@ func (qd *queueData) validateFIFO(body, messageGroupID, messageDeduplicationID s
 	}
 
 	// Clean up expired deduplication entries.
-	for id, entry := range qd.deduplicationCache {
-		if now.After(entry.expiresAt) {
-			delete(qd.deduplicationCache, id)
+	for id, entry := range qd.DeduplicationCache {
+		if now.After(entry.ExpiresAt) {
+			delete(qd.DeduplicationCache, id)
 		}
 	}
 
 	// Check deduplication cache (5-minute window).
-	if entry, exists := qd.deduplicationCache[dedupID]; exists {
-		for _, msg := range qd.messages {
-			if msg.MessageID == entry.messageID {
-				return &fifoResult{existingMsg: msg}, nil
+	if entry, exists := qd.DeduplicationCache[dedupID]; exists {
+		for _, msg := range qd.Messages {
+			if msg.MessageID == entry.MessageID {
+				return &FifoResult{ExistingMsg: msg}, nil
 			}
 		}
 	}
 
 	// Generate sequence number.
-	qd.sequenceCounter++
+	qd.SequenceCounter++
 
 	// Add to deduplication cache (5-minute TTL).
-	qd.deduplicationCache[dedupID] = deduplicationEntry{
-		messageID: "",
-		expiresAt: now.Add(5 * time.Minute),
+	qd.DeduplicationCache[dedupID] = DeduplicationEntry{
+		MessageID: "",
+		ExpiresAt: now.Add(5 * time.Minute),
 	}
 
-	return &fifoResult{
-		sequenceNumber: fmt.Sprintf("%d", qd.sequenceCounter),
-		dedupID:        dedupID,
+	return &FifoResult{
+		SequenceNumber: fmt.Sprintf("%d", qd.SequenceCounter),
+		DedupID:        dedupID,
 	}, nil
 }
 
 // updateFIFOCache updates the deduplication cache with the message ID.
-func (qd *queueData) updateFIFOCache(dedupID, messageID string) {
-	entry := qd.deduplicationCache[dedupID]
-	entry.messageID = messageID
-	qd.deduplicationCache[dedupID] = entry
+func (qd *QueueData) updateFIFOCache(dedupID, messageID string) {
+	entry := qd.DeduplicationCache[dedupID]
+	entry.MessageID = messageID
+	qd.DeduplicationCache[dedupID] = entry
 }
 
 // SendMessage sends a message to a queue.
@@ -262,7 +340,7 @@ func (s *MemoryStorage) SendMessage(_ context.Context, queueURL, body string, de
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	qd, exists := s.queues[queueURL]
+	qd, exists := s.Queues[queueURL]
 	if !exists {
 		return nil, ErrQueueDoesNotExist
 	}
@@ -271,23 +349,23 @@ func (s *MemoryStorage) SendMessage(_ context.Context, queueURL, body string, de
 	delay := delaySeconds
 
 	if delay == 0 {
-		delay = qd.queue.DelaySeconds
+		delay = qd.Queue.DelaySeconds
 	}
 
 	var sequenceNumber, dedupID string
 
-	if qd.queue.FifoQueue {
+	if qd.Queue.FifoQueue {
 		result, err := qd.validateFIFO(body, messageGroupID, messageDeduplicationID, now)
 		if err != nil {
 			return nil, err
 		}
 
-		if result.existingMsg != nil {
-			return result.existingMsg, nil
+		if result.ExistingMsg != nil {
+			return result.ExistingMsg, nil
 		}
 
-		sequenceNumber = result.sequenceNumber
-		dedupID = result.dedupID
+		sequenceNumber = result.SequenceNumber
+		dedupID = result.DedupID
 	}
 
 	// MD5 is required by SQS specification for message body hash.
@@ -309,11 +387,11 @@ func (s *MemoryStorage) SendMessage(_ context.Context, queueURL, body string, de
 		},
 	}
 
-	if qd.queue.FifoQueue {
+	if qd.Queue.FifoQueue {
 		qd.updateFIFOCache(dedupID, msg.MessageID)
 	}
 
-	qd.messages = append(qd.messages, msg)
+	qd.Messages = append(qd.Messages, msg)
 
 	return msg, nil
 }
@@ -323,20 +401,20 @@ func (s *MemoryStorage) ReceiveMessage(_ context.Context, queueURL string, maxMe
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	qd, exists := s.queues[queueURL]
+	qd, exists := s.Queues[queueURL]
 	if !exists {
 		return nil, ErrQueueDoesNotExist
 	}
 
 	if visibilityTimeout == 0 {
-		visibilityTimeout = qd.queue.VisibilityTimeout
+		visibilityTimeout = qd.Queue.VisibilityTimeout
 	}
 
 	now := time.Now()
 	result := make([]*Message, 0, maxMessages)
-	remaining := make([]*Message, 0, len(qd.messages))
+	remaining := make([]*Message, 0, len(qd.Messages))
 
-	for _, msg := range qd.messages {
+	for _, msg := range qd.Messages {
 		if len(result) >= maxMessages {
 			remaining = append(remaining, msg)
 
@@ -359,11 +437,11 @@ func (s *MemoryStorage) ReceiveMessage(_ context.Context, queueURL string, maxMe
 			msg.Attributes["ApproximateFirstReceiveTimestamp"] = fmt.Sprintf("%d", now.UnixMilli())
 		}
 
-		qd.inflight[msg.ReceiptHandle] = msg
+		qd.Inflight[msg.ReceiptHandle] = msg
 		result = append(result, msg)
 	}
 
-	qd.messages = remaining
+	qd.Messages = remaining
 
 	return result, nil
 }
@@ -373,16 +451,16 @@ func (s *MemoryStorage) DeleteMessage(_ context.Context, queueURL, receiptHandle
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	qd, exists := s.queues[queueURL]
+	qd, exists := s.Queues[queueURL]
 	if !exists {
 		return ErrQueueDoesNotExist
 	}
 
-	if _, exists := qd.inflight[receiptHandle]; !exists {
+	if _, exists := qd.Inflight[receiptHandle]; !exists {
 		return ErrReceiptHandleInvalid
 	}
 
-	delete(qd.inflight, receiptHandle)
+	delete(qd.Inflight, receiptHandle)
 
 	return nil
 }
@@ -392,13 +470,13 @@ func (s *MemoryStorage) PurgeQueue(_ context.Context, queueURL string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	qd, exists := s.queues[queueURL]
+	qd, exists := s.Queues[queueURL]
 	if !exists {
 		return ErrQueueDoesNotExist
 	}
 
-	qd.messages = make([]*Message, 0)
-	qd.inflight = make(map[string]*Message)
+	qd.Messages = make([]*Message, 0)
+	qd.Inflight = make(map[string]*Message)
 
 	return nil
 }
@@ -408,12 +486,12 @@ func (s *MemoryStorage) GetQueueAttributes(_ context.Context, queueURL string, a
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	qd, exists := s.queues[queueURL]
+	qd, exists := s.Queues[queueURL]
 	if !exists {
 		return nil, ErrQueueDoesNotExist
 	}
 
-	q := qd.queue
+	q := qd.Queue
 	allAttrs := map[string]string{
 		"QueueArn":                              q.ARN,
 		"CreatedTimestamp":                      fmt.Sprintf("%d", q.CreatedTimestamp.Unix()),
@@ -423,8 +501,8 @@ func (s *MemoryStorage) GetQueueAttributes(_ context.Context, queueURL string, a
 		"DelaySeconds":                          fmt.Sprintf("%d", q.DelaySeconds),
 		"MaximumMessageSize":                    fmt.Sprintf("%d", q.MaxMessageSize),
 		"ReceiveMessageWaitTimeSeconds":         fmt.Sprintf("%d", q.ReceiveWaitTimeSeconds),
-		"ApproximateNumberOfMessages":           fmt.Sprintf("%d", len(qd.messages)),
-		"ApproximateNumberOfMessagesNotVisible": fmt.Sprintf("%d", len(qd.inflight)),
+		"ApproximateNumberOfMessages":           fmt.Sprintf("%d", len(qd.Messages)),
+		"ApproximateNumberOfMessagesNotVisible": fmt.Sprintf("%d", len(qd.Inflight)),
 		"FifoQueue":                             fmt.Sprintf("%t", q.FifoQueue),
 		"ContentBasedDeduplication":             fmt.Sprintf("%t", q.ContentBasedDeduplication),
 	}
@@ -450,13 +528,13 @@ func (s *MemoryStorage) SetQueueAttributes(_ context.Context, queueURL string, a
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	qd, exists := s.queues[queueURL]
+	qd, exists := s.Queues[queueURL]
 	if !exists {
 		return ErrQueueDoesNotExist
 	}
 
-	applyQueueAttributes(qd.queue, attributes)
-	qd.queue.LastModifiedTimestamp = time.Now()
+	applyQueueAttributes(qd.Queue, attributes)
+	qd.Queue.LastModifiedTimestamp = time.Now()
 
 	return nil
 }

--- a/internal/service/ssm/service.go
+++ b/internal/service/ssm/service.go
@@ -1,14 +1,25 @@
 package ssm
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the SSM Parameter Store service.
@@ -67,4 +78,15 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeSSMError(w, ErrInvalidParameterValue, "The action "+action+" is not valid", http.StatusBadRequest)
 	}
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/ssm/storage.go
+++ b/internal/service/ssm/storage.go
@@ -2,11 +2,14 @@ package ssm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Storage defines the SSM Parameter Store storage interface.
@@ -20,21 +23,95 @@ type Storage interface {
 	DescribeParameters(ctx context.Context, maxResults int, nextToken string) ([]*Parameter, string, error)
 }
 
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu         sync.RWMutex
-	parameters map[string]*Parameter
+	mu         sync.RWMutex          `json:"-"`
+	Parameters map[string]*Parameter `json:"parameters"`
 	region     string
 	accountID  string
+	dataDir    string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		parameters: make(map[string]*Parameter),
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Parameters: make(map[string]*Parameter),
 		region:     "us-east-1",
 		accountID:  "000000000000",
 	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "ssm", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Parameters == nil {
+		s.Parameters = make(map[string]*Parameter)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "ssm", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // PutParameter creates or updates a parameter.
@@ -42,7 +119,7 @@ func (s *MemoryStorage) PutParameter(_ context.Context, req *PutParameterRequest
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	existing, exists := s.parameters[req.Name]
+	existing, exists := s.Parameters[req.Name]
 
 	// Check if parameter exists and overwrite is not set
 	if exists && !req.Overwrite {
@@ -89,7 +166,7 @@ func (s *MemoryStorage) PutParameter(_ context.Context, req *PutParameterRequest
 		Description:      req.Description,
 	}
 
-	s.parameters[req.Name] = param
+	s.Parameters[req.Name] = param
 
 	return param, nil
 }
@@ -99,7 +176,7 @@ func (s *MemoryStorage) GetParameter(_ context.Context, name string) (*Parameter
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	param, exists := s.parameters[name]
+	param, exists := s.Parameters[name]
 	if !exists {
 		return nil, &ParameterError{
 			Type:    ErrParameterNotFound,
@@ -120,7 +197,7 @@ func (s *MemoryStorage) GetParameters(_ context.Context, names []string) ([]*Par
 	var invalidParams []string
 
 	for _, name := range names {
-		param, exists := s.parameters[name]
+		param, exists := s.Parameters[name]
 		if exists {
 			params = append(params, param)
 		} else {
@@ -152,7 +229,7 @@ func (s *MemoryStorage) GetParametersByPath(_ context.Context, path string, recu
 	// Collect matching parameters
 	var matches []*Parameter
 
-	for name, param := range s.parameters {
+	for name, param := range s.Parameters {
 		if matchesPath(name, path, recursive) {
 			matches = append(matches, param)
 		}
@@ -212,14 +289,14 @@ func (s *MemoryStorage) DeleteParameter(_ context.Context, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.parameters[name]; !exists {
+	if _, exists := s.Parameters[name]; !exists {
 		return &ParameterError{
 			Type:    ErrParameterNotFound,
 			Message: fmt.Sprintf("Parameter %s not found.", name),
 		}
 	}
 
-	delete(s.parameters, name)
+	delete(s.Parameters, name)
 
 	return nil
 }
@@ -234,8 +311,8 @@ func (s *MemoryStorage) DeleteParameters(_ context.Context, names []string) ([]s
 	var invalid []string
 
 	for _, name := range names {
-		if _, exists := s.parameters[name]; exists {
-			delete(s.parameters, name)
+		if _, exists := s.Parameters[name]; exists {
+			delete(s.Parameters, name)
 
 			deleted = append(deleted, name)
 		} else {
@@ -256,8 +333,8 @@ func (s *MemoryStorage) DescribeParameters(_ context.Context, maxResults int, ne
 	}
 
 	// Collect all parameters
-	params := make([]*Parameter, 0, len(s.parameters))
-	for _, p := range s.parameters {
+	params := make([]*Parameter, 0, len(s.Parameters))
+	for _, p := range s.Parameters {
 		params = append(params, p)
 	}
 

--- a/internal/service/sts/service.go
+++ b/internal/service/sts/service.go
@@ -1,12 +1,23 @@
 package sts
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	storage := NewMemoryStorage()
-	service.Register(New(storage))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the STS service.
@@ -51,3 +62,14 @@ func (s *Service) Actions() []string {
 
 // QueryProtocol is a marker method that indicates STS uses AWS Query protocol.
 func (s *Service) QueryProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/sts/storage.go
+++ b/internal/service/sts/storage.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 const (
@@ -26,6 +29,22 @@ type Storage interface {
 	GetSessionToken(ctx context.Context, input *GetSessionTokenInput) (*Credentials, error)
 	GetFederationToken(ctx context.Context, input *GetFederationTokenInput) (*FederationTokenResult, error)
 }
+
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
 
 // AssumeRoleResult represents the result of an AssumeRole operation.
 type AssumeRoleResult struct {
@@ -49,11 +68,47 @@ type FederationTokenResult struct {
 }
 
 // MemoryStorage implements Storage with in-memory data.
-type MemoryStorage struct{}
+type MemoryStorage struct {
+	dataDir string
+}
 
 // NewMemoryStorage creates a new MemoryStorage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{}
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "sts", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+// STS is stateless, so we return an empty JSON object.
+func (m *MemoryStorage) MarshalJSON() ([]byte, error) {
+	return []byte("{}"), nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+// STS is stateless, so there is nothing to restore.
+func (m *MemoryStorage) UnmarshalJSON(_ []byte) error {
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (m *MemoryStorage) Close() error {
+	if m.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(m.dataDir, "sts", m); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
 }
 
 // AssumeRole generates temporary credentials for an assumed role.

--- a/internal/service/xray/service.go
+++ b/internal/service/xray/service.go
@@ -1,11 +1,23 @@
 package xray
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/sivchari/kumo/internal/service"
 )
 
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
 func init() {
-	service.Register(New(NewMemoryStorage()))
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
 }
 
 // Service implements the X-Ray service.
@@ -34,4 +46,15 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.HandleFunc("POST", "/ServiceGraph", s.GetServiceGraph)
 	r.HandleFunc("POST", "/CreateGroup", s.CreateGroup)
 	r.HandleFunc("POST", "/DeleteGroup", s.DeleteGroup)
+}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/internal/service/xray/storage.go
+++ b/internal/service/xray/storage.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
 )
 
 // Error codes.
@@ -26,25 +28,107 @@ type Storage interface {
 	DeleteGroup(ctx context.Context, groupName, groupARN string) error
 }
 
-// MemoryStorage implements Storage with in-memory data structures.
-type MemoryStorage struct {
-	mu       sync.RWMutex
-	traces   map[string]*Trace   // key: traceID
-	segments map[string]*Segment // key: segmentID
-	groups   map[string]*Group   // key: groupName
-}
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
 
-// NewMemoryStorage creates a new in-memory storage.
-func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		traces:   make(map[string]*Trace),
-		segments: make(map[string]*Segment),
-		groups:   make(map[string]*Group),
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
 	}
 }
 
-// segmentDocument represents the structure of a segment document.
-type segmentDocument struct {
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
+// MemoryStorage implements Storage with in-memory data structures.
+type MemoryStorage struct {
+	mu       sync.RWMutex        `json:"-"`
+	Traces   map[string]*Trace   `json:"traces"`   // key: traceID
+	Segments map[string]*Segment `json:"segments"` // key: segmentID
+	Groups   map[string]*Group   `json:"groups"`   // key: groupName
+	dataDir  string
+}
+
+// NewMemoryStorage creates a new in-memory storage.
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		Traces:   make(map[string]*Trace),
+		Segments: make(map[string]*Segment),
+		Groups:   make(map[string]*Group),
+	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "xray", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Traces == nil {
+		s.Traces = make(map[string]*Trace)
+	}
+
+	if s.Segments == nil {
+		s.Segments = make(map[string]*Segment)
+	}
+
+	if s.Groups == nil {
+		s.Groups = make(map[string]*Group)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "xray", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
+}
+
+// SegmentDocument represents the structure of a segment document.
+type SegmentDocument struct {
 	ID         string  `json:"id"`
 	TraceID    string  `json:"trace_id"`
 	Name       string  `json:"name"`
@@ -80,7 +164,7 @@ func (s *MemoryStorage) PutTraceSegments(_ context.Context, documents []string) 
 	var unprocessed []UnprocessedTraceSegment
 
 	for _, doc := range documents {
-		var segDoc segmentDocument
+		var segDoc SegmentDocument
 		if err := json.Unmarshal([]byte(doc), &segDoc); err != nil {
 			unprocessed = append(unprocessed, UnprocessedTraceSegment{
 				ID:        "",
@@ -104,16 +188,16 @@ func (s *MemoryStorage) PutTraceSegments(_ context.Context, documents []string) 
 			Document: doc,
 		}
 
-		s.segments[segDoc.ID] = segment
+		s.Segments[segDoc.ID] = segment
 
 		// Create or update trace.
-		trace, exists := s.traces[segDoc.TraceID]
+		trace, exists := s.Traces[segDoc.TraceID]
 		if !exists {
 			trace = &Trace{
 				ID:       segDoc.TraceID,
 				Segments: []*Segment{},
 			}
-			s.traces[segDoc.TraceID] = trace
+			s.Traces[segDoc.TraceID] = trace
 		}
 
 		trace.Segments = append(trace.Segments, segment)
@@ -135,9 +219,9 @@ func (s *MemoryStorage) GetTraceSummaries(_ context.Context, _, _ time.Time) ([]
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	summaries := make([]TraceSummary, 0, len(s.traces))
+	summaries := make([]TraceSummary, 0, len(s.Traces))
 
-	for _, trace := range s.traces {
+	for _, trace := range s.Traces {
 		summary := TraceSummary{
 			ID:       trace.ID,
 			Duration: trace.Duration,
@@ -145,7 +229,7 @@ func (s *MemoryStorage) GetTraceSummaries(_ context.Context, _, _ time.Time) ([]
 
 		// Parse first segment to get additional info.
 		if len(trace.Segments) > 0 {
-			var segDoc segmentDocument
+			var segDoc SegmentDocument
 			if err := json.Unmarshal([]byte(trace.Segments[0].Document), &segDoc); err == nil {
 				summary.HasFault = segDoc.Fault
 				summary.HasError = segDoc.Error
@@ -176,7 +260,7 @@ func (s *MemoryStorage) BatchGetTraces(_ context.Context, traceIDs []string) ([]
 	var unprocessed []string
 
 	for _, id := range traceIDs {
-		if trace, exists := s.traces[id]; exists {
+		if trace, exists := s.Traces[id]; exists {
 			traces = append(traces, trace)
 		} else {
 			unprocessed = append(unprocessed, id)
@@ -194,9 +278,9 @@ func (s *MemoryStorage) GetServiceGraph(_ context.Context, _, _ time.Time, _ str
 	// Build service graph from traces.
 	serviceMap := make(map[string]*ServiceNode)
 
-	for _, trace := range s.traces {
+	for _, trace := range s.Traces {
 		for _, segment := range trace.Segments {
-			var segDoc segmentDocument
+			var segDoc SegmentDocument
 			if err := json.Unmarshal([]byte(segment.Document), &segDoc); err != nil {
 				continue
 			}
@@ -249,7 +333,7 @@ func (s *MemoryStorage) CreateGroup(_ context.Context, input *CreateGroupInput) 
 		}
 	}
 
-	if _, exists := s.groups[input.GroupName]; exists {
+	if _, exists := s.Groups[input.GroupName]; exists {
 		return nil, &Error{
 			Code:    errInvalidRequest,
 			Message: fmt.Sprintf("Group %s already exists", input.GroupName),
@@ -266,7 +350,7 @@ func (s *MemoryStorage) CreateGroup(_ context.Context, input *CreateGroupInput) 
 		InsightsConfiguration: input.InsightsConfiguration,
 	}
 
-	s.groups[input.GroupName] = group
+	s.Groups[input.GroupName] = group
 
 	return group, nil
 }
@@ -282,7 +366,7 @@ func (s *MemoryStorage) DeleteGroup(_ context.Context, groupName, groupARN strin
 	if groupName != "" {
 		targetName = groupName
 	} else if groupARN != "" {
-		for name, group := range s.groups {
+		for name, group := range s.Groups {
 			if group.GroupARN == groupARN {
 				targetName = name
 
@@ -298,14 +382,14 @@ func (s *MemoryStorage) DeleteGroup(_ context.Context, groupName, groupARN strin
 		}
 	}
 
-	if _, exists := s.groups[targetName]; !exists {
+	if _, exists := s.Groups[targetName]; !exists {
 		return &Error{
 			Code:    errNotFound,
 			Message: fmt.Sprintf("Group %s not found", targetName),
 		}
 	}
 
-	delete(s.groups, targetName)
+	delete(s.Groups, targetName)
 
 	return nil
 }

--- a/internal/storage/persistence.go
+++ b/internal/storage/persistence.go
@@ -1,0 +1,56 @@
+// Package storage provides common storage utilities.
+package storage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Load reads a JSON snapshot from dataDir/{name}.json and unmarshals it into v.
+// Returns nil if the file does not exist.
+func Load(dataDir, name string, v json.Unmarshaler) error {
+	path := filepath.Join(dataDir, name+".json")
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to read snapshot %s: %w", path, err)
+	}
+
+	if err := v.UnmarshalJSON(data); err != nil {
+		return fmt.Errorf("failed to unmarshal snapshot %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// Save marshals v to JSON and writes it atomically to dataDir/{name}.json.
+func Save(dataDir, name string, v json.Marshaler) error {
+	data, err := v.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("failed to marshal snapshot %s: %w", name, err)
+	}
+
+	if err := os.MkdirAll(dataDir, 0o750); err != nil {
+		return fmt.Errorf("failed to create data directory %s: %w", dataDir, err)
+	}
+
+	path := filepath.Join(dataDir, name+".json")
+	tmp := path + ".tmp"
+
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write temporary snapshot %s: %w", tmp, err)
+	}
+
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("failed to rename snapshot %s to %s: %w", tmp, path, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- Add optional snapshot-based persistence to all 71 services via `KUMO_DATA_DIR` environment variable
- Each `MemoryStorage` implements `json.Marshaler`/`json.Unmarshaler` and serializes state to `$KUMO_DATA_DIR/{service}.json` on shutdown
- Default behavior (in-memory only) is completely unchanged when `KUMO_DATA_DIR` is not set

## Changes

- `internal/storage/persistence.go` (NEW): Shared `Load`/`Save` utilities with atomic writes (tmp file + rename)
- `internal/server/server.go`: Call `io.Closer` on all services during graceful shutdown
- All `storage.go`: `Option` pattern (`WithDataDir`), exported data fields with json tags, `MarshalJSON`/`UnmarshalJSON`/`Close` methods
- All `service.go`: Read `KUMO_DATA_DIR` env var in `init()`, implement `io.Closer` to delegate to storage
- `README.md`: Add persistence documentation, Docker/binary/compose examples
- Ephemeral state excluded from persistence: SQS in-flight messages, S3 multipart uploads, deduplication caches

## Test plan

- [ ] Verify `go build ./...` passes
- [ ] Verify `go vet ./...` passes
- [ ] Set `KUMO_DATA_DIR=/tmp/kumo-data`, create resources via SDK, restart server, confirm resources persist
- [ ] Confirm default behavior unchanged without `KUMO_DATA_DIR`

Closes #377