### PR TITLE
feat(dynamodb): support Local Secondary Index (LSI)

### DIFF
--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -446,6 +446,8 @@ func (s *Service) Scan(w http.ResponseWriter, r *http.Request) {
 }
 
 // tableToDescription converts a Table to TableDescription.
+//
+//nolint:funlen // Struct initialization with GSI/LSI conversion requires many statements.
 func tableToDescription(table *Table) TableDescription {
 	desc := TableDescription{
 		TableName:                 table.Name,
@@ -492,6 +494,19 @@ func tableToDescription(table *Table) TableDescription {
 		}
 
 		desc.GlobalSecondaryIndexes = append(desc.GlobalSecondaryIndexes, gsiDesc)
+	}
+
+	for _, lsi := range table.LocalSecondaryIndexes {
+		lsiDesc := LocalSecondaryIndexDescription{
+			IndexName:      lsi.IndexName,
+			KeySchema:      lsi.KeySchema,
+			Projection:     lsi.Projection,
+			IndexArn:       fmt.Sprintf("%s/index/%s", table.TableARN, lsi.IndexName),
+			ItemCount:      table.ItemCount,
+			IndexSizeBytes: table.TableSizeBytes,
+		}
+
+		desc.LocalSecondaryIndexes = append(desc.LocalSecondaryIndexes, lsiDesc)
 	}
 
 	return desc

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -156,6 +156,7 @@ func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) 
 		AttributeDefinitions:   req.AttributeDefinitions,
 		ProvisionedThroughput:  req.ProvisionedThroughput,
 		GlobalSecondaryIndexes: req.GlobalSecondaryIndexes,
+		LocalSecondaryIndexes:  req.LocalSecondaryIndexes,
 		CreationDateTime:       time.Now(),
 		TableStatus:            "ACTIVE",
 		ItemCount:              0,
@@ -438,6 +439,32 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 	}
 }
 
+// resolveKeySchema returns the key schema for the given index name.
+// If indexName is empty, the table's key schema is returned.
+// It searches both GSIs and LSIs.
+func resolveKeySchema(table *Table, indexName string) ([]KeySchemaElement, error) {
+	if indexName == "" {
+		return table.KeySchema, nil
+	}
+
+	for _, gsi := range table.GlobalSecondaryIndexes {
+		if gsi.IndexName == indexName {
+			return gsi.KeySchema, nil
+		}
+	}
+
+	for _, lsi := range table.LocalSecondaryIndexes {
+		if lsi.IndexName == indexName {
+			return lsi.KeySchema, nil
+		}
+	}
+
+	return nil, &TableError{
+		Code:    "ValidationException",
+		Message: fmt.Sprintf("The table does not have the specified index: %s", indexName),
+	}
+}
+
 // Query queries items from a table.
 //
 //nolint:cyclop,funlen,gocognit // Query has inherent complexity from DynamoDB protocol requirements.
@@ -453,27 +480,10 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 		}
 	}
 
-	// Determine key schema to use (table or GSI).
-	keySchema := td.Table.KeySchema
-
-	if indexName != "" {
-		found := false
-
-		for _, gsi := range td.Table.GlobalSecondaryIndexes {
-			if gsi.IndexName == indexName {
-				keySchema = gsi.KeySchema
-				found = true
-
-				break
-			}
-		}
-
-		if !found {
-			return nil, nil, 0, &TableError{
-				Code:    "ValidationException",
-				Message: fmt.Sprintf("The table does not have the specified index: %s", indexName),
-			}
-		}
+	// Determine key schema to use (table, GSI, or LSI).
+	keySchema, err := resolveKeySchema(td.Table, indexName)
+	if err != nil {
+		return nil, nil, 0, err
 	}
 
 	// Get partition key attribute name from the resolved key schema.

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -74,6 +74,23 @@ type GlobalSecondaryIndex struct {
 	ProvisionedThroughput *ProvisionedThroughput `json:"ProvisionedThroughput,omitempty"`
 }
 
+// LocalSecondaryIndex represents an LSI definition in CreateTable requests.
+type LocalSecondaryIndex struct {
+	IndexName  string             `json:"IndexName"`
+	KeySchema  []KeySchemaElement `json:"KeySchema"`
+	Projection Projection         `json:"Projection"`
+}
+
+// LocalSecondaryIndexDescription represents an LSI in DescribeTable responses.
+type LocalSecondaryIndexDescription struct {
+	IndexName      string             `json:"IndexName"`
+	KeySchema      []KeySchemaElement `json:"KeySchema"`
+	Projection     Projection         `json:"Projection"`
+	IndexArn       string             `json:"IndexArn"`
+	ItemCount      int64              `json:"ItemCount"`
+	IndexSizeBytes int64              `json:"IndexSizeBytes"`
+}
+
 // GlobalSecondaryIndexDescription represents a GSI in DescribeTable responses.
 type GlobalSecondaryIndexDescription struct {
 	IndexName             string                            `json:"IndexName"`
@@ -93,6 +110,7 @@ type Table struct {
 	AttributeDefinitions   []AttributeDefinition
 	ProvisionedThroughput  *ProvisionedThroughput
 	GlobalSecondaryIndexes []GlobalSecondaryIndex
+	LocalSecondaryIndexes  []LocalSecondaryIndex
 	CreationDateTime       time.Time
 	TableStatus            string
 	ItemCount              int64
@@ -115,6 +133,7 @@ type TableDescription struct {
 	AttributeDefinitions      []AttributeDefinition             `json:"AttributeDefinitions"`
 	ProvisionedThroughput     *ProvisionedThroughputDescription `json:"ProvisionedThroughput,omitempty"`
 	GlobalSecondaryIndexes    []GlobalSecondaryIndexDescription `json:"GlobalSecondaryIndexes,omitempty"`
+	LocalSecondaryIndexes     []LocalSecondaryIndexDescription  `json:"LocalSecondaryIndexes,omitempty"`
 	ItemCount                 int64                             `json:"ItemCount"`
 	TableSizeBytes            int64                             `json:"TableSizeBytes"`
 	BillingModeSummary        *BillingModeSummary               `json:"BillingModeSummary,omitempty"`
@@ -139,6 +158,7 @@ type CreateTableRequest struct {
 	AttributeDefinitions      []AttributeDefinition  `json:"AttributeDefinitions"`
 	ProvisionedThroughput     *ProvisionedThroughput `json:"ProvisionedThroughput,omitempty"`
 	GlobalSecondaryIndexes    []GlobalSecondaryIndex `json:"GlobalSecondaryIndexes,omitempty"`
+	LocalSecondaryIndexes     []LocalSecondaryIndex  `json:"LocalSecondaryIndexes,omitempty"`
 	BillingMode               string                 `json:"BillingMode,omitempty"`
 	DeletionProtectionEnabled bool                   `json:"DeletionProtectionEnabled,omitempty"`
 }


### PR DESCRIPTION
## Summary
- CreateTable accepts LocalSecondaryIndexes parameter
- Query can target an LSI via IndexName
- DescribeTable returns LSI information in response

Closes #456