### PR TITLE
feat: add Pinpoint SMS Voice v2 service with SendTextMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **AWS SDK v2 compatible** - Works seamlessly with Go AWS SDK v2
 - **Optional data persistence** - Survive restarts with `KUMO_DATA_DIR`
 
-## Supported Services (75 services)
+## Supported Services (76 services)
 
 ### Storage
 | Service | Description |
@@ -105,6 +105,7 @@
 | Step Functions | Workflow orchestration |
 | AppSync | GraphQL API |
 | SES v2 | Email service |
+| Pinpoint SMS Voice v2 | SMS messaging |
 | Scheduler | Task scheduling |
 | Amplify | Full-stack application hosting |
 
@@ -457,6 +458,7 @@ kumo provides additional endpoints under the `/kumo/` prefix for testing purpose
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/kumo/ses/v2/sent-emails` | Retrieve a list of emails sent via the SES v2 `SendEmail` API |
+| GET | `/kumo/pinpointsmsvoicev2/sent-messages` | Retrieve a list of SMS messages sent via the Pinpoint SMS Voice v2 `SendTextMessage` API |
 
 ### Example: Retrieving sent emails
 
@@ -477,6 +479,28 @@ Response:
       },
       "Subject": "Hello",
       "Body": "Hello, World!",
+      "SentAt": "2025-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+### Example: Retrieving sent SMS messages
+
+```bash
+curl http://localhost:4566/kumo/pinpointsmsvoicev2/sent-messages
+```
+
+Response:
+
+```json
+{
+  "SentTextMessages": [
+    {
+      "MessageId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "DestinationPhoneNumber": "+1234567890",
+      "OriginationIdentity": "+0987654321",
+      "MessageBody": "Hello!",
       "SentAt": "2025-01-01T00:00:00Z"
     }
   ]

--- a/cmd/kumo/main.go
+++ b/cmd/kumo/main.go
@@ -60,6 +60,7 @@ import (
 	_ "github.com/sivchari/kumo/internal/service/mq"
 	_ "github.com/sivchari/kumo/internal/service/neptune"
 	_ "github.com/sivchari/kumo/internal/service/organizations"
+	_ "github.com/sivchari/kumo/internal/service/pinpointsmsvoicev2"
 	_ "github.com/sivchari/kumo/internal/service/pipes"
 	_ "github.com/sivchari/kumo/internal/service/rds"
 	_ "github.com/sivchari/kumo/internal/service/redshift"

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,11 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.41.6 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
+	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.1 // indirect
+	github.com/aws/smithy-go v1.25.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,13 @@
+github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
+github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22/go.mod h1:KIpEUx0JuRZLO7U6cbV204cWAEco2iC3l061IxlwLtI=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.1 h1:/VHcMhlAlke9EAA00VbUu/Qi7QTfqSn/ubE7+G063f8=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.1/go.mod h1:nP/WmnsBm7G24zucbAUnYp7t6qsipB6Ed1k50oD7Xck=
+github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
+github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/service/pinpointsmsvoicev2/handlers.go
+++ b/internal/service/pinpointsmsvoicev2/handlers.go
@@ -1,0 +1,122 @@
+package pinpointsmsvoicev2
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// DispatchAction routes requests based on the X-Amz-Target header.
+func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
+	target := r.Header.Get("X-Amz-Target")
+	if target == "" {
+		writeError(w, errInvalidParameter, "Missing X-Amz-Target header", http.StatusBadRequest)
+
+		return
+	}
+
+	parts := strings.Split(target, ".")
+	if len(parts) != 2 {
+		writeError(w, errInvalidParameter, "Invalid X-Amz-Target header", http.StatusBadRequest)
+
+		return
+	}
+
+	operation := parts[1]
+
+	switch operation {
+	case "SendTextMessage":
+		s.SendTextMessage(w, r)
+	default:
+		writeError(w, errInvalidParameter, fmt.Sprintf("Unknown operation: %s", operation), http.StatusBadRequest)
+	}
+}
+
+// SendTextMessage handles the SendTextMessage operation.
+func (s *Service) SendTextMessage(w http.ResponseWriter, r *http.Request) {
+	var req SendTextMessageInput
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	messageID, err := s.storage.SendTextMessage(r.Context(), &req)
+	if err != nil {
+		var sErr *Error
+		if errors.As(err, &sErr) {
+			writeError(w, sErr.Code, sErr.Message, http.StatusBadRequest)
+
+			return
+		}
+
+		writeError(w, "InternalServiceError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, SendTextMessageOutput{
+		MessageID: messageID,
+	})
+}
+
+// GetSentTextMessages handles the GetSentTextMessages operation.
+func (s *Service) GetSentTextMessages(w http.ResponseWriter, r *http.Request) {
+	messages, err := s.storage.GetSentTextMessages(r.Context())
+	if err != nil {
+		writeError(w, "InternalServiceError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, GetSentTextMessagesResponse{
+		SentTextMessages: messages,
+	})
+}
+
+// Helper functions.
+
+// readJSONRequest reads and decodes JSON request body.
+func readJSONRequest(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return nil
+}
+
+// writeJSONResponse writes a JSON response with HTTP 200 OK.
+func writeJSONResponse(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+
+	if v != nil {
+		_ = json.NewEncoder(w).Encode(v)
+	}
+}
+
+// writeError writes an error response.
+func writeError(w http.ResponseWriter, code, message string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{
+		Type:    code,
+		Message: message,
+	})
+}

