### PR TITLE
feat: support EmailContent.Raw in SES v2 SendEmail

### DIFF
--- a/internal/service/sesv2/storage.go
+++ b/internal/service/sesv2/storage.go
@@ -1,9 +1,14 @@
 package sesv2
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/mail"
 	"strings"
 	"sync"
 	"time"
@@ -352,8 +357,17 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 	// Generate message ID.
 	messageID := uuid.New().String()
 
-	// Extract subject and body from simple email content.
-	subject, body := extractSimpleEmailContent(req.Content.Simple)
+	// Extract content based on email type.
+	var subject, body string
+	var rawData []byte
+
+	switch {
+	case req.Content.Raw != nil:
+		rawData = req.Content.Raw.Data
+		subject, body = extractRawEmailContent(rawData)
+	case req.Content.Simple != nil:
+		subject, body = extractSimpleEmailContent(req.Content.Simple)
+	}
 
 	// Store the sent email.
 	sentEmail := &SentEmail{
@@ -362,6 +376,7 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 		Destination:          req.Destination,
 		Subject:              subject,
 		Body:                 body,
+		RawData:              rawData,
 		ConfigurationSetName: req.ConfigurationSetName,
 		SentAt:               time.Now(),
 	}
@@ -377,6 +392,45 @@ func (s *MemoryStorage) GetSentEmails(_ context.Context) ([]*SentEmail, error) {
 	defer s.mu.RUnlock()
 
 	return s.SentEmails, nil
+}
+
+// extractRawEmailContent parses an RFC 2822 MIME message and extracts subject and body.
+func extractRawEmailContent(data []byte) (subject, body string) {
+	msg, err := mail.ReadMessage(bytes.NewReader(data))
+	if err != nil {
+		return "", ""
+	}
+
+	subject = msg.Header.Get("Subject")
+
+	mediaType, params, err := mime.ParseMediaType(msg.Header.Get("Content-Type"))
+	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
+		// Not multipart; read body directly.
+		b, err := io.ReadAll(msg.Body)
+		if err != nil {
+			return subject, ""
+		}
+		return subject, string(b)
+	}
+
+	// Multipart message: find text/plain or text/html part.
+	reader := multipart.NewReader(msg.Body, params["boundary"])
+	for {
+		part, err := reader.NextPart()
+		if err != nil {
+			break
+		}
+		partType, _, _ := mime.ParseMediaType(part.Header.Get("Content-Type"))
+		if partType == "text/plain" || partType == "text/html" {
+			b, err := io.ReadAll(part)
+			if err != nil {
+				continue
+			}
+			return subject, string(b)
+		}
+	}
+
+	return subject, ""
 }
 
 // extractSimpleEmailContent extracts subject and body from a SimpleEmail.

--- a/internal/service/sesv2/storage.go
+++ b/internal/service/sesv2/storage.go
@@ -358,8 +358,10 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 	messageID := uuid.New().String()
 
 	// Extract content based on email type.
