### PR TITLE
feat: support init directory execution on startup

### DIFF
--- a/internal/initdir/initdir.go
+++ b/internal/initdir/initdir.go
@@ -1,0 +1,86 @@
+// Package initdir executes shell scripts from a directory after kumo starts.
+// This provides functionality similar to LocalStack's init/ready.d/ mechanism.
+package initdir
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Run executes all .sh files in the given directory sequentially in alphabetical order.
+// Each script runs independently — a failure in one script does not prevent subsequent scripts from running.
+func Run(ctx context.Context, dir string, logger *slog.Logger) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read init directory %s: %w", dir, err)
+	}
+
+	var scripts []string
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		if strings.HasSuffix(entry.Name(), ".sh") {
+			scripts = append(scripts, entry.Name())
+		}
+	}
+
+	sort.Strings(scripts)
+
+	if len(scripts) == 0 {
+		logger.Info("no init scripts found", "dir", dir)
+
+		return nil
+	}
+
+	logger.Info("executing init scripts", "dir", dir, "count", len(scripts))
+
+	var failed int
+
+	for _, name := range scripts {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("init script execution cancelled: %w", err)
+		}
+
+		path := filepath.Join(dir, name)
+		logger.Info("executing init script", "script", name)
+
+		if err := runScript(ctx, path); err != nil {
+			logger.Error("init script failed", "script", name, "error", err)
+
+			failed++
+
+			continue
+		}
+
+		logger.Info("init script completed", "script", name)
+	}
+
+	if failed > 0 {
+		logger.Warn("some init scripts failed", "failed", failed, "total", len(scripts))
+	}
+
+	return nil
+}
+
+func runScript(ctx context.Context, path string) error {
+	cmd := exec.CommandContext(ctx, "sh", path)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// Inherit environment so scripts can use AWS_ENDPOINT_URL, AWS_DEFAULT_REGION, etc.
+	cmd.Env = os.Environ()
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("script %s exited with error: %w", filepath.Base(path), err)
+	}
+
+	return nil
+}

