### PR TITLE
feat(s3): add CORS response headers and OPTIONS preflight support

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -20,6 +20,80 @@ const (
 	timeFormatHTTP = "Mon, 02 Jan 2006 15:04:05 GMT"
 )
 
+// applyCORSHeaders sets CORS response headers if the bucket has CORS configured and the request Origin matches.
+func (s *Service) applyCORSHeaders(w http.ResponseWriter, r *http.Request, bucket string) {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return
+	}
+
+	rules := s.storage.GetCORSRules(r.Context(), bucket)
+	if len(rules) == 0 {
+		return
+	}
+
+	for _, rule := range rules {
+		if !matchOrigin(origin, rule.AllowedOrigins) {
+			continue
+		}
+
+		if !matchMethod(r.Method, rule.AllowedMethods) {
+			continue
+		}
+
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Methods", strings.Join(rule.AllowedMethods, ", "))
+
+		if len(rule.AllowedHeaders) > 0 {
+			w.Header().Set("Access-Control-Allow-Headers", strings.Join(rule.AllowedHeaders, ", "))
+		}
+
+		if len(rule.ExposeHeaders) > 0 {
+			w.Header().Set("Access-Control-Expose-Headers", strings.Join(rule.ExposeHeaders, ", "))
+		}
+
+		if rule.MaxAgeSeconds > 0 {
+			w.Header().Set("Access-Control-Max-Age", strconv.Itoa(rule.MaxAgeSeconds))
+		}
+
+		return
+	}
+}
+
+func matchOrigin(origin string, allowed []string) bool {
+	for _, a := range allowed {
+		if a == "*" || a == origin {
+			return true
+		}
+	}
+
+	return false
+}
+
+func matchMethod(method string, allowed []string) bool {
+	for _, a := range allowed {
+		if strings.EqualFold(a, method) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HandleCORSPreflight handles OPTIONS requests for CORS preflight.
+// For preflight, the actual method is in Access-Control-Request-Method header.
+func (s *Service) HandleCORSPreflight(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	// Override method for CORS matching: use the requested method from the preflight header.
+	if reqMethod := r.Header.Get("Access-Control-Request-Method"); reqMethod != "" {
+		r.Method = reqMethod
+	}
+
+	s.applyCORSHeaders(w, r, bucket)
+	w.WriteHeader(http.StatusOK)
+}
+
 // Route Dispatchers - dispatch based on query parameters
 
 // handleBucketGet dispatches GET /{bucket} requests based on query parameters.
@@ -58,6 +132,8 @@ func (s *Service) handleBucketPost(w http.ResponseWriter, r *http.Request) {
 
 // handleObjectPut dispatches PUT /{bucket}/{key} requests based on query parameters.
 func (s *Service) handleObjectPut(w http.ResponseWriter, r *http.Request) {
+	s.applyCORSHeaders(w, r, r.PathValue("bucket"))
+
 	if r.URL.Query().Get("uploadId") != "" && r.URL.Query().Get("partNumber") != "" {
 		s.UploadPart(w, r)
 
@@ -69,6 +145,8 @@ func (s *Service) handleObjectPut(w http.ResponseWriter, r *http.Request) {
 
 // handleObjectGet dispatches GET /{bucket}/{key} requests based on query parameters.
 func (s *Service) handleObjectGet(w http.ResponseWriter, r *http.Request) {
+	s.applyCORSHeaders(w, r, r.PathValue("bucket"))
+
 	if r.URL.Query().Get("uploadId") != "" {
 		s.ListParts(w, r)
 

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -75,6 +75,9 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("DELETE", "/{bucket}/{key...}", s.handleObjectDelete)
 	r.Handle("HEAD", "/{bucket}/{key...}", s.HeadObject)
 	r.Handle("POST", "/{bucket}/{key...}", s.handleObjectPost)
+
+	// CORS preflight
+	r.Handle("OPTIONS", "/{bucket}/{key...}", s.HandleCORSPreflight)
 }
 
 // Close saves the storage state if persistence is enabled.

--- a/test/integration/s3_cors_test.go
+++ b/test/integration/s3_cors_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestS3_CORS(t *testing.T) {
+	s3Client := newS3Client(t)
+	ctx := t.Context()
+
+	bucketName := "cors-test-bucket"
+
+	// 1. Create bucket.
+	_, err := s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Set CORS configuration.
+	corsXML := `<CORSConfiguration>
+		<CORSRule>
+			<AllowedOrigin>http://localhost:3200</AllowedOrigin>
+			<AllowedMethod>GET</AllowedMethod>
+			<AllowedMethod>PUT</AllowedMethod>
+			<AllowedMethod>POST</AllowedMethod>
+			<AllowedMethod>HEAD</AllowedMethod>
+			<AllowedHeader>*</AllowedHeader>
+		</CORSRule>
+	</CORSConfiguration>`
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		"http://localhost:4566/"+bucketName+"?cors",
+		bytes.NewReader([]byte(corsXML)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PutBucketCors returned %d", resp.StatusCode)
+	}
+
+	// 3. Upload an object.
+	_, err = s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("test.txt"),
+		Body:   bytes.NewReader([]byte("hello")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. GET with matching Origin - should have CORS headers.
+	getReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"http://localhost:4566/"+bucketName+"/test.txt", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getReq.Header.Set("Origin", "http://localhost:3200")
+
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = io.Copy(io.Discard, getResp.Body)
+	getResp.Body.Close()
+
+	acao := getResp.Header.Get("Access-Control-Allow-Origin")
+	if acao != "http://localhost:3200" {
+		t.Errorf("expected Access-Control-Allow-Origin=http://localhost:3200, got %q", acao)
+	}
+
+	// 5. GET with non-matching Origin - should NOT have CORS headers.
+	getReq2, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"http://localhost:4566/"+bucketName+"/test.txt", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getReq2.Header.Set("Origin", "http://evil.example.com")
+
+	getResp2, err := http.DefaultClient.Do(getReq2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = io.Copy(io.Discard, getResp2.Body)
+	getResp2.Body.Close()
+
+	acao2 := getResp2.Header.Get("Access-Control-Allow-Origin")
+	if acao2 != "" {
+		t.Errorf("expected no CORS header for non-matching origin, got %q", acao2)
+	}
+
+	// 6. OPTIONS preflight with matching Origin.
+	optReq, err := http.NewRequestWithContext(ctx, http.MethodOptions,
+		"http://localhost:4566/"+bucketName+"/test.txt", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	optReq.Header.Set("Origin", "http://localhost:3200")
+	optReq.Header.Set("Access-Control-Request-Method", "PUT")
+
+	optResp, err := http.DefaultClient.Do(optReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = io.Copy(io.Discard, optResp.Body)
+	optResp.Body.Close()
+
+	if optResp.StatusCode != http.StatusOK {
+		t.Fatalf("OPTIONS returned %d", optResp.StatusCode)
+	}
+
+	optACO := optResp.Header.Get("Access-Control-Allow-Origin")
+	if optACO != "http://localhost:3200" {
+		t.Errorf("OPTIONS: expected Access-Control-Allow-Origin=http://localhost:3200, got %q", optACO)
+	}
+
+	// 7. GET without Origin - should NOT have CORS headers.
+	getReq3, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"http://localhost:4566/"+bucketName+"/test.txt", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getResp3, err := http.DefaultClient.Do(getReq3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = io.Copy(io.Discard, getResp3.Body)
+	getResp3.Body.Close()
+
+	acao3 := getResp3.Header.Get("Access-Control-Allow-Origin")
+	if acao3 != "" {
+		t.Errorf("expected no CORS header without Origin, got %q", acao3)
+	}
+}


### PR DESCRIPTION
## Summary

- Apply stored CORS rules to S3 GET/PUT object responses when the request `Origin` header matches an allowed origin
- Add OPTIONS preflight handler for `/{bucket}/{key...}`

## Changes

- `applyCORSHeaders`: match request Origin and Method against stored CORS rules, set `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, `Access-Control-Expose-Headers`, `Access-Control-Max-Age`
- `HandleCORSPreflight`: use `Access-Control-Request-Method` header for method matching during preflight
- `handleObjectPut` / `handleObjectGet`: call `applyCORSHeaders` before dispatching
- Register `OPTIONS /{bucket}/{key...}` route

## Behavior

- Buckets without CORS configuration are unaffected (no overhead)
- Non-matching origins receive no CORS headers (correct security behavior)
- Preflight checks use the requested method, not OPTIONS itself

## Test plan

- [x] Integration test: `TestS3_CORS` - verifies matching origin, non-matching origin, preflight OPTIONS, and no-origin scenarios