### PR TITLE
feat: allow raw email submission without explicit Destination

### DIFF
--- a/internal/service/sesv2/storage.go
+++ b/internal/service/sesv2/storage.go
@@ -336,21 +336,25 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Basic validation.
-	if req.Destination == nil ||
-		(len(req.Destination.ToAddresses) == 0 &&
-			len(req.Destination.CcAddresses) == 0 &&
-			len(req.Destination.BccAddresses) == 0) {
-		return "", &IdentityError{
-			Code:    errBadRequest,
-			Message: "Destination is required",
-		}
-	}
-
 	if req.Content == nil {
 		return "", &IdentityError{
 			Code:    errBadRequest,
 			Message: "Content is required",
+		}
+	}
+
+	// Basic validation.
+	// Destination is not required when Content.Raw is set,
+	// because recipients can be extracted from MIME headers.
+	hasDestination := req.Destination != nil &&
+		(len(req.Destination.ToAddresses) > 0 ||
+			len(req.Destination.CcAddresses) > 0 ||
+			len(req.Destination.BccAddresses) > 0)
+
+	if !hasDestination && req.Content.Raw == nil {
+		return "", &IdentityError{
+			Code:    errBadRequest,
+			Message: "Destination is required",
 		}
 	}
 
@@ -361,12 +365,17 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 	var (
 		subject, body string
 		rawData       []byte
+		destination   = req.Destination
 	)
 
 	switch {
 	case req.Content.Raw != nil:
 		rawData = req.Content.Raw.Data
 		subject, body = extractRawEmailContent(rawData)
+
+		if !hasDestination {
+			destination = extractRawEmailDestination(rawData)
+		}
 	case req.Content.Simple != nil:
 		subject, body = extractSimpleEmailContent(req.Content.Simple)
 	}