--- a/internal/service/pinpointsmsvoicev2/service.go
+++ b/internal/service/pinpointsmsvoicev2/service.go
@@ -1,0 +1,63 @@
+package pinpointsmsvoicev2
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
+func init() {
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Service implements the Pinpoint SMS Voice v2 service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new Pinpoint SMS Voice v2 service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "pinpointsmsvoicev2"
+}
+
+// RegisterRoutes registers the Pinpoint SMS Voice v2 routes.
+func (s *Service) RegisterRoutes(r service.Router) {
+	// kumo-specific endpoint for testing.
+	r.HandleFunc("GET", "/kumo/pinpointsmsvoicev2/sent-messages", s.GetSentTextMessages)
+}
+
+// TargetPrefix returns the X-Amz-Target header prefix.
+func (s *Service) TargetPrefix() string {
+	return "PinpointSMSVoiceV2"
+}
+
+// JSONProtocol is a marker method that indicates this service uses AWS JSON 1.0 protocol.
+func (s *Service) JSONProtocol() {}
+
+// Close saves the storage state if persistence is enabled.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/pinpointsmsvoicev2/storage.go
+++ b/internal/service/pinpointsmsvoicev2/storage.go
@@ -1,0 +1,148 @@
+package pinpointsmsvoicev2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/storage"
+)
+
+// Error codes.
+const (
+	errInvalidParameter = "ValidationException"
+)
+
+// Storage defines the interface for Pinpoint SMS Voice v2 storage operations.
+type Storage interface {
+	SendTextMessage(ctx context.Context, req *SendTextMessageInput) (string, error)
+	GetSentTextMessages(ctx context.Context) ([]*SentTextMessage, error)
+}
+
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the specified directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
+// MemoryStorage implements Storage with in-memory data structures.
+type MemoryStorage struct {
+	mu               sync.RWMutex       `json:"-"`
+	SentTextMessages []*SentTextMessage `json:"sentTextMessages"`
+	dataDir          string
+}
+
+// NewMemoryStorage creates a new in-memory storage.
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{
+		SentTextMessages: make([]*SentTextMessage, 0),
+	}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "pinpointsmsvoicev2", s)
+	}
+
+	return s
+}
+
+// MarshalJSON serializes the storage state to JSON.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the storage state from JSON.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.SentTextMessages == nil {
+		s.SentTextMessages = make([]*SentTextMessage, 0)
+	}
+
+	return nil
+}
+
+// Close saves the storage state to disk if persistence is enabled.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "pinpointsmsvoicev2", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
+}
+
+// SendTextMessage sends a text message (stores it for testing).
+func (s *MemoryStorage) SendTextMessage(_ context.Context, req *SendTextMessageInput) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if req.DestinationPhoneNumber == "" {
+		return "", &Error{
+			Code:    errInvalidParameter,
+			Message: "DestinationPhoneNumber is required",
+		}
+	}
+
+	messageID := uuid.New().String()
+
+	msg := &SentTextMessage{
+		MessageID:              messageID,
+		DestinationPhoneNumber: req.DestinationPhoneNumber,
+		OriginationIdentity:    req.OriginationIdentity,
+		MessageBody:            req.MessageBody,
+		MessageType:            req.MessageType,
+		ConfigurationSetName:   req.ConfigurationSetName,
+		SentAt:                 time.Now(),
+	}
+
+	s.SentTextMessages = append(s.SentTextMessages, msg)
+
+	return messageID, nil
+}
+
+// GetSentTextMessages returns all sent text messages.
+func (s *MemoryStorage) GetSentTextMessages(_ context.Context) ([]*SentTextMessage, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.SentTextMessages, nil
+}

