### PR TITLE
feat: add EventBridge event pattern matching and delivery tracking

### DIFF
--- a/internal/service/eventbridge/handlers.go
+++ b/internal/service/eventbridge/handlers.go
@@ -372,6 +372,15 @@ func (s *Service) PutEvents(w http.ResponseWriter, r *http.Request) {
 	writeResponse(w, resp)
 }
 
+// GetDeliveredEvents returns events that were matched against rules and delivered to targets.
+// This is a kumo-specific endpoint for test verification.
+func (s *Service) GetDeliveredEvents(w http.ResponseWriter, r *http.Request) {
+	events := s.storage.GetDeliveredEvents(r.Context())
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(events)
+}
+
 // writeResponse writes a JSON response.
 func writeResponse(w http.ResponseWriter, resp any) {
 	w.Header().Set("Content-Type", "application/x-amz-json-1.1")

--- a/internal/service/eventbridge/handlers.go
+++ b/internal/service/eventbridge/handlers.go
@@ -376,6 +376,7 @@ func (s *Service) PutEvents(w http.ResponseWriter, r *http.Request) {
 // This is a kumo-specific endpoint for test verification.
 func (s *Service) GetDeliveredEvents(w http.ResponseWriter, r *http.Request) {
 	events := s.storage.GetDeliveredEvents(r.Context())
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(events)

--- a/internal/service/eventbridge/pattern.go
+++ b/internal/service/eventbridge/pattern.go
@@ -1,0 +1,130 @@
+package eventbridge
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// matchEventPattern checks if an event matches an EventPattern.
+// EventPattern is a JSON object where each key maps to an array of acceptable values.
+// An event matches if ALL keys in the pattern match.
+// For each key, the event's value must match at least one value in the pattern array.
+func matchEventPattern(patternJSON string, event PutEventsRequestEntry) bool {
+	if patternJSON == "" {
+		return true
+	}
+
+	var pattern map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(patternJSON), &pattern); err != nil {
+		return false
+	}
+
+	for key, rawValues := range pattern {
+		switch key {
+		case "source":
+			if !matchStringField(rawValues, event.Source) {
+				return false
+			}
+		case "detail-type":
+			if !matchStringField(rawValues, event.DetailType) {
+				return false
+			}
+		case "detail":
+			if !matchDetailField(rawValues, event.Detail) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// matchStringField checks if a field value matches any of the pattern values.
+// Pattern values can be a JSON array of strings: ["value1", "value2"].
+func matchStringField(rawValues json.RawMessage, fieldValue string) bool {
+	var values []string
+	if err := json.Unmarshal(rawValues, &values); err != nil {
+		return false
+	}
+
+	for _, v := range values {
+		if v == fieldValue {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchDetailField checks if an event detail matches the detail pattern.
+// The detail pattern is a nested JSON object with arrays of acceptable values.
+func matchDetailField(rawPattern json.RawMessage, detailJSON string) bool {
+	if detailJSON == "" {
+		return false
+	}
+
+	var pattern map[string]json.RawMessage
+	if err := json.Unmarshal(rawPattern, &pattern); err != nil {
+		return false
+	}
+
+	var detail map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(detailJSON), &detail); err != nil {
+		return false
+	}
+
+	for key, patternValue := range pattern {
+		detailValue, exists := detail[key]
+		if !exists {
+			return false
+		}
+
+		if !matchDetailValue(patternValue, detailValue) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// matchDetailValue checks if a detail value matches a pattern value.
+// Handles both arrays of primitive values and nested objects.
+func matchDetailValue(patternValue, detailValue json.RawMessage) bool {
+	// Try as array of strings first.
+	var strValues []string
+	if err := json.Unmarshal(patternValue, &strValues); err == nil {
+		var actual string
+		if err := json.Unmarshal(detailValue, &actual); err == nil {
+			for _, v := range strValues {
+				if v == actual {
+					return true
+				}
+			}
+
+			return false
+		}
+	}
+
+	// Try as array of numbers.
+	var numValues []float64
+	if err := json.Unmarshal(patternValue, &numValues); err == nil {
+		var actual float64
+		if err := json.Unmarshal(detailValue, &actual); err == nil {
+			for _, v := range numValues {
+				if v == actual {
+					return true
+				}
+			}
+
+			return false
+		}
+	}
+
+	// Try as nested object pattern.
+	patternStr := strings.TrimSpace(string(patternValue))
+	if strings.HasPrefix(patternStr, "{") {
+		return matchDetailField(patternValue, string(detailValue))
+	}
+
+	return false
+}

--- a/internal/service/eventbridge/pattern.go
+++ b/internal/service/eventbridge/pattern.go
@@ -9,7 +9,7 @@ import (
 // EventPattern is a JSON object where each key maps to an array of acceptable values.
 // An event matches if ALL keys in the pattern match.
 // For each key, the event's value must match at least one value in the pattern array.
-func matchEventPattern(patternJSON string, event PutEventsRequestEntry) bool {
+func matchEventPattern(patternJSON string, event *PutEventsRequestEntry) bool {
 	if patternJSON == "" {
 		return true
 	}

--- a/internal/service/eventbridge/pattern_test.go
+++ b/internal/service/eventbridge/pattern_test.go
@@ -1,0 +1,106 @@
+package eventbridge
+
+import (
+	"testing"
+)
+
+func TestMatchEventPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pattern string
+		event   PutEventsRequestEntry
+		want    bool
+	}{
+		{
+			name:    "empty pattern matches everything",
+			pattern: "",
+			event:   PutEventsRequestEntry{Source: "my.app", DetailType: "OrderCreated"},
+			want:    true,
+		},
+		{
+			name:    "source match",
+			pattern: `{"source": ["my.app"]}`,
+			event:   PutEventsRequestEntry{Source: "my.app", DetailType: "OrderCreated"},
+			want:    true,
+		},
+		{
+			name:    "source mismatch",
+			pattern: `{"source": ["other.app"]}`,
+			event:   PutEventsRequestEntry{Source: "my.app", DetailType: "OrderCreated"},
+			want:    false,
+		},
+		{
+			name:    "source multiple values",
+			pattern: `{"source": ["app.a", "app.b", "my.app"]}`,
+			event:   PutEventsRequestEntry{Source: "my.app"},
+			want:    true,
+		},
+		{
+			name:    "detail-type match",
+			pattern: `{"detail-type": ["OrderCreated"]}`,
+			event:   PutEventsRequestEntry{Source: "my.app", DetailType: "OrderCreated"},
+			want:    true,
+		},
+		{
+			name:    "detail-type mismatch",
+			pattern: `{"detail-type": ["OrderDeleted"]}`,
+			event:   PutEventsRequestEntry{Source: "my.app", DetailType: "OrderCreated"},
+			want:    false,
+		},
+		{
+			name:    "source AND detail-type both match",
+			pattern: `{"source": ["my.app"], "detail-type": ["OrderCreated"]}`,
+			event:   PutEventsRequestEntry{Source: "my.app", DetailType: "OrderCreated"},
+			want:    true,
+		},
+		{
+			name:    "source matches but detail-type does not",
+			pattern: `{"source": ["my.app"], "detail-type": ["OrderDeleted"]}`,
+			event:   PutEventsRequestEntry{Source: "my.app", DetailType: "OrderCreated"},
+			want:    false,
+		},
+		{
+			name:    "detail field match",
+			pattern: `{"source": ["my.app"], "detail": {"status": ["completed"]}}`,
+			event:   PutEventsRequestEntry{Source: "my.app", Detail: `{"status": "completed", "amount": 100}`},
+			want:    true,
+		},
+		{
+			name:    "detail field mismatch",
+			pattern: `{"detail": {"status": ["pending"]}}`,
+			event:   PutEventsRequestEntry{Source: "my.app", Detail: `{"status": "completed"}`},
+			want:    false,
+		},
+		{
+			name:    "detail nested object match",
+			pattern: `{"detail": {"order": {"type": ["premium"]}}}`,
+			event:   PutEventsRequestEntry{Detail: `{"order": {"type": "premium", "id": "123"}}`},
+			want:    true,
+		},
+		{
+			name:    "detail number match",
+			pattern: `{"detail": {"count": [1, 2, 3]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"count": 2}`},
+			want:    true,
+		},
+		{
+			name:    "invalid pattern JSON",
+			pattern: `{invalid}`,
+			event:   PutEventsRequestEntry{Source: "my.app"},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := matchEventPattern(tt.pattern, tt.event)
+			if got != tt.want {
+				t.Errorf("matchEventPattern() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/service/eventbridge/pattern_test.go
+++ b/internal/service/eventbridge/pattern_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 )
 
+//nolint:funlen // Table-driven test with comprehensive pattern matching coverage.
 func TestMatchEventPattern(t *testing.T) {
 	t.Parallel()
 
@@ -97,7 +98,7 @@ func TestMatchEventPattern(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := matchEventPattern(tt.pattern, tt.event)
+			got := matchEventPattern(tt.pattern, &tt.event)
 			if got != tt.want {
 				t.Errorf("matchEventPattern() = %v, want %v", got, tt.want)
 			}

--- a/internal/service/eventbridge/service.go
+++ b/internal/service/eventbridge/service.go
@@ -36,8 +36,9 @@ func (s *Service) TargetPrefix() string {
 func (s *Service) JSONProtocol() {}
 
 // RegisterRoutes registers the service routes.
-func (s *Service) RegisterRoutes(_ service.Router) {
-	// Routes are handled via X-Amz-Target header dispatching.
+func (s *Service) RegisterRoutes(r service.Router) {
+	// kumo-specific endpoint for testing.
+	r.HandleFunc("GET", "/kumo/eventbridge/delivered-events", s.GetDeliveredEvents)
 }
 
 func init() {

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -45,6 +45,7 @@ type Storage interface {
 
 	// Event operations.
 	PutEvents(ctx context.Context, entries []PutEventsRequestEntry) ([]PutEventsResultEntry, error)
+	GetDeliveredEvents(ctx context.Context) []DeliveredEvent
 
 	// DispatchAction dispatches the request to the appropriate handler.
 	DispatchAction(action string) bool
@@ -68,13 +69,14 @@ var (
 
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu         sync.RWMutex                    `json:"-"`
-	EventBuses map[string]*EventBus            `json:"eventBuses"`
-	Rules      map[string]map[string]*Rule     `json:"rules"`
-	Targets    map[string]map[string][]*Target `json:"targets"`
-	region     string
-	accountID  string
-	dataDir    string
+	mu              sync.RWMutex                    `json:"-"`
+	EventBuses      map[string]*EventBus            `json:"eventBuses"`
+	Rules           map[string]map[string]*Rule     `json:"rules"`
+	Targets         map[string]map[string][]*Target `json:"targets"`
+	DeliveredEvents []DeliveredEvent                `json:"deliveredEvents"`
+	region          string
+	accountID       string
+	dataDir         string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
@@ -502,18 +504,77 @@ func (s *MemoryStorage) ListTargetsByRule(_ context.Context, eventBusName, ruleN
 	return targets, "", nil
 }
 
-// PutEvents puts events to the event bus.
+// PutEvents puts events to the event bus, matches against rules, and records deliveries.
 func (s *MemoryStorage) PutEvents(_ context.Context, entries []PutEventsRequestEntry) ([]PutEventsResultEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	results := make([]PutEventsResultEntry, len(entries))
 
-	for i := range entries {
-		// Generate event ID for successful entries.
-		results[i] = PutEventsResultEntry{
-			EventID: uuid.New().String(),
+	for i, entry := range entries {
+		eventID := uuid.New().String()
+		results[i] = PutEventsResultEntry{EventID: eventID}
+
+		eventBusName := entry.EventBusName
+		if eventBusName == "" {
+			eventBusName = defaultEventBusName
 		}
+
+		s.matchAndDeliver(eventID, eventBusName, entry)
 	}
 
 	return results, nil
+}
+
+// matchAndDeliver matches an event against rules and records deliveries. Must be called under lock.
+func (s *MemoryStorage) matchAndDeliver(eventID, eventBusName string, entry PutEventsRequestEntry) {
+	rules, exists := s.Rules[eventBusName]
+	if !exists {
+		return
+	}
+
+	for _, rule := range rules {
+		if rule.State != RuleStateEnabled {
+			continue
+		}
+
+		if !matchEventPattern(rule.EventPattern, entry) {
+			continue
+		}
+
+		targetKey := eventBusName + ":" + rule.Name
+		ruleTargets := s.Targets[targetKey][rule.Name]
+
+		var eventTime string
+		if entry.Time != nil {
+			eventTime = entry.Time.Format(time.RFC3339)
+		}
+
+		for _, target := range ruleTargets {
+			s.DeliveredEvents = append(s.DeliveredEvents, DeliveredEvent{
+				EventID:      eventID,
+				Source:       entry.Source,
+				DetailType:   entry.DetailType,
+				Detail:       entry.Detail,
+				EventBusName: eventBusName,
+				RuleName:     rule.Name,
+				TargetID:     target.ID,
+				TargetArn:    target.Arn,
+				Time:         eventTime,
+			})
+		}
+	}
+}
+
+// GetDeliveredEvents returns all delivered events.
+func (s *MemoryStorage) GetDeliveredEvents(_ context.Context) []DeliveredEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]DeliveredEvent, len(s.DeliveredEvents))
+	copy(result, s.DeliveredEvents)
+
+	return result
 }
 
 // DispatchAction checks if the action is valid.

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -520,14 +520,14 @@ func (s *MemoryStorage) PutEvents(_ context.Context, entries []PutEventsRequestE
 			eventBusName = defaultEventBusName
 		}
 
-		s.matchAndDeliver(eventID, eventBusName, entry)
+		s.matchAndDeliver(eventID, eventBusName, &entry)
 	}
 
 	return results, nil
 }
 
 // matchAndDeliver matches an event against rules and records deliveries. Must be called under lock.
-func (s *MemoryStorage) matchAndDeliver(eventID, eventBusName string, entry PutEventsRequestEntry) {
+func (s *MemoryStorage) matchAndDeliver(eventID, eventBusName string, entry *PutEventsRequestEntry) {
 	rules, exists := s.Rules[eventBusName]
 	if !exists {
 		return

--- a/internal/service/eventbridge/types.go
+++ b/internal/service/eventbridge/types.go
@@ -284,6 +284,19 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
+// DeliveredEvent represents an event that was matched to a rule and delivered to a target.
+type DeliveredEvent struct {
+	EventID      string `json:"EventId"`
+	Source       string `json:"Source"`
+	DetailType   string `json:"DetailType"`
+	Detail       string `json:"Detail,omitempty"`
+	EventBusName string `json:"EventBusName"`
+	RuleName     string `json:"RuleName"`
+	TargetID     string `json:"TargetId"`
+	TargetArn    string `json:"TargetArn"`
+	Time         string `json:"Time,omitempty"`
+}
+
 // ServiceError represents a service-level error.
 type ServiceError struct {
 	Code    string

--- a/test/integration/eventbridge_test.go
+++ b/test/integration/eventbridge_test.go
@@ -3,6 +3,9 @@
 package integration
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -323,6 +326,102 @@ func TestEventBridge_DeleteEventBus(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for deleted event bus")
+	}
+}
+
+func TestEventBridge_PutEvents_Delivery(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := t.Context()
+
+	// Create rule with event pattern.
+	_, err := client.PutRule(ctx, &eventbridge.PutRuleInput{
+		Name:         aws.String("delivery-test-rule"),
+		EventPattern: aws.String(`{"source": ["order.service"], "detail-type": ["OrderCreated"]}`),
+		State:        types.RuleStateEnabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add target to rule.
+	_, err = client.PutTargets(ctx, &eventbridge.PutTargetsInput{
+		Rule: aws.String("delivery-test-rule"),
+		Targets: []types.Target{
+			{
+				Id:  aws.String("sqs-target"),
+				Arn: aws.String("arn:aws:sqs:us-east-1:000000000000:order-queue"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put matching event.
+	_, err = client.PutEvents(ctx, &eventbridge.PutEventsInput{
+		Entries: []types.PutEventsRequestEntry{
+			{
+				Source:     aws.String("order.service"),
+				DetailType: aws.String("OrderCreated"),
+				Detail:     aws.String(`{"orderId": "123"}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put non-matching event.
+	_, err = client.PutEvents(ctx, &eventbridge.PutEventsInput{
+		Entries: []types.PutEventsRequestEntry{
+			{
+				Source:     aws.String("other.service"),
+				DetailType: aws.String("SomethingElse"),
+				Detail:     aws.String(`{"data": "ignored"}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check delivered events via kumo endpoint.
+	resp, err := http.Get("http://localhost:4566/kumo/eventbridge/delivered-events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var delivered []struct {
+		Source     string `json:"Source"`
+		DetailType string `json:"DetailType"`
+		RuleName   string `json:"RuleName"`
+		TargetID   string `json:"TargetId"`
+		TargetArn  string `json:"TargetArn"`
+	}
+
+	if err := json.Unmarshal(body, &delivered); err != nil {
+		t.Fatal(err)
+	}
+
+	// Find our delivery.
+	found := false
+
+	for _, d := range delivered {
+		if d.Source == "order.service" && d.RuleName == "delivery-test-rule" && d.TargetID == "sqs-target" {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected matching event to be delivered to sqs-target, got: %s", string(body))
 	}
 }
 


### PR DESCRIPTION
## Summary

- PutEvents now matches events against enabled rules with EventPattern
- Record matched events per-target in DeliveredEvents for test verification
- Add kumo-specific endpoint GET /kumo/eventbridge/delivered-events
- Support EventPattern matching: source, detail-type, detail (nested objects, string/number arrays)

## Test plan

- [x] 13 unit tests for EventPattern matching (pattern_test.go)
- [x] Integration test verifying matching event is delivered and non-matching is not
- [x] All 11 existing EventBridge integration tests pass

Closes #439