### PR TITLE
fix(server): use mime.ParseMediaType for Content-Type matching

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"os"
 	"os/signal"
@@ -93,10 +94,11 @@ func New(config Config) *Server {
 
 // unifiedDispatcher routes requests to JSON or Query protocol handlers based on Content-Type.
 func (s *Server) unifiedDispatcher(w http.ResponseWriter, r *http.Request) {
-	contentType := r.Header.Get("Content-Type")
+	// Parse media type per RFC 2045 (e.g. "application/x-www-form-urlencoded; charset=utf-8").
+	mediaType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 
 	// Query protocol uses form-urlencoded.
-	if contentType == "application/x-www-form-urlencoded" {
+	if mediaType == "application/x-www-form-urlencoded" {
 		s.queryDispatcher.ServeHTTP(w, r)
 
 		return


### PR DESCRIPTION
AWS CLI sends "application/x-www-form-urlencoded; charset=utf-8" which did not match the exact string comparison, causing EC2 Query protocol requests to fall through to the JSON dispatcher.