### PR TITLE
feat(eventbridge): support API Destinations with actual HTTP delivery

### DIFF
--- a/internal/service/eventbridge/handlers.go
+++ b/internal/service/eventbridge/handlers.go
@@ -15,18 +15,24 @@ type handlerFunc func(http.ResponseWriter, *http.Request)
 // getActionHandlers returns a map of action names to handler functions.
 func (s *Service) getActionHandlers() map[string]handlerFunc {
 	return map[string]handlerFunc{
-		"CreateEventBus":    s.CreateEventBus,
-		"DeleteEventBus":    s.DeleteEventBus,
-		"DescribeEventBus":  s.DescribeEventBus,
-		"ListEventBuses":    s.ListEventBuses,
-		"PutRule":           s.PutRule,
-		"DeleteRule":        s.DeleteRule,
-		"DescribeRule":      s.DescribeRule,
-		"ListRules":         s.ListRules,
-		"PutTargets":        s.PutTargets,
-		"RemoveTargets":     s.RemoveTargets,
-		"ListTargetsByRule": s.ListTargetsByRule,
-		"PutEvents":         s.PutEvents,
+		"CreateEventBus":         s.CreateEventBus,
+		"DeleteEventBus":         s.DeleteEventBus,
+		"DescribeEventBus":       s.DescribeEventBus,
+		"ListEventBuses":         s.ListEventBuses,
+		"PutRule":                s.PutRule,
+		"DeleteRule":             s.DeleteRule,
+		"DescribeRule":           s.DescribeRule,
+		"ListRules":              s.ListRules,
+		"PutTargets":             s.PutTargets,
+		"RemoveTargets":          s.RemoveTargets,
+		"ListTargetsByRule":      s.ListTargetsByRule,
+		"PutEvents":              s.PutEvents,
+		"CreateConnection":       s.CreateConnection,
+		"DescribeConnection":     s.DescribeConnection,
+		"DeleteConnection":       s.DeleteConnection,
+		"CreateApiDestination":   s.CreateAPIDestination,
+		"DescribeApiDestination": s.DescribeAPIDestination,
+		"DeleteApiDestination":   s.DeleteAPIDestination,
 	}
 }
 
