### PR TITLE
feat(eventbridge): deliver events to SQS targets and apply InputPath

### DIFF
--- a/internal/service/eventbridge/service.go
+++ b/internal/service/eventbridge/service.go
@@ -45,6 +45,7 @@ func (s *Service) RegisterRoutes(r service.Router) {
 
 func init() {
 	baseURL := defaultBaseURL
+
 	if host := os.Getenv("KUMO_HOST"); host != "" {
 		port := os.Getenv("KUMO_PORT")
 		if port == "" {

--- a/internal/service/eventbridge/service.go
+++ b/internal/service/eventbridge/service.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sivchari/kumo/internal/service"
 )
 
+const defaultBaseURL = "http://localhost:4566"
+
 // Compile-time check that Service implements io.Closer.
 var _ io.Closer = (*Service)(nil)
 
@@ -42,7 +44,22 @@ func (s *Service) RegisterRoutes(r service.Router) {
 }
 
 func init() {
+	baseURL := defaultBaseURL
+	if host := os.Getenv("KUMO_HOST"); host != "" {
+		port := os.Getenv("KUMO_PORT")
+		if port == "" {
+			port = "4566"
+		}
+
+		baseURL = fmt.Sprintf("http://%s:%s", host, port)
+	} else if port := os.Getenv("KUMO_PORT"); port != "" {
+		baseURL = fmt.Sprintf("http://localhost:%s", port)
+	}
+
 	var opts []Option
+
+	opts = append(opts, WithBaseURL(baseURL))
+
 	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
 		opts = append(opts, WithDataDir(dir))
 	}

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -75,6 +75,13 @@ func WithDataDir(dir string) Option {
 	}
 }
 
+// WithBaseURL sets the base URL for internal service-to-service communication.
+func WithBaseURL(url string) Option {
+	return func(s *MemoryStorage) {
+		s.baseURL = url
+	}
+}
+
 // Compile-time interface checks.
 var (
 	_ json.Marshaler   = (*MemoryStorage)(nil)
@@ -93,6 +100,7 @@ type MemoryStorage struct {
 	region          string
 	accountID       string
 	dataDir         string
+	baseURL         string
 	logger          *slog.Logger
 }
 
@@ -106,6 +114,7 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 		APIDestinations: make(map[string]*APIDestination),
 		region:          "us-east-1",
 		accountID:       "000000000000",
+		baseURL:         "http://localhost:4566",
 		logger:          slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 	for _, o := range opts {
@@ -729,7 +738,7 @@ func (s *MemoryStorage) deliverToSQS(target *Target, payload []byte) {
 	}
 
 	queueName := parts[len(parts)-1]
-	sqsEndpoint := fmt.Sprintf("http://localhost:4566/000000000000/%s", queueName)
+	sqsEndpoint := fmt.Sprintf("%s/000000000000/%s", s.baseURL, queueName)
 
 	reqBody := map[string]any{
 		"QueueUrl":    sqsEndpoint,
@@ -743,7 +752,7 @@ func (s *MemoryStorage) deliverToSQS(target *Target, payload []byte) {
 		return
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://localhost:4566/", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, s.baseURL+"/", bytes.NewReader(body))
 	if err != nil {
 		s.logger.Error("failed to create SQS request", "error", err, "queue", queueName)
 

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -584,27 +584,26 @@ func (s *MemoryStorage) matchAndDeliver(eventID, eventBusName string, entry *Put
 				Time:         eventTime,
 			})
 
+			payload := s.buildEventPayload(eventID, eventBusName, target, entry)
+
 			// Deliver to API Destination via HTTP if the target ARN is an API destination.
 			if dest := s.resolveAPIDestination(target.Arn); dest != nil {
-				go s.deliverToHTTP(dest, target, entry)
+				go s.deliverToHTTP(dest, target, payload)
+			}
+
+			// Deliver to SQS if the target ARN is an SQS queue.
+			if isSQSArn(target.Arn) {
+				go s.deliverToSQS(target, payload)
 			}
 		}
 	}
 }
 
-// deliverToHTTP sends an event to an API Destination's HTTP endpoint.
-func (s *MemoryStorage) deliverToHTTP(dest *APIDestination, target *Target, entry *PutEventsRequestEntry) {
-	endpoint := dest.InvocationEndpoint
-	method := dest.HTTPMethod
-
-	if method == "" {
-		method = http.MethodPost
-	}
-
-	// Build the event payload.
+// buildEventPayload builds the CloudWatch Events envelope for delivery.
+func (s *MemoryStorage) buildEventPayload(eventID, eventBusName string, target *Target, entry *PutEventsRequestEntry) []byte {
 	payload := map[string]any{
 		"version":     "0",
-		"id":          uuid.New().String(),
+		"id":          eventID,
 		"source":      entry.Source,
 		"detail-type": entry.DetailType,
 		"detail":      json.RawMessage(entry.Detail),
@@ -613,14 +612,76 @@ func (s *MemoryStorage) deliverToHTTP(dest *APIDestination, target *Target, entr
 		"time":        time.Now().Format(time.RFC3339),
 	}
 
+	if eventBusName != defaultEventBusName {
+		payload["event-bus-name"] = eventBusName
+	}
+
 	body, err := json.Marshal(payload)
 	if err != nil {
-		s.logger.Error("failed to marshal event for HTTP delivery", "error", err)
+		s.logger.Error("failed to marshal event payload", "error", err)
 
+		return nil
+	}
+
+	// Apply InputPath if set on the target.
+	if target.InputPath != "" {
+		if resolved := resolveInputPath(body, target.InputPath); resolved != nil {
+			return resolved
+		}
+	}
+
+	return body
+}
+
+// resolveInputPath extracts a sub-field from payload using a simple JSONPath expression.
+// Supports paths like "$.detail", "$.detail.payload", "$.source".
+func resolveInputPath(payload []byte, inputPath string) []byte {
+	path := strings.TrimPrefix(inputPath, "$.")
+	if path == "" || path == "$" {
+		return payload
+	}
+
+	parts := strings.Split(path, ".")
+
+	var current any
+	if err := json.Unmarshal(payload, &current); err != nil {
+		return nil
+	}
+
+	for _, part := range parts {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return nil
+		}
+
+		current, ok = obj[part]
+		if !ok {
+			return nil
+		}
+	}
+
+	result, err := json.Marshal(current)
+	if err != nil {
+		return nil
+	}
+
+	return result
+}
+
+// deliverToHTTP sends an event to an API Destination's HTTP endpoint.
+func (s *MemoryStorage) deliverToHTTP(dest *APIDestination, target *Target, payload []byte) {
+	if payload == nil {
 		return
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), method, endpoint, bytes.NewReader(body))
+	endpoint := dest.InvocationEndpoint
+	method := dest.HTTPMethod
+
+	if method == "" {
+		method = http.MethodPost
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, endpoint, bytes.NewReader(payload))
 	if err != nil {
 		s.logger.Error("failed to create HTTP request for API destination", "error", err, "endpoint", endpoint)
 
@@ -645,8 +706,67 @@ func (s *MemoryStorage) deliverToHTTP(dest *APIDestination, target *Target, entr
 	s.logger.Info("delivered event to API destination",
 		"endpoint", endpoint,
 		"status", resp.StatusCode,
-		"source", entry.Source,
-		"detail_type", entry.DetailType,
+	)
+}
+
+// isSQSArn returns true if the ARN is an SQS queue ARN.
+func isSQSArn(arn string) bool {
+	return strings.Contains(arn, ":sqs:")
+}
+
+// deliverToSQS sends an event to an SQS queue via the local kumo SQS endpoint.
+func (s *MemoryStorage) deliverToSQS(target *Target, payload []byte) {
+	if payload == nil {
+		return
+	}
+
+	// Extract queue name from ARN: arn:aws:sqs:region:account:queue-name
+	parts := strings.Split(target.Arn, ":")
+	if len(parts) < 6 {
+		s.logger.Error("invalid SQS ARN", "arn", target.Arn)
+
+		return
+	}
+
+	queueName := parts[len(parts)-1]
+	sqsEndpoint := fmt.Sprintf("http://localhost:4566/000000000000/%s", queueName)
+
+	reqBody := map[string]any{
+		"QueueUrl":    sqsEndpoint,
+		"MessageBody": string(payload),
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		s.logger.Error("failed to marshal SQS SendMessage request", "error", err)
+
+		return
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://localhost:4566/", bytes.NewReader(body))
+	if err != nil {
+		s.logger.Error("failed to create SQS request", "error", err, "queue", queueName)
+
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AmazonSQS.SendMessage")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		s.logger.Error("failed to deliver event to SQS", "error", err, "queue", queueName)
+
+		return
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	s.logger.Info("delivered event to SQS",
+		"queue", queueName,
+		"status", resp.StatusCode,
 	)
 }
 

--- a/internal/service/eventbridge/storage_test.go
+++ b/internal/service/eventbridge/storage_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 )
 
+//nolint:funlen // Table-driven test with comprehensive InputPath coverage.
 func TestResolveInputPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/eventbridge/storage_test.go
+++ b/internal/service/eventbridge/storage_test.go
@@ -1,0 +1,120 @@
+package eventbridge
+
+import (
+	"testing"
+)
+
+func TestResolveInputPath(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"version":"0","id":"abc","source":"my.app","detail-type":"OrderCreated","detail":{"orderId":"123","nested":{"key":"val"}},"region":"us-east-1","account":"000000000000","time":"2026-01-01T00:00:00Z"}`)
+
+	tests := []struct {
+		name      string
+		inputPath string
+		wantNil   bool
+		want      string
+	}{
+		{
+			name:      "empty path returns original",
+			inputPath: "",
+			want:      string(payload),
+		},
+		{
+			name:      "dollar only returns original",
+			inputPath: "$",
+			want:      string(payload),
+		},
+		{
+			name:      "extract detail",
+			inputPath: "$.detail",
+			want:      `{"nested":{"key":"val"},"orderId":"123"}`,
+		},
+		{
+			name:      "extract nested field",
+			inputPath: "$.detail.nested",
+			want:      `{"key":"val"}`,
+		},
+		{
+			name:      "extract scalar field",
+			inputPath: "$.detail.orderId",
+			want:      `"123"`,
+		},
+		{
+			name:      "extract source",
+			inputPath: "$.source",
+			want:      `"my.app"`,
+		},
+		{
+			name:      "non-existent path returns nil",
+			inputPath: "$.nonexistent",
+			wantNil:   true,
+		},
+		{
+			name:      "non-existent nested path returns nil",
+			inputPath: "$.detail.nonexistent.deep",
+			wantNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveInputPath(payload, tt.inputPath)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("resolveInputPath() = %s, want nil", string(got))
+				}
+
+				return
+			}
+
+			if string(got) != tt.want {
+				t.Errorf("resolveInputPath() = %s, want %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSQSArn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arn  string
+		want bool
+	}{
+		{
+			name: "SQS ARN",
+			arn:  "arn:aws:sqs:us-east-1:000000000000:my-queue",
+			want: true,
+		},
+		{
+			name: "Lambda ARN",
+			arn:  "arn:aws:lambda:us-east-1:000000000000:function:my-func",
+			want: false,
+		},
+		{
+			name: "API destination ARN",
+			arn:  "arn:aws:events:us-east-1:000000000000:api-destination/my-dest",
+			want: false,
+		},
+		{
+			name: "empty string",
+			arn:  "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isSQSArn(tt.arn); got != tt.want {
+				t.Errorf("isSQSArn(%q) = %v, want %v", tt.arn, got, tt.want)
+			}
+		})
+	}
+}

--- a/test/integration/eventbridge_test.go
+++ b/test/integration/eventbridge_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/sivchari/golden"
 )
 
@@ -422,6 +423,194 @@ func TestEventBridge_PutEvents_Delivery(t *testing.T) {
 
 	if !found {
 		t.Fatalf("expected matching event to be delivered to sqs-target, got: %s", string(body))
+	}
+}
+
+func TestEventBridge_PutEvents_SQSDelivery(t *testing.T) {
+	ebClient := newEventBridgeClient(t)
+	sqsClient := newSQSClient(t)
+	ctx := t.Context()
+
+	queueName := "eb-sqs-delivery-test"
+
+	// Create SQS queue.
+	_, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create rule matching the event.
+	_, err = ebClient.PutRule(ctx, &eventbridge.PutRuleInput{
+		Name:         aws.String("sqs-delivery-rule"),
+		EventPattern: aws.String(`{"source": ["payment.service"], "detail-type": ["PaymentProcessed"]}`),
+		State:        types.RuleStateEnabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add SQS target.
+	_, err = ebClient.PutTargets(ctx, &eventbridge.PutTargetsInput{
+		Rule: aws.String("sqs-delivery-rule"),
+		Targets: []types.Target{
+			{
+				Id:  aws.String("sqs-delivery-target"),
+				Arn: aws.String("arn:aws:sqs:us-east-1:000000000000:" + queueName),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put matching event.
+	putOutput, err := ebClient.PutEvents(ctx, &eventbridge.PutEventsInput{
+		Entries: []types.PutEventsRequestEntry{
+			{
+				Source:     aws.String("payment.service"),
+				DetailType: aws.String("PaymentProcessed"),
+				Detail:     aws.String(`{"paymentId": "pay-001"}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("EventId", "ResultMetadata")).Assert(t.Name()+"_put_events", putOutput)
+
+	// Receive message from SQS to confirm delivery.
+	var recvOutput *sqs.ReceiveMessageOutput
+
+	for range 10 {
+		recvOutput, err = sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:        aws.String("http://localhost:4566/000000000000/" + queueName),
+			WaitTimeSeconds: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(recvOutput.Messages) > 0 {
+			break
+		}
+	}
+
+	if len(recvOutput.Messages) == 0 {
+		t.Fatal("expected event to be delivered to SQS queue, but no message received")
+	}
+
+	// Parse the message body to verify it's a valid EventBridge event envelope.
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(*recvOutput.Messages[0].Body), &envelope); err != nil {
+		t.Fatalf("failed to parse SQS message body as JSON: %v", err)
+	}
+
+	if envelope["source"] != "payment.service" {
+		t.Errorf("expected source=payment.service, got %v", envelope["source"])
+	}
+
+	if envelope["detail-type"] != "PaymentProcessed" {
+		t.Errorf("expected detail-type=PaymentProcessed, got %v", envelope["detail-type"])
+	}
+}
+
+func TestEventBridge_PutEvents_InputPath(t *testing.T) {
+	ebClient := newEventBridgeClient(t)
+	sqsClient := newSQSClient(t)
+	ctx := t.Context()
+
+	queueName := "eb-inputpath-test"
+
+	// Create SQS queue.
+	_, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create rule.
+	_, err = ebClient.PutRule(ctx, &eventbridge.PutRuleInput{
+		Name:         aws.String("inputpath-rule"),
+		EventPattern: aws.String(`{"source": ["notif.service"], "detail-type": ["notifevent"]}`),
+		State:        types.RuleStateEnabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add SQS target with InputPath.
+	putTargetsOutput, err := ebClient.PutTargets(ctx, &eventbridge.PutTargetsInput{
+		Rule: aws.String("inputpath-rule"),
+		Targets: []types.Target{
+			{
+				Id:        aws.String("inputpath-target"),
+				Arn:       aws.String("arn:aws:sqs:us-east-1:000000000000:" + queueName),
+				InputPath: aws.String("$.detail"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_put_targets", putTargetsOutput)
+
+	// Put matching event.
+	_, err = ebClient.PutEvents(ctx, &eventbridge.PutEventsInput{
+		Entries: []types.PutEventsRequestEntry{
+			{
+				Source:     aws.String("notif.service"),
+				DetailType: aws.String("notifevent"),
+				Detail:     aws.String(`{"message": "hello", "userId": "u-001"}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Receive message from SQS.
+	var recvOutput *sqs.ReceiveMessageOutput
+
+	for range 10 {
+		recvOutput, err = sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:        aws.String("http://localhost:4566/000000000000/" + queueName),
+			WaitTimeSeconds: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(recvOutput.Messages) > 0 {
+			break
+		}
+	}
+
+	if len(recvOutput.Messages) == 0 {
+		t.Fatal("expected event to be delivered to SQS queue, but no message received")
+	}
+
+	// Verify that InputPath was applied: message body should be the detail only.
+	var detail map[string]any
+	if err := json.Unmarshal([]byte(*recvOutput.Messages[0].Body), &detail); err != nil {
+		t.Fatalf("failed to parse SQS message body: %v (body: %s)", err, *recvOutput.Messages[0].Body)
+	}
+
+	if detail["message"] != "hello" {
+		t.Errorf("expected message=hello, got %v", detail["message"])
+	}
+
+	if detail["userId"] != "u-001" {
+		t.Errorf("expected userId=u-001, got %v", detail["userId"])
+	}
+
+	// Verify envelope fields are NOT present (InputPath extracts only $.detail).
+	if _, hasVersion := detail["version"]; hasVersion {
+		t.Errorf("expected InputPath to strip envelope, but found 'version' in: %s", *recvOutput.Messages[0].Body)
 	}
 }
 

--- a/test/integration/testdata/eventbridge_test_TestEventBridge_PutEvents_InputPath_TestEventBridge_PutEvents_InputPath_put_targets.golden.go
+++ b/test/integration/testdata/eventbridge_test_TestEventBridge_PutEvents_InputPath_TestEventBridge_PutEvents_InputPath_put_targets.golden.go
@@ -1,0 +1,5 @@
+{
+  "FailedEntries": null,
+  "FailedEntryCount": 0,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/eventbridge_test_TestEventBridge_PutEvents_SQSDelivery_TestEventBridge_PutEvents_SQSDelivery_put_events.golden.go
+++ b/test/integration/testdata/eventbridge_test_TestEventBridge_PutEvents_SQSDelivery_TestEventBridge_PutEvents_SQSDelivery_put_events.golden.go
@@ -1,0 +1,11 @@
+{
+  "Entries": [
+    {
+      "ErrorCode": null,
+      "ErrorMessage": null,
+      "EventId": "eac63028-9033-4493-8e1a-e8320a71bbdd"
+    }
+  ],
+  "FailedEntryCount": 0,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add actual event delivery to SQS queue targets when EventBridge PutEvents matches a rule
- Apply InputPath on targets to deliver only the extracted sub-field instead of the full event envelope

Previously, only API Destination targets received actual HTTP delivery; SQS targets were only recorded in the DeliveredEvents list.

## Changes

- `buildEventPayload`: consolidate event envelope construction and InputPath application
- `resolveInputPath`: support simple JSONPath expressions (`$.detail`, `$.detail.payload`)
- `isSQSArn`: detect SQS queue ARNs
- `deliverToSQS`: send events to the internal SQS service via JSON protocol
- `deliverToHTTP`: refactor to accept pre-built payload bytes

## Test plan

- [x] Unit test: `TestResolveInputPath` (JSONPath extraction for various paths)
- [x] Unit test: `TestIsSQSArn` (ARN detection)
- [x] Integration test: `TestEventBridge_PutEvents_SQSDelivery` (golden)
- [x] Integration test: `TestEventBridge_PutEvents_InputPath` (golden)