--- a/internal/service/pinpointsmsvoicev2/types.go
+++ b/internal/service/pinpointsmsvoicev2/types.go
@@ -1,0 +1,51 @@
+// Package pinpointsmsvoicev2 provides Pinpoint SMS Voice v2 service emulation for kumo.
+package pinpointsmsvoicev2
+
+import "time"
+
+// SentTextMessage represents a sent text message for debugging purposes.
+type SentTextMessage struct {
+	MessageID              string    `json:"MessageId"`
+	DestinationPhoneNumber string    `json:"DestinationPhoneNumber"`
+	OriginationIdentity    string    `json:"OriginationIdentity,omitempty"`
+	MessageBody            string    `json:"MessageBody,omitempty"`
+	MessageType            string    `json:"MessageType,omitempty"`
+	ConfigurationSetName   string    `json:"ConfigurationSetName,omitempty"`
+	SentAt                 time.Time `json:"SentAt"`
+}
+
+// SendTextMessageInput is the request for SendTextMessage.
+type SendTextMessageInput struct {
+	DestinationPhoneNumber string `json:"DestinationPhoneNumber"`
+	OriginationIdentity    string `json:"OriginationIdentity,omitempty"`
+	MessageBody            string `json:"MessageBody,omitempty"`
+	MessageType            string `json:"MessageType,omitempty"`
+	ConfigurationSetName   string `json:"ConfigurationSetName,omitempty"`
+}
+
+// SendTextMessageOutput is the response for SendTextMessage.
+type SendTextMessageOutput struct {
+	MessageID string `json:"MessageId,omitempty"`
+}
+
+// GetSentTextMessagesResponse is the response for GetSentTextMessages.
+type GetSentTextMessagesResponse struct {
+	SentTextMessages []*SentTextMessage `json:"SentTextMessages"`
+}
+
+// ErrorResponse represents an error response.
+type ErrorResponse struct {
+	Type    string `json:"__type"`
+	Message string `json:"message"`
+}
+
+// Error represents a service error.
+type Error struct {
+	Code    string
+	Message string
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return e.Message
+}

--- a/internal/service/pinpointsmsvoicev2/types.go
+++ b/internal/service/pinpointsmsvoicev2/types.go
@@ -1,4 +1,4 @@
-// Package pinpointsmsvoicev2 provides Pinpoint SMS Voice v2 service emulation for kumo.
+//nolint:tagliatelle // AWS Pinpoint SMS Voice v2 API uses PascalCase for JSON tags
 package pinpointsmsvoicev2
 
 import "time"

--- a/test/go.mod
+++ b/test/go.mod
@@ -3,7 +3,7 @@ module github.com/sivchari/kumo/test
 go 1.25.0
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.41.5
+	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
 	github.com/aws/aws-sdk-go-v2/service/acm v1.37.19
@@ -82,15 +82,15 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
 	github.com/aws/aws-sdk-go-v2/service/xray v1.36.17
-	github.com/aws/smithy-go v1.24.2
+	github.com/aws/smithy-go v1.25.0
 	github.com/sivchari/golden v0.3.0
 )
 
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
@@ -98,6 +98,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.18 // indirect
+	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
+github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4/go.mod h1:IOAPF6oT9KCsceNTvvYMNHy0+kMF8akOjeDvPENWxp4=
 github.com/aws/aws-sdk-go-v2/config v1.32.7 h1:vxUyWGUwmkQ2g19n7JY/9YL8MfAIl7bTesIUykECXmY=
@@ -10,8 +12,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 h1:I0GyV8wiYrP8XpA70g1HBc
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17/go.mod h1:tyw7BOl5bBe/oqvoIeECFJjMdzXoa/dfVz3QQ5lgHGA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22/go.mod h1:KIpEUx0JuRZLO7U6cbV204cWAEco2iC3l061IxlwLtI=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 h1:JqcdRG//czea7Ppjb+g/n4o8i/R50aTBHkA7vu0lK+k=
@@ -134,6 +140,8 @@ github.com/aws/aws-sdk-go-v2/service/neptune v1.44.3 h1:YlOAIqn5ShfNnplTj17y/4W7
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.3/go.mod h1:iJQ7qpaNp26sMZvqmSF0zGz0beApcLcWkAerfsoCTrs=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.50.3 h1:pqPwpyOjYTYwlexnCxSsy6kIz2lopj7AMA0TEpwvKfw=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.50.3/go.mod h1:v6v+HUbPtcnQ5iMgpz3vj9yV5pmMJ88PVJv1RbkCg74=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.1 h1:/VHcMhlAlke9EAA00VbUu/Qi7QTfqSn/ubE7+G063f8=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.28.1/go.mod h1:nP/WmnsBm7G24zucbAUnYp7t6qsipB6Ed1k50oD7Xck=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.23.17 h1:mVj6qM8m1vacLPRvpYsrhqIopj1gVSz0VbVxZDb6HQQ=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.23.17/go.mod h1:eLlxQF7rzISHqpiOqcW/IdjS7kwO+t1NdEpfLFIapAA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.115.0 h1:oNl6YghOtxu3MiFk1tQ86QlrYMIEJazGUDbBCg9nxLA=
@@ -186,5 +194,7 @@ github.com/aws/aws-sdk-go-v2/service/xray v1.36.17 h1:b480fLepDHf9B7FXgcgB7XVDN3
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.17/go.mod h1:ASKVut5pRPVm4bF9/P01ClCthnIopv1PjxWsLOTjKPU=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
+github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/sivchari/golden v0.3.0 h1:WUtMlhvqeH8mXcX4hsZwyfrA5jeNz5F9IL1w+u7Ew7w=
 github.com/sivchari/golden v0.3.0/go.mod h1:gddwjsjxPtLYRCq0M471x9WD9khQWty82Yn/PZ/2I8E=

