### PR TITLE
feat(s3): emit EventBridge events on PutObject and store notification/CORS config

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -345,6 +345,9 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+
+	// Emit EventBridge notification if enabled.
+	go s.emitObjectCreatedEvent(context.Background(), bucket, key, obj.Size, obj.ETag)
 }
 
 // GetObject handles GET /{bucket}/{key...} - download an object.
@@ -799,19 +802,13 @@ func (s *Service) handleBucketPut(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, ok := r.URL.Query()["notification"]; ok {
-		// Stub: accept notification configuration without error.
-		_, _ = io.Copy(io.Discard, r.Body)
-
-		w.WriteHeader(http.StatusOK)
+		s.PutBucketNotificationConfiguration(w, r)
 
 		return
 	}
 
 	if _, ok := r.URL.Query()["cors"]; ok {
-		// Stub: accept CORS configuration without error.
-		_, _ = io.Copy(io.Discard, r.Body)
-
-		w.WriteHeader(http.StatusOK)
+		s.PutBucketCors(w, r)
 
 		return
 	}
@@ -1205,6 +1202,40 @@ func (s *Service) ListParts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeXMLResponse(w, result)
+}
+
+// PutBucketNotificationConfiguration handles PUT /{bucket}?notification.
+func (s *Service) PutBucketNotificationConfiguration(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	var config NotificationConfiguration
+	if err := xml.NewDecoder(r.Body).Decode(&config); err != nil {
+		// Accept even if body is empty or malformed (AWS is lenient).
+		w.WriteHeader(http.StatusOK)
+
+		return
+	}
+
+	enabled := config.EventBridgeConfig != nil
+	s.storage.SetEventBridgeNotification(r.Context(), bucket, enabled)
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// PutBucketCors handles PUT /{bucket}?cors.
+func (s *Service) PutBucketCors(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	var config CORSConfiguration
+	if err := xml.NewDecoder(r.Body).Decode(&config); err != nil {
+		writeS3Error(w, r, "MalformedXML", "The XML you provided was not well-formed", http.StatusBadRequest)
+
+		return
+	}
+
+	s.storage.SetCORSConfiguration(r.Context(), bucket, config.CORSRules)
+
+	w.WriteHeader(http.StatusOK)
 }
 
 // handleMultipartError handles errors from multipart upload operations.

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -95,13 +95,9 @@ func (s *Service) emitObjectCreatedEvent(ctx context.Context, bucket, key string
 	}
 
 	detail := map[string]any{
-		"version": "0",
-		"bucket":  map[string]string{"name": bucket},
-		"object": map[string]any{
-			"key":  key,
-			"size": size,
-			"etag": etag,
-		},
+		"version":    "0",
+		"bucket":     map[string]string{"name": bucket},
+		"object":     map[string]any{"key": key, "size": size, "etag": etag},
 		"request-id": uuid.New().String(),
 	}
 
@@ -112,23 +108,17 @@ func (s *Service) emitObjectCreatedEvent(ctx context.Context, bucket, key string
 		return
 	}
 
-	entry := map[string]any{
-		"Entries": []map[string]any{
-			{
-				"Source":     "aws.s3",
-				"DetailType": "Object Created",
-				"Detail":     string(detailJSON),
-			},
-		},
-	}
+	body, _ := json.Marshal(map[string]any{
+		"Entries": []map[string]any{{
+			"Source": "aws.s3", "DetailType": "Object Created", "Detail": string(detailJSON),
+		}},
+	})
 
-	body, err := json.Marshal(entry)
-	if err != nil {
-		s.logger.Error("failed to marshal PutEvents request", "error", err)
+	s.putEvents(ctx, body, bucket, key)
+}
 
-		return
-	}
-
+// putEvents sends a PutEvents request to the internal EventBridge endpoint.
+func (s *Service) putEvents(ctx context.Context, body []byte, bucket, key string) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+"/", bytes.NewReader(body))
 	if err != nil {
 		s.logger.Error("failed to create EventBridge request", "error", err)
@@ -139,9 +129,7 @@ func (s *Service) emitObjectCreatedEvent(ctx context.Context, bucket, key string
 	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
 	req.Header.Set("X-Amz-Target", "AWSEvents.PutEvents")
 
-	client := &http.Client{Timeout: 5 * time.Second}
-
-	resp, err := client.Do(req)
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
 	if err != nil {
 		s.logger.Error("failed to emit S3 event to EventBridge", "error", err)
 
@@ -150,9 +138,5 @@ func (s *Service) emitObjectCreatedEvent(ctx context.Context, bucket, key string
 
 	defer func() { _ = resp.Body.Close() }()
 
-	s.logger.Info("emitted S3 Object Created event",
-		"bucket", bucket,
-		"key", key,
-		"status", resp.StatusCode,
-	)
+	s.logger.Info("emitted S3 Object Created event", "bucket", bucket, "key", key, "status", resp.StatusCode)
 }

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -1,34 +1,54 @@
 package s3
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
+	"net/http"
 	"os"
+	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/sivchari/kumo/internal/service"
 )
+
+const defaultBaseURL = "http://localhost:4566"
 
 // Compile-time check that Service implements io.Closer.
 var _ io.Closer = (*Service)(nil)
 
 func init() {
+	baseURL := defaultBaseURL
+
+	if port := os.Getenv("KUMO_PORT"); port != "" {
+		baseURL = fmt.Sprintf("http://localhost:%s", port)
+	}
+
 	var opts []Option
 	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
 		opts = append(opts, WithDataDir(dir))
 	}
 
-	service.Register(New(NewMemoryStorage(opts...)))
+	service.Register(New(NewMemoryStorage(opts...), baseURL))
 }
 
 // Service implements the S3 service.
 type Service struct {
 	storage Storage
+	baseURL string
+	logger  *slog.Logger
 }
 
 // New creates a new S3 service.
-func New(storage Storage) *Service {
+func New(storage Storage, baseURL string) *Service {
 	return &Service{
 		storage: storage,
+		baseURL: baseURL,
+		logger:  slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 }
 
@@ -66,4 +86,73 @@ func (s *Service) Close() error {
 	}
 
 	return nil
+}
+
+// emitObjectCreatedEvent sends an S3 Object Created event to EventBridge.
+func (s *Service) emitObjectCreatedEvent(ctx context.Context, bucket, key string, size int64, etag string) {
+	if !s.storage.IsEventBridgeEnabled(ctx, bucket) {
+		return
+	}
+
+	detail := map[string]any{
+		"version": "0",
+		"bucket":  map[string]string{"name": bucket},
+		"object": map[string]any{
+			"key":  key,
+			"size": size,
+			"etag": etag,
+		},
+		"request-id": uuid.New().String(),
+	}
+
+	detailJSON, err := json.Marshal(detail)
+	if err != nil {
+		s.logger.Error("failed to marshal S3 event detail", "error", err)
+
+		return
+	}
+
+	entry := map[string]any{
+		"Entries": []map[string]any{
+			{
+				"Source":     "aws.s3",
+				"DetailType": "Object Created",
+				"Detail":     string(detailJSON),
+			},
+		},
+	}
+
+	body, err := json.Marshal(entry)
+	if err != nil {
+		s.logger.Error("failed to marshal PutEvents request", "error", err)
+
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+"/", bytes.NewReader(body))
+	if err != nil {
+		s.logger.Error("failed to create EventBridge request", "error", err)
+
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", "AWSEvents.PutEvents")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		s.logger.Error("failed to emit S3 event to EventBridge", "error", err)
+
+		return
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	s.logger.Info("emitted S3 Object Created event",
+		"bucket", bucket,
+		"key", key,
+		"status", resp.StatusCode,
+	)
 }

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -51,6 +51,12 @@ type Storage interface {
 	AbortMultipartUpload(ctx context.Context, bucket, key, uploadID string) error
 	ListMultipartUploads(ctx context.Context, bucket, prefix string, maxUploads int) ([]*MultipartUpload, error)
 	ListParts(ctx context.Context, bucket, key, uploadID string, maxParts int) ([]*Part, error)
+
+	// Notification and CORS
+	SetEventBridgeNotification(ctx context.Context, bucket string, enabled bool)
+	IsEventBridgeEnabled(ctx context.Context, bucket string) bool
+	SetCORSConfiguration(ctx context.Context, bucket string, rules []CORSRule)
+	GetCORSRules(ctx context.Context, bucket string) []CORSRule
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -78,13 +84,15 @@ type MemoryStorage struct {
 
 // MemoryBucket holds the data for a single S3 bucket.
 type MemoryBucket struct {
-	Name             string                      `json:"name"`
-	CreationDate     time.Time                   `json:"creationDate"`
-	Objects          map[string]*Object          `json:"objects"`          // current/latest version per key
-	Versions         map[string][]*Object        `json:"versions"`         // all versions per key (newest first)
-	VersioningStatus string                      `json:"versioningStatus"` // "", "Enabled", "Suspended"
-	VersionIDCounter uint64                      `json:"versionIdcounter"` // counter for generating version IDs
-	MultipartUploads map[string]*MultipartUpload `json:"-"`                // uploadID -> MultipartUpload
+	Name               string                      `json:"name"`
+	CreationDate       time.Time                   `json:"creationDate"`
+	Objects            map[string]*Object          `json:"objects"`             // current/latest version per key
+	Versions           map[string][]*Object        `json:"versions"`            // all versions per key (newest first)
+	VersioningStatus   string                      `json:"versioningStatus"`    // "", "Enabled", "Suspended"
+	VersionIDCounter   uint64                      `json:"versionIdcounter"`    // counter for generating version IDs
+	MultipartUploads   map[string]*MultipartUpload `json:"-"`                   // uploadID -> MultipartUpload
+	EventBridgeEnabled bool                        `json:"eventBridgeEnabled"`  // EventBridge notification
+	CORSRules          []CORSRule                  `json:"corsRules,omitempty"` // CORS configuration
 }
 
 // NewMemoryStorage creates a new in-memory S3 storage.
@@ -992,4 +1000,48 @@ func calculateMultipartETag(partRequests []PartRequest, parts map[int]*Part) str
 	finalHash := md5.Sum(md5Concat) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
 
 	return fmt.Sprintf("%q", fmt.Sprintf("%s-%d", hex.EncodeToString(finalHash[:]), len(partRequests)))
+}
+
+// SetEventBridgeNotification enables or disables EventBridge notification for a bucket.
+func (s *MemoryStorage) SetEventBridgeNotification(_ context.Context, bucket string, enabled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if b, exists := s.Buckets[bucket]; exists {
+		b.EventBridgeEnabled = enabled
+	}
+}
+
+// IsEventBridgeEnabled returns whether EventBridge notification is enabled for a bucket.
+func (s *MemoryStorage) IsEventBridgeEnabled(_ context.Context, bucket string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if b, exists := s.Buckets[bucket]; exists {
+		return b.EventBridgeEnabled
+	}
+
+	return false
+}
+
+// SetCORSConfiguration sets the CORS configuration for a bucket.
+func (s *MemoryStorage) SetCORSConfiguration(_ context.Context, bucket string, rules []CORSRule) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if b, exists := s.Buckets[bucket]; exists {
+		b.CORSRules = rules
+	}
+}
+
+// GetCORSRules returns the CORS rules for a bucket.
+func (s *MemoryStorage) GetCORSRules(_ context.Context, bucket string) []CORSRule {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if b, exists := s.Buckets[bucket]; exists {
+		return b.CORSRules
+	}
+
+	return nil
 }

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -281,3 +281,27 @@ type CopyPartResult struct {
 	LastModified string   `xml:"LastModified"`
 	ETag         string   `xml:"ETag"`
 }
+
+// NotificationConfiguration represents S3 bucket notification configuration.
+type NotificationConfiguration struct {
+	XMLName           xml.Name           `xml:"NotificationConfiguration"`
+	EventBridgeConfig *EventBridgeConfig `xml:"EventBridgeConfiguration,omitempty"`
+}
+
+// EventBridgeConfig represents EventBridge notification configuration.
+type EventBridgeConfig struct{}
+
+// CORSConfiguration represents S3 bucket CORS configuration (XML request body).
+type CORSConfiguration struct {
+	XMLName   xml.Name   `xml:"CORSConfiguration"`
+	CORSRules []CORSRule `xml:"CORSRule"`
+}
+
+// CORSRule represents a single CORS rule.
+type CORSRule struct {
+	AllowedHeaders []string `json:"allowedHeaders,omitempty" xml:"AllowedHeader"`
+	AllowedMethods []string `json:"allowedMethods"           xml:"AllowedMethod"`
+	AllowedOrigins []string `json:"allowedOrigins"           xml:"AllowedOrigin"`
+	ExposeHeaders  []string `json:"exposeHeaders,omitempty"  xml:"ExposeHeader"`
+	MaxAgeSeconds  int      `json:"maxAgeSeconds,omitempty"  xml:"MaxAgeSeconds"`
+}

--- a/test/integration/s3_eventbridge_test.go
+++ b/test/integration/s3_eventbridge_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/sivchari/golden"
+)
+
+func TestS3_EventBridgeNotification(t *testing.T) {
+	s3Client := newS3Client(t)
+	ebClient := newEventBridgeClient(t)
+	sqsClient := newSQSClient(t)
+	ctx := t.Context()
+
+	bucketName := "s3-eb-notif-test"
+	queueName := "s3-eb-notif-queue"
+
+	// 1. Create S3 bucket.
+	_, err := s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Enable EventBridge notification on the bucket.
+	notifXML := `<NotificationConfiguration><EventBridgeConfiguration></EventBridgeConfiguration></NotificationConfiguration>`
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		"http://localhost:4566/"+bucketName+"?notification",
+		bytes.NewReader([]byte(notifXML)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PutBucketNotificationConfiguration returned %d", resp.StatusCode)
+	}
+
+	// 3. Create SQS queue.
+	createQueueOutput, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queueURL := *createQueueOutput.QueueUrl
+
+	// 4. Create EventBridge rule matching S3 Object Created events for this bucket.
+	_, err = ebClient.PutRule(ctx, &eventbridge.PutRuleInput{
+		Name:         aws.String("s3-notif-rule"),
+		EventPattern: aws.String(`{"source": ["aws.s3"], "detail-type": ["Object Created"], "detail": {"bucket": {"name": ["` + bucketName + `"]}}}`),
+		State:        ebtypes.RuleStateEnabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 5. Add SQS target.
+	putTargetsOutput, err := ebClient.PutTargets(ctx, &eventbridge.PutTargetsInput{
+		Rule: aws.String("s3-notif-rule"),
+		Targets: []ebtypes.Target{
+			{
+				Id:  aws.String("s3-notif-sqs"),
+				Arn: aws.String("arn:aws:sqs:us-east-1:000000000000:" + queueName),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_put_targets", putTargetsOutput)
+
+	// 6. Upload an object to trigger the notification.
+	putObjOutput, err := s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("test-file.txt"),
+		Body:   bytes.NewReader([]byte("hello world")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("ETag", "VersionId", "ResultMetadata")).Assert(t.Name()+"_put_object", putObjOutput)
+
+	// Wait for async EventBridge notification goroutine to complete.
+	time.Sleep(500 * time.Millisecond)
+
+	// 7. Receive message from SQS to confirm the event was delivered.
+	var recvOutput *sqs.ReceiveMessageOutput
+
+	for range 10 {
+		recvOutput, err = sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:        aws.String(queueURL),
+			WaitTimeSeconds: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(recvOutput.Messages) > 0 {
+			break
+		}
+	}
+
+	if len(recvOutput.Messages) == 0 {
+		t.Fatal("expected S3 event to be delivered to SQS queue, but no message received")
+	}
+
+	// 8. Verify the event payload.
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(*recvOutput.Messages[0].Body), &envelope); err != nil {
+		t.Fatalf("failed to parse SQS message body: %v", err)
+	}
+
+	if envelope["source"] != "aws.s3" {
+		t.Errorf("expected source=aws.s3, got %v", envelope["source"])
+	}
+
+	if envelope["detail-type"] != "Object Created" {
+		t.Errorf("expected detail-type=Object Created, got %v", envelope["detail-type"])
+	}
+}

--- a/test/integration/testdata/s3_eventbridge_test_TestS3_EventBridgeNotification_TestS3_EventBridgeNotification_put_object.golden.go
+++ b/test/integration/testdata/s3_eventbridge_test_TestS3_EventBridgeNotification_TestS3_EventBridgeNotification_put_object.golden.go
@@ -1,0 +1,20 @@
+{
+  "BucketKeyEnabled": null,
+  "ChecksumCRC32": null,
+  "ChecksumCRC32C": null,
+  "ChecksumCRC64NVME": null,
+  "ChecksumSHA1": null,
+  "ChecksumSHA256": null,
+  "ChecksumType": "",
+  "ETag": "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"",
+  "Expiration": null,
+  "RequestCharged": "",
+  "SSECustomerAlgorithm": null,
+  "SSECustomerKeyMD5": null,
+  "SSEKMSEncryptionContext": null,
+  "SSEKMSKeyId": null,
+  "ServerSideEncryption": "",
+  "Size": null,
+  "VersionId": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/s3_eventbridge_test_TestS3_EventBridgeNotification_TestS3_EventBridgeNotification_put_targets.golden.go
+++ b/test/integration/testdata/s3_eventbridge_test_TestS3_EventBridgeNotification_TestS3_EventBridgeNotification_put_targets.golden.go
@@ -1,0 +1,5 @@
+{
+  "FailedEntries": null,
+  "FailedEntryCount": 0,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Replace stub implementations of `PutBucketNotificationConfiguration` and `PutBucketCors` with actual storage
- When EventBridge notification is enabled on a bucket, `PutObject` emits an `Object Created` event to EventBridge via the internal JSON protocol dispatcher
- Store CORS rules per bucket for future CORS header support

## Changes

- `MemoryBucket`: add `EventBridgeEnabled` and `CORSRules` fields
- `types.go`: add `CORSRule`, `CORSConfiguration`, `NotificationConfiguration`, `EventBridgeConfig` types
- `storage.go`: add `SetEventBridgeNotification`, `IsEventBridgeEnabled`, `SetCORSConfiguration`, `GetCORSRules` methods
- `service.go`: add `baseURL` field and `emitObjectCreatedEvent` for async EventBridge notification
- `handlers.go`: replace notification/CORS stubs with actual handler methods; add `go s.emitObjectCreatedEvent()` after PutObject success

## Behavior

- Buckets without `PutBucketNotificationConfiguration` are unaffected (no overhead)
- Event emission is async (goroutine) and does not block PutObject response
- EventBridge events use `source: "aws.s3"` and `detail-type: "Object Created"` matching real AWS format

## Test plan

- [x] Integration test: `TestS3_EventBridgeNotification` (S3 PutObject -> EventBridge rule match -> SQS delivery, golden)