### PR TITLE
feat(chart): add Helm chart for kumo

### DIFF
--- a/.github/workflows/helm-e2e.yaml
+++ b/.github/workflows/helm-e2e.yaml
@@ -1,0 +1,37 @@
+name: Helm E2E Test
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+      - 'test/e2e/**'
+      - '.github/workflows/helm-e2e.yaml'
+  pull_request:
+    paths:
+      - 'charts/**'
+      - 'test/e2e/**'
+      - '.github/workflows/helm-e2e.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  helm-e2e:
+    name: Helm e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install kind
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          install_only: true
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+
+      - name: Run Helm e2e
+        run: make test-helm-e2e

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -75,3 +75,42 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+  helm-push:
+    needs: [tagpr, goreleaser]
+    if: needs.tagpr.outputs.tagpr-tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      TAG: ${{ needs.tagpr.outputs.tagpr-tag }}
+      OWNER: ${{ github.repository_owner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.tagpr.outputs.tagpr-tag }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+
+      - name: Login to GitHub Container Registry
+        env:
+          HELM_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: echo "${HELM_PASSWORD}" | helm registry login ghcr.io -u "${GHCR_USER}" --password-stdin
+
+      - name: Update chart image repository for forks
+        if: github.repository_owner != 'sivchari'
+        run: |
+          yq -i '.kumo.image.repository = strenv(OWNER) + "/kumo"' charts/kumo/values.yaml
+
+      - name: Lint Helm Chart
+        run: helm lint charts/kumo
+
+      - name: Package and Push Helm Chart
+        run: |
+          VERSION="${TAG#v}"
+          helm package charts/kumo --version "${VERSION}" --app-version "${VERSION}"
+          helm push "kumo-${VERSION}.tgz" "oci://ghcr.io/${OWNER}/helm-charts"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ release:
 
 dockers:
   - image_templates:
-      - "ghcr.io/sivchari/kumo:{{ .Version }}-amd64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/kumo:{{ .Version }}-amd64"
     use: buildx
     goos: linux
     goarch: amd64
@@ -55,10 +55,10 @@ dockers:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.source=https://github.com/sivchari/kumo"
+      - "--label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPOSITORY }}"
 
   - image_templates:
-      - "ghcr.io/sivchari/kumo:{{ .Version }}-arm64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/kumo:{{ .Version }}-arm64"
     use: buildx
     goos: linux
     goarch: arm64
@@ -67,7 +67,7 @@ dockers:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.source=https://github.com/sivchari/kumo"
+      - "--label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPOSITORY }}"
 
 homebrew_casks:
   - name: kumo
@@ -75,19 +75,19 @@ homebrew_casks:
       - kumo
     binaries:
       - kumo
-    homepage: "https://github.com/sivchari/kumo"
+    homepage: "https://github.com/{{ .Env.GITHUB_REPOSITORY }}"
     description: "A lightweight AWS service emulator for CI/CD environments"
     repository:
-      owner: sivchari
+      owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
 docker_manifests:
-  - name_template: "ghcr.io/sivchari/kumo:{{ .Version }}"
+  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/kumo:{{ .Version }}"
     image_templates:
-      - "ghcr.io/sivchari/kumo:{{ .Version }}-amd64"
-      - "ghcr.io/sivchari/kumo:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/sivchari/kumo:latest"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/kumo:{{ .Version }}-amd64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/kumo:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/kumo:latest"
     image_templates:
-      - "ghcr.io/sivchari/kumo:{{ .Version }}-amd64"
-      - "ghcr.io/sivchari/kumo:{{ .Version }}-arm64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/kumo:{{ .Version }}-amd64"
+      - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/kumo:{{ .Version }}-arm64"

--- a/.tagpr
+++ b/.tagpr
@@ -4,5 +4,5 @@
 	vPrefix = true
 	releaseBranch = main
 	release = draft
-	versionFile = version.go
+	versionFile = version.go,charts/kumo/Chart.yaml,charts/kumo/values.yaml
 	changelog = true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-integration clean docker lint lint-fix fmt fmt-diff
+.PHONY: build run test test-integration test-helm-e2e clean docker lint lint-fix fmt fmt-diff
 
 BINARY_NAME=kumo
 VERSION?=$(shell grep 'const Version' version.go | cut -d'"' -f2)
@@ -22,6 +22,9 @@ test-cover:
 
 test-integration:
 	go test -C test -v -tags=integration ./integration/...
+
+test-helm-e2e:
+	bash test/e2e/helm-e2e.sh
 
 # Lint
 lint:

--- a/charts/kumo/.helmignore
+++ b/charts/kumo/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kumo/Chart.yaml
+++ b/charts/kumo/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kumo
+description: Lightweight AWS service emulator for Kubernetes with automatic AWS_ENDPOINT_URL injection
+type: application
+version: 0.8.0
+appVersion: "0.8.0"

--- a/charts/kumo/templates/NOTES.txt
+++ b/charts/kumo/templates/NOTES.txt
@@ -1,0 +1,21 @@
+kumo has been deployed to namespace {{ .Release.Namespace }}.
+
+Endpoint: http://{{ include "kumo.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:4566
+{{- if .Values.injection.enabled }}
+
+Kyverno ClusterPolicy is ENABLED.
+{{- if empty .Values.injection.namespaceSelector }}
+Label your namespaces to enable AWS endpoint injection:
+
+  kubectl label namespace <namespace> {{ .Values.injection.namespaceLabelKey }}={{ .Values.injection.namespaceLabelValue }}
+{{- else }}
+Custom namespaceSelector is configured.
+Review your values to determine which namespaces opt in to injection.
+{{- end }}
+{{- else }}
+
+Kyverno ClusterPolicy is DISABLED (default).
+To enable automatic AWS_ENDPOINT_URL injection into Pods, set:
+
+  helm upgrade {{ .Release.Name }} kumo --set injection.enabled=true
+{{- end }}

--- a/charts/kumo/templates/_helpers.tpl
+++ b/charts/kumo/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kumo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kumo.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kumo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kumo.labels" -}}
+helm.sh/chart: {{ include "kumo.chart" . }}
+{{ include "kumo.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kumo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kumo.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/kumo/templates/clusterpolicy.yaml
+++ b/charts/kumo/templates/clusterpolicy.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.injection.enabled }}
+{{- $kumoEndpoint := printf "http://%s.%s.svc.cluster.local:4566" (include "kumo.fullname" .) .Release.Namespace }}
+{{- $defaultNamespaceSelector := dict "matchLabels" (dict .Values.injection.namespaceLabelKey .Values.injection.namespaceLabelValue) }}
+{{- $namespaceSelector := .Values.injection.namespaceSelector | default $defaultNamespaceSelector }}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "kumo.fullname" . }}-inject-aws-env
+  labels:
+    {{- include "kumo.labels" . | nindent 4 }}
+  annotations:
+    policies.kyverno.io/title: Inject AWS kumo endpoint
+    policies.kyverno.io/description: >-
+      Inject AWS_ENDPOINT_URL environment variable into Pods
+      to redirect AWS API calls to kumo.
+spec:
+  failurePolicy: {{ .Values.injection.failurePolicy }}
+  mutateExistingOnPolicyUpdate: false
+  rules:
+    - name: inject-aws-env
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaceSelector:
+{{ toYaml $namespaceSelector | indent 16 }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                - {{ .Release.Namespace }}
+      mutate:
+        patchStrategicMerge:
+          spec:
+            containers:
+              - (name): "*"
+                env:
+                  - name: AWS_ENDPOINT_URL
+                    value: {{ $kumoEndpoint | quote }}
+                  - name: AWS_ACCESS_KEY_ID
+                    value: {{ .Values.injection.aws.accessKeyId | quote }}
+                  - name: AWS_SECRET_ACCESS_KEY
+                    value: {{ .Values.injection.aws.secretAccessKey | quote }}
+                  - name: AWS_DEFAULT_REGION
+                    value: {{ .Values.injection.aws.region | quote }}
+            initContainers:
+              - (name): "*"
+                env:
+                  - name: AWS_ENDPOINT_URL
+                    value: {{ $kumoEndpoint | quote }}
+                  - name: AWS_ACCESS_KEY_ID
+                    value: {{ .Values.injection.aws.accessKeyId | quote }}
+                  - name: AWS_SECRET_ACCESS_KEY
+                    value: {{ .Values.injection.aws.secretAccessKey | quote }}
+                  - name: AWS_DEFAULT_REGION
+                    value: {{ .Values.injection.aws.region | quote }}
+{{- end }}

--- a/charts/kumo/templates/networkpolicy.yaml
+++ b/charts/kumo/templates/networkpolicy.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kumo.fullname" . }}
+  labels:
+    {{- include "kumo.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kumo.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress: []
+{{- end }}

--- a/charts/kumo/templates/service.yaml
+++ b/charts/kumo/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kumo.fullname" . }}
+  labels:
+    {{- include "kumo.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 4566
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "kumo.selectorLabels" . | nindent 4 }}

--- a/charts/kumo/templates/statefulset.yaml
+++ b/charts/kumo/templates/statefulset.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "kumo.fullname" . }}
+  labels:
+    {{- include "kumo.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "kumo.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "kumo.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kumo.selectorLabels" . | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: 35
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        fsGroup: 10000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kumo
+          image: "{{ .Values.kumo.image.registry }}/{{ .Values.kumo.image.repository }}:{{ .Values.kumo.image.tag | default .Chart.AppVersion }}"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          ports:
+            - name: http
+              containerPort: 4566
+              protocol: TCP
+          env:
+            - name: KUMO_DATA_DIR
+              value: "/data"
+            - name: KUMO_LOG_LEVEL
+              value: {{ .Values.kumo.logLevel | quote }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.kumo.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+{{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+{{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}

--- a/charts/kumo/values.yaml
+++ b/charts/kumo/values.yaml
@@ -1,0 +1,52 @@
+# -- kumo server settings
+kumo:
+  image:
+    registry: ghcr.io
+    repository: sivchari/kumo
+    # -- Overrides the image tag whose default is the chart appVersion
+    tag: ""
+  logLevel: info
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# -- Data persistence (PVC via StatefulSet volumeClaimTemplates)
+persistence:
+  size: 1Gi
+  storageClass: ""
+
+# -- AWS environment variable injection settings (requires Kyverno)
+injection:
+  # -- Enable Kyverno ClusterPolicy for automatic AWS_ENDPOINT_URL injection
+  enabled: false
+
+  # -- ClusterPolicy failurePolicy (Fail or Ignore)
+  failurePolicy: Fail
+
+  # -- Maintainer-owned opt-in label key for AWS env injection.
+  # Override when kumo gets a canonical project domain.
+  namespaceLabelKey: "sivchari.github.io/kumo-inject"
+
+  # -- Value required on namespaceLabelKey for opt-in injection.
+  namespaceLabelValue: "enabled"
+
+  # -- Advanced override for the Kyverno namespaceSelector.
+  # Leave empty to use namespaceLabelKey/namespaceLabelValue.
+  namespaceSelector: {}
+
+  # -- AWS credentials and region to inject (dummy values for emulator)
+  aws:
+    region: us-east-1
+    accessKeyId: test
+    secretAccessKey: test
+
+# -- NetworkPolicy (egress deny-all for security hardening)
+networkPolicy:
+  enabled: true
+
+nameOverride: ""
+fullnameOverride: ""

--- a/charts/kumo/values.yaml
+++ b/charts/kumo/values.yaml
@@ -3,8 +3,8 @@ kumo:
   image:
     registry: ghcr.io
     repository: sivchari/kumo
-    # -- Overrides the image tag whose default is the chart appVersion
-    tag: ""
+    # -- Image tag for kumo. Set to empty to fall back to the chart appVersion.
+    tag: "0.8.0"
   logLevel: info
   resources:
     requests:

--- a/test/e2e/helm-e2e.sh
+++ b/test/e2e/helm-e2e.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+CLUSTER_NAME="${CLUSTER_NAME:-kumo-e2e}"
+KUMO_IMAGE="${KUMO_IMAGE:-ghcr.io/sivchari/kumo:e2e-local}"
+ACK_SQS_CHART_VERSION="${ACK_SQS_CHART_VERSION:-1.4.1}"
+QUEUE_NAME="helm-e2e-$(date +%s)"
+
+KUMO_NS="kumo-system"
+ACK_NS="ack-system"
+QUEUE_NS="ack-test"
+KUMO_RELEASE="kumo"
+ACK_RELEASE="ack-sqs-controller"
+KUMO_ENDPOINT="http://${KUMO_RELEASE}.${KUMO_NS}.svc.cluster.local:4566"
+ACK_LABEL="app.kubernetes.io/instance=${ACK_RELEASE}"
+LOCAL_ENDPOINT="http://127.0.0.1:14566"
+
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ENDPOINT_URL="$LOCAL_ENDPOINT"
+
+KUBECTL=(kubectl --context "kind-${CLUSTER_NAME}")
+PORT_FORWARD_PID=""
+PORT_FORWARD_LOG=""
+
+cleanup() {
+  if [[ -n "$PORT_FORWARD_PID" ]]; then
+    kill "$PORT_FORWARD_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$PORT_FORWARD_LOG" ]]; then
+    rm -f "$PORT_FORWARD_LOG"
+  fi
+  kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+}
+
+start_port_forward() {
+  local i
+  PORT_FORWARD_LOG="$(mktemp)"
+
+  "${KUBECTL[@]}" port-forward -n "$KUMO_NS" "svc/${KUMO_RELEASE}" 14566:4566 >"$PORT_FORWARD_LOG" 2>&1 &
+  PORT_FORWARD_PID=$!
+
+  for i in $(seq 1 30); do
+    if curl -fs "${LOCAL_ENDPOINT}/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    if ! kill -0 "$PORT_FORWARD_PID" >/dev/null 2>&1; then
+      cat "$PORT_FORWARD_LOG"
+      return 1
+    fi
+    sleep 1
+  done
+
+  cat "$PORT_FORWARD_LOG"
+  return 1
+}
+
+wait_for_queue_url() {
+  local queue_url=""
+  local terminal=""
+  local i
+
+  for i in $(seq 1 90); do
+    queue_url="$("${KUBECTL[@]}" get queue -n "$QUEUE_NS" "$QUEUE_NAME" -o jsonpath='{.status.queueURL}' 2>/dev/null || true)"
+    if [[ -n "$queue_url" ]]; then
+      printf '%s\n' "$queue_url"
+      return 0
+    fi
+
+    terminal="$("${KUBECTL[@]}" get queue -n "$QUEUE_NS" "$QUEUE_NAME" -o jsonpath='{.status.conditions[?(@.type=="ACK.Terminal")].status}' 2>/dev/null || true)"
+    if [[ "$terminal" == "True" ]]; then
+      "${KUBECTL[@]}" get queue -n "$QUEUE_NS" "$QUEUE_NAME" -o yaml
+      return 1
+    fi
+
+    sleep 2
+  done
+
+  "${KUBECTL[@]}" get queue -n "$QUEUE_NS" "$QUEUE_NAME" -o yaml || true
+  return 1
+}
+
+main() {
+  local endpoint=""
+  local queue_url=""
+  local resolved_queue_url=""
+  local queue_tag=""
+  local message_id=""
+  local message_body=""
+  local queue_count=""
+  local list_queues_output=""
+  local i
+
+  trap cleanup EXIT
+
+  command -v kind >/dev/null
+  command -v helm >/dev/null
+  command -v kubectl >/dev/null
+  command -v docker >/dev/null
+  command -v jq >/dev/null
+  command -v aws >/dev/null
+  command -v curl >/dev/null
+
+  echo "Build kumo image"
+  docker build -f "$REPO_ROOT/docker/Dockerfile" -t "$KUMO_IMAGE" "$REPO_ROOT"
+
+  kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+  kind create cluster --name "$CLUSTER_NAME" --wait 60s
+  kind load docker-image "$KUMO_IMAGE" --name "$CLUSTER_NAME"
+
+  echo "Install Kyverno"
+  helm repo add kyverno https://kyverno.github.io/kyverno/ --force-update >/dev/null
+  helm install kyverno kyverno/kyverno \
+    -n kyverno \
+    --create-namespace \
+    --set admissionController.replicas=2 \
+    --set backgroundController.enabled=false \
+    --set cleanupController.enabled=false \
+    --set reportsController.enabled=false \
+    --set features.policyExceptions.enabled=true \
+    --wait \
+    --timeout 3m
+  "${KUBECTL[@]}" wait --for=condition=Established "crd/clusterpolicies.kyverno.io" --timeout=120s >/dev/null
+
+  echo "Install kumo chart"
+  helm install "$KUMO_RELEASE" "$REPO_ROOT/charts/kumo" \
+    -n "$KUMO_NS" \
+    --create-namespace \
+    --set injection.enabled=true \
+    --set injection.namespaceLabelKey=sivchari.github.io/kumo-inject \
+    --set injection.namespaceLabelValue=enabled \
+    --set kumo.image.tag=e2e-local \
+    --wait \
+    --timeout 2m
+  "${KUBECTL[@]}" rollout status "statefulset/${KUMO_RELEASE}" -n "$KUMO_NS" --timeout=120s
+
+  echo "Install ACK SQS controller"
+  "${KUBECTL[@]}" create namespace "$ACK_NS" --dry-run=client -o yaml | "${KUBECTL[@]}" apply -f -
+  "${KUBECTL[@]}" label namespace "$ACK_NS" sivchari.github.io/kumo-inject=enabled --overwrite >/dev/null
+  helm install "$ACK_RELEASE" oci://public.ecr.aws/aws-controllers-k8s/sqs-chart \
+    -n "$ACK_NS" \
+    --version "$ACK_SQS_CHART_VERSION" \
+    --set aws.region=us-east-1 \
+    --set aws.allow_unsafe_aws_endpoint_urls=true \
+    --wait \
+    --timeout 3m
+  "${KUBECTL[@]}" wait --for=condition=Established "crd/queues.sqs.services.k8s.aws" --timeout=120s >/dev/null
+  "${KUBECTL[@]}" wait --for=condition=ready pod -l "$ACK_LABEL" -n "$ACK_NS" --timeout=180s >/dev/null
+
+  endpoint="$("${KUBECTL[@]}" get pod -n "$ACK_NS" -l "$ACK_LABEL" -o jsonpath='{range .items[0].spec.containers[?(@.name=="controller")].env[?(@.name=="AWS_ENDPOINT_URL")]}{.value}{end}')"
+  if [[ "$endpoint" != "$KUMO_ENDPOINT" ]]; then
+    echo "ERROR: ACK controller AWS_ENDPOINT_URL mismatch. expected=${KUMO_ENDPOINT} actual=${endpoint}" >&2
+    "${KUBECTL[@]}" get pod -n "$ACK_NS" -l "$ACK_LABEL" -o yaml
+    exit 1
+  fi
+
+  start_port_forward
+
+  echo "Create ACK queue"
+  "${KUBECTL[@]}" create namespace "$QUEUE_NS" --dry-run=client -o yaml | "${KUBECTL[@]}" apply -f -
+  cat <<EOF | "${KUBECTL[@]}" apply -f -
+apiVersion: sqs.services.k8s.aws/v1alpha1
+kind: Queue
+metadata:
+  name: ${QUEUE_NAME}
+  namespace: ${QUEUE_NS}
+spec:
+  queueName: ${QUEUE_NAME}
+  tags:
+    purpose: helm-e2e
+EOF
+
+  queue_url="$(wait_for_queue_url)"
+  resolved_queue_url="$(aws sqs get-queue-url --queue-name "$QUEUE_NAME" --output json | jq -r '.QueueUrl // empty')"
+  if [[ "$resolved_queue_url" != "$queue_url" ]]; then
+    echo "ERROR: queue URL mismatch between Queue.status and sqs get-queue-url. status=${queue_url} get-queue-url=${resolved_queue_url}" >&2
+    exit 1
+  fi
+
+  queue_tag="$(aws sqs list-queue-tags --queue-url "$queue_url" --output json | jq -r '.Tags.purpose // empty')"
+  if [[ "$queue_tag" != "helm-e2e" ]]; then
+    echo "ERROR: queue tag 'purpose' mismatch. expected=helm-e2e actual=${queue_tag}" >&2
+    exit 1
+  fi
+
+  message_id="$(aws sqs send-message --queue-url "$queue_url" --message-body "hello from ACK" --output json | jq -r '.MessageId // empty')"
+  if [[ -z "$message_id" ]]; then
+    echo "ERROR: aws sqs send-message returned empty MessageId for queue=${queue_url}" >&2
+    exit 1
+  fi
+
+  message_body="$(aws sqs receive-message --queue-url "$queue_url" --max-number-of-messages 1 --wait-time-seconds 1 --output json | jq -r '.Messages[0].Body // empty')"
+  if [[ "$message_body" != "hello from ACK" ]]; then
+    echo "ERROR: received message body mismatch. expected='hello from ACK' actual='${message_body}'" >&2
+    exit 1
+  fi
+
+  echo "Delete ACK queue"
+  "${KUBECTL[@]}" delete "queue/${QUEUE_NAME}" -n "$QUEUE_NS" >/dev/null
+  "${KUBECTL[@]}" wait --for=delete "queue/${QUEUE_NAME}" -n "$QUEUE_NS" --timeout=180s >/dev/null
+
+  for i in $(seq 1 60); do
+    list_queues_output="$(aws sqs list-queues --queue-name-prefix "$QUEUE_NAME" --output json || true)"
+    if [[ -z "$list_queues_output" ]]; then
+      queue_count="0"
+    else
+      queue_count="$(jq '.QueueUrls // [] | length' <<<"$list_queues_output")"
+    fi
+    if [[ "$queue_count" == "0" ]]; then
+      echo "Helm e2e passed"
+      return 0
+    fi
+    sleep 2
+  done
+
+  exit 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a Helm chart for deploying kumo

## Manual Test
Screenshot of `make test-helm-e2e` running.

<img width="3456" height="2184" alt="CleanShot 2026-04-03 at 22 01 44@2x" src="https://github.com/user-attachments/assets/6838c8cd-c113-4f13-8ae7-2015c37932be" />

Release looks good so far in [kahirokunn/kumo#3](https://github.com/kahirokunn/kumo/pull/3).