### PR TITLE
feat: add DynamoDB ConditionExpression support

### DIFF
--- a/internal/service/dynamodb/condition.go
+++ b/internal/service/dynamodb/condition.go
@@ -1,0 +1,648 @@
+package dynamodb
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ConditionInput holds the parameters for evaluating a condition expression.
+type ConditionInput struct {
+	Expression string
+	ExprNames  map[string]string
+	ExprValues map[string]AttributeValue
+}
+
+// evaluateCondition evaluates a condition expression against an item.
+// Returns true if the condition is satisfied or the expression is empty.
+func evaluateCondition(item Item, cond ConditionInput) (bool, error) {
+	if cond.Expression == "" {
+		return true, nil
+	}
+
+	expr := resolveNames(cond.Expression, cond.ExprNames)
+
+	result, _, err := parseOrExpr(expr, item, cond.ExprValues)
+	if err != nil {
+		return false, fmt.Errorf("failed to evaluate condition: %w", err)
+	}
+
+	return result, nil
+}
+
+// resolveNames replaces expression attribute name placeholders with actual names.
+func resolveNames(expr string, names map[string]string) string {
+	for placeholder, name := range names {
+		expr = strings.ReplaceAll(expr, placeholder, name)
+	}
+
+	return expr
+}
+
+// parseOrExpr parses an OR expression: expr OR expr OR ...
+func parseOrExpr(expr string, item Item, values map[string]AttributeValue) (bool, string, error) {
+	result, rest, err := parseAndExpr(expr, item, values)
+	if err != nil {
+		return false, "", err
+	}
+
+	for {
+		rest = strings.TrimSpace(rest)
+		if !startsWithKeyword(rest, "OR") {
+			return result, rest, nil
+		}
+
+		rest = strings.TrimSpace(rest[2:])
+
+		right, newRest, err := parseAndExpr(rest, item, values)
+		if err != nil {
+			return false, "", err
+		}
+
+		result = result || right
+		rest = newRest
+	}
+}
+
+// parseAndExpr parses an AND expression: expr AND expr AND ...
+func parseAndExpr(expr string, item Item, values map[string]AttributeValue) (bool, string, error) {
+	result, rest, err := parseNotExpr(expr, item, values)
+	if err != nil {
+		return false, "", err
+	}
+
+	for {
+		rest = strings.TrimSpace(rest)
+		if !startsWithKeyword(rest, "AND") {
+			return result, rest, nil
+		}
+
+		rest = strings.TrimSpace(rest[3:])
+
+		right, newRest, err := parseNotExpr(rest, item, values)
+		if err != nil {
+			return false, "", err
+		}
+
+		result = result && right
+		rest = newRest
+	}
+}
+
+// parseNotExpr parses a NOT expression or delegates to primary.
+func parseNotExpr(expr string, item Item, values map[string]AttributeValue) (bool, string, error) {
+	trimmed := strings.TrimSpace(expr)
+	if startsWithKeyword(trimmed, "NOT") {
+		rest := strings.TrimSpace(trimmed[3:])
+
+		result, newRest, err := parsePrimary(rest, item, values)
+		if err != nil {
+			return false, "", err
+		}
+
+		return !result, newRest, nil
+	}
+
+	return parsePrimary(trimmed, item, values)
+}
+
+// parsePrimary parses a primary expression: parenthesized, function call, or comparison.
+//
+//nolint:cyclop,funlen // Expression parsing inherently requires many branches.
+func parsePrimary(expr string, item Item, values map[string]AttributeValue) (bool, string, error) {
+	trimmed := strings.TrimSpace(expr)
+
+	// Parenthesized expression.
+	if strings.HasPrefix(trimmed, "(") {
+		inner := trimmed[1:]
+
+		result, rest, err := parseOrExpr(inner, item, values)
+		if err != nil {
+			return false, "", err
+		}
+
+		rest = strings.TrimSpace(rest)
+		if !strings.HasPrefix(rest, ")") {
+			return false, "", fmt.Errorf("expected closing parenthesis")
+		}
+
+		return result, rest[1:], nil
+	}
+
+	// Function calls.
+	for _, fn := range []string{"attribute_exists", "attribute_not_exists", "begins_with", "contains"} {
+		if strings.HasPrefix(trimmed, fn+"(") {
+			return parseFunctionCall(fn, trimmed[len(fn):], item, values)
+		}
+	}
+
+	// size() function used in comparison: size(path) op value
+	if strings.HasPrefix(trimmed, "size(") {
+		return parseSizeComparison(trimmed, item, values)
+	}
+
+	// Comparison: operand op operand
+	return parseComparison(trimmed, item, values)
+}
+
+// parseFunctionCall parses and evaluates a function call.
+func parseFunctionCall(fn, argsStr string, item Item, values map[string]AttributeValue) (bool, string, error) {
+	args, rest, err := parseArgList(argsStr)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to parse %s arguments: %w", fn, err)
+	}
+
+	switch fn {
+	case "attribute_exists":
+		if len(args) != 1 {
+			return false, "", fmt.Errorf("attribute_exists requires 1 argument")
+		}
+
+		path := strings.TrimSpace(args[0])
+		_, exists := resolveItemPath(item, path)
+
+		return exists, rest, nil
+
+	case "attribute_not_exists":
+		if len(args) != 1 {
+			return false, "", fmt.Errorf("attribute_not_exists requires 1 argument")
+		}
+
+		path := strings.TrimSpace(args[0])
+		_, exists := resolveItemPath(item, path)
+
+		return !exists, rest, nil
+
+	case "begins_with":
+		if len(args) != 2 {
+			return false, "", fmt.Errorf("begins_with requires 2 arguments")
+		}
+
+		path := strings.TrimSpace(args[0])
+		val := resolveOperand(strings.TrimSpace(args[1]), item, values)
+
+		av, exists := resolveItemPath(item, path)
+		if !exists || av.S == nil || val.S == nil {
+			return false, rest, nil
+		}
+
+		return strings.HasPrefix(*av.S, *val.S), rest, nil
+
+	case "contains":
+		if len(args) != 2 {
+			return false, "", fmt.Errorf("contains requires 2 arguments")
+		}
+
+		path := strings.TrimSpace(args[0])
+		val := resolveOperand(strings.TrimSpace(args[1]), item, values)
+
+		av, exists := resolveItemPath(item, path)
+		if !exists {
+			return false, rest, nil
+		}
+
+		return evalContains(av, val), rest, nil
+
+	default:
+		return false, "", fmt.Errorf("unknown function: %s", fn)
+	}
+}
+
+// evalContains evaluates the contains function for various types.
+//
+//nolint:gocritic // hugeParam: AttributeValue passed by value intentionally.
+func evalContains(av AttributeValue, operand AttributeValue) bool {
+	// String contains substring.
+	if av.S != nil && operand.S != nil {
+		return strings.Contains(*av.S, *operand.S)
+	}
+
+	// String set contains value.
+	if av.SS != nil && operand.S != nil {
+		for _, s := range av.SS {
+			if s == *operand.S {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// Number set contains value.
+	if av.NS != nil && operand.N != nil {
+		for _, n := range av.NS {
+			if n == *operand.N {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// List contains value.
+	if av.L != nil {
+		for _, elem := range av.L {
+			if attributeValuesEqualStatic(elem, operand) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	return false
+}
+
+// parseSizeComparison parses size(path) op value.
+func parseSizeComparison(expr string, item Item, values map[string]AttributeValue) (bool, string, error) {
+	// Extract path from size(...).
+	inner := expr[5:] // skip "size("
+
+	parenDepth := 1
+	idx := 0
+
+	for idx < len(inner) && parenDepth > 0 {
+		if inner[idx] == '(' {
+			parenDepth++
+		} else if inner[idx] == ')' {
+			parenDepth--
+		}
+
+		if parenDepth > 0 {
+			idx++
+		}
+	}
+
+	if parenDepth != 0 {
+		return false, "", fmt.Errorf("unmatched parenthesis in size()")
+	}
+
+	path := strings.TrimSpace(inner[:idx])
+	rest := strings.TrimSpace(inner[idx+1:])
+
+	// Get the size of the attribute.
+	av, exists := resolveItemPath(item, path)
+	if !exists {
+		return false, "", fmt.Errorf("attribute %s not found for size()", path)
+	}
+
+	sizeVal := attributeSize(av)
+
+	// Parse operator.
+	op, afterOp, err := parseComparisonOp(rest)
+	if err != nil {
+		return false, "", err
+	}
+
+	// Parse right operand.
+	rightToken, finalRest := nextToken(strings.TrimSpace(afterOp))
+	rightVal := resolveOperand(rightToken, item, values)
+
+	if rightVal.N == nil {
+		return false, "", fmt.Errorf("size() comparison requires numeric operand")
+	}
+
+	rightNum, err := strconv.ParseFloat(*rightVal.N, 64)
+	if err != nil {
+		return false, "", fmt.Errorf("invalid number: %s", *rightVal.N)
+	}
+
+	result := compareNumbers(float64(sizeVal), rightNum, op)
+
+	return result, finalRest, nil
+}
+
+// attributeSize returns the size of an attribute value.
+//
+//nolint:gocritic // hugeParam: AttributeValue passed by value intentionally.
+func attributeSize(av AttributeValue) int {
+	switch {
+	case av.S != nil:
+		return len(*av.S)
+	case av.N != nil:
+		return len(*av.N)
+	case av.B != nil:
+		return len(av.B)
+	case av.SS != nil:
+		return len(av.SS)
+	case av.NS != nil:
+		return len(av.NS)
+	case av.BS != nil:
+		return len(av.BS)
+	case av.L != nil:
+		return len(av.L)
+	case av.M != nil:
+		return len(av.M)
+	default:
+		return 0
+	}
+}
+
+// parseComparison parses a comparison expression: operand op operand.
+func parseComparison(expr string, item Item, values map[string]AttributeValue) (bool, string, error) {
+	leftToken, rest := nextToken(strings.TrimSpace(expr))
+	if leftToken == "" {
+		return false, "", fmt.Errorf("expected operand")
+	}
+
+	rest = strings.TrimSpace(rest)
+
+	op, afterOp, err := parseComparisonOp(rest)
+	if err != nil {
+		return false, "", err
+	}
+
+	rightToken, finalRest := nextToken(strings.TrimSpace(afterOp))
+	if rightToken == "" {
+		return false, "", fmt.Errorf("expected right operand")
+	}
+
+	left := resolveOperand(leftToken, item, values)
+	right := resolveOperand(rightToken, item, values)
+
+	result := compareAttributeValues(left, right, op)
+
+	return result, finalRest, nil
+}
+
+// parseComparisonOp extracts a comparison operator from the front of the string.
+func parseComparisonOp(s string) (string, string, error) {
+	if strings.HasPrefix(s, "<>") {
+		return "<>", s[2:], nil
+	}
+
+	if strings.HasPrefix(s, "<=") {
+		return "<=", s[2:], nil
+	}
+
+	if strings.HasPrefix(s, ">=") {
+		return ">=", s[2:], nil
+	}
+
+	if strings.HasPrefix(s, "=") {
+		return "=", s[1:], nil
+	}
+
+	if strings.HasPrefix(s, "<") {
+		return "<", s[1:], nil
+	}
+
+	if strings.HasPrefix(s, ">") {
+		return ">", s[1:], nil
+	}
+
+	return "", "", fmt.Errorf("expected comparison operator, got: %.20s", s)
+}
+
+// nextToken extracts the next token from the string.
+// A token is a contiguous sequence of non-whitespace, non-operator characters,
+// or a value placeholder starting with ':'.
+func nextToken(s string) (string, string) {
+	if s == "" {
+		return "", ""
+	}
+
+	i := 0
+	for i < len(s) {
+		ch := s[i]
+		if ch == ' ' || ch == '\t' || ch == ')' {
+			break
+		}
+
+		if i > 0 && isOperatorStart(s[i:]) {
+			break
+		}
+
+		i++
+	}
+
+	return s[:i], s[i:]
+}
+
+// isOperatorStart checks if the string starts with a comparison operator or keyword.
+func isOperatorStart(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+
+	switch s[0] {
+	case '=', '<', '>':
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveOperand resolves an operand token to an AttributeValue.
+// It can be a value placeholder (:val), or an attribute path.
+//
+//nolint:gocritic // hugeParam: AttributeValue returned by value.
+func resolveOperand(token string, item Item, values map[string]AttributeValue) AttributeValue {
+	if strings.HasPrefix(token, ":") {
+		if val, ok := values[token]; ok {
+			return val
+		}
+
+		return AttributeValue{}
+	}
+
+	av, _ := resolveItemPath(item, token)
+
+	return av
+}
+
+// resolveItemPath resolves a dotted path on an item, returning the value and whether it exists.
+//
+//nolint:gocritic // hugeParam: AttributeValue returned by value.
+func resolveItemPath(item Item, path string) (AttributeValue, bool) {
+	parts := strings.Split(path, ".")
+
+	if len(parts) == 1 {
+		val, ok := item[path]
+
+		return val, ok
+	}
+
+	// Nested path traversal.
+	val, ok := item[parts[0]]
+	if !ok {
+		return AttributeValue{}, false
+	}
+
+	for _, part := range parts[1:] {
+		if val.M == nil {
+			return AttributeValue{}, false
+		}
+
+		val, ok = val.M[part]
+		if !ok {
+			return AttributeValue{}, false
+		}
+	}
+
+	return val, true
+}
+
+// compareAttributeValues compares two attribute values using the given operator.
+//
+//nolint:gocritic,cyclop // hugeParam: AttributeValue passed by value for comparison.
+func compareAttributeValues(a, b AttributeValue, op string) bool {
+	// String comparison.
+	if a.S != nil && b.S != nil {
+		return compareStrings(*a.S, *b.S, op)
+	}
+
+	// Number comparison.
+	if a.N != nil && b.N != nil {
+		aNum, err1 := strconv.ParseFloat(*a.N, 64)
+		bNum, err2 := strconv.ParseFloat(*b.N, 64)
+
+		if err1 != nil || err2 != nil {
+			return false
+		}
+
+		return compareNumbers(aNum, bNum, op)
+	}
+
+	// Boolean comparison (only = and <>).
+	if a.BOOL != nil && b.BOOL != nil {
+		switch op {
+		case "=":
+			return *a.BOOL == *b.BOOL
+		case "<>":
+			return *a.BOOL != *b.BOOL
+		default:
+			return false
+		}
+	}
+
+	// NULL comparison (only = and <>).
+	if a.NULL != nil && b.NULL != nil {
+		switch op {
+		case "=":
+			return *a.NULL == *b.NULL
+		case "<>":
+			return *a.NULL != *b.NULL
+		default:
+			return false
+		}
+	}
+
+	// Type mismatch or unsupported types: only <> returns true.
+	return op == "<>"
+}
+
+func compareStrings(a, b, op string) bool {
+	switch op {
+	case "=":
+		return a == b
+	case "<>":
+		return a != b
+	case "<":
+		return a < b
+	case "<=":
+		return a <= b
+	case ">":
+		return a > b
+	case ">=":
+		return a >= b
+	default:
+		return false
+	}
+}
+
+func compareNumbers(a, b float64, op string) bool {
+	switch op {
+	case "=":
+		return a == b
+	case "<>":
+		return a != b
+	case "<":
+		return a < b
+	case "<=":
+		return a <= b
+	case ">":
+		return a > b
+	case ">=":
+		return a >= b
+	default:
+		return false
+	}
+}
+
+// attributeValuesEqualStatic compares two attribute values for equality (static function).
+//
+//nolint:gocritic // hugeParam: AttributeValue passed by value for comparison.
+func attributeValuesEqualStatic(a, b AttributeValue) bool {
+	if a.S != nil && b.S != nil {
+		return *a.S == *b.S
+	}
+
+	if a.N != nil && b.N != nil {
+		return *a.N == *b.N
+	}
+
+	if a.BOOL != nil && b.BOOL != nil {
+		return *a.BOOL == *b.BOOL
+	}
+
+	if a.NULL != nil && b.NULL != nil {
+		return *a.NULL == *b.NULL
+	}
+
+	return false
+}
+
+// parseArgList parses a parenthesized, comma-separated argument list.
+// Input should start with "(" and returns the arguments and remaining string after ")".
+func parseArgList(s string) ([]string, string, error) {
+	if !strings.HasPrefix(s, "(") {
+		return nil, "", fmt.Errorf("expected '('")
+	}
+
+	s = s[1:] // skip '('
+
+	var args []string
+
+	depth := 1
+	start := 0
+
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				arg := strings.TrimSpace(s[start:i])
+				if arg != "" {
+					args = append(args, arg)
+				}
+
+				return args, s[i+1:], nil
+			}
+		case ',':
+			if depth == 1 {
+				args = append(args, strings.TrimSpace(s[start:i]))
+				start = i + 1
+			}
+		}
+	}
+
+	return nil, "", fmt.Errorf("unmatched parenthesis")
+}
+
+// startsWithKeyword checks if s starts with the given keyword followed by a space or end of string.
+func startsWithKeyword(s, keyword string) bool {
+	if !strings.HasPrefix(strings.ToUpper(s), keyword) {
+		return false
+	}
+
+	if len(s) == len(keyword) {
+		return true
+	}
+
+	next := s[len(keyword)]
+
+	return next == ' ' || next == '\t' || next == '('
+}

--- a/internal/service/dynamodb/condition.go
+++ b/internal/service/dynamodb/condition.go
@@ -107,8 +107,6 @@ func parseNotExpr(expr string, item Item, values map[string]AttributeValue) (boo
 }
 
 // parsePrimary parses a primary expression: parenthesized, function call, or comparison.
-//
-//nolint:cyclop,funlen // Expression parsing inherently requires many branches.
 func parsePrimary(expr string, item Item, values map[string]AttributeValue) (bool, string, error) {
 	trimmed := strings.TrimSpace(expr)
 
@@ -262,9 +260,10 @@ func parseSizeComparison(expr string, item Item, values map[string]AttributeValu
 	idx := 0
 
 	for idx < len(inner) && parenDepth > 0 {
-		if inner[idx] == '(' {
+		switch inner[idx] {
+		case '(':
 			parenDepth++
-		} else if inner[idx] == ')' {
+		case ')':
 			parenDepth--
 		}
 
@@ -421,7 +420,7 @@ func nextToken(s string) (string, string) {
 
 // isOperatorStart checks if the string starts with a comparison operator or keyword.
 func isOperatorStart(s string) bool {
-	if len(s) == 0 {
+	if s == "" {
 		return false
 	}
 
@@ -435,8 +434,6 @@ func isOperatorStart(s string) bool {
 
 // resolveOperand resolves an operand token to an AttributeValue.
 // It can be a value placeholder (:val), or an attribute path.
-//
-//nolint:gocritic // hugeParam: AttributeValue returned by value.
 func resolveOperand(token string, item Item, values map[string]AttributeValue) AttributeValue {
 	if strings.HasPrefix(token, ":") {
 		if val, ok := values[token]; ok {
@@ -452,8 +449,6 @@ func resolveOperand(token string, item Item, values map[string]AttributeValue) A
 }
 
 // resolveItemPath resolves a dotted path on an item, returning the value and whether it exists.
-//
-//nolint:gocritic // hugeParam: AttributeValue returned by value.
 func resolveItemPath(item Item, path string) (AttributeValue, bool) {
 	parts := strings.Split(path, ".")
 

--- a/internal/service/dynamodb/condition_test.go
+++ b/internal/service/dynamodb/condition_test.go
@@ -8,7 +8,7 @@ import (
 
 func ptr[T any](v T) *T { return &v }
 
-//nolint:cyclop // Test function exercises multiple storage operations sequentially.
+//nolint:cyclop,funlen // Test function exercises multiple storage operations sequentially.
 func TestConditionThroughStorage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/dynamodb/condition_test.go
+++ b/internal/service/dynamodb/condition_test.go
@@ -47,7 +47,7 @@ func TestConditionThroughStorage(t *testing.T) {
 	}
 
 	var tErr *TableError
-	if !errors.As(err, &tErr) || tErr.Code != "ConditionalCheckFailedException" {
+	if !errors.As(err, &tErr) || tErr.Code != ErrCodeConditionalCheckFailed {
 		t.Fatalf("expected ConditionalCheckFailedException, got: %v", err)
 	}
 

--- a/internal/service/dynamodb/condition_test.go
+++ b/internal/service/dynamodb/condition_test.go
@@ -1,0 +1,457 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestConditionThroughStorage(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := s.CreateTable(ctx, &CreateTableRequest{
+		TableName: "test",
+		KeySchema: []KeySchemaElement{
+			{AttributeName: "pk", KeyType: "HASH"},
+		},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "pk", AttributeType: "S"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// PutItem with attribute_not_exists should succeed on new item.
+	_, err = s.PutItem(ctx, "test", Item{
+		"pk":      {S: ptr("1")},
+		"version": {N: ptr("1")},
+		"status":  {S: ptr("active")},
+	}, false, ConditionInput{Expression: "attribute_not_exists(pk)"})
+	if err != nil {
+		t.Fatalf("first put should succeed: %v", err)
+	}
+
+	// PutItem with attribute_not_exists should fail on existing item.
+	_, err = s.PutItem(ctx, "test", Item{
+		"pk":      {S: ptr("1")},
+		"version": {N: ptr("99")},
+	}, false, ConditionInput{Expression: "attribute_not_exists(pk)"})
+	if err == nil {
+		t.Fatal("second put should fail")
+	}
+
+	var tErr *TableError
+	if !errors.As(err, &tErr) || tErr.Code != "ConditionalCheckFailedException" {
+		t.Fatalf("expected ConditionalCheckFailedException, got: %v", err)
+	}
+
+	// Verify original item preserved.
+	item, err := s.GetItem(ctx, "test", Item{"pk": {S: ptr("1")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if item["version"].N == nil || *item["version"].N != "1" {
+		t.Fatalf("version should be 1, got: %v", item["version"])
+	}
+
+	// UpdateItem with version check (optimistic locking).
+	_, err = s.UpdateItem(ctx, "test", Item{"pk": {S: ptr("1")}},
+		"SET version = :new", nil,
+		map[string]AttributeValue{
+			":cur": {N: ptr("1")},
+			":new": {N: ptr("2")},
+		},
+		ReturnValuesAllNew,
+		ConditionInput{
+			Expression: "version = :cur",
+			ExprValues: map[string]AttributeValue{":cur": {N: ptr("1")}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("update with correct version should succeed: %v", err)
+	}
+
+	// UpdateItem with stale version should fail.
+	_, err = s.UpdateItem(ctx, "test", Item{"pk": {S: ptr("1")}},
+		"SET version = :new", nil,
+		map[string]AttributeValue{
+			":cur": {N: ptr("1")},
+			":new": {N: ptr("3")},
+		},
+		"",
+		ConditionInput{
+			Expression: "version = :cur",
+			ExprValues: map[string]AttributeValue{":cur": {N: ptr("1")}},
+		},
+	)
+	if err == nil {
+		t.Fatal("update with stale version should fail")
+	}
+
+	// Comparison operators: version >= 2 should pass.
+	_, err = s.UpdateItem(ctx, "test", Item{"pk": {S: ptr("1")}},
+		"SET version = :new", nil,
+		map[string]AttributeValue{
+			":new": {N: ptr("3")},
+		},
+		ReturnValuesAllNew,
+		ConditionInput{
+			Expression: "version >= :min",
+			ExprValues: map[string]AttributeValue{":min": {N: ptr("2")}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("update with version >= 2 should succeed: %v", err)
+	}
+
+	// Comparison: version < 2 should fail (version is now 3).
+	_, err = s.UpdateItem(ctx, "test", Item{"pk": {S: ptr("1")}},
+		"SET version = :new", nil,
+		map[string]AttributeValue{":new": {N: ptr("4")}},
+		"",
+		ConditionInput{
+			Expression: "version < :max",
+			ExprValues: map[string]AttributeValue{":max": {N: ptr("2")}},
+		},
+	)
+	if err == nil {
+		t.Fatal("update with version < 2 should fail (version=3)")
+	}
+
+	// String comparison: status = "active" AND version > 1.
+	_, err = s.UpdateItem(ctx, "test", Item{"pk": {S: ptr("1")}},
+		"SET #s = :new_status", map[string]string{"#s": "status"},
+		map[string]AttributeValue{":new_status": {S: ptr("done")}},
+		ReturnValuesAllNew,
+		ConditionInput{
+			Expression: "#s = :expected AND version > :min_ver",
+			ExprNames:  map[string]string{"#s": "status"},
+			ExprValues: map[string]AttributeValue{
+				":expected": {S: ptr("active")},
+				":min_ver":  {N: ptr("1")},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("compound condition should succeed: %v", err)
+	}
+
+	// DeleteItem with wrong condition should fail.
+	_, err = s.DeleteItem(ctx, "test", Item{"pk": {S: ptr("1")}}, false, ConditionInput{
+		Expression: "status = :expected",
+		ExprValues: map[string]AttributeValue{":expected": {S: ptr("active")}},
+	})
+	if err == nil {
+		t.Fatal("delete with wrong status should fail (status=done)")
+	}
+
+	// DeleteItem with correct condition should succeed.
+	_, err = s.DeleteItem(ctx, "test", Item{"pk": {S: ptr("1")}}, false, ConditionInput{
+		Expression: "status = :expected",
+		ExprValues: map[string]AttributeValue{":expected": {S: ptr("done")}},
+	})
+	if err != nil {
+		t.Fatalf("delete with correct status should succeed: %v", err)
+	}
+
+	// Verify deleted.
+	item, err = s.GetItem(ctx, "test", Item{"pk": {S: ptr("1")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if item != nil {
+		t.Fatalf("item should be deleted, got: %v", item)
+	}
+}
+
+func TestEvaluateCondition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		item    Item
+		cond    ConditionInput
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "empty expression returns true",
+			item: Item{"pk": {S: ptr("1")}},
+			cond: ConditionInput{},
+			want: true,
+		},
+		{
+			name: "attribute_exists succeeds when attribute present",
+			item: Item{"pk": {S: ptr("1")}, "name": {S: ptr("Alice")}},
+			cond: ConditionInput{
+				Expression: "attribute_exists(name)",
+			},
+			want: true,
+		},
+		{
+			name: "attribute_exists fails when attribute missing",
+			item: Item{"pk": {S: ptr("1")}},
+			cond: ConditionInput{
+				Expression: "attribute_exists(name)",
+			},
+			want: false,
+		},
+		{
+			name: "attribute_not_exists succeeds when attribute missing",
+			item: Item{"pk": {S: ptr("1")}},
+			cond: ConditionInput{
+				Expression: "attribute_not_exists(name)",
+			},
+			want: true,
+		},
+		{
+			name: "attribute_not_exists on nil item (new item)",
+			item: nil,
+			cond: ConditionInput{
+				Expression: "attribute_not_exists(pk)",
+			},
+			want: true,
+		},
+		{
+			name: "attribute_not_exists fails when attribute present",
+			item: Item{"pk": {S: ptr("1")}, "name": {S: ptr("Alice")}},
+			cond: ConditionInput{
+				Expression: "attribute_not_exists(name)",
+			},
+			want: false,
+		},
+		{
+			name: "string equality",
+			item: Item{"pk": {S: ptr("1")}, "status": {S: ptr("active")}},
+			cond: ConditionInput{
+				Expression: "status = :val",
+				ExprValues: map[string]AttributeValue{
+					":val": {S: ptr("active")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "string inequality",
+			item: Item{"pk": {S: ptr("1")}, "status": {S: ptr("active")}},
+			cond: ConditionInput{
+				Expression: "status <> :val",
+				ExprValues: map[string]AttributeValue{
+					":val": {S: ptr("inactive")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "number comparison less than",
+			item: Item{"pk": {S: ptr("1")}, "age": {N: ptr("25")}},
+			cond: ConditionInput{
+				Expression: "age < :val",
+				ExprValues: map[string]AttributeValue{
+					":val": {N: ptr("30")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "number comparison greater equal",
+			item: Item{"pk": {S: ptr("1")}, "age": {N: ptr("25")}},
+			cond: ConditionInput{
+				Expression: "age >= :val",
+				ExprValues: map[string]AttributeValue{
+					":val": {N: ptr("25")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "AND both true",
+			item: Item{"pk": {S: ptr("1")}, "status": {S: ptr("active")}, "age": {N: ptr("25")}},
+			cond: ConditionInput{
+				Expression: "status = :status AND age >= :age",
+				ExprValues: map[string]AttributeValue{
+					":status": {S: ptr("active")},
+					":age":    {N: ptr("20")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "AND left false",
+			item: Item{"pk": {S: ptr("1")}, "status": {S: ptr("inactive")}, "age": {N: ptr("25")}},
+			cond: ConditionInput{
+				Expression: "status = :status AND age >= :age",
+				ExprValues: map[string]AttributeValue{
+					":status": {S: ptr("active")},
+					":age":    {N: ptr("20")},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "OR one true",
+			item: Item{"pk": {S: ptr("1")}, "status": {S: ptr("inactive")}},
+			cond: ConditionInput{
+				Expression: "status = :s1 OR status = :s2",
+				ExprValues: map[string]AttributeValue{
+					":s1": {S: ptr("active")},
+					":s2": {S: ptr("inactive")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "NOT expression",
+			item: Item{"pk": {S: ptr("1")}, "status": {S: ptr("active")}},
+			cond: ConditionInput{
+				Expression: "NOT status = :val",
+				ExprValues: map[string]AttributeValue{
+					":val": {S: ptr("inactive")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "expression attribute names",
+			item: Item{"pk": {S: ptr("1")}, "status": {S: ptr("active")}},
+			cond: ConditionInput{
+				Expression: "#s = :val",
+				ExprNames:  map[string]string{"#s": "status"},
+				ExprValues: map[string]AttributeValue{
+					":val": {S: ptr("active")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "begins_with true",
+			item: Item{"pk": {S: ptr("1")}, "email": {S: ptr("alice@example.com")}},
+			cond: ConditionInput{
+				Expression: "begins_with(email, :prefix)",
+				ExprValues: map[string]AttributeValue{
+					":prefix": {S: ptr("alice@")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "begins_with false",
+			item: Item{"pk": {S: ptr("1")}, "email": {S: ptr("bob@example.com")}},
+			cond: ConditionInput{
+				Expression: "begins_with(email, :prefix)",
+				ExprValues: map[string]AttributeValue{
+					":prefix": {S: ptr("alice@")},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "contains string",
+			item: Item{"pk": {S: ptr("1")}, "name": {S: ptr("Alice Smith")}},
+			cond: ConditionInput{
+				Expression: "contains(name, :sub)",
+				ExprValues: map[string]AttributeValue{
+					":sub": {S: ptr("Smith")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "contains string set",
+			item: Item{"pk": {S: ptr("1")}, "tags": {SS: []string{"golang", "rust", "python"}}},
+			cond: ConditionInput{
+				Expression: "contains(tags, :tag)",
+				ExprValues: map[string]AttributeValue{
+					":tag": {S: ptr("rust")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "contains string set missing",
+			item: Item{"pk": {S: ptr("1")}, "tags": {SS: []string{"golang", "rust"}}},
+			cond: ConditionInput{
+				Expression: "contains(tags, :tag)",
+				ExprValues: map[string]AttributeValue{
+					":tag": {S: ptr("java")},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "size comparison",
+			item: Item{"pk": {S: ptr("1")}, "items": {L: []AttributeValue{{S: ptr("a")}, {S: ptr("b")}, {S: ptr("c")}}}},
+			cond: ConditionInput{
+				Expression: "size(items) > :min",
+				ExprValues: map[string]AttributeValue{
+					":min": {N: ptr("2")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "size comparison fails",
+			item: Item{"pk": {S: ptr("1")}, "items": {L: []AttributeValue{{S: ptr("a")}}}},
+			cond: ConditionInput{
+				Expression: "size(items) > :min",
+				ExprValues: map[string]AttributeValue{
+					":min": {N: ptr("2")},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "parenthesized expression",
+			item: Item{"pk": {S: ptr("1")}, "a": {N: ptr("1")}, "b": {N: ptr("2")}},
+			cond: ConditionInput{
+				Expression: "(a = :v1) AND (b = :v2)",
+				ExprValues: map[string]AttributeValue{
+					":v1": {N: ptr("1")},
+					":v2": {N: ptr("2")},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "idempotency pattern: attribute_not_exists on pk",
+			item: Item{"pk": {S: ptr("existing-id")}, "data": {S: ptr("value")}},
+			cond: ConditionInput{
+				Expression: "attribute_not_exists(pk)",
+			},
+			want: false,
+		},
+		{
+			name: "nested path attribute_exists",
+			item: Item{"pk": {S: ptr("1")}, "meta": {M: map[string]AttributeValue{"version": {N: ptr("1")}}}},
+			cond: ConditionInput{
+				Expression: "attribute_exists(meta.version)",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := evaluateCondition(tt.item, tt.cond)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("evaluateCondition() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("evaluateCondition() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/service/dynamodb/condition_test.go
+++ b/internal/service/dynamodb/condition_test.go
@@ -8,6 +8,7 @@ import (
 
 func ptr[T any](v T) *T { return &v }
 
+//nolint:cyclop // Test function exercises multiple storage operations sequentially.
 func TestConditionThroughStorage(t *testing.T) {
 	t.Parallel()
 
@@ -172,6 +173,7 @@ func TestConditionThroughStorage(t *testing.T) {
 	}
 }
 
+//nolint:funlen // Table-driven test with comprehensive condition expression coverage.
 func TestEvaluateCondition(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -175,7 +175,7 @@ func (s *Service) PutItem(w http.ResponseWriter, r *http.Request) {
 		var tErr *TableError
 		if errors.As(err, &tErr) {
 			status := http.StatusBadRequest
-			if tErr.Code == "ConditionalCheckFailedException" {
+			if tErr.Code == ErrCodeConditionalCheckFailed {
 				status = http.StatusConflict
 			}
 
@@ -268,7 +268,7 @@ func (s *Service) DeleteItem(w http.ResponseWriter, r *http.Request) {
 		var tErr *TableError
 		if errors.As(err, &tErr) {
 			status := http.StatusBadRequest
-			if tErr.Code == "ConditionalCheckFailedException" {
+			if tErr.Code == ErrCodeConditionalCheckFailed {
 				status = http.StatusConflict
 			}
 
@@ -328,7 +328,7 @@ func (s *Service) UpdateItem(w http.ResponseWriter, r *http.Request) {
 		var tErr *TableError
 		if errors.As(err, &tErr) {
 			status := http.StatusBadRequest
-			if tErr.Code == "ConditionalCheckFailedException" {
+			if tErr.Code == ErrCodeConditionalCheckFailed {
 				status = http.StatusConflict
 			}
 

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -164,11 +164,22 @@ func (s *Service) PutItem(w http.ResponseWriter, r *http.Request) {
 
 	returnOld := req.ReturnValues == "ReturnValuesAllOld"
 
-	oldItem, err := s.storage.PutItem(r.Context(), req.TableName, req.Item, returnOld)
+	cond := ConditionInput{
+		Expression: req.ConditionExpression,
+		ExprNames:  req.ExpressionAttributeNames,
+		ExprValues: req.ExpressionAttributeValues,
+	}
+
+	oldItem, err := s.storage.PutItem(r.Context(), req.TableName, req.Item, returnOld, cond)
 	if err != nil {
 		var tErr *TableError
 		if errors.As(err, &tErr) {
-			writeDynamoDBError(w, tErr.Code, tErr.Message, http.StatusBadRequest)
+			status := http.StatusBadRequest
+			if tErr.Code == "ConditionalCheckFailedException" {
+				status = http.StatusConflict
+			}
+
+			writeDynamoDBError(w, tErr.Code, tErr.Message, status)
 
 			return
 		}
@@ -246,11 +257,22 @@ func (s *Service) DeleteItem(w http.ResponseWriter, r *http.Request) {
 
 	returnOld := req.ReturnValues == "ReturnValuesAllOld"
 
-	oldItem, err := s.storage.DeleteItem(r.Context(), req.TableName, req.Key, returnOld)
+	cond := ConditionInput{
+		Expression: req.ConditionExpression,
+		ExprNames:  req.ExpressionAttributeNames,
+		ExprValues: req.ExpressionAttributeValues,
+	}
+
+	oldItem, err := s.storage.DeleteItem(r.Context(), req.TableName, req.Key, returnOld, cond)
 	if err != nil {
 		var tErr *TableError
 		if errors.As(err, &tErr) {
-			writeDynamoDBError(w, tErr.Code, tErr.Message, http.StatusBadRequest)
+			status := http.StatusBadRequest
+			if tErr.Code == "ConditionalCheckFailedException" {
+				status = http.StatusConflict
+			}
+
+			writeDynamoDBError(w, tErr.Code, tErr.Message, status)
 
 			return
 		}
@@ -286,6 +308,12 @@ func (s *Service) UpdateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cond := ConditionInput{
+		Expression: req.ConditionExpression,
+		ExprNames:  req.ExpressionAttributeNames,
+		ExprValues: req.ExpressionAttributeValues,
+	}
+
 	result, err := s.storage.UpdateItem(
 		r.Context(),
 		req.TableName,
@@ -294,11 +322,17 @@ func (s *Service) UpdateItem(w http.ResponseWriter, r *http.Request) {
 		req.ExpressionAttributeNames,
 		req.ExpressionAttributeValues,
 		req.ReturnValues,
+		cond,
 	)
 	if err != nil {
 		var tErr *TableError
 		if errors.As(err, &tErr) {
-			writeDynamoDBError(w, tErr.Code, tErr.Message, http.StatusBadRequest)
+			status := http.StatusBadRequest
+			if tErr.Code == "ConditionalCheckFailedException" {
+				status = http.StatusConflict
+			}
+
+			writeDynamoDBError(w, tErr.Code, tErr.Message, status)
 
 			return
 		}

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -281,7 +281,7 @@ func (m *MemoryStorage) PutItem(_ context.Context, tableName string, item Item, 
 		}
 	} else if !ok {
 		return nil, &TableError{
-			Code:    "ConditionalCheckFailedException",
+			Code:    ErrCodeConditionalCheckFailed,
 			Message: "The conditional request failed",
 		}
 	}
@@ -347,7 +347,7 @@ func (m *MemoryStorage) DeleteItem(_ context.Context, tableName string, key Item
 		}
 	} else if !ok {
 		return nil, &TableError{
-			Code:    "ConditionalCheckFailedException",
+			Code:    ErrCodeConditionalCheckFailed,
 			Message: "The conditional request failed",
 		}
 	}
@@ -394,7 +394,7 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 		}
 	} else if !ok {
 		return nil, &TableError{
-			Code:    "ConditionalCheckFailedException",
+			Code:    ErrCodeConditionalCheckFailed,
 			Message: "The conditional request failed",
 		}
 	}

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -25,10 +25,10 @@ type Storage interface {
 	DeleteTable(ctx context.Context, tableName string) (*Table, error)
 	ListTables(ctx context.Context, exclusiveStartTableName string, limit int) ([]string, string, error)
 	DescribeTable(ctx context.Context, tableName string) (*Table, error)
-	PutItem(ctx context.Context, tableName string, item Item, returnOld bool) (Item, error)
+	PutItem(ctx context.Context, tableName string, item Item, returnOld bool, cond ConditionInput) (Item, error)
 	GetItem(ctx context.Context, tableName string, key Item) (Item, error)
-	DeleteItem(ctx context.Context, tableName string, key Item, returnOld bool) (Item, error)
-	UpdateItem(ctx context.Context, tableName string, key Item, updateExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, returnValues string) (Item, error)
+	DeleteItem(ctx context.Context, tableName string, key Item, returnOld bool, cond ConditionInput) (Item, error)
+	UpdateItem(ctx context.Context, tableName string, key Item, updateExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, returnValues string, cond ConditionInput) (Item, error)
 	Query(ctx context.Context, tableName string, keyCondExpr string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item, scanForward bool) ([]Item, Item, int, error)
 	Scan(ctx context.Context, tableName string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item) ([]Item, Item, int, error)
 	UpdateTimeToLive(ctx context.Context, tableName, attributeName string, enabled bool) error
@@ -254,7 +254,7 @@ func (m *MemoryStorage) DescribeTable(_ context.Context, tableName string) (*Tab
 }
 
 // PutItem puts an item into a table.
-func (m *MemoryStorage) PutItem(_ context.Context, tableName string, item Item, returnOld bool) (Item, error) {
+func (m *MemoryStorage) PutItem(_ context.Context, tableName string, item Item, returnOld bool, cond ConditionInput) (Item, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -268,12 +268,28 @@ func (m *MemoryStorage) PutItem(_ context.Context, tableName string, item Item, 
 
 	key := m.serializeKey(td.Table, item)
 
+	// Evaluate condition against existing item (nil if not exists).
+	var existingItem Item
+	if existing, ok := td.Items[key]; ok {
+		existingItem = existing
+	}
+
+	if ok, err := evaluateCondition(existingItem, cond); err != nil {
+		return nil, &TableError{
+			Code:    "ValidationException",
+			Message: fmt.Sprintf("Invalid ConditionExpression: %s", err),
+		}
+	} else if !ok {
+		return nil, &TableError{
+			Code:    "ConditionalCheckFailedException",
+			Message: "The conditional request failed",
+		}
+	}
+
 	var oldItem Item
 
-	if returnOld {
-		if existing, ok := td.Items[key]; ok {
-			oldItem = m.copyItem(existing)
-		}
+	if returnOld && existingItem != nil {
+		oldItem = m.copyItem(existingItem)
 	}
 
 	td.Items[key] = m.copyItem(item)
@@ -304,7 +320,7 @@ func (m *MemoryStorage) GetItem(_ context.Context, tableName string, key Item) (
 }
 
 // DeleteItem deletes an item from a table.
-func (m *MemoryStorage) DeleteItem(_ context.Context, tableName string, key Item, returnOld bool) (Item, error) {
+func (m *MemoryStorage) DeleteItem(_ context.Context, tableName string, key Item, returnOld bool, cond ConditionInput) (Item, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -318,11 +334,29 @@ func (m *MemoryStorage) DeleteItem(_ context.Context, tableName string, key Item
 
 	keyStr := m.serializeKey(td.Table, key)
 
+	// Evaluate condition against existing item.
+	var existingItem Item
+	if existing, ok := td.Items[keyStr]; ok {
+		existingItem = existing
+	}
+
+	if ok, err := evaluateCondition(existingItem, cond); err != nil {
+		return nil, &TableError{
+			Code:    "ValidationException",
+			Message: fmt.Sprintf("Invalid ConditionExpression: %s", err),
+		}
+	} else if !ok {
+		return nil, &TableError{
+			Code:    "ConditionalCheckFailedException",
+			Message: "The conditional request failed",
+		}
+	}
+
 	var oldItem Item
 
-	if existing, ok := td.Items[keyStr]; ok {
+	if existingItem != nil {
 		if returnOld {
-			oldItem = m.copyItem(existing)
+			oldItem = m.copyItem(existingItem)
 		}
 
 		delete(td.Items, keyStr)
@@ -332,7 +366,7 @@ func (m *MemoryStorage) DeleteItem(_ context.Context, tableName string, key Item
 }
 
 // UpdateItem updates an item in a table.
-func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item, updateExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, returnValues string) (Item, error) {
+func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item, updateExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, returnValues string, cond ConditionInput) (Item, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -346,6 +380,24 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 
 	keyStr := m.serializeKey(td.Table, key)
 	item, itemExists := td.Items[keyStr]
+
+	// Evaluate condition against existing item.
+	var condItem Item
+	if itemExists {
+		condItem = item
+	}
+
+	if ok, err := evaluateCondition(condItem, cond); err != nil {
+		return nil, &TableError{
+			Code:    "ValidationException",
+			Message: fmt.Sprintf("Invalid ConditionExpression: %s", err),
+		}
+	} else if !ok {
+		return nil, &TableError{
+			Code:    "ConditionalCheckFailedException",
+			Message: "The conditional request failed",
+		}
+	}
 
 	var oldItem Item
 	if itemExists {
@@ -725,39 +777,18 @@ func (m *MemoryStorage) extractPartitionKeyValue(keyCondExpr, partitionKeyName s
 	return nil
 }
 
-// evaluateFilterExpression evaluates a simple filter expression against an item.
+// evaluateFilterExpression evaluates a filter expression against an item.
 func (m *MemoryStorage) evaluateFilterExpression(item Item, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue) bool {
-	if filterExpr == "" {
+	result, err := evaluateCondition(item, ConditionInput{
+		Expression: filterExpr,
+		ExprNames:  exprNames,
+		ExprValues: exprValues,
+	})
+	if err != nil {
 		return true
 	}
 
-	// Very simplified filter expression evaluation.
-	// Only supports simple equality checks.
-	expr := filterExpr
-	for placeholder, name := range exprNames {
-		expr = strings.ReplaceAll(expr, placeholder, name)
-	}
-
-	// Handle simple equality: "attr = :val".
-	if strings.Contains(expr, "=") && !strings.Contains(expr, "<>") {
-		parts := strings.SplitN(expr, "=", 2)
-		if len(parts) == 2 {
-			attrName := strings.TrimSpace(parts[0])
-			valuePlaceholder := strings.TrimSpace(parts[1])
-
-			itemVal, hasAttr := item[attrName]
-			exprVal, hasExpr := exprValues[valuePlaceholder]
-
-			if !hasAttr || !hasExpr {
-				return false
-			}
-
-			return m.attributeValuesEqual(itemVal, exprVal)
-		}
-	}
-
-	// Default to true for unsupported expressions.
-	return true
+	return result
 }
 
 // attributeValuesEqual compares two attribute values for equality.

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -13,6 +13,11 @@ const (
 	ReturnValuesUpdatedNew = "UPDATED_NEW"
 )
 
+// Error code constants.
+const (
+	ErrCodeConditionalCheckFailed = "ConditionalCheckFailedException"
+)
+
 // AttributeValue represents a DynamoDB attribute value.
 // Only one field should be set at a time.
 type AttributeValue struct {

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -602,4 +603,311 @@ func TestDynamoDB_UpdateTimeToLive(t *testing.T) {
 		t.Fatal(err)
 	}
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_describe", describeOutput)
+}
+
+func TestDynamoDB_PutItem_ConditionExpression_AttributeNotExists(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-condition-put"
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// First put should succeed (item does not exist).
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"pk":   &types.AttributeValueMemberS{Value: "id-1"},
+			"data": &types.AttributeValueMemberS{Value: "first"},
+		},
+		ConditionExpression: aws.String("attribute_not_exists(pk)"),
+	})
+	if err != nil {
+		t.Fatalf("first PutItem should succeed: %v", err)
+	}
+
+	// Second put with same key should fail (item exists).
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"pk":   &types.AttributeValueMemberS{Value: "id-1"},
+			"data": &types.AttributeValueMemberS{Value: "second"},
+		},
+		ConditionExpression: aws.String("attribute_not_exists(pk)"),
+	})
+	if err == nil {
+		t.Fatal("second PutItem should fail with ConditionalCheckFailedException")
+	}
+
+	var ccfe *types.ConditionalCheckFailedException
+	if !errors.As(err, &ccfe) {
+		t.Fatalf("expected ConditionalCheckFailedException, got: %T: %v", err, err)
+	}
+
+	// Verify original item is preserved.
+	getOutput, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: "id-1"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_get", getOutput)
+}
+
+func TestDynamoDB_PutItem_ConditionExpression_Equality(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-condition-equality"
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Put initial item.
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"pk":     &types.AttributeValueMemberS{Value: "id-1"},
+			"status": &types.AttributeValueMemberS{Value: "active"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update with correct condition should succeed.
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"pk":     &types.AttributeValueMemberS{Value: "id-1"},
+			"status": &types.AttributeValueMemberS{Value: "inactive"},
+		},
+		ConditionExpression: aws.String("#s = :expected"),
+		ExpressionAttributeNames: map[string]string{
+			"#s": "status",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":expected": &types.AttributeValueMemberS{Value: "active"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("conditional put with matching status should succeed: %v", err)
+	}
+
+	// Update with wrong condition should fail.
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"pk":     &types.AttributeValueMemberS{Value: "id-1"},
+			"status": &types.AttributeValueMemberS{Value: "deleted"},
+		},
+		ConditionExpression: aws.String("#s = :expected"),
+		ExpressionAttributeNames: map[string]string{
+			"#s": "status",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":expected": &types.AttributeValueMemberS{Value: "active"},
+		},
+	})
+	if err == nil {
+		t.Fatal("conditional put with wrong status should fail")
+	}
+
+	var ccfe *types.ConditionalCheckFailedException
+	if !errors.As(err, &ccfe) {
+		t.Fatalf("expected ConditionalCheckFailedException, got: %T: %v", err, err)
+	}
+}
+
+func TestDynamoDB_DeleteItem_ConditionExpression(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-condition-delete"
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Put item.
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"pk":     &types.AttributeValueMemberS{Value: "id-1"},
+			"status": &types.AttributeValueMemberS{Value: "active"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete with wrong condition should fail.
+	_, err = client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: "id-1"},
+		},
+		ConditionExpression: aws.String("#s = :expected"),
+		ExpressionAttributeNames: map[string]string{
+			"#s": "status",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":expected": &types.AttributeValueMemberS{Value: "inactive"},
+		},
+	})
+	if err == nil {
+		t.Fatal("delete with wrong condition should fail")
+	}
+
+	var ccfe *types.ConditionalCheckFailedException
+	if !errors.As(err, &ccfe) {
+		t.Fatalf("expected ConditionalCheckFailedException, got: %T: %v", err, err)
+	}
+
+	// Delete with correct condition should succeed.
+	_, err = client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: "id-1"},
+		},
+		ConditionExpression: aws.String("#s = :expected"),
+		ExpressionAttributeNames: map[string]string{
+			"#s": "status",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":expected": &types.AttributeValueMemberS{Value: "active"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("delete with correct condition should succeed: %v", err)
+	}
+}
+
+func TestDynamoDB_UpdateItem_ConditionExpression(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-condition-update"
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Put initial item.
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"pk":      &types.AttributeValueMemberS{Value: "id-1"},
+			"version": &types.AttributeValueMemberN{Value: "1"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update with correct version (optimistic locking).
+	_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: "id-1"},
+		},
+		UpdateExpression:    aws.String("SET version = :newver"),
+		ConditionExpression: aws.String("version = :curver"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":curver": &types.AttributeValueMemberN{Value: "1"},
+			":newver": &types.AttributeValueMemberN{Value: "2"},
+		},
+		ReturnValues: types.ReturnValueAllNew,
+	})
+	if err != nil {
+		t.Fatalf("update with correct version should succeed: %v", err)
+	}
+
+	// Update with stale version should fail.
+	_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: "id-1"},
+		},
+		UpdateExpression:    aws.String("SET version = :newver"),
+		ConditionExpression: aws.String("version = :curver"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":curver": &types.AttributeValueMemberN{Value: "1"},
+			":newver": &types.AttributeValueMemberN{Value: "3"},
+		},
+	})
+	if err == nil {
+		t.Fatal("update with stale version should fail")
+	}
+
+	var ccfe *types.ConditionalCheckFailedException
+	if !errors.As(err, &ccfe) {
+		t.Fatalf("expected ConditionalCheckFailedException, got: %T: %v", err, err)
+	}
 }

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_PutItem_ConditionExpression_AttributeNotExists_TestDynamoDB_PutItem_ConditionExpression_AttributeNotExists_get.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_PutItem_ConditionExpression_AttributeNotExists_TestDynamoDB_PutItem_ConditionExpression_AttributeNotExists_get.golden.go
@@ -1,0 +1,12 @@
+{
+  "ConsumedCapacity": null,
+  "Item": {
+    "data": {
+      "Value": "first"
+    },
+    "pk": {
+      "Value": "id-1"
+    }
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Implement ConditionExpression evaluation for PutItem, UpdateItem, and DeleteItem
- Support comparisons (=, <>, <, <=, >, >=), functions (attribute_exists, attribute_not_exists, begins_with, contains, size), logical operators (AND, OR, NOT), and nested attribute paths
- Return ConditionalCheckFailedException (HTTP 409) when condition is not met
- Replace the simplified evaluateFilterExpression with the new expression evaluator

## Test plan

- [x] 25 unit tests for condition expression evaluator (condition_test.go)
- [x] Storage-level integration test covering optimistic locking, comparisons, compound conditions (condition_test.go)
- [x] 4 integration tests using AWS SDK v2 (dynamodb_test.go): attribute_not_exists, equality, delete condition, update optimistic locking
- [x] All existing tests pass with no regressions

Closes #436