@@ -324,11 +330,12 @@ func (s *Service) ListTargetsByRule(w http.ResponseWriter, r *http.Request) {
 
 	for i, target := range targets {
 		outputs[i] = TargetOutput{
-			ID:        target.ID,
-			Arn:       target.Arn,
-			RoleArn:   target.RoleArn,
-			Input:     target.Input,
-			InputPath: target.InputPath,
+			ID:             target.ID,
+			Arn:            target.Arn,
+			RoleArn:        target.RoleArn,
+			Input:          target.Input,
+			InputPath:      target.InputPath,
+			HTTPParameters: target.HTTPParameters,
 		}
 	}
 
@@ -370,6 +377,150 @@ func (s *Service) PutEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeResponse(w, resp)
+}
+
+// CreateConnection handles the CreateConnection API.
+func (s *Service) CreateConnection(w http.ResponseWriter, r *http.Request) {
+	var req CreateConnectionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	conn, err := s.storage.CreateConnection(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &CreateConnectionResponse{
+		ConnectionArn:    conn.Arn,
+		ConnectionState:  conn.ConnectionState,
+		CreationTime:     float64(conn.CreationTime.Unix()),
+		LastModifiedTime: float64(conn.LastModifiedTime.Unix()),
+	})
+}
+
+// DescribeConnection handles the DescribeConnection API.
+func (s *Service) DescribeConnection(w http.ResponseWriter, r *http.Request) {
+	var req DescribeConnectionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	conn, err := s.storage.DescribeConnection(r.Context(), req.Name)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DescribeConnectionResponse{
+		Name:               conn.Name,
+		ConnectionArn:      conn.Arn,
+		ConnectionState:    conn.ConnectionState,
+		AuthorizationType:  conn.AuthorizationType,
+		CreationTime:       float64(conn.CreationTime.Unix()),
+		LastModifiedTime:   float64(conn.LastModifiedTime.Unix()),
+		LastAuthorizedTime: float64(conn.LastAuthorizedTime.Unix()),
+	})
+}
+
+// DeleteConnection handles the DeleteConnection API.
+func (s *Service) DeleteConnection(w http.ResponseWriter, r *http.Request) {
+	var req DeleteConnectionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	conn, err := s.storage.DeleteConnection(r.Context(), req.Name)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DeleteConnectionResponse{
+		ConnectionArn:   conn.Arn,
+		ConnectionState: "DELETING",
+	})
+}
+
+// CreateAPIDestination handles the CreateApiDestination API.
+func (s *Service) CreateAPIDestination(w http.ResponseWriter, r *http.Request) {
+	var req CreateAPIDestinationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	dest, err := s.storage.CreateAPIDestination(r.Context(), &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &CreateAPIDestinationResponse{
+		APIDestinationArn:   dest.Arn,
+		APIDestinationState: dest.APIDestinationState,
+		CreationTime:        float64(dest.CreationTime.Unix()),
+		LastModifiedTime:    float64(dest.LastModifiedTime.Unix()),
+	})
+}
+
+// DescribeAPIDestination handles the DescribeApiDestination API.
+func (s *Service) DescribeAPIDestination(w http.ResponseWriter, r *http.Request) {
+	var req DescribeAPIDestinationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	dest, err := s.storage.DescribeAPIDestination(r.Context(), req.Name)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DescribeAPIDestinationResponse{
+		Name:                         dest.Name,
+		APIDestinationArn:            dest.Arn,
+		ConnectionArn:                dest.ConnectionArn,
+		InvocationEndpoint:           dest.InvocationEndpoint,
+		HTTPMethod:                   dest.HTTPMethod,
+		InvocationRateLimitPerSecond: dest.InvocationRateLimitPerSecond,
+		APIDestinationState:          dest.APIDestinationState,
+		CreationTime:                 float64(dest.CreationTime.Unix()),
+		LastModifiedTime:             float64(dest.LastModifiedTime.Unix()),
+	})
+}
+
+// DeleteAPIDestination handles the DeleteApiDestination API.
+func (s *Service) DeleteAPIDestination(w http.ResponseWriter, r *http.Request) {
+	var req DeleteAPIDestinationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteAPIDestination(r.Context(), req.Name); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DeleteAPIDestinationResponse{})
 }
 
 // GetDeliveredEvents returns events that were matched against rules and delivered to targets.

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -1,9 +1,13 @@
 package eventbridge
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -47,6 +51,16 @@ type Storage interface {
 	PutEvents(ctx context.Context, entries []PutEventsRequestEntry) ([]PutEventsResultEntry, error)
 	GetDeliveredEvents(ctx context.Context) []DeliveredEvent
 
+	// Connection operations.
+	CreateConnection(ctx context.Context, req *CreateConnectionRequest) (*Connection, error)
+	DescribeConnection(ctx context.Context, name string) (*Connection, error)
+	DeleteConnection(ctx context.Context, name string) (*Connection, error)
+
+	// API Destination operations.
+	CreateAPIDestination(ctx context.Context, req *CreateAPIDestinationRequest) (*APIDestination, error)
+	DescribeAPIDestination(ctx context.Context, name string) (*APIDestination, error)
+	DeleteAPIDestination(ctx context.Context, name string) error
+
 	// DispatchAction dispatches the request to the appropriate handler.
 	DispatchAction(action string) bool
 }
