### PR TITLE
feat: add DynamoDB BatchWriteItem/BatchGetItem support

### DIFF
--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -697,7 +697,95 @@ func (s *Service) actionHandlers() map[string]func(http.ResponseWriter, *http.Re
 		"DescribeTimeToLive": s.DescribeTimeToLive,
 		"TransactWriteItems": s.TransactWriteItems,
 		"TransactGetItems":   s.TransactGetItems,
+		"BatchWriteItem":     s.BatchWriteItem,
+		"BatchGetItem":       s.BatchGetItem,
 	}
+}
+
+// BatchWriteItem handles the BatchWriteItem action.
+func (s *Service) BatchWriteItem(w http.ResponseWriter, r *http.Request) {
+	var req BatchWriteItemRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if len(req.RequestItems) == 0 {
+		writeDynamoDBError(w, "ValidationException", "RequestItems is required", http.StatusBadRequest)
+
+		return
+	}
+
+	totalItems := 0
+	for _, reqs := range req.RequestItems {
+		totalItems += len(reqs)
+	}
+
+	if totalItems > 25 {
+		writeDynamoDBError(w, "ValidationException", "Too many items requested for the BatchWriteItem call", http.StatusBadRequest)
+
+		return
+	}
+
+	unprocessed, err := s.storage.BatchWriteItem(r.Context(), req.RequestItems)
+	if err != nil {
+		var tErr *TableError
+		if errors.As(err, &tErr) {
+			writeDynamoDBError(w, tErr.Code, tErr.Message, http.StatusBadRequest)
+
+			return
+		}
+
+		writeDynamoDBError(w, "InternalServerError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, BatchWriteItemResponse{UnprocessedItems: unprocessed})
+}
+
+// BatchGetItem handles the BatchGetItem action.
+func (s *Service) BatchGetItem(w http.ResponseWriter, r *http.Request) {
+	var req BatchGetItemRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if len(req.RequestItems) == 0 {
+		writeDynamoDBError(w, "ValidationException", "RequestItems is required", http.StatusBadRequest)
+
+		return
+	}
+
+	totalKeys := 0
+	for _, ka := range req.RequestItems {
+		totalKeys += len(ka.Keys)
+	}
+
+	if totalKeys > 100 {
+		writeDynamoDBError(w, "ValidationException", "Too many items requested for the BatchGetItem call", http.StatusBadRequest)
+
+		return
+	}
+
+	responses, err := s.storage.BatchGetItem(r.Context(), req.RequestItems)
+	if err != nil {
+		var tErr *TableError
+		if errors.As(err, &tErr) {
+			writeDynamoDBError(w, tErr.Code, tErr.Message, http.StatusBadRequest)
+
+			return
+		}
+
+		writeDynamoDBError(w, "InternalServerError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, BatchGetItemResponse{Responses: responses})
 }
 
 // DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -33,6 +33,8 @@ type Storage interface {
 	Scan(ctx context.Context, tableName string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item) ([]Item, Item, int, error)
 	TransactWriteItems(ctx context.Context, items []TransactWriteItem) ([]CancellationReason, error)
 	TransactGetItems(ctx context.Context, items []TransactGetItem) ([]Item, error)
+	BatchWriteItem(ctx context.Context, requestItems map[string][]WriteRequest) (map[string][]WriteRequest, error)
+	BatchGetItem(ctx context.Context, requestItems map[string]KeysAndAttributes) (map[string][]Item, error)
 	UpdateTimeToLive(ctx context.Context, tableName, attributeName string, enabled bool) error
 	DescribeTimeToLive(ctx context.Context, tableName string) (string, bool, error)
 }
@@ -989,6 +991,69 @@ func (m *MemoryStorage) TransactGetItems(_ context.Context, items []TransactGetI
 	}
 
 	return results, nil
+}
+
+// BatchWriteItem writes/deletes multiple items across tables.
+func (m *MemoryStorage) BatchWriteItem(_ context.Context, requestItems map[string][]WriteRequest) (map[string][]WriteRequest, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for tableName, requests := range requestItems {
+		td, exists := m.Tables[tableName]
+		if !exists {
+			return nil, &TableError{
+				Code:    "ResourceNotFoundException",
+				Message: fmt.Sprintf("Requested resource not found: Table: %s not found", tableName),
+			}
+		}
+
+		for _, req := range requests {
+			switch {
+			case req.PutRequest != nil:
+				key := m.serializeKey(td.Table, req.PutRequest.Item)
+				td.Items[key] = m.copyItem(req.PutRequest.Item)
+			case req.DeleteRequest != nil:
+				key := m.serializeKey(td.Table, req.DeleteRequest.Key)
+				delete(td.Items, key)
+			}
+		}
+	}
+
+	// kumo processes all items; never returns UnprocessedItems.
+	return nil, nil
+}
+
+// BatchGetItem retrieves multiple items across tables.
+func (m *MemoryStorage) BatchGetItem(_ context.Context, requestItems map[string]KeysAndAttributes) (map[string][]Item, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	responses := make(map[string][]Item)
+
+	for tableName, ka := range requestItems {
+		td, exists := m.Tables[tableName]
+		if !exists {
+			return nil, &TableError{
+				Code:    "ResourceNotFoundException",
+				Message: fmt.Sprintf("Requested resource not found: Table: %s not found", tableName),
+			}
+		}
+
+		var items []Item
+
+		for _, key := range ka.Keys {
+			keyStr := m.serializeKey(td.Table, key)
+			if item, ok := td.Items[keyStr]; ok {
+				items = append(items, m.copyItem(item))
+			}
+		}
+
+		if len(items) > 0 {
+			responses[tableName] = items
+		}
+	}
+
+	return responses, nil
 }
 
 // UpdateTimeToLive updates the TTL configuration for a table.

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -1020,7 +1020,7 @@ func (m *MemoryStorage) BatchWriteItem(_ context.Context, requestItems map[strin
 	}
 
 	// kumo processes all items; never returns UnprocessedItems.
-	return nil, nil
+	return nil, nil //nolint:nilnil // Intentional: nil UnprocessedItems means all items were processed.
 }
 
 // BatchGetItem retrieves multiple items across tables.

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -390,6 +390,51 @@ type TransactionCanceledResponse struct {
 	CancellationReasons []CancellationReason `json:"CancellationReasons"`
 }
 
+// BatchWriteItemRequest is the request for BatchWriteItem.
+type BatchWriteItemRequest struct {
+	RequestItems map[string][]WriteRequest `json:"RequestItems"`
+}
+
+// WriteRequest represents a single write request in a batch.
+type WriteRequest struct {
+	PutRequest    *BatchPutRequest    `json:"PutRequest,omitempty"`
+	DeleteRequest *BatchDeleteRequest `json:"DeleteRequest,omitempty"`
+}
+
+// BatchPutRequest represents a put request in a batch write.
+type BatchPutRequest struct {
+	Item Item `json:"Item"`
+}
+
+// BatchDeleteRequest represents a delete request in a batch write.
+type BatchDeleteRequest struct {
+	Key Item `json:"Key"`
+}
+
+// BatchWriteItemResponse is the response for BatchWriteItem.
+type BatchWriteItemResponse struct {
+	UnprocessedItems map[string][]WriteRequest `json:"UnprocessedItems,omitempty"`
+}
+
+// BatchGetItemRequest is the request for BatchGetItem.
+type BatchGetItemRequest struct {
+	RequestItems map[string]KeysAndAttributes `json:"RequestItems"`
+}
+
+// KeysAndAttributes represents keys and optional projection for batch get.
+type KeysAndAttributes struct {
+	Keys                     []Item            `json:"Keys"`
+	ProjectionExpression     string            `json:"ProjectionExpression,omitempty"`
+	ExpressionAttributeNames map[string]string `json:"ExpressionAttributeNames,omitempty"`
+	ConsistentRead           bool              `json:"ConsistentRead,omitempty"`
+}
+
+// BatchGetItemResponse is the response for BatchGetItem.
+type BatchGetItemResponse struct {
+	Responses       map[string][]Item            `json:"Responses,omitempty"`
+	UnprocessedKeys map[string]KeysAndAttributes `json:"UnprocessedKeys,omitempty"`
+}
+
 // ErrorResponse represents a DynamoDB error response in JSON format.
 type ErrorResponse struct {
 	Type    string `json:"__type"`

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -1072,3 +1072,139 @@ func TestDynamoDB_TransactGetItems(t *testing.T) {
 
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), result)
 }
+
+func TestDynamoDB_BatchWriteItem(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-batch-write"
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Batch write 3 items.
+	_, err = client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			tableName: {
+				{PutRequest: &types.PutRequest{Item: map[string]types.AttributeValue{
+					"pk": &types.AttributeValueMemberS{Value: "bw-1"}, "data": &types.AttributeValueMemberS{Value: "one"},
+				}}},
+				{PutRequest: &types.PutRequest{Item: map[string]types.AttributeValue{
+					"pk": &types.AttributeValueMemberS{Value: "bw-2"}, "data": &types.AttributeValueMemberS{Value: "two"},
+				}}},
+				{PutRequest: &types.PutRequest{Item: map[string]types.AttributeValue{
+					"pk": &types.AttributeValueMemberS{Value: "bw-3"}, "data": &types.AttributeValueMemberS{Value: "three"},
+				}}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify items via scan.
+	scanOutput, err := client.Scan(ctx, &dynamodb.ScanInput{
+		TableName: aws.String(tableName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_scan", scanOutput)
+
+	// Batch delete one item.
+	_, err = client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]types.WriteRequest{
+			tableName: {
+				{DeleteRequest: &types.DeleteRequest{Key: map[string]types.AttributeValue{
+					"pk": &types.AttributeValueMemberS{Value: "bw-2"},
+				}}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify bw-2 deleted.
+	getOutput, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key:       map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "bw-2"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_deleted", getOutput)
+}
+
+func TestDynamoDB_BatchGetItem(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-batch-get"
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Put items.
+	for _, id := range []string{"bg-1", "bg-2", "bg-3"} {
+		_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item: map[string]types.AttributeValue{
+				"pk":   &types.AttributeValueMemberS{Value: id},
+				"data": &types.AttributeValueMemberS{Value: "data-" + id},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Batch get 2 existing + 1 missing.
+	result, err := client.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]types.KeysAndAttributes{
+			tableName: {
+				Keys: []map[string]types.AttributeValue{
+					{"pk": &types.AttributeValueMemberS{Value: "bg-1"}},
+					{"pk": &types.AttributeValueMemberS{Value: "bg-3"}},
+					{"pk": &types.AttributeValueMemberS{Value: "bg-missing"}},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), result)
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_BatchGetItem_TestDynamoDB_BatchGetItem.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_BatchGetItem_TestDynamoDB_BatchGetItem.golden.go
@@ -1,0 +1,25 @@
+{
+  "ConsumedCapacity": null,
+  "Responses": {
+    "test-table-batch-get": [
+      {
+        "data": {
+          "Value": "data-bg-1"
+        },
+        "pk": {
+          "Value": "bg-1"
+        }
+      },
+      {
+        "data": {
+          "Value": "data-bg-3"
+        },
+        "pk": {
+          "Value": "bg-3"
+        }
+      }
+    ]
+  },
+  "UnprocessedKeys": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_BatchWriteItem_TestDynamoDB_BatchWriteItem_deleted.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_BatchWriteItem_TestDynamoDB_BatchWriteItem_deleted.golden.go
@@ -1,0 +1,5 @@
+{
+  "ConsumedCapacity": null,
+  "Item": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_BatchWriteItem_TestDynamoDB_BatchWriteItem_scan.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_BatchWriteItem_TestDynamoDB_BatchWriteItem_scan.golden.go
@@ -1,0 +1,33 @@
+{
+  "ConsumedCapacity": null,
+  "Count": 3,
+  "Items": [
+    {
+      "data": {
+        "Value": "one"
+      },
+      "pk": {
+        "Value": "bw-1"
+      }
+    },
+    {
+      "data": {
+        "Value": "two"
+      },
+      "pk": {
+        "Value": "bw-2"
+      }
+    },
+    {
+      "data": {
+        "Value": "three"
+      },
+      "pk": {
+        "Value": "bw-3"
+      }
+    }
+  ],
+  "LastEvaluatedKey": null,
+  "ScannedCount": 3,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Implement BatchWriteItem for bulk Put/Delete across tables (max 25 items)
- Implement BatchGetItem for bulk retrieval across tables (max 100 keys)
- Item count validation for both operations
- Integration tests with golden files

## Test plan

- [x] Integration tests with golden files for BatchWriteItem (write + scan + delete verification)
- [x] Integration tests with golden files for BatchGetItem (existing + missing keys)
- [x] All existing tests pass with no regressions

Closes #438