### PR TITLE
fix(cognito): generate valid UserPoolId format

### DIFF
--- a/internal/service/cognito/handlers.go
+++ b/internal/service/cognito/handlers.go
@@ -588,7 +588,7 @@ func extractRegion(r *http.Request) (string, error) {
 		credVal = credVal[:commaIdx]
 	}
 
-	// Credential=AKID/DATE/REGION/SERVICE/aws4_request
+	// Format: AKID/DATE/REGION/SERVICE/aws4_request
 	parts := strings.Split(credVal, "/")
 	if len(parts) < 3 {
 		return "", errors.New("invalid Credential format in Authorization header")

--- a/internal/service/cognito/handlers.go
+++ b/internal/service/cognito/handlers.go
@@ -58,6 +58,15 @@ func (s *Service) CreateUserPool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	region, err := extractRegion(r)
+	if err != nil {
+		writeError(w, "ValidationException", err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	req.Region = region
+
 	pool, err := s.storage.CreateUserPool(r.Context(), &req)
 	if err != nil {
 		handleError(w, err)
@@ -562,4 +571,28 @@ func getErrorStatus(code string) int {
 	default:
 		return http.StatusBadRequest
 	}
+}
+
+// extractRegion extracts the AWS region from the Authorization header.
+// The header format is: AWS4-HMAC-SHA256 Credential=AKID/DATE/REGION/SERVICE/aws4_request, ...
+func extractRegion(r *http.Request) (string, error) {
+	auth := r.Header.Get("Authorization")
+
+	credIdx := strings.Index(auth, "Credential=")
+	if credIdx == -1 {
+		return "", errors.New("missing Credential in Authorization header")
+	}
+
+	credVal := auth[credIdx+len("Credential="):]
+	if commaIdx := strings.Index(credVal, ","); commaIdx != -1 {
+		credVal = credVal[:commaIdx]
+	}
+
+	// Credential=AKID/DATE/REGION/SERVICE/aws4_request
+	parts := strings.Split(credVal, "/")
+	if len(parts) < 3 {
+		return "", errors.New("invalid Credential format in Authorization header")
+	}
+
+	return parts[2], nil
 }

--- a/internal/service/cognito/storage.go
+++ b/internal/service/cognito/storage.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,8 +23,6 @@ const (
 	errUsernameExists         = "UsernameExistsException"
 	errNotAuthorized          = "NotAuthorizedException"
 	errInvalidParameter       = "InvalidParameterException"
-
-	defaultRegion = "us-east-1"
 )
 
 // Storage defines the Cognito storage interface.
@@ -166,7 +165,8 @@ func (s *MemoryStorage) CreateUserPool(_ context.Context, req *CreateUserPoolReq
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	poolID := fmt.Sprintf("%s_%s", defaultRegion, uuid.New().String()[:9])
+	id := strings.ReplaceAll(uuid.New().String(), "-", "")[:9]
+	poolID := fmt.Sprintf("%s_%s", req.Region, id)
 	now := time.Now()
 
 	pool := &UserPool{

--- a/internal/service/cognito/types.go
+++ b/internal/service/cognito/types.go
@@ -155,6 +155,7 @@ type CreateUserPoolRequest struct {
 	UsernameAttributes     []string                 `json:"UsernameAttributes,omitempty"`
 	MfaConfiguration       string                   `json:"MfaConfiguration,omitempty"`
 	EmailConfiguration     *EmailConfigurationInput `json:"EmailConfiguration,omitempty"`
+	Region                 string                   `json:"-"`
 }
 
 // UserPoolPoliciesInput represents user pool policies in requests.


### PR DESCRIPTION
## Summary
- Remove hyphens from UUID before slicing to avoid trailing `-` that violates AWS UserPoolId regex `/^[\w-]+_[0-9a-zA-Z]+$/`
- Extract region from Authorization header instead of hardcoding `us-east-1`, returning an error if the header is missing

## Test plan
- [ ] Verify generated UserPoolId matches `/^[\w-]+_[0-9a-zA-Z]+$/`
- [ ] Verify region in UserPoolId reflects the client's configured region

Closes #470