### PR TITLE
feat: add DynamoDB TransactWriteItems/TransactGetItems support

### DIFF
--- a/internal/service/dynamodb/condition_test.go
+++ b/internal/service/dynamodb/condition_test.go
@@ -173,6 +173,178 @@ func TestConditionThroughStorage(t *testing.T) {
 	}
 }
 
+//nolint:cyclop // Test function exercises multiple transaction operations sequentially.
+func TestTransactWriteItems(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := s.CreateTable(ctx, &CreateTableRequest{
+		TableName:            "accounts",
+		KeySchema:            []KeySchemaElement{{AttributeName: "id", KeyType: "HASH"}},
+		AttributeDefinitions: []AttributeDefinition{{AttributeName: "id", AttributeType: "S"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Successful transaction: put two items atomically.
+	reasons, err := s.TransactWriteItems(ctx, []TransactWriteItem{
+		{Put: &TransactPut{
+			TableName:           "accounts",
+			Item:                Item{"id": {S: ptr("acc-1")}, "balance": {N: ptr("100")}},
+			ConditionExpression: "attribute_not_exists(id)",
+		}},
+		{Put: &TransactPut{
+			TableName:           "accounts",
+			Item:                Item{"id": {S: ptr("acc-2")}, "balance": {N: ptr("200")}},
+			ConditionExpression: "attribute_not_exists(id)",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("transaction should succeed: %v", err)
+	}
+
+	if reasons != nil {
+		t.Fatalf("expected no cancellation reasons, got: %v", reasons)
+	}
+
+	// Verify both items exist.
+	item1, _ := s.GetItem(ctx, "accounts", Item{"id": {S: ptr("acc-1")}})
+	item2, _ := s.GetItem(ctx, "accounts", Item{"id": {S: ptr("acc-2")}})
+
+	if item1 == nil || item2 == nil {
+		t.Fatal("both items should exist after transaction")
+	}
+
+	// Failed transaction: second put has condition that fails.
+	reasons, err = s.TransactWriteItems(ctx, []TransactWriteItem{
+		{Put: &TransactPut{
+			TableName:           "accounts",
+			Item:                Item{"id": {S: ptr("acc-3")}, "balance": {N: ptr("300")}},
+			ConditionExpression: "attribute_not_exists(id)",
+		}},
+		{Put: &TransactPut{
+			TableName:           "accounts",
+			Item:                Item{"id": {S: ptr("acc-1")}, "balance": {N: ptr("999")}},
+			ConditionExpression: "attribute_not_exists(id)", // Fails: acc-1 already exists.
+		}},
+	})
+
+	var tErr *TableError
+	if !errors.As(err, &tErr) || tErr.Code != "TransactionCanceledException" {
+		t.Fatalf("expected TransactionCanceledException, got: %v", err)
+	}
+
+	// Verify reasons: first should be empty, second should be ConditionalCheckFailed.
+	if reasons[0].Code != "" {
+		t.Fatalf("first reason should be empty, got: %s", reasons[0].Code)
+	}
+
+	if reasons[1].Code != "ConditionalCheckFailed" {
+		t.Fatalf("second reason should be ConditionalCheckFailed, got: %s", reasons[1].Code)
+	}
+
+	// Verify acc-3 was NOT created (all-or-nothing).
+	item3, _ := s.GetItem(ctx, "accounts", Item{"id": {S: ptr("acc-3")}})
+	if item3 != nil {
+		t.Fatal("acc-3 should not exist after failed transaction")
+	}
+
+	// Transaction with Update and ConditionCheck.
+	reasons, err = s.TransactWriteItems(ctx, []TransactWriteItem{
+		{Update: &TransactUpdate{
+			TableName:        "accounts",
+			Key:              Item{"id": {S: ptr("acc-1")}},
+			UpdateExpression: "SET balance = :new",
+			ExpressionAttributeValues: map[string]AttributeValue{
+				":new": {N: ptr("150")},
+			},
+		}},
+		{ConditionCheck: &TransactConditionCheck{
+			TableName:           "accounts",
+			Key:                 Item{"id": {S: ptr("acc-2")}},
+			ConditionExpression: "attribute_exists(id)",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("update+conditioncheck transaction should succeed: %v", err)
+	}
+
+	// Verify acc-1 balance updated.
+	item1, _ = s.GetItem(ctx, "accounts", Item{"id": {S: ptr("acc-1")}})
+	if item1["balance"].N == nil || *item1["balance"].N != "150" {
+		t.Fatalf("acc-1 balance should be 150, got: %v", item1["balance"])
+	}
+
+	// Transaction with Delete.
+	reasons, err = s.TransactWriteItems(ctx, []TransactWriteItem{
+		{Delete: &TransactDelete{
+			TableName: "accounts",
+			Key:       Item{"id": {S: ptr("acc-2")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("delete transaction should succeed: %v", err)
+	}
+
+	item2, _ = s.GetItem(ctx, "accounts", Item{"id": {S: ptr("acc-2")}})
+	if item2 != nil {
+		t.Fatal("acc-2 should be deleted")
+	}
+}
+
+func TestTransactGetItems(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := s.CreateTable(ctx, &CreateTableRequest{
+		TableName:            "users",
+		KeySchema:            []KeySchemaElement{{AttributeName: "pk", KeyType: "HASH"}},
+		AttributeDefinitions: []AttributeDefinition{{AttributeName: "pk", AttributeType: "S"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert items.
+	for _, id := range []string{"u1", "u2", "u3"} {
+		_, err = s.PutItem(ctx, "users", Item{"pk": {S: ptr(id)}, "name": {S: ptr("User-" + id)}}, false, ConditionInput{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// TransactGetItems: get u1 and u3 (skip u2).
+	items, err := s.TransactGetItems(ctx, []TransactGetItem{
+		{Get: &TransactGet{TableName: "users", Key: Item{"pk": {S: ptr("u1")}}}},
+		{Get: &TransactGet{TableName: "users", Key: Item{"pk": {S: ptr("u3")}}}},
+		{Get: &TransactGet{TableName: "users", Key: Item{"pk": {S: ptr("missing")}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(items) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(items))
+	}
+
+	if items[0] == nil || *items[0]["name"].S != "User-u1" {
+		t.Fatalf("first item should be u1, got: %v", items[0])
+	}
+
+	if items[1] == nil || *items[1]["name"].S != "User-u3" {
+		t.Fatalf("second item should be u3, got: %v", items[1])
+	}
+
+	if items[2] != nil {
+		t.Fatalf("third item should be nil (not found), got: %v", items[2])
+	}
+}
+
 //nolint:funlen // Table-driven test with comprehensive condition expression coverage.
 func TestEvaluateCondition(t *testing.T) {
 	t.Parallel()

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -587,6 +587,99 @@ func (s *Service) DescribeTimeToLive(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// TransactWriteItems handles the TransactWriteItems action.
+func (s *Service) TransactWriteItems(w http.ResponseWriter, r *http.Request) {
+	var req TransactWriteItemsRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if len(req.TransactItems) == 0 {
+		writeDynamoDBError(w, "ValidationException", "TransactItems is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if len(req.TransactItems) > 100 {
+		writeDynamoDBError(w, "ValidationException", "Member must have length less than or equal to 100", http.StatusBadRequest)
+
+		return
+	}
+
+	reasons, err := s.storage.TransactWriteItems(r.Context(), req.TransactItems)
+	if err != nil {
+		var tErr *TableError
+		if errors.As(err, &tErr) {
+			if tErr.Code == "TransactionCanceledException" && reasons != nil {
+				w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(TransactionCanceledResponse{
+					Type:                "TransactionCanceledException",
+					Message:             tErr.Message,
+					CancellationReasons: reasons,
+				})
+
+				return
+			}
+
+			writeDynamoDBError(w, tErr.Code, tErr.Message, http.StatusBadRequest)
+
+			return
+		}
+
+		writeDynamoDBError(w, "InternalServerError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, TransactWriteItemsResponse{})
+}
+
+// TransactGetItems handles the TransactGetItems action.
+func (s *Service) TransactGetItems(w http.ResponseWriter, r *http.Request) {
+	var req TransactGetItemsRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if len(req.TransactItems) == 0 {
+		writeDynamoDBError(w, "ValidationException", "TransactItems is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if len(req.TransactItems) > 100 {
+		writeDynamoDBError(w, "ValidationException", "Member must have length less than or equal to 100", http.StatusBadRequest)
+
+		return
+	}
+
+	items, err := s.storage.TransactGetItems(r.Context(), req.TransactItems)
+	if err != nil {
+		var tErr *TableError
+		if errors.As(err, &tErr) {
+			writeDynamoDBError(w, tErr.Code, tErr.Message, http.StatusBadRequest)
+
+			return
+		}
+
+		writeDynamoDBError(w, "InternalServerError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	responses := make([]TransactGetItemResponse, len(items))
+	for i, item := range items {
+		responses[i] = TransactGetItemResponse{Item: item}
+	}
+
+	writeJSONResponse(w, TransactGetItemsResponse{Responses: responses})
+}
+
 // DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.
 // This method implements the JSONProtocolService interface.
 func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
@@ -618,6 +711,10 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 		s.UpdateTimeToLive(w, r)
 	case "DescribeTimeToLive":
 		s.DescribeTimeToLive(w, r)
+	case "TransactWriteItems":
+		s.TransactWriteItems(w, r)
+	case "TransactGetItems":
+		s.TransactGetItems(w, r)
 	default:
 		writeDynamoDBError(w, "UnknownOperationException", "The action "+action+" is not valid", http.StatusBadRequest)
 	}

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -844,8 +844,6 @@ func (m *MemoryStorage) applyUpdateExpression(item Item, updateExpr string, expr
 }
 
 // TransactWriteItems executes a transactional write with all-or-nothing semantics.
-//
-//nolint:cyclop,funlen // Transaction processing requires validating all items before applying.
 func (m *MemoryStorage) TransactWriteItems(_ context.Context, items []TransactWriteItem) ([]CancellationReason, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -885,87 +883,52 @@ func (m *MemoryStorage) TransactWriteItems(_ context.Context, items []TransactWr
 func (m *MemoryStorage) validateTransactWriteItem(twi TransactWriteItem) (*CancellationReason, error) {
 	switch {
 	case twi.Put != nil:
-		td, exists := m.Tables[twi.Put.TableName]
-		if !exists {
-			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.Put.TableName)}
-		}
-
-		key := m.serializeKey(td.Table, twi.Put.Item)
-		var existing Item
-		if e, ok := td.Items[key]; ok {
-			existing = e
-		}
-
-		if ok, err := evaluateCondition(existing, ConditionInput{
+		return m.checkTransactCondition(twi.Put.TableName, twi.Put.Item, ConditionInput{
 			Expression: twi.Put.ConditionExpression, ExprNames: twi.Put.ExpressionAttributeNames, ExprValues: twi.Put.ExpressionAttributeValues,
-		}); err != nil {
-			return &CancellationReason{Code: "ValidationError", Message: err.Error()}, nil
-		} else if !ok {
-			return &CancellationReason{Code: "ConditionalCheckFailed"}, nil
-		}
-
+		})
 	case twi.Delete != nil:
-		td, exists := m.Tables[twi.Delete.TableName]
-		if !exists {
-			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.Delete.TableName)}
-		}
-
-		key := m.serializeKey(td.Table, twi.Delete.Key)
-		var existing Item
-		if e, ok := td.Items[key]; ok {
-			existing = e
-		}
-
-		if ok, err := evaluateCondition(existing, ConditionInput{
+		return m.checkTransactCondition(twi.Delete.TableName, twi.Delete.Key, ConditionInput{
 			Expression: twi.Delete.ConditionExpression, ExprNames: twi.Delete.ExpressionAttributeNames, ExprValues: twi.Delete.ExpressionAttributeValues,
-		}); err != nil {
-			return &CancellationReason{Code: "ValidationError", Message: err.Error()}, nil
-		} else if !ok {
-			return &CancellationReason{Code: "ConditionalCheckFailed"}, nil
-		}
-
+		})
 	case twi.Update != nil:
-		td, exists := m.Tables[twi.Update.TableName]
-		if !exists {
-			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.Update.TableName)}
-		}
-
-		key := m.serializeKey(td.Table, twi.Update.Key)
-		var existing Item
-		if e, ok := td.Items[key]; ok {
-			existing = e
-		}
-
-		if ok, err := evaluateCondition(existing, ConditionInput{
+		return m.checkTransactCondition(twi.Update.TableName, twi.Update.Key, ConditionInput{
 			Expression: twi.Update.ConditionExpression, ExprNames: twi.Update.ExpressionAttributeNames, ExprValues: twi.Update.ExpressionAttributeValues,
-		}); err != nil {
-			return &CancellationReason{Code: "ValidationError", Message: err.Error()}, nil
-		} else if !ok {
-			return &CancellationReason{Code: "ConditionalCheckFailed"}, nil
-		}
-
+		})
 	case twi.ConditionCheck != nil:
-		td, exists := m.Tables[twi.ConditionCheck.TableName]
-		if !exists {
-			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.ConditionCheck.TableName)}
-		}
-
-		key := m.serializeKey(td.Table, twi.ConditionCheck.Key)
-		var existing Item
-		if e, ok := td.Items[key]; ok {
-			existing = e
-		}
-
-		if ok, err := evaluateCondition(existing, ConditionInput{
+		return m.checkTransactCondition(twi.ConditionCheck.TableName, twi.ConditionCheck.Key, ConditionInput{
 			Expression: twi.ConditionCheck.ConditionExpression, ExprNames: twi.ConditionCheck.ExpressionAttributeNames, ExprValues: twi.ConditionCheck.ExpressionAttributeValues,
-		}); err != nil {
-			return &CancellationReason{Code: "ValidationError", Message: err.Error()}, nil
-		} else if !ok {
-			return &CancellationReason{Code: "ConditionalCheckFailed"}, nil
-		}
+		})
 	}
 
+	//nolint:nilnil // No action specified is valid (returns success).
 	return nil, nil
+}
+
+// checkTransactCondition checks a condition against the existing item in a table.
+// Must be called under lock.
+func (m *MemoryStorage) checkTransactCondition(tableName string, keyOrItem Item, cond ConditionInput) (*CancellationReason, error) {
+	td, exists := m.Tables[tableName]
+	if !exists {
+		return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", tableName)}
+	}
+
+	key := m.serializeKey(td.Table, keyOrItem)
+
+	var existing Item
+	if e, ok := td.Items[key]; ok {
+		existing = e
+	}
+
+	ok, err := evaluateCondition(existing, cond)
+	if err != nil {
+		return &CancellationReason{Code: "ValidationError", Message: err.Error()}, nil
+	}
+
+	if !ok {
+		return &CancellationReason{Code: "ConditionalCheckFailed"}, nil
+	}
+
+	return nil, nil //nolint:nilnil // Condition passed, no cancellation reason.
 }
 
 // applyTransactWriteItem applies a single write item mutation. Must be called under lock.

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -31,6 +31,8 @@ type Storage interface {
 	UpdateItem(ctx context.Context, tableName string, key Item, updateExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, returnValues string, cond ConditionInput) (Item, error)
 	Query(ctx context.Context, tableName string, keyCondExpr string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item, scanForward bool) ([]Item, Item, int, error)
 	Scan(ctx context.Context, tableName string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item) ([]Item, Item, int, error)
+	TransactWriteItems(ctx context.Context, items []TransactWriteItem) ([]CancellationReason, error)
+	TransactGetItems(ctx context.Context, items []TransactGetItem) ([]Item, error)
 	UpdateTimeToLive(ctx context.Context, tableName, attributeName string, enabled bool) error
 	DescribeTimeToLive(ctx context.Context, tableName string) (string, bool, error)
 }
@@ -839,6 +841,193 @@ func (m *MemoryStorage) applyUpdateExpression(item Item, updateExpr string, expr
 	}
 
 	return item
+}
+
+// TransactWriteItems executes a transactional write with all-or-nothing semantics.
+//
+//nolint:cyclop,funlen // Transaction processing requires validating all items before applying.
+func (m *MemoryStorage) TransactWriteItems(_ context.Context, items []TransactWriteItem) ([]CancellationReason, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	reasons := make([]CancellationReason, len(items))
+	hasFailure := false
+
+	// Phase 1: Validate all conditions without modifying state.
+	for i, twi := range items {
+		reason, err := m.validateTransactWriteItem(twi)
+		if err != nil {
+			return nil, err
+		}
+
+		if reason != nil {
+			reasons[i] = *reason
+			hasFailure = true
+		}
+	}
+
+	if hasFailure {
+		return reasons, &TableError{
+			Code:    "TransactionCanceledException",
+			Message: "Transaction cancelled, please refer cancellation reasons for specific reasons [CancellationReason]",
+		}
+	}
+
+	// Phase 2: Apply all mutations atomically.
+	for _, twi := range items {
+		m.applyTransactWriteItem(twi)
+	}
+
+	return nil, nil
+}
+
+// validateTransactWriteItem validates a single write item's condition without applying changes.
+func (m *MemoryStorage) validateTransactWriteItem(twi TransactWriteItem) (*CancellationReason, error) {
+	switch {
+	case twi.Put != nil:
+		td, exists := m.Tables[twi.Put.TableName]
+		if !exists {
+			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.Put.TableName)}
+		}
+
+		key := m.serializeKey(td.Table, twi.Put.Item)
+		var existing Item
+		if e, ok := td.Items[key]; ok {
+			existing = e
+		}
+
+		if ok, err := evaluateCondition(existing, ConditionInput{
+			Expression: twi.Put.ConditionExpression, ExprNames: twi.Put.ExpressionAttributeNames, ExprValues: twi.Put.ExpressionAttributeValues,
+		}); err != nil {
+			return &CancellationReason{Code: "ValidationError", Message: err.Error()}, nil
+		} else if !ok {
+			return &CancellationReason{Code: "ConditionalCheckFailed"}, nil
+		}
+
+	case twi.Delete != nil:
+		td, exists := m.Tables[twi.Delete.TableName]
+		if !exists {
+			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.Delete.TableName)}
+		}
+
+		key := m.serializeKey(td.Table, twi.Delete.Key)
+		var existing Item
+		if e, ok := td.Items[key]; ok {
+			existing = e
+		}
+
+		if ok, err := evaluateCondition(existing, ConditionInput{
+			Expression: twi.Delete.ConditionExpression, ExprNames: twi.Delete.ExpressionAttributeNames, ExprValues: twi.Delete.ExpressionAttributeValues,
+		}); err != nil {
+			return &CancellationReason{Code: "ValidationError", Message: err.Error()}, nil
+		} else if !ok {
+			return &CancellationReason{Code: "ConditionalCheckFailed"}, nil
+		}
+
+	case twi.Update != nil:
+		td, exists := m.Tables[twi.Update.TableName]
+		if !exists {
+			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.Update.TableName)}
+		}
+
+		key := m.serializeKey(td.Table, twi.Update.Key)
+		var existing Item
+		if e, ok := td.Items[key]; ok {
+			existing = e
+		}
+
+		if ok, err := evaluateCondition(existing, ConditionInput{
+			Expression: twi.Update.ConditionExpression, ExprNames: twi.Update.ExpressionAttributeNames, ExprValues: twi.Update.ExpressionAttributeValues,
+		}); err != nil {
+			return &CancellationReason{Code: "ValidationError", Message: err.Error()}, nil
+		} else if !ok {
+			return &CancellationReason{Code: "ConditionalCheckFailed"}, nil
+		}
+
+	case twi.ConditionCheck != nil:
+		td, exists := m.Tables[twi.ConditionCheck.TableName]
+		if !exists {
+			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.ConditionCheck.TableName)}
+		}
+
+		key := m.serializeKey(td.Table, twi.ConditionCheck.Key)
+		var existing Item
+		if e, ok := td.Items[key]; ok {
+			existing = e
+		}
+
+		if ok, err := evaluateCondition(existing, ConditionInput{
+			Expression: twi.ConditionCheck.ConditionExpression, ExprNames: twi.ConditionCheck.ExpressionAttributeNames, ExprValues: twi.ConditionCheck.ExpressionAttributeValues,
+		}); err != nil {
+			return &CancellationReason{Code: "ValidationError", Message: err.Error()}, nil
+		} else if !ok {
+			return &CancellationReason{Code: "ConditionalCheckFailed"}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// applyTransactWriteItem applies a single write item mutation. Must be called under lock.
+func (m *MemoryStorage) applyTransactWriteItem(twi TransactWriteItem) {
+	switch {
+	case twi.Put != nil:
+		td := m.Tables[twi.Put.TableName]
+		key := m.serializeKey(td.Table, twi.Put.Item)
+		td.Items[key] = m.copyItem(twi.Put.Item)
+
+	case twi.Delete != nil:
+		td := m.Tables[twi.Delete.TableName]
+		key := m.serializeKey(td.Table, twi.Delete.Key)
+		delete(td.Items, key)
+
+	case twi.Update != nil:
+		td := m.Tables[twi.Update.TableName]
+		key := m.serializeKey(td.Table, twi.Update.Key)
+
+		item, ok := td.Items[key]
+		if !ok {
+			item = m.copyItem(twi.Update.Key)
+		}
+
+		if twi.Update.UpdateExpression != "" {
+			item = m.applyUpdateExpression(item, twi.Update.UpdateExpression, twi.Update.ExpressionAttributeNames, twi.Update.ExpressionAttributeValues)
+		}
+
+		td.Items[key] = item
+
+	case twi.ConditionCheck != nil:
+		// No mutation needed.
+	}
+}
+
+// TransactGetItems retrieves multiple items transactionally.
+func (m *MemoryStorage) TransactGetItems(_ context.Context, items []TransactGetItem) ([]Item, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	results := make([]Item, len(items))
+
+	for i, tgi := range items {
+		if tgi.Get == nil {
+			continue
+		}
+
+		td, exists := m.Tables[tgi.Get.TableName]
+		if !exists {
+			return nil, &TableError{
+				Code:    "ResourceNotFoundException",
+				Message: fmt.Sprintf("Requested resource not found: Table: %s not found", tgi.Get.TableName),
+			}
+		}
+
+		key := m.serializeKey(td.Table, tgi.Get.Key)
+		if item, ok := td.Items[key]; ok {
+			results[i] = m.copyItem(item)
+		}
+	}
+
+	return results, nil
 }
 
 // UpdateTimeToLive updates the TTL configuration for a table.

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -290,6 +290,106 @@ type DescribeTimeToLiveResponse struct {
 	TimeToLiveDescription TimeToLiveDescription `json:"TimeToLiveDescription"`
 }
 
+// TransactWriteItemsRequest is the request for TransactWriteItems.
+type TransactWriteItemsRequest struct {
+	TransactItems               []TransactWriteItem `json:"TransactItems"`
+	ClientRequestToken          string              `json:"ClientRequestToken,omitempty"`
+	ReturnConsumedCapacity      string              `json:"ReturnConsumedCapacity,omitempty"`
+	ReturnItemCollectionMetrics string              `json:"ReturnItemCollectionMetrics,omitempty"`
+}
+
+// TransactWriteItem represents a single item in a TransactWriteItems request.
+type TransactWriteItem struct {
+	ConditionCheck *TransactConditionCheck `json:"ConditionCheck,omitempty"`
+	Delete         *TransactDelete         `json:"Delete,omitempty"`
+	Put            *TransactPut            `json:"Put,omitempty"`
+	Update         *TransactUpdate         `json:"Update,omitempty"`
+}
+
+// TransactConditionCheck represents a ConditionCheck action in a transaction.
+type TransactConditionCheck struct {
+	TableName                 string                    `json:"TableName"`
+	Key                       Item                      `json:"Key"`
+	ConditionExpression       string                    `json:"ConditionExpression"`
+	ExpressionAttributeNames  map[string]string         `json:"ExpressionAttributeNames,omitempty"`
+	ExpressionAttributeValues map[string]AttributeValue `json:"ExpressionAttributeValues,omitempty"`
+}
+
+// TransactDelete represents a Delete action in a transaction.
+type TransactDelete struct {
+	TableName                 string                    `json:"TableName"`
+	Key                       Item                      `json:"Key"`
+	ConditionExpression       string                    `json:"ConditionExpression,omitempty"`
+	ExpressionAttributeNames  map[string]string         `json:"ExpressionAttributeNames,omitempty"`
+	ExpressionAttributeValues map[string]AttributeValue `json:"ExpressionAttributeValues,omitempty"`
+}
+
+// TransactPut represents a Put action in a transaction.
+type TransactPut struct {
+	TableName                 string                    `json:"TableName"`
+	Item                      Item                      `json:"Item"`
+	ConditionExpression       string                    `json:"ConditionExpression,omitempty"`
+	ExpressionAttributeNames  map[string]string         `json:"ExpressionAttributeNames,omitempty"`
+	ExpressionAttributeValues map[string]AttributeValue `json:"ExpressionAttributeValues,omitempty"`
+}
+
+// TransactUpdate represents an Update action in a transaction.
+type TransactUpdate struct {
+	TableName                 string                    `json:"TableName"`
+	Key                       Item                      `json:"Key"`
+	UpdateExpression          string                    `json:"UpdateExpression"`
+	ConditionExpression       string                    `json:"ConditionExpression,omitempty"`
+	ExpressionAttributeNames  map[string]string         `json:"ExpressionAttributeNames,omitempty"`
+	ExpressionAttributeValues map[string]AttributeValue `json:"ExpressionAttributeValues,omitempty"`
+}
+
+// TransactWriteItemsResponse is the response for TransactWriteItems.
+type TransactWriteItemsResponse struct {
+	// Empty on success - DynamoDB returns minimal response.
+}
+
+// TransactGetItemsRequest is the request for TransactGetItems.
+type TransactGetItemsRequest struct {
+	TransactItems          []TransactGetItem `json:"TransactItems"`
+	ReturnConsumedCapacity string            `json:"ReturnConsumedCapacity,omitempty"`
+}
+
+// TransactGetItem represents a single item in a TransactGetItems request.
+type TransactGetItem struct {
+	Get *TransactGet `json:"Get"`
+}
+
+// TransactGet represents a Get action in a transaction.
+type TransactGet struct {
+	TableName                string            `json:"TableName"`
+	Key                      Item              `json:"Key"`
+	ProjectionExpression     string            `json:"ProjectionExpression,omitempty"`
+	ExpressionAttributeNames map[string]string `json:"ExpressionAttributeNames,omitempty"`
+}
+
+// TransactGetItemsResponse is the response for TransactGetItems.
+type TransactGetItemsResponse struct {
+	Responses []TransactGetItemResponse `json:"Responses"`
+}
+
+// TransactGetItemResponse wraps a single item in the TransactGetItems response.
+type TransactGetItemResponse struct {
+	Item Item `json:"Item,omitempty"`
+}
+
+// CancellationReason represents a reason for transaction cancellation.
+type CancellationReason struct {
+	Code    string `json:"Code"`
+	Message string `json:"Message,omitempty"`
+}
+
+// TransactionCanceledResponse represents the error response for canceled transactions.
+type TransactionCanceledResponse struct {
+	Type                string               `json:"__type"`
+	Message             string               `json:"message"`
+	CancellationReasons []CancellationReason `json:"CancellationReasons"`
+}
+
 // ErrorResponse represents a DynamoDB error response in JSON format.
 type ErrorResponse struct {
 	Type    string `json:"__type"`

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -906,8 +906,169 @@ func TestDynamoDB_UpdateItem_ConditionExpression(t *testing.T) {
 		t.Fatal("update with stale version should fail")
 	}
 
-	var ccfe *types.ConditionalCheckFailedException
-	if !errors.As(err, &ccfe) {
+	var ccfe2 *types.ConditionalCheckFailedException
+	if !errors.As(err, &ccfe2) {
 		t.Fatalf("expected ConditionalCheckFailedException, got: %T: %v", err, err)
 	}
+}
+
+func TestDynamoDB_TransactWriteItems(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-transact-write"
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Successful transaction: put two items.
+	_, err = client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+		TransactItems: []types.TransactWriteItem{
+			{Put: &types.Put{
+				TableName:           aws.String(tableName),
+				Item:                map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "tx-1"}, "data": &types.AttributeValueMemberS{Value: "first"}},
+				ConditionExpression: aws.String("attribute_not_exists(pk)"),
+			}},
+			{Put: &types.Put{
+				TableName:           aws.String(tableName),
+				Item:                map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "tx-2"}, "data": &types.AttributeValueMemberS{Value: "second"}},
+				ConditionExpression: aws.String("attribute_not_exists(pk)"),
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("transaction should succeed: %v", err)
+	}
+
+	// Verify both items exist.
+	get1, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key:       map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "tx-1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_get_tx1", get1)
+
+	get2, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key:       map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "tx-2"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_get_tx2", get2)
+
+	// Failed transaction: one condition fails, nothing should be written.
+	_, err = client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+		TransactItems: []types.TransactWriteItem{
+			{Put: &types.Put{
+				TableName:           aws.String(tableName),
+				Item:                map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "tx-3"}, "data": &types.AttributeValueMemberS{Value: "third"}},
+				ConditionExpression: aws.String("attribute_not_exists(pk)"),
+			}},
+			{Put: &types.Put{
+				TableName:           aws.String(tableName),
+				Item:                map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "tx-1"}, "data": &types.AttributeValueMemberS{Value: "overwrite"}},
+				ConditionExpression: aws.String("attribute_not_exists(pk)"),
+			}},
+		},
+	})
+	if err == nil {
+		t.Fatal("transaction should fail because tx-1 already exists")
+	}
+
+	var txErr *types.TransactionCanceledException
+	if !errors.As(err, &txErr) {
+		t.Fatalf("expected TransactionCanceledException, got: %T: %v", err, err)
+	}
+
+	// Verify tx-3 was NOT created (all-or-nothing).
+	get3, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key:       map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "tx-3"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_get_tx3_not_exists", get3)
+}
+
+func TestDynamoDB_TransactGetItems(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-transact-get"
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Put items.
+	for _, id := range []string{"g1", "g2"} {
+		_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item: map[string]types.AttributeValue{
+				"pk":   &types.AttributeValueMemberS{Value: id},
+				"data": &types.AttributeValueMemberS{Value: "data-" + id},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// TransactGetItems.
+	result, err := client.TransactGetItems(ctx, &dynamodb.TransactGetItemsInput{
+		TransactItems: []types.TransactGetItem{
+			{Get: &types.Get{
+				TableName: aws.String(tableName),
+				Key:       map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "g1"}},
+			}},
+			{Get: &types.Get{
+				TableName: aws.String(tableName),
+				Key:       map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "g2"}},
+			}},
+			{Get: &types.Get{
+				TableName: aws.String(tableName),
+				Key:       map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "missing"}},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), result)
 }

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_TransactGetItems_TestDynamoDB_TransactGetItems.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_TransactGetItems_TestDynamoDB_TransactGetItems.golden.go
@@ -1,0 +1,29 @@
+{
+  "ConsumedCapacity": null,
+  "Responses": [
+    {
+      "Item": {
+        "data": {
+          "Value": "data-g1"
+        },
+        "pk": {
+          "Value": "g1"
+        }
+      }
+    },
+    {
+      "Item": {
+        "data": {
+          "Value": "data-g2"
+        },
+        "pk": {
+          "Value": "g2"
+        }
+      }
+    },
+    {
+      "Item": null
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_TransactWriteItems_TestDynamoDB_TransactWriteItems_get_tx1.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_TransactWriteItems_TestDynamoDB_TransactWriteItems_get_tx1.golden.go
@@ -1,0 +1,12 @@
+{
+  "ConsumedCapacity": null,
+  "Item": {
+    "data": {
+      "Value": "first"
+    },
+    "pk": {
+      "Value": "tx-1"
+    }
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_TransactWriteItems_TestDynamoDB_TransactWriteItems_get_tx2.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_TransactWriteItems_TestDynamoDB_TransactWriteItems_get_tx2.golden.go
@@ -1,0 +1,12 @@
+{
+  "ConsumedCapacity": null,
+  "Item": {
+    "data": {
+      "Value": "second"
+    },
+    "pk": {
+      "Value": "tx-2"
+    }
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_TransactWriteItems_TestDynamoDB_TransactWriteItems_get_tx3_not_exists.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_TransactWriteItems_TestDynamoDB_TransactWriteItems_get_tx3_not_exists.golden.go
@@ -1,0 +1,5 @@
+{
+  "ConsumedCapacity": null,
+  "Item": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Implement TransactWriteItems with all-or-nothing semantics (Put/Delete/Update/ConditionCheck)
- Implement TransactGetItems for batch retrieval of multiple items
- Two-phase validation: check all conditions before applying any mutations
- Return TransactionCanceledException with per-item CancellationReasons on failure

## Test plan

- [x] Unit tests for TransactWriteItems (success, failure with rollback, Update+ConditionCheck, Delete)
- [x] Unit tests for TransactGetItems (existing items, missing items)
- [x] Integration tests with golden files for TransactWriteItems and TransactGetItems
- [x] All existing tests pass with no regressions

Closes #437