--- a/internal/initdir/initdir_test.go
+++ b/internal/initdir/initdir_test.go
@@ -1,0 +1,144 @@
+package initdir
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRun_alphabetical_order(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	dir := t.TempDir()
+	output := filepath.Join(dir, "output.txt")
+
+	writeScript(t, dir, "02_second.sh", `echo "second" >> `+output)
+	writeScript(t, dir, "01_first.sh", `echo "first" >> `+output)
+	writeScript(t, dir, "03_third.sh", `echo "third" >> `+output)
+
+	if err := Run(context.Background(), dir, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(output) //nolint:gosec // test file path from t.TempDir
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	want := "first\nsecond\nthird\n"
+	if string(data) != want {
+		t.Errorf("got %q, want %q", string(data), want)
+	}
+}
+
+func TestRun_skips_non_sh_files(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	dir := t.TempDir()
+	output := filepath.Join(dir, "output.txt")
+
+	writeScript(t, dir, "run.sh", `echo "executed" >> `+output)
+	writeFile(t, dir, "skip.txt", "should not run")
+	writeFile(t, dir, "skip.py", "should not run")
+
+	if err := Run(context.Background(), dir, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(output) //nolint:gosec // test file path from t.TempDir
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	want := "executed\n"
+	if string(data) != want {
+		t.Errorf("got %q, want %q", string(data), want)
+	}
+}
+
+func TestRun_continues_after_failure(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	dir := t.TempDir()
+	output := filepath.Join(dir, "output.txt")
+
+	writeScript(t, dir, "01_ok.sh", `echo "first" >> `+output)
+	writeScript(t, dir, "02_fail.sh", `exit 1`)
+	writeScript(t, dir, "03_ok.sh", `echo "third" >> `+output)
+
+	if err := Run(context.Background(), dir, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(output) //nolint:gosec // test file path from t.TempDir
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	want := "first\nthird\n"
+	if string(data) != want {
+		t.Errorf("got %q, want %q", string(data), want)
+	}
+}
+
+func TestRun_empty_directory(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	dir := t.TempDir()
+
+	if err := Run(context.Background(), dir, logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_nonexistent_directory(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	err := Run(context.Background(), "/nonexistent/path", logger)
+	if err == nil {
+		t.Fatal("expected error for nonexistent directory")
+	}
+}
+
+func TestRun_respects_context_cancellation(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	dir := t.TempDir()
+
+	writeScript(t, dir, "01_slow.sh", `sleep 10`)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := Run(ctx, dir, logger)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func writeScript(t *testing.T, dir, name, content string) {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+content+"\n"), 0o700); err != nil { //nolint:gosec // test script needs execute permission
+		t.Fatalf("failed to write script %s: %v", name, err)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write file %s: %v", name, err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,12 +8,14 @@ import (
 	"io"
 	"log/slog"
 	"mime"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
+	"github.com/sivchari/kumo/internal/initdir"
 	"github.com/sivchari/kumo/internal/service"
 )
 
@@ -22,6 +24,7 @@ type Config struct {
 	Host     string
 	Port     int
 	LogLevel slog.Level
+	InitDir  string // Directory containing init scripts to execute on startup
 }
 
 // DefaultConfig returns the default server configuration.
@@ -30,6 +33,7 @@ func DefaultConfig() Config {
 		Host:     "0.0.0.0",
 		Port:     4566,
 		LogLevel: slog.LevelInfo,
+		InitDir:  os.Getenv("KUMO_INIT_DIR"),
 	}
 }
 
@@ -165,10 +169,10 @@ func (s *Server) Handler() http.Handler {
 	return s.router
 }
 
-// Start starts the HTTP server.
-func (s *Server) Start() error {
+// Start starts the HTTP server. It accepts an optional readyCh channel that will be
+// closed once the server is listening and ready to accept connections.
+func (s *Server) Start(readyCh ...chan struct{}) error {
 	s.server = &http.Server{
-		Addr:              s.Addr(),
 		Handler:           s.router,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
@@ -180,7 +184,17 @@ func (s *Server) Start() error {
 		s.logger.Info("service available", "name", name)
 	}
 
-	if err := s.server.ListenAndServe(); err != nil {
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", s.Addr())
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", s.Addr(), err)
+	}
+
+	// Signal that the server is ready to accept connections.
+	if len(readyCh) > 0 && readyCh[0] != nil {
+		close(readyCh[0])
+	}
+
+	if err := s.server.Serve(ln); err != nil {
 		return fmt.Errorf("failed to start server: %w", err)
 	}
 
@@ -216,12 +230,23 @@ func (s *Server) Run() error {
 	// Channel to receive server errors
 	errChan := make(chan error, 1)
 
+	// Channel to signal server readiness
+	readyCh := make(chan struct{})
+
 	// Start server in a goroutine
 	go func() {
-		if err := s.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := s.Start(readyCh); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errChan <- err
 		}
 	}()
+
+	// Wait for server to be ready, then execute init scripts
+	select {
+	case <-readyCh:
+		s.runInitScripts()
+	case err := <-errChan:
+		return fmt.Errorf("server error: %w", err)
+	}
 
 	// Wait for signal or error
 	select {
@@ -236,4 +261,20 @@ func (s *Server) Run() error {
 	defer cancel()
 
 	return s.Shutdown(ctx)
+}
+
+// runInitScripts executes init scripts from the configured directory.
+func (s *Server) runInitScripts() {
+	if s.config.InitDir == "" {
+		return
+	}
+
+	s.logger.Info("running init scripts", "dir", s.config.InitDir)
+
+	go func() {
+		ctx := context.Background()
+		if err := initdir.Run(ctx, s.config.InitDir, s.logger); err != nil {
+			s.logger.Error("failed to run init scripts", "error", err)
+		}
+	}()
 }


### PR DESCRIPTION
## Summary
- Add `KUMO_INIT_DIR` environment variable to specify a directory containing shell scripts
- Scripts are executed sequentially in alphabetical order after the server starts listening
- Failures in one script do not block subsequent scripts

Closes #454