### PR TITLE
feat: add DynamoDB Global Secondary Index (GSI) support

### DIFF
--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -370,6 +370,7 @@ func (s *Service) Query(w http.ResponseWriter, r *http.Request) {
 	items, lastKey, scannedCount, err := s.storage.Query(
 		r.Context(),
 		req.TableName,
+		req.IndexName,
 		req.KeyConditionExpression,
 		req.FilterExpression,
 		req.ExpressionAttributeNames,
@@ -470,6 +471,27 @@ func tableToDescription(table *Table) TableDescription {
 		desc.BillingModeSummary = &BillingModeSummary{
 			BillingMode: table.BillingMode,
 		}
+	}
+
+	for _, gsi := range table.GlobalSecondaryIndexes {
+		gsiDesc := GlobalSecondaryIndexDescription{
+			IndexName:      gsi.IndexName,
+			KeySchema:      gsi.KeySchema,
+			Projection:     gsi.Projection,
+			IndexStatus:    "ACTIVE",
+			IndexArn:       fmt.Sprintf("%s/index/%s", table.TableARN, gsi.IndexName),
+			ItemCount:      table.ItemCount,
+			IndexSizeBytes: table.TableSizeBytes,
+		}
+
+		if gsi.ProvisionedThroughput != nil {
+			gsiDesc.ProvisionedThroughput = &ProvisionedThroughputDescription{
+				ReadCapacityUnits:  gsi.ProvisionedThroughput.ReadCapacityUnits,
+				WriteCapacityUnits: gsi.ProvisionedThroughput.WriteCapacityUnits,
+			}
+		}
+
+		desc.GlobalSecondaryIndexes = append(desc.GlobalSecondaryIndexes, gsiDesc)
 	}
 
 	return desc

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -440,7 +440,7 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 
 // Query queries items from a table.
 //
-//nolint:cyclop,funlen // Query has inherent complexity from DynamoDB protocol requirements.
+//nolint:cyclop,funlen,gocognit // Query has inherent complexity from DynamoDB protocol requirements.
 func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondExpr, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item, scanForward bool) ([]Item, Item, int, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -902,7 +902,7 @@ func (m *MemoryStorage) TransactWriteItems(_ context.Context, items []TransactWr
 		m.applyTransactWriteItem(twi)
 	}
 
-	return nil, nil
+	return nil, nil //nolint:nilnil // Success: nil CancellationReasons means no failures.
 }
 
 // validateTransactWriteItem validates a single write item's condition without applying changes.

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -902,7 +902,7 @@ func (m *MemoryStorage) TransactWriteItems(_ context.Context, items []TransactWr
 		m.applyTransactWriteItem(twi)
 	}
 
-	return nil, nil //nolint:nilnil // Success: nil CancellationReasons means no failures.
+	return nil, nil // Success: nil CancellationReasons means no failures.
 }
 
 // validateTransactWriteItem validates a single write item's condition without applying changes.

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -29,7 +29,7 @@ type Storage interface {
 	GetItem(ctx context.Context, tableName string, key Item) (Item, error)
 	DeleteItem(ctx context.Context, tableName string, key Item, returnOld bool, cond ConditionInput) (Item, error)
 	UpdateItem(ctx context.Context, tableName string, key Item, updateExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, returnValues string, cond ConditionInput) (Item, error)
-	Query(ctx context.Context, tableName string, keyCondExpr string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item, scanForward bool) ([]Item, Item, int, error)
+	Query(ctx context.Context, tableName, indexName string, keyCondExpr string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item, scanForward bool) ([]Item, Item, int, error)
 	Scan(ctx context.Context, tableName string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item) ([]Item, Item, int, error)
 	TransactWriteItems(ctx context.Context, items []TransactWriteItem) ([]CancellationReason, error)
 	TransactGetItems(ctx context.Context, items []TransactGetItem) ([]Item, error)
@@ -151,17 +151,18 @@ func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) 
 	}
 
 	table := &Table{
-		Name:                  req.TableName,
-		KeySchema:             req.KeySchema,
-		AttributeDefinitions:  req.AttributeDefinitions,
-		ProvisionedThroughput: req.ProvisionedThroughput,
-		CreationDateTime:      time.Now(),
-		TableStatus:           "ACTIVE",
-		ItemCount:             0,
-		TableSizeBytes:        0,
-		TableARN:              fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", defaultRegion, defaultAccountID, req.TableName),
-		BillingMode:           billingMode,
-		DeletionProtection:    req.DeletionProtectionEnabled,
+		Name:                   req.TableName,
+		KeySchema:              req.KeySchema,
+		AttributeDefinitions:   req.AttributeDefinitions,
+		ProvisionedThroughput:  req.ProvisionedThroughput,
+		GlobalSecondaryIndexes: req.GlobalSecondaryIndexes,
+		CreationDateTime:       time.Now(),
+		TableStatus:            "ACTIVE",
+		ItemCount:              0,
+		TableSizeBytes:         0,
+		TableARN:               fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", defaultRegion, defaultAccountID, req.TableName),
+		BillingMode:            billingMode,
+		DeletionProtection:     req.DeletionProtectionEnabled,
 	}
 
 	m.Tables[req.TableName] = &tableData{
@@ -440,7 +441,7 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 // Query queries items from a table.
 //
 //nolint:cyclop,funlen // Query has inherent complexity from DynamoDB protocol requirements.
-func (m *MemoryStorage) Query(_ context.Context, tableName, keyCondExpr, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item, scanForward bool) ([]Item, Item, int, error) {
+func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondExpr, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item, scanForward bool) ([]Item, Item, int, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -452,10 +453,33 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, keyCondExpr, filterE
 		}
 	}
 