-	var subject, body string
-	var rawData []byte
+	var (
+		subject, body string
+		rawData       []byte
+	)
 
 	switch {
 	case req.Content.Raw != nil:
@@ -410,22 +412,27 @@ func extractRawEmailContent(data []byte) (subject, body string) {
 		if err != nil {
 			return subject, ""
 		}
+
 		return subject, string(b)
 	}
 
 	// Multipart message: find text/plain or text/html part.
 	reader := multipart.NewReader(msg.Body, params["boundary"])
+
 	for {
 		part, err := reader.NextPart()
 		if err != nil {
 			break
 		}
+
 		partType, _, _ := mime.ParseMediaType(part.Header.Get("Content-Type"))
+
 		if partType == "text/plain" || partType == "text/html" {
 			b, err := io.ReadAll(part)
 			if err != nil {
 				continue
 			}
+
 			return subject, string(b)
 		}
 	}

--- a/internal/service/sesv2/types.go
+++ b/internal/service/sesv2/types.go
@@ -59,6 +59,7 @@ type SentEmail struct {
 	Destination          *Destination `json:"Destination,omitempty"`
 	Subject              string       `json:"Subject,omitempty"`
 	Body                 string       `json:"Body,omitempty"`
+	RawData              []byte       `json:"RawData,omitempty"`
 	ConfigurationSetName string       `json:"ConfigurationSetName,omitempty"`
 	SentAt               time.Time    `json:"SentAt"`
 }

--- a/test/integration/sesv2_test.go
+++ b/test/integration/sesv2_test.go
@@ -287,7 +287,7 @@ func TestSESv2_SendRawEmail(t *testing.T) {
 		"Raw test body content"
 
 	// Send raw email.
-	sendOutput, err := client.SendEmail(ctx, &sesv2.SendEmailInput{
+	_, err := client.SendEmail(ctx, &sesv2.SendEmailInput{
 		FromEmailAddress: aws.String(emailIdentity),
 		Destination: &types.Destination{
 			ToAddresses: []string{"recipient@example.com"},
@@ -301,7 +301,6 @@ func TestSESv2_SendRawEmail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	golden.New(t, golden.WithIgnoreFields("MessageId", "ResultMetadata")).Assert(t.Name()+"_send", sendOutput)
 
 	// Verify sent email via kumo-specific endpoint.
 	resp, err := http.Get("http://localhost:4566/kumo/ses/v2/sent-emails")
@@ -310,37 +309,16 @@ func TestSESv2_SendRawEmail(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	var result map[string]interface{}
+	var result struct {
+		SentEmails []json.RawMessage `json:"SentEmails"`
+	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatal(err)
 	}
 
-	emails, ok := result["SentEmails"].([]interface{})
-	if !ok {
-		t.Fatal("SentEmails is not an array")
-	}
-
-	var found bool
-	for _, e := range emails {
-		email, ok := e.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if email["FromEmailAddress"] == emailIdentity && email["Subject"] == "Raw Test Subject" {
-			if email["Body"] != "Raw test body content" {
-				t.Errorf("expected body %q, got %q", "Raw test body content", email["Body"])
-			}
-			if email["RawData"] == nil {
-				t.Error("expected RawData to be present")
-			}
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		t.Errorf("sent raw email from %s with subject 'Raw Test Subject' not found", emailIdentity)
-	}
+	// Find the raw email sent in this test (other tests may have sent emails too).
+	raw := findSentEmail(t, result.SentEmails, emailIdentity, "Raw Test Subject")
+	golden.New(t, golden.WithIgnoreFields("MessageId", "SentAt")).Assert(t.Name(), raw)
 }
 
 func TestSESv2_EmailIdentityNotFound(t *testing.T) {
@@ -442,4 +420,23 @@ func TestSESv2_GetSentEmails(t *testing.T) {
 	if !found {
 		t.Errorf("sent email from %s with subject 'Test Subject' not found", fromEmail)
 	}
+}
+
+func findSentEmail(t *testing.T, emails []json.RawMessage, from, subject string) json.RawMessage {
+	t.Helper()
+
+	for _, raw := range emails {
+		var email map[string]interface{}
+		if err := json.Unmarshal(raw, &email); err != nil {
+			continue
+		}
+
+		if email["FromEmailAddress"] == from && email["Subject"] == subject {
+			return raw
+		}
+	}
+
+	t.Fatalf("sent email from %s with subject %q not found", from, subject)
+
+	return nil
 }

--- a/test/integration/sesv2_test.go
+++ b/test/integration/sesv2_test.go
@@ -268,6 +268,81 @@ func TestSESv2_SendEmail(t *testing.T) {
 	golden.New(t, golden.WithIgnoreFields("MessageId", "ResultMetadata")).Assert(t.Name(), sendOutput)
 }
 
+func TestSESv2_SendRawEmail(t *testing.T) {
+	client := newSESv2Client(t)
+	ctx := t.Context()
+
+	// Create email identity first.
+	emailIdentity := "raw-sender@example.com"
+	_, _ = client.CreateEmailIdentity(ctx, &sesv2.CreateEmailIdentityInput{
+		EmailIdentity: aws.String(emailIdentity),
+	})
+
+	// Build raw MIME message.
+	rawMessage := "From: raw-sender@example.com\r\n" +
+		"To: recipient@example.com\r\n" +
+		"Subject: Raw Test Subject\r\n" +
+		"Content-Type: text/plain; charset=UTF-8\r\n" +
+		"\r\n" +
+		"Raw test body content"
+
+	// Send raw email.
+	sendOutput, err := client.SendEmail(ctx, &sesv2.SendEmailInput{
+		FromEmailAddress: aws.String(emailIdentity),
+		Destination: &types.Destination{
+			ToAddresses: []string{"recipient@example.com"},
+		},
+		Content: &types.EmailContent{
+			Raw: &types.RawMessage{
+				Data: []byte(rawMessage),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("MessageId", "ResultMetadata")).Assert(t.Name()+"_send", sendOutput)
+
+	// Verify sent email via kumo-specific endpoint.
+	resp, err := http.Get("http://localhost:4566/kumo/ses/v2/sent-emails")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+
+	emails, ok := result["SentEmails"].([]interface{})
+	if !ok {
+		t.Fatal("SentEmails is not an array")
+	}
+
+	var found bool
+	for _, e := range emails {
+		email, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if email["FromEmailAddress"] == emailIdentity && email["Subject"] == "Raw Test Subject" {
+			if email["Body"] != "Raw test body content" {
+				t.Errorf("expected body %q, got %q", "Raw test body content", email["Body"])
+			}
+			if email["RawData"] == nil {
+				t.Error("expected RawData to be present")
+			}
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("sent raw email from %s with subject 'Raw Test Subject' not found", emailIdentity)
+	}
+}
+
 func TestSESv2_EmailIdentityNotFound(t *testing.T) {
 	client := newSESv2Client(t)
 	ctx := t.Context()

--- a/test/integration/testdata/sesv2_test_TestSESv2_SendRawEmail_TestSESv2_SendRawEmail.golden.go
+++ b/test/integration/testdata/sesv2_test_TestSESv2_SendRawEmail_TestSESv2_SendRawEmail.golden.go
@@ -1,0 +1,13 @@
+{
+  "MessageId": "72588443-b4fe-48d2-a673-95ecb877313c",
+  "FromEmailAddress": "raw-sender@example.com",
+  "Destination": {
+    "ToAddresses": [
+      "recipient@example.com"
+    ]
+  },
+  "Subject": "Raw Test Subject",
+  "Body": "Raw test body content",
+  "RawData": "RnJvbTogcmF3LXNlbmRlckBleGFtcGxlLmNvbQ0KVG86IHJlY2lwaWVudEBleGFtcGxlLmNvbQ0KU3ViamVjdDogUmF3IFRlc3QgU3ViamVjdA0KQ29udGVudC1UeXBlOiB0ZXh0L3BsYWluOyBjaGFyc2V0PVVURi04DQoNClJhdyB0ZXN0IGJvZHkgY29udGVudA==",
+  "SentAt": "2026-04-22T14:07:34.921789+09:00"
+}

--- a/test/integration/testdata/sesv2_test_TestSESv2_SendRawEmail_TestSESv2_SendRawEmail_send.golden.go
+++ b/test/integration/testdata/sesv2_test_TestSESv2_SendRawEmail_TestSESv2_SendRawEmail_send.golden.go
@@ -1,4 +1,0 @@
-{
-  "MessageId": "72588443-b4fe-48d2-a673-95ecb877313c",
-  "ResultMetadata": {}
-}

--- a/test/integration/testdata/sesv2_test_TestSESv2_SendRawEmail_TestSESv2_SendRawEmail_send.golden.go
+++ b/test/integration/testdata/sesv2_test_TestSESv2_SendRawEmail_TestSESv2_SendRawEmail_send.golden.go
@@ -1,0 +1,4 @@
+{
+  "MessageId": "72588443-b4fe-48d2-a673-95ecb877313c",
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
- Store `EmailContent.Raw` MIME data in `SentEmail.RawData` field
- Parse RFC 2822 messages to extract subject and body (text/plain or text/html) for convenience
- Add integration test with golden file for raw email sending

Closes #431
## Test plan
- [x] `TestSESv2_SendRawEmail` passes with golden file assertion
- [x] All existing SESv2 integration tests pass
- [x] `go vet` / build pass