@@ -73,20 +87,26 @@ type MemoryStorage struct {
 	EventBuses      map[string]*EventBus            `json:"eventBuses"`
 	Rules           map[string]map[string]*Rule     `json:"rules"`
 	Targets         map[string]map[string][]*Target `json:"targets"`
+	Connections     map[string]*Connection          `json:"connections"`
+	APIDestinations map[string]*APIDestination      `json:"apiDestinations"`
 	DeliveredEvents []DeliveredEvent                `json:"deliveredEvents"`
 	region          string
 	accountID       string
 	dataDir         string
+	logger          *slog.Logger
 }
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	s := &MemoryStorage{
-		EventBuses: make(map[string]*EventBus),
-		Rules:      make(map[string]map[string]*Rule),
-		Targets:    make(map[string]map[string][]*Target),
-		region:     "us-east-1",
-		accountID:  "000000000000",
+		EventBuses:      make(map[string]*EventBus),
+		Rules:           make(map[string]map[string]*Rule),
+		Targets:         make(map[string]map[string][]*Target),
+		Connections:     make(map[string]*Connection),
+		APIDestinations: make(map[string]*APIDestination),
+		region:          "us-east-1",
+		accountID:       "000000000000",
+		logger:          slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 	for _, o := range opts {
 		o(s)
@@ -411,11 +431,12 @@ func (s *MemoryStorage) PutTargets(_ context.Context, eventBusName, ruleName str
 
 	for _, t := range targets {
 		target := &Target{
-			ID:        t.ID,
-			Arn:       t.Arn,
-			RoleArn:   t.RoleArn,
-			Input:     t.Input,
-			InputPath: t.InputPath,
+			ID:             t.ID,
+			Arn:            t.Arn,
+			RoleArn:        t.RoleArn,
+			Input:          t.Input,
+			InputPath:      t.InputPath,
+			HTTPParameters: t.HTTPParameters,
 		}
 
 		// Find and update existing target or add new one.
@@ -526,7 +547,7 @@ func (s *MemoryStorage) PutEvents(_ context.Context, entries []PutEventsRequestE
 	return results, nil
 }
 
-// matchAndDeliver matches an event against rules and records deliveries. Must be called under lock.
+// matchAndDeliver matches an event against rules, records deliveries, and performs HTTP delivery for API destinations. Must be called under lock.
 func (s *MemoryStorage) matchAndDeliver(eventID, eventBusName string, entry *PutEventsRequestEntry) {
 	rules, exists := s.Rules[eventBusName]
 	if !exists {
@@ -562,7 +583,90 @@ func (s *MemoryStorage) matchAndDeliver(eventID, eventBusName string, entry *Put
 				TargetArn:    target.Arn,
 				Time:         eventTime,
 			})
+
+			// Deliver to API Destination via HTTP if the target ARN is an API destination.
+			if dest := s.resolveAPIDestination(target.Arn); dest != nil {
+				go s.deliverToHTTP(dest, target, entry)
+			}
 		}
+	}
+}
+
+// deliverToHTTP sends an event to an API Destination's HTTP endpoint.
+func (s *MemoryStorage) deliverToHTTP(dest *APIDestination, target *Target, entry *PutEventsRequestEntry) {
+	endpoint := dest.InvocationEndpoint
+	method := dest.HTTPMethod
+
+	if method == "" {
+		method = http.MethodPost
+	}
+
+	// Build the event payload.
+	payload := map[string]any{
+		"version":     "0",
+		"id":          uuid.New().String(),
+		"source":      entry.Source,
+		"detail-type": entry.DetailType,
+		"detail":      json.RawMessage(entry.Detail),
+		"region":      s.region,
+		"account":     s.accountID,
+		"time":        time.Now().Format(time.RFC3339),
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		s.logger.Error("failed to marshal event for HTTP delivery", "error", err)
+
+		return
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, endpoint, bytes.NewReader(body))
+	if err != nil {
+		s.logger.Error("failed to create HTTP request for API destination", "error", err, "endpoint", endpoint)
+
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Amazon/EventBridge/ApiDestinations")
+	applyHTTPParameters(req, target.HTTPParameters)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		s.logger.Error("failed to deliver event to API destination", "error", err, "endpoint", endpoint)
+
+		return
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	s.logger.Info("delivered event to API destination",
+		"endpoint", endpoint,
+		"status", resp.StatusCode,
+		"source", entry.Source,
+		"detail_type", entry.DetailType,
+	)
+}
+
+// applyHTTPParameters applies HTTP parameters from a target to an HTTP request.
+func applyHTTPParameters(req *http.Request, params *HTTPParameters) {
+	if params == nil {
+		return
+	}
+
+	for k, v := range params.HeaderParameters {
+		req.Header.Set(k, v)
+	}
+
+	if len(params.QueryStringParameters) > 0 {
+		q := req.URL.Query()
+		for k, v := range params.QueryStringParameters {
+			q.Set(k, v)
+		}
+
+		req.URL.RawQuery = q.Encode()
 	}
 }
 
@@ -575,6 +679,130 @@ func (s *MemoryStorage) GetDeliveredEvents(_ context.Context) []DeliveredEvent {
 	copy(result, s.DeliveredEvents)
 
 	return result
+}
+
+// CreateConnection creates a new connection.
+func (s *MemoryStorage) CreateConnection(_ context.Context, req *CreateConnectionRequest) (*Connection, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.Connections[req.Name]; exists {
+		return nil, &ServiceError{Code: errEventBusAlreadyExists, Message: "Connection already exists"}
+	}
+
+	now := time.Now()
+	conn := &Connection{
+		Name:               req.Name,
+		Arn:                fmt.Sprintf("arn:aws:events:%s:%s:connection/%s", s.region, s.accountID, req.Name),
+		ConnectionState:    "AUTHORIZED",
+		AuthorizationType:  req.AuthorizationType,
+		AuthParameters:     req.AuthParameters,
+		CreationTime:       now,
+		LastModifiedTime:   now,
+		LastAuthorizedTime: now,
+	}
+
+	s.Connections[req.Name] = conn
+
+	return conn, nil
+}
+
+// DescribeConnection describes a connection.
+func (s *MemoryStorage) DescribeConnection(_ context.Context, name string) (*Connection, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	conn, exists := s.Connections[name]
+	if !exists {
+		return nil, &ServiceError{Code: errEventBusNotFound, Message: "Connection not found"}
+	}
+
+	return conn, nil
+}
+
+// DeleteConnection deletes a connection.
+func (s *MemoryStorage) DeleteConnection(_ context.Context, name string) (*Connection, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	conn, exists := s.Connections[name]
+	if !exists {
+		return nil, &ServiceError{Code: errEventBusNotFound, Message: "Connection not found"}
+	}
+
+	delete(s.Connections, name)
+
+	return conn, nil
+}
+
+// CreateAPIDestination creates a new API destination.
+func (s *MemoryStorage) CreateAPIDestination(_ context.Context, req *CreateAPIDestinationRequest) (*APIDestination, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.APIDestinations[req.Name]; exists {
+		return nil, &ServiceError{Code: errEventBusAlreadyExists, Message: "API destination already exists"}
+	}
+
+	rateLimit := req.InvocationRateLimitPerSecond
+	if rateLimit == 0 {
+		rateLimit = 300
+	}
+
+	now := time.Now()
+	dest := &APIDestination{
+		Name:                         req.Name,
+		Arn:                          fmt.Sprintf("arn:aws:events:%s:%s:api-destination/%s", s.region, s.accountID, req.Name),
+		ConnectionArn:                req.ConnectionArn,
+		InvocationEndpoint:           req.InvocationEndpoint,
+		HTTPMethod:                   req.HTTPMethod,
+		InvocationRateLimitPerSecond: rateLimit,
+		APIDestinationState:          "ACTIVE",
+		CreationTime:                 now,
+		LastModifiedTime:             now,
+	}
+
+	s.APIDestinations[req.Name] = dest
+
+	return dest, nil
+}
+
+// DescribeAPIDestination describes an API destination.
+func (s *MemoryStorage) DescribeAPIDestination(_ context.Context, name string) (*APIDestination, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dest, exists := s.APIDestinations[name]
+	if !exists {
+		return nil, &ServiceError{Code: errEventBusNotFound, Message: "API destination not found"}
+	}
+
+	return dest, nil
+}
+
+// DeleteAPIDestination deletes an API destination.
+func (s *MemoryStorage) DeleteAPIDestination(_ context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.APIDestinations[name]; !exists {
+		return &ServiceError{Code: errEventBusNotFound, Message: "API destination not found"}
+	}
+
+	delete(s.APIDestinations, name)
+
+	return nil
+}
+
+// resolveAPIDestination finds the API destination and its endpoint from a target ARN.
+func (s *MemoryStorage) resolveAPIDestination(targetArn string) *APIDestination {
+	for _, dest := range s.APIDestinations {
+		if dest.Arn == targetArn {
+			return dest
+		}
+	}
+
+	return nil
 }
 
 // DispatchAction checks if the action is valid.

--- a/internal/service/eventbridge/types.go
+++ b/internal/service/eventbridge/types.go
@@ -48,11 +48,12 @@ type Rule struct {
 
 // Target represents a rule target.
 type Target struct {
-	ID        string `json:"id"`
-	Arn       string `json:"arn"`
-	RoleArn   string `json:"roleArn,omitempty"`
-	Input     string `json:"input,omitempty"`
-	InputPath string `json:"inputPath,omitempty"`
+	ID             string          `json:"id"`
+	Arn            string          `json:"arn"`
+	RoleArn        string          `json:"roleArn,omitempty"`
+	Input          string          `json:"input,omitempty"`
+	InputPath      string          `json:"inputPath,omitempty"`
+	HTTPParameters *HTTPParameters `json:"httpParameters,omitempty"`
 }
 
 // PutEventsRequestEntry represents an entry in PutEvents request.
@@ -196,11 +197,12 @@ type ListRulesResponse struct {
 
 // TargetInput represents a target in API requests.
 type TargetInput struct {
-	ID        string `json:"Id"`
-	Arn       string `json:"Arn"`
-	RoleArn   string `json:"RoleArn,omitempty"`
-	Input     string `json:"Input,omitempty"`
-	InputPath string `json:"InputPath,omitempty"`
+	ID             string          `json:"Id"`
+	Arn            string          `json:"Arn"`
+	RoleArn        string          `json:"RoleArn,omitempty"`
+	Input          string          `json:"Input,omitempty"`
+	InputPath      string          `json:"InputPath,omitempty"`
+	HTTPParameters *HTTPParameters `json:"HttpParameters,omitempty"`
 }
 
 // PutTargetsRequest is the request for PutTargets.
@@ -265,11 +267,12 @@ type ListTargetsByRuleRequest struct {
 
 // TargetOutput represents a target in API responses.
 type TargetOutput struct {
-	ID        string `json:"Id,omitempty"`
-	Arn       string `json:"Arn,omitempty"`
-	RoleArn   string `json:"RoleArn,omitempty"`
-	Input     string `json:"Input,omitempty"`
-	InputPath string `json:"InputPath,omitempty"`
+	ID             string          `json:"Id,omitempty"`
+	Arn            string          `json:"Arn,omitempty"`
+	RoleArn        string          `json:"RoleArn,omitempty"`
+	Input          string          `json:"Input,omitempty"`
+	InputPath      string          `json:"InputPath,omitempty"`
+	HTTPParameters *HTTPParameters `json:"HttpParameters,omitempty"`
 }
 
 // ListTargetsByRuleResponse is the response for ListTargetsByRule.
@@ -295,6 +298,172 @@ type DeliveredEvent struct {
 	TargetID     string `json:"TargetId"`
 	TargetArn    string `json:"TargetArn"`
 	Time         string `json:"Time,omitempty"`
+}
+
+// Connection represents an EventBridge connection.
+type Connection struct {
+	Name               string         `json:"name"`
+	Arn                string         `json:"arn"`
+	ConnectionState    string         `json:"connectionState"`
+	AuthorizationType  string         `json:"authorizationType"`
+	AuthParameters     AuthParameters `json:"authParameters,omitempty"`
+	CreationTime       time.Time      `json:"creationTime"`
+	LastModifiedTime   time.Time      `json:"lastModifiedTime"`
+	LastAuthorizedTime time.Time      `json:"lastAuthorizedTime"`
+}
+
+// AuthParameters represents connection auth parameters.
+type AuthParameters struct {
+	APIKeyAuthParameters     *APIKeyAuthParameters     `json:"ApiKeyAuthParameters,omitempty"`
+	BasicAuthParameters      *BasicAuthParameters      `json:"BasicAuthParameters,omitempty"`
+	OAuthParameters          *OAuthParameters          `json:"OAuthParameters,omitempty"`
+	InvocationHTTPParameters *InvocationHTTPParameters `json:"InvocationHttpParameters,omitempty"`
+}
+
+// APIKeyAuthParameters represents API key auth parameters.
+type APIKeyAuthParameters struct {
+	APIKeyName  string `json:"ApiKeyName"`
+	APIKeyValue string `json:"ApiKeyValue"`
+}
+
+// BasicAuthParameters represents basic auth parameters.
+type BasicAuthParameters struct {
+	Username string `json:"Username"`
+	Password string `json:"Password"`
+}
+
+// OAuthParameters represents OAuth auth parameters.
+type OAuthParameters struct {
+	AuthorizationEndpoint string                 `json:"AuthorizationEndpoint"`
+	HTTPMethod            string                 `json:"HttpMethod"`
+	ClientParameters      *OAuthClientParameters `json:"ClientParameters,omitempty"`
+}
+
+// OAuthClientParameters represents OAuth client parameters.
+type OAuthClientParameters struct {
+	ClientID     string `json:"ClientID"`
+	ClientSecret string `json:"ClientSecret"`
+}
+
+// InvocationHTTPParameters represents HTTP parameters for invocation.
+type InvocationHTTPParameters struct {
+	HeaderParameters      []ConnectionHTTPParameter `json:"HeaderParameters,omitempty"`
+	QueryStringParameters []ConnectionHTTPParameter `json:"QueryStringParameters,omitempty"`
+	BodyParameters        []ConnectionHTTPParameter `json:"BodyParameters,omitempty"`
+}
+
+// ConnectionHTTPParameter represents an HTTP parameter.
+type ConnectionHTTPParameter struct {
+	Key      string `json:"Key"`
+	Value    string `json:"Value"`
+	IsSecret bool   `json:"IsValueSecret"`
+}
+
+// CreateConnectionRequest is the request for CreateConnection.
+type CreateConnectionRequest struct {
+	Name              string         `json:"Name"`
+	AuthorizationType string         `json:"AuthorizationType"`
+	AuthParameters    AuthParameters `json:"AuthParameters"`
+	Description       string         `json:"Description,omitempty"`
+}
+
+// CreateConnectionResponse is the response for CreateConnection.
+type CreateConnectionResponse struct {
+	ConnectionArn    string  `json:"ConnectionArn"`
+	ConnectionState  string  `json:"ConnectionState"`
+	CreationTime     float64 `json:"CreationTime"`
+	LastModifiedTime float64 `json:"LastModifiedTime"`
+}
+
+// DescribeConnectionRequest is the request for DescribeConnection.
+type DescribeConnectionRequest struct {
+	Name string `json:"Name"`
+}
+
+// DescribeConnectionResponse is the response for DescribeConnection.
+type DescribeConnectionResponse struct {
+	Name               string  `json:"Name"`
+	ConnectionArn      string  `json:"ConnectionArn"`
+	ConnectionState    string  `json:"ConnectionState"`
+	AuthorizationType  string  `json:"AuthorizationType"`
+	CreationTime       float64 `json:"CreationTime"`
+	LastModifiedTime   float64 `json:"LastModifiedTime"`
+	LastAuthorizedTime float64 `json:"LastAuthorizedTime"`
+}
+
+// DeleteConnectionRequest is the request for DeleteConnection.
+type DeleteConnectionRequest struct {
+	Name string `json:"Name"`
+}
+
+// DeleteConnectionResponse is the response for DeleteConnection.
+type DeleteConnectionResponse struct {
+	ConnectionArn   string `json:"ConnectionArn"`
+	ConnectionState string `json:"ConnectionState"`
+}
+
+// APIDestination represents an EventBridge API destination.
+type APIDestination struct {
+	Name                         string    `json:"name"`
+	Arn                          string    `json:"arn"`
+	ConnectionArn                string    `json:"connectionArn"`
+	InvocationEndpoint           string    `json:"invocationEndpoint"`
+	HTTPMethod                   string    `json:"httpMethod"`
+	InvocationRateLimitPerSecond int32     `json:"invocationRateLimitPerSecond"`
+	APIDestinationState          string    `json:"apiDestinationState"`
+	CreationTime                 time.Time `json:"creationTime"`
+	LastModifiedTime             time.Time `json:"lastModifiedTime"`
+}
+
+// CreateAPIDestinationRequest is the request for CreateApiDestination.
+type CreateAPIDestinationRequest struct {
+	Name                         string `json:"Name"`
+	ConnectionArn                string `json:"ConnectionArn"`
+	InvocationEndpoint           string `json:"InvocationEndpoint"`
+	HTTPMethod                   string `json:"HttpMethod"`
+	InvocationRateLimitPerSecond int32  `json:"InvocationRateLimitPerSecond,omitempty"`
+	Description                  string `json:"Description,omitempty"`
+}
+
+// CreateAPIDestinationResponse is the response for CreateApiDestination.
+type CreateAPIDestinationResponse struct {
+	APIDestinationArn   string  `json:"ApiDestinationArn"`
+	APIDestinationState string  `json:"ApiDestinationState"`
+	CreationTime        float64 `json:"CreationTime"`
+	LastModifiedTime    float64 `json:"LastModifiedTime"`
+}
+
+// DescribeAPIDestinationRequest is the request for DescribeApiDestination.
+type DescribeAPIDestinationRequest struct {
+	Name string `json:"Name"`
+}
+
+// DescribeAPIDestinationResponse is the response for DescribeApiDestination.
+type DescribeAPIDestinationResponse struct {
+	Name                         string  `json:"Name"`
+	APIDestinationArn            string  `json:"ApiDestinationArn"`
+	ConnectionArn                string  `json:"ConnectionArn"`
+	InvocationEndpoint           string  `json:"InvocationEndpoint"`
+	HTTPMethod                   string  `json:"HttpMethod"`
+	InvocationRateLimitPerSecond int32   `json:"InvocationRateLimitPerSecond"`
+	APIDestinationState          string  `json:"ApiDestinationState"`
+	CreationTime                 float64 `json:"CreationTime"`
+	LastModifiedTime             float64 `json:"LastModifiedTime"`
+}
+
+// DeleteAPIDestinationRequest is the request for DeleteApiDestination.
+type DeleteAPIDestinationRequest struct {
+	Name string `json:"Name"`
+}
+
+// DeleteAPIDestinationResponse is the response for DeleteApiDestination.
+type DeleteAPIDestinationResponse struct{}
+
+// HTTPParameters represents HTTP parameters in a target.
+type HTTPParameters struct {
+	PathParameterValues   []string          `json:"PathParameterValues,omitempty"`
+	HeaderParameters      map[string]string `json:"HeaderParameters,omitempty"`
+	QueryStringParameters map[string]string `json:"QueryStringParameters,omitempty"`
 }
 
 // ServiceError represents a service-level error.


### PR DESCRIPTION
## Summary
- Add CreateConnection, DescribeConnection, DeleteConnection APIs
- Add CreateApiDestination, DescribeApiDestination, DeleteApiDestination APIs
- PutEvents now delivers events to API Destination HTTP endpoints when matched
- HttpParameters (headers, query strings) are applied to requests

Closes #458