-	// Get partition key attribute name.
+	// Determine key schema to use (table or GSI).
+	keySchema := td.Table.KeySchema
+
+	if indexName != "" {
+		found := false
+
+		for _, gsi := range td.Table.GlobalSecondaryIndexes {
+			if gsi.IndexName == indexName {
+				keySchema = gsi.KeySchema
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			return nil, nil, 0, &TableError{
+				Code:    "ValidationException",
+				Message: fmt.Sprintf("The table does not have the specified index: %s", indexName),
+			}
+		}
+	}
+
+	// Get partition key attribute name from the resolved key schema.
 	var partitionKeyName string
 
-	for _, ks := range td.Table.KeySchema {
+	for _, ks := range keySchema {
 		if ks.KeyType == "HASH" {
 			partitionKeyName = ks.AttributeName
 

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -60,21 +60,48 @@ type ProvisionedThroughputDescription struct {
 	NumberOfDecreasesToday int64  `json:"NumberOfDecreasesToday"`
 }
 
+// Projection represents a GSI projection.
+type Projection struct {
+	ProjectionType   string   `json:"ProjectionType"`
+	NonKeyAttributes []string `json:"NonKeyAttributes,omitempty"`
+}
+
+// GlobalSecondaryIndex represents a GSI definition in CreateTable requests.
+type GlobalSecondaryIndex struct {
+	IndexName             string                 `json:"IndexName"`
+	KeySchema             []KeySchemaElement     `json:"KeySchema"`
+	Projection            Projection             `json:"Projection"`
+	ProvisionedThroughput *ProvisionedThroughput `json:"ProvisionedThroughput,omitempty"`
+}
+
+// GlobalSecondaryIndexDescription represents a GSI in DescribeTable responses.
+type GlobalSecondaryIndexDescription struct {
+	IndexName             string                            `json:"IndexName"`
+	KeySchema             []KeySchemaElement                `json:"KeySchema"`
+	Projection            Projection                        `json:"Projection"`
+	IndexStatus           string                            `json:"IndexStatus"`
+	IndexArn              string                            `json:"IndexArn"`
+	ItemCount             int64                             `json:"ItemCount"`
+	IndexSizeBytes        int64                             `json:"IndexSizeBytes"`
+	ProvisionedThroughput *ProvisionedThroughputDescription `json:"ProvisionedThroughput,omitempty"`
+}
+
 // Table represents a DynamoDB table.
 type Table struct {
-	Name                  string
-	KeySchema             []KeySchemaElement
-	AttributeDefinitions  []AttributeDefinition
-	ProvisionedThroughput *ProvisionedThroughput
-	CreationDateTime      time.Time
-	TableStatus           string
-	ItemCount             int64
-	TableSizeBytes        int64
-	TableARN              string
-	BillingMode           string
-	DeletionProtection    bool
-	TTLAttributeName      string
-	TTLEnabled            bool
+	Name                   string
+	KeySchema              []KeySchemaElement
+	AttributeDefinitions   []AttributeDefinition
+	ProvisionedThroughput  *ProvisionedThroughput
+	GlobalSecondaryIndexes []GlobalSecondaryIndex
+	CreationDateTime       time.Time
+	TableStatus            string
+	ItemCount              int64
+	TableSizeBytes         int64
+	TableARN               string
+	BillingMode            string
+	DeletionProtection     bool
+	TTLAttributeName       string
+	TTLEnabled             bool
 }
 
 // TableDescription represents a table description in responses.
@@ -87,6 +114,7 @@ type TableDescription struct {
 	KeySchema                 []KeySchemaElement                `json:"KeySchema"`
 	AttributeDefinitions      []AttributeDefinition             `json:"AttributeDefinitions"`
 	ProvisionedThroughput     *ProvisionedThroughputDescription `json:"ProvisionedThroughput,omitempty"`
+	GlobalSecondaryIndexes    []GlobalSecondaryIndexDescription `json:"GlobalSecondaryIndexes,omitempty"`
 	ItemCount                 int64                             `json:"ItemCount"`
 	TableSizeBytes            int64                             `json:"TableSizeBytes"`
 	BillingModeSummary        *BillingModeSummary               `json:"BillingModeSummary,omitempty"`
@@ -110,6 +138,7 @@ type CreateTableRequest struct {
 	KeySchema                 []KeySchemaElement     `json:"KeySchema"`
 	AttributeDefinitions      []AttributeDefinition  `json:"AttributeDefinitions"`
 	ProvisionedThroughput     *ProvisionedThroughput `json:"ProvisionedThroughput,omitempty"`
+	GlobalSecondaryIndexes    []GlobalSecondaryIndex `json:"GlobalSecondaryIndexes,omitempty"`
 	BillingMode               string                 `json:"BillingMode,omitempty"`
 	DeletionProtectionEnabled bool                   `json:"DeletionProtectionEnabled,omitempty"`
 }
@@ -214,6 +243,7 @@ type UpdateItemResponse struct {
 // QueryRequest is the request for Query.
 type QueryRequest struct {
 	TableName                 string                    `json:"TableName"`
+	IndexName                 string                    `json:"IndexName,omitempty"`
 	KeyConditionExpression    string                    `json:"KeyConditionExpression,omitempty"`
 	FilterExpression          string                    `json:"FilterExpression,omitempty"`
 	ProjectionExpression      string                    `json:"ProjectionExpression,omitempty"`

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -1073,6 +1073,95 @@ func TestDynamoDB_TransactGetItems(t *testing.T) {
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), result)
 }
 
+func TestDynamoDB_GlobalSecondaryIndex(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-gsi"
+
+	// Create table with GSI.
+	createOutput, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+			{AttributeName: aws.String("sk"), KeyType: types.KeyTypeRange},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+			{AttributeName: aws.String("sk"), AttributeType: types.ScalarAttributeTypeS},
+			{AttributeName: aws.String("gsi_pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+			{
+				IndexName: aws.String("gsi-index"),
+				KeySchema: []types.KeySchemaElement{
+					{AttributeName: aws.String("gsi_pk"), KeyType: types.KeyTypeHash},
+				},
+				Projection: &types.Projection{
+					ProjectionType: types.ProjectionTypeAll,
+				},
+			},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("TableArn", "TableId", "CreationDateTime", "ResultMetadata", "IndexArn")).Assert(t.Name()+"_create", createOutput)
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Put items with GSI key.
+	for _, item := range []struct{ pk, sk, gsiPK, data string }{
+		{"user-1", "order-1", "region-east", "data1"},
+		{"user-1", "order-2", "region-west", "data2"},
+		{"user-2", "order-3", "region-east", "data3"},
+	} {
+		_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item: map[string]types.AttributeValue{
+				"pk":     &types.AttributeValueMemberS{Value: item.pk},
+				"sk":     &types.AttributeValueMemberS{Value: item.sk},
+				"gsi_pk": &types.AttributeValueMemberS{Value: item.gsiPK},
+				"data":   &types.AttributeValueMemberS{Value: item.data},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Query via GSI.
+	queryOutput, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(tableName),
+		IndexName:              aws.String("gsi-index"),
+		KeyConditionExpression: aws.String("gsi_pk = :val"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":val": &types.AttributeValueMemberS{Value: "region-east"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_query_gsi", queryOutput)
+
+	// Query via table primary key still works.
+	queryTableOutput, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(tableName),
+		KeyConditionExpression: aws.String("pk = :val"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":val": &types.AttributeValueMemberS{Value: "user-1"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_query_table", queryTableOutput)
+}
+
 func TestDynamoDB_BatchWriteItem(t *testing.T) {
 	client := newDynamoDBClient(t)
 	ctx := t.Context()

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_create.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_create.golden.go
@@ -1,0 +1,80 @@
+{
+  "TableDescription": {
+    "ArchivalSummary": null,
+    "AttributeDefinitions": [
+      {
+        "AttributeName": "pk",
+        "AttributeType": "S"
+      },
+      {
+        "AttributeName": "sk",
+        "AttributeType": "S"
+      },
+      {
+        "AttributeName": "gsi_pk",
+        "AttributeType": "S"
+      }
+    ],
+    "BillingModeSummary": {
+      "BillingMode": "PAY_PER_REQUEST",
+      "LastUpdateToPayPerRequestDateTime": null
+    },
+    "CreationDateTime": "2026-04-22T01:08:47Z",
+    "DeletionProtectionEnabled": false,
+    "GlobalSecondaryIndexes": [
+      {
+        "Backfilling": null,
+        "IndexArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-table-gsi/index/gsi-index",
+        "IndexName": "gsi-index",
+        "IndexSizeBytes": 0,
+        "IndexStatus": "ACTIVE",
+        "ItemCount": 0,
+        "KeySchema": [
+          {
+            "AttributeName": "gsi_pk",
+            "KeyType": "HASH"
+          }
+        ],
+        "OnDemandThroughput": null,
+        "Projection": {
+          "NonKeyAttributes": null,
+          "ProjectionType": "ALL"
+        },
+        "ProvisionedThroughput": null,
+        "WarmThroughput": null
+      }
+    ],
+    "GlobalTableSettingsReplicationMode": "",
+    "GlobalTableVersion": null,
+    "GlobalTableWitnesses": null,
+    "ItemCount": 0,
+    "KeySchema": [
+      {
+        "AttributeName": "pk",
+        "KeyType": "HASH"
+      },
+      {
+        "AttributeName": "sk",
+        "KeyType": "RANGE"
+      }
+    ],
+    "LatestStreamArn": null,
+    "LatestStreamLabel": null,
+    "LocalSecondaryIndexes": null,
+    "MultiRegionConsistency": "",
+    "OnDemandThroughput": null,
+    "ProvisionedThroughput": null,
+    "Replicas": null,
+    "RestoreSummary": null,
+    "SSEDescription": null,
+    "StreamSpecification": null,
+    "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-table-gsi",
+    "TableClassSummary": null,
+    "TableId": "ad896e2b-c27f-45be-a28a-8f444a5560d9",
+    "TableName": "test-table-gsi",
+    "TableSizeBytes": 0,
+    "TableStatus": "ACTIVE",
+    "WarmThroughput": null
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_query_gsi.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_query_gsi.golden.go
@@ -1,0 +1,37 @@
+{
+  "ConsumedCapacity": null,
+  "Count": 2,
+  "Items": [
+    {
+      "data": {
+        "Value": "data3"
+      },
+      "gsi_pk": {
+        "Value": "region-east"
+      },
+      "pk": {
+        "Value": "user-2"
+      },
+      "sk": {
+        "Value": "order-3"
+      }
+    },
+    {
+      "data": {
+        "Value": "data1"
+      },
+      "gsi_pk": {
+        "Value": "region-east"
+      },
+      "pk": {
+        "Value": "user-1"
+      },
+      "sk": {
+        "Value": "order-1"
+      }
+    }
+  ],
+  "LastEvaluatedKey": null,
+  "ScannedCount": 3,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_query_table.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_query_table.golden.go
@@ -1,0 +1,37 @@
+{
+  "ConsumedCapacity": null,
+  "Count": 2,
+  "Items": [
+    {
+      "data": {
+        "Value": "data1"
+      },
+      "gsi_pk": {
+        "Value": "region-east"
+      },
+      "pk": {
+        "Value": "user-1"
+      },
+      "sk": {
+        "Value": "order-1"
+      }
+    },
+    {
+      "data": {
+        "Value": "data2"
+      },
+      "gsi_pk": {
+        "Value": "region-west"
+      },
+      "pk": {
+        "Value": "user-1"
+      },
+      "sk": {
+        "Value": "order-2"
+      }
+    }
+  ],
+  "LastEvaluatedKey": null,
+  "ScannedCount": 3,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- CreateTable accepts GlobalSecondaryIndexes (KeySchema, Projection)
- DescribeTable returns GSI information (IndexStatus, IndexArn)
- Query supports IndexName parameter to query against GSI key schema
- Validates that specified index exists on the table

## Test plan

- [x] Integration test with golden files: create table with GSI, put items, query via GSI, query via table key
- [x] All existing DynamoDB tests pass with no regressions

Closes #441