### PR TITLE
feat(s3): stub support for PutBucketNotificationConfiguration and PutBucketCors

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -798,6 +798,24 @@ func (s *Service) handleBucketPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, ok := r.URL.Query()["notification"]; ok {
+		// Stub: accept notification configuration without error.
+		_, _ = io.Copy(io.Discard, r.Body)
+
+		w.WriteHeader(http.StatusOK)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["cors"]; ok {
+		// Stub: accept CORS configuration without error.
+		_, _ = io.Copy(io.Discard, r.Body)
+
+		w.WriteHeader(http.StatusOK)
+
+		return
+	}
+
 	s.CreateBucket(w, r)
 }
 


### PR DESCRIPTION
## Summary
- Accept PutBucketNotificationConfiguration requests without error (no-op stub)
- Accept PutBucketCors requests without error (no-op stub)
- Prevents init scripts from failing when configuring bucket notifications and CORS

Closes #460