@@ -375,7 +384,7 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 	sentEmail := &SentEmail{
 		MessageID:            messageID,
 		FromEmailAddress:     req.FromEmailAddress,
-		Destination:          req.Destination,
+		Destination:          destination,
 		Subject:              subject,
 		Body:                 body,
 		RawData:              rawData,
@@ -394,6 +403,45 @@ func (s *MemoryStorage) GetSentEmails(_ context.Context) ([]*SentEmail, error) {
 	defer s.mu.RUnlock()
 
 	return s.SentEmails, nil
+}
+
+// extractRawEmailDestination parses an RFC 2822 MIME message and extracts destination addresses.
+func extractRawEmailDestination(data []byte) *Destination {
+	msg, err := mail.ReadMessage(bytes.NewReader(data))
+	if err != nil {
+		return nil
+	}
+
+	dest := &Destination{}
+
+	if to := msg.Header.Get("To"); to != "" {
+		addrs, err := mail.ParseAddressList(to)
+		if err == nil {
+			for _, a := range addrs {
+				dest.ToAddresses = append(dest.ToAddresses, a.Address)
+			}
+		}
+	}
+
+	if cc := msg.Header.Get("Cc"); cc != "" {
+		addrs, err := mail.ParseAddressList(cc)
+		if err == nil {
+			for _, a := range addrs {
+				dest.CcAddresses = append(dest.CcAddresses, a.Address)
+			}
+		}
+	}
+
+	if bcc := msg.Header.Get("Bcc"); bcc != "" {
+		addrs, err := mail.ParseAddressList(bcc)
+		if err == nil {
+			for _, a := range addrs {
+				dest.BccAddresses = append(dest.BccAddresses, a.Address)
+			}
+		}
+	}
+
+	return dest
 }
 
 // extractRawEmailContent parses an RFC 2822 MIME message and extracts subject and body.

--- a/internal/service/sesv2/storage_test.go
+++ b/internal/service/sesv2/storage_test.go
@@ -1,0 +1,106 @@
+package sesv2
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSendEmail_RawEmailWithoutDestination(t *testing.T) {
+	storage := &MemoryStorage{}
+	ctx := context.Background()
+
+	rawMessage := "From: sender@example.com\r\n" +
+		"To: recipient@example.com\r\n" +
+		"Cc: cc@example.com\r\n" +
+		"Subject: Test Subject\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"\r\n" +
+		"Test body"
+
+	req := &SendEmailRequest{
+		FromEmailAddress: "sender@example.com",
+		// Destination is intentionally nil
+		Content: &EmailContent{
+			Raw: &RawEmail{
+				Data: []byte(rawMessage),
+			},
+		},
+	}
+
+	messageID, err := storage.SendEmail(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if messageID == "" {
+		t.Fatal("expected non-empty message ID")
+	}
+
+	// Verify that the sent email was stored
+	sentEmails, err := storage.GetSentEmails(ctx)
+	if err != nil {
+		t.Fatalf("failed to get sent emails: %v", err)
+	}
+
+	if len(sentEmails) == 0 {
+		t.Fatal("expected sent email to be stored")
+	}
+
+	email := sentEmails[0]
+	if email.MessageID != messageID {
+		t.Errorf("expected message ID %s, got %s", messageID, email.MessageID)
+	}
+
+	// Verify destination was extracted from MIME headers
+	if email.Destination == nil {
+		t.Fatal("expected destination to be extracted from MIME headers")
+	}
+
+	if len(email.Destination.ToAddresses) != 1 || email.Destination.ToAddresses[0] != "recipient@example.com" {
+		t.Errorf("expected To: recipient@example.com, got %v", email.Destination.ToAddresses)
+	}
+
+	if len(email.Destination.CcAddresses) != 1 || email.Destination.CcAddresses[0] != "cc@example.com" {
+		t.Errorf("expected Cc: cc@example.com, got %v", email.Destination.CcAddresses)
+	}
+
+	if email.Subject != "Test Subject" {
+		t.Errorf("expected subject 'Test Subject', got '%s'", email.Subject)
+	}
+}
+
+func TestSendEmail_SimpleEmailWithoutDestination_ShouldFail(t *testing.T) {
+	storage := &MemoryStorage{}
+	ctx := context.Background()
+
+	req := &SendEmailRequest{
+		FromEmailAddress: "sender@example.com",
+		// Destination is nil
+		Content: &EmailContent{
+			Simple: &SimpleEmail{
+				Subject: &Content{
+					Data: "Test",
+				},
+				Body: &Body{
+					Text: &Content{
+						Data: "Test body",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := storage.SendEmail(ctx, req)
+	if err == nil {
+		t.Fatal("expected error for simple email without destination")
+	}
+
+	identityErr, ok := err.(*IdentityError)
+	if !ok {
+		t.Fatalf("expected IdentityError, got %T", err)
+	}
+
+	if identityErr.Message != "Destination is required" {
+		t.Errorf("expected 'Destination is required', got '%s'", identityErr.Message)
+	}
+}

--- a/internal/service/sesv2/storage_test.go
+++ b/internal/service/sesv2/storage_test.go
@@ -2,6 +2,7 @@ package sesv2
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -95,8 +96,8 @@ func TestSendEmail_SimpleEmailWithoutDestination_ShouldFail(t *testing.T) {
 		t.Fatal("expected error for simple email without destination")
 	}
 
-	identityErr, ok := err.(*IdentityError)
-	if !ok {
+	var identityErr *IdentityError
+	if !errors.As(err, &identityErr) {
 		t.Fatalf("expected IdentityError, got %T", err)
 	}
 

--- a/test/integration/sesv2_test.go
+++ b/test/integration/sesv2_test.go
@@ -321,6 +321,56 @@ func TestSESv2_SendRawEmail(t *testing.T) {
 	golden.New(t, golden.WithIgnoreFields("MessageId", "SentAt")).Assert(t.Name(), raw)
 }
 
+func TestSESv2_SendRawEmailWithoutDestination(t *testing.T) {
+	client := newSESv2Client(t)
+	ctx := t.Context()
+
+	// Create email identity first.
+	emailIdentity := "raw-no-dest@example.com"
+	_, _ = client.CreateEmailIdentity(ctx, &sesv2.CreateEmailIdentityInput{
+		EmailIdentity: aws.String(emailIdentity),
+	})
+
+	// Build raw MIME message with recipients in headers only.
+	rawMessage := "From: raw-no-dest@example.com\r\n" +
+		"To: to-recipient@example.com\r\n" +
+		"Cc: cc-recipient@example.com\r\n" +
+		"Subject: Raw No Destination Test\r\n" +
+		"Content-Type: text/plain; charset=UTF-8\r\n" +
+		"\r\n" +
+		"Raw email without explicit Destination"
+
+	// Send raw email without Destination.
+	_, err := client.SendEmail(ctx, &sesv2.SendEmailInput{
+		FromEmailAddress: aws.String(emailIdentity),
+		Content: &types.EmailContent{
+			Raw: &types.RawMessage{
+				Data: []byte(rawMessage),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify sent email via kumo-specific endpoint.
+	resp, err := http.Get("http://localhost:4566/kumo/ses/v2/sent-emails")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		SentEmails []json.RawMessage `json:"SentEmails"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+
+	raw := findSentEmail(t, result.SentEmails, emailIdentity, "Raw No Destination Test")
+	golden.New(t, golden.WithIgnoreFields("MessageId", "SentAt")).Assert(t.Name(), raw)
+}
+
 func TestSESv2_EmailIdentityNotFound(t *testing.T) {
 	client := newSESv2Client(t)
 	ctx := t.Context()

--- a/test/integration/testdata/sesv2_test_TestSESv2_SendRawEmailWithoutDestination_TestSESv2_SendRawEmailWithoutDestination.golden.go
+++ b/test/integration/testdata/sesv2_test_TestSESv2_SendRawEmailWithoutDestination_TestSESv2_SendRawEmailWithoutDestination.golden.go
@@ -1,0 +1,16 @@
+{
+  "MessageId": "00000000-0000-0000-0000-000000000000",
+  "FromEmailAddress": "raw-no-dest@example.com",
+  "Destination": {
+    "ToAddresses": [
+      "to-recipient@example.com"
+    ],
+    "CcAddresses": [
+      "cc-recipient@example.com"
+    ]
+  },
+  "Subject": "Raw No Destination Test",
+  "Body": "Raw email without explicit Destination",
+  "RawData": "RnJvbTogcmF3LW5vLWRlc3RAZXhhbXBsZS5jb20NClRvOiB0by1yZWNpcGllbnRAZXhhbXBsZS5jb20NCkNjOiBjYy1yZWNpcGllbnRAZXhhbXBsZS5jb20NClN1YmplY3Q6IFJhdyBObyBEZXN0aW5hdGlvbiBUZXN0DQpDb250ZW50LVR5cGU6IHRleHQvcGxhaW47IGNoYXJzZXQ9VVRGLTgNCg0KUmF3IGVtYWlsIHdpdGhvdXQgZXhwbGljaXQgRGVzdGluYXRpb24=",
+  "SentAt": "2026-04-23T10:30:00Z"
+}


### PR DESCRIPTION
## Summary

- Relax `Destination` validation for `Content.Raw` requests in SES v2 `SendEmail`, aligning with [AWS SES API behavior](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html)
- Extract recipient addresses (To, Cc, Bcc) from MIME headers when `Destination` is omitted
- Add unit tests and integration test with golden file

Closes #452