--- a/test/integration/pinpointsmsvoicev2_test.go
+++ b/test/integration/pinpointsmsvoicev2_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2"
+)
+
+func newPinpointSMSVoiceV2Client(t *testing.T) *pinpointsmsvoicev2.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	return pinpointsmsvoicev2.NewFromConfig(cfg, func(o *pinpointsmsvoicev2.Options) {
+		o.BaseEndpoint = aws.String("http://localhost:4566")
+	})
+}
+
+func TestPinpointSMSVoiceV2_SendTextMessage(t *testing.T) {
+	client := newPinpointSMSVoiceV2Client(t)
+	ctx := t.Context()
+
+	output, err := client.SendTextMessage(ctx, &pinpointsmsvoicev2.SendTextMessageInput{
+		DestinationPhoneNumber: aws.String("+1234567890"),
+		MessageBody:            aws.String("Hello from kumo"),
+		OriginationIdentity:    aws.String("+0987654321"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if output.MessageId == nil || *output.MessageId == "" {
+		t.Fatal("expected non-empty MessageId")
+	}
+}
+
+func TestPinpointSMSVoiceV2_GetSentTextMessages(t *testing.T) {
+	client := newPinpointSMSVoiceV2Client(t)
+	ctx := t.Context()
+
+	// Send a text message.
+	destPhone := "+1112223333"
+	msgBody := "Test SMS body"
+
+	_, err := client.SendTextMessage(ctx, &pinpointsmsvoicev2.SendTextMessageInput{
+		DestinationPhoneNumber: aws.String(destPhone),
+		MessageBody:            aws.String(msgBody),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get sent messages via kumo-specific endpoint.
+	resp, err := http.Get("http://localhost:4566/kumo/pinpointsmsvoicev2/sent-messages")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected status %d, got %d, body: %s", http.StatusOK, resp.StatusCode, body)
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+
+	sentMessages, ok := result["SentTextMessages"]
+	if !ok {
+		t.Fatal("SentTextMessages field not found in response")
+	}
+
+	messages, ok := sentMessages.([]interface{})
+	if !ok {
+		t.Fatal("SentTextMessages is not an array")
+	}
+
+	if len(messages) == 0 {
+		t.Fatal("no sent messages found")
+	}
+
+	// Find our message.
+	var found bool
+
+	for _, m := range messages {
+		msg, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if msg["DestinationPhoneNumber"] == destPhone && msg["MessageBody"] == msgBody {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("sent message to %s with body '%s' not found", destPhone, msgBody)
+	}
+}


### PR DESCRIPTION
## Summary
- Add new Pinpoint SMS Voice v2 service emulation with `SendTextMessage` operation
- Add kumo-specific `GET /kumo/pinpointsmsvoicev2/sent-messages` endpoint for retrieving sent SMS messages in tests
- Uses JSON protocol (`X-Amz-Target: PinpointSMSVoiceV2.SendTextMessage`)
- Includes in-memory storage with optional persistence via `KUMO_DATA_DIR`
- Update README with new service listing and kumo-specific endpoint documentation

Partial fix for #431 (SMS part)

## Test plan
- [ ] Integration test `TestPinpointSMSVoiceV2_SendTextMessage` verifies message sending
- [ ] Integration test `TestPinpointSMSVoiceV2_GetSentTextMessages` verifies kumo-specific endpoint returns sent messages
- [ ] Verify response includes `DestinationPhoneNumber`, `MessageBody`, `SentAt` fields