### PR TITLE
feat(s3): implement CopyObject

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"errors"
@@ -136,6 +137,12 @@ func (s *Service) handleObjectPut(w http.ResponseWriter, r *http.Request) {
 
 	if r.URL.Query().Get("uploadId") != "" && r.URL.Query().Get("partNumber") != "" {
 		s.UploadPart(w, r)
+
+		return
+	}
+
+	if r.Header.Get("X-Amz-Copy-Source") != "" {
+		s.CopyObject(w, r)
 
 		return
 	}
@@ -426,6 +433,64 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 
 	// Emit EventBridge notification if enabled.
 	go s.emitObjectCreatedEvent(context.Background(), bucket, key, obj.Size, obj.ETag)
+}
+
+// CopyObject handles PUT /{bucket}/{key} with X-Amz-Copy-Source header.
+func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
+	dstBucket := r.PathValue("bucket")
+	dstKey := r.PathValue("key")
+
+	copySource := r.Header.Get("X-Amz-Copy-Source")
+	srcBucket, srcKey := parseCopySource(copySource)
+
+	if srcBucket == "" || srcKey == "" {
+		writeS3Error(w, r, "InvalidArgument", "Invalid copy source", http.StatusBadRequest)
+
+		return
+	}
+
+	srcObj, err := s.storage.GetObject(r.Context(), srcBucket, srcKey)
+	if err != nil {
+		handleGetObjectError(w, r, err)
+
+		return
+	}
+
+	dstObj, err := s.storage.PutObject(r.Context(), dstBucket, dstKey, bytes.NewReader(srcObj.Body), srcObj.Metadata)
+	if err != nil {
+		var bucketErr *BucketError
+		if errors.As(err, &bucketErr) {
+			writeS3Error(w, r, bucketErr.Code, bucketErr.Message, http.StatusNotFound)
+
+			return
+		}
+
+		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	result := CopyObjectResult{
+		ETag:         dstObj.ETag,
+		LastModified: dstObj.LastModified.Format(timeFormatISO),
+	}
+
+	writeXMLResponse(w, result)
+
+	go s.emitObjectCreatedEvent(context.Background(), dstBucket, dstKey, dstObj.Size, dstObj.ETag)
+}
+
+// parseCopySource parses the X-Amz-Copy-Source header value.
+// Format: /bucket/key or bucket/key (URL-encoded).
+func parseCopySource(source string) (bucket, key string) {
+	source = strings.TrimPrefix(source, "/")
+
+	idx := strings.IndexByte(source, '/')
+	if idx < 0 {
+		return "", ""
+	}
+
+	return source[:idx], source[idx+1:]
 }
 
 // GetObject handles GET /{bucket}/{key...} - download an object.

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -274,6 +274,13 @@ type PartInfo struct {
 	Size         int64  `xml:"Size"`
 }
 
+// CopyObjectResult is the response for CopyObject.
+type CopyObjectResult struct {
+	XMLName      xml.Name `xml:"CopyObjectResult"`
+	ETag         string   `xml:"ETag"`
+	LastModified string   `xml:"LastModified"`
+}
+
 // CopyPartResult is the response for UploadPartCopy.
 type CopyPartResult struct {
 	XMLName      xml.Name `xml:"CopyPartResult"`

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1298,3 +1298,42 @@ func TestS3_DeleteObjects(t *testing.T) {
 		t.Errorf("expected 0 objects after delete, got %d", len(listOutput.Contents))
 	}
 }
+
+func TestS3_CopyObject(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucketName := "test-copy-object-bucket"
+
+	// Create bucket.
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put source object.
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("source.txt"),
+		Body:   bytes.NewReader([]byte("copy me")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy object within same bucket.
+	copyOutput, err := client.CopyObject(ctx, &s3.CopyObjectInput{
+		Bucket:     aws.String(bucketName),
+		Key:        aws.String("dest.txt"),
+		CopySource: aws.String(bucketName + "/source.txt"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"ETag", "LastModified", "ResultMetadata",
+		"ServerSideEncryption", "CopySourceVersionId",
+	)).Assert(t.Name(), copyOutput)
+}

--- a/test/integration/testdata/s3_test_TestS3_CopyObject_TestS3_CopyObject.golden.go
+++ b/test/integration/testdata/s3_test_TestS3_CopyObject_TestS3_CopyObject.golden.go
@@ -1,0 +1,23 @@
+{
+  "BucketKeyEnabled": null,
+  "CopyObjectResult": {
+    "ChecksumCRC32": null,
+    "ChecksumCRC32C": null,
+    "ChecksumCRC64NVME": null,
+    "ChecksumSHA1": null,
+    "ChecksumSHA256": null,
+    "ChecksumType": "",
+    "ETag": "\"56fe0b1409a5662d70cfedc4555d4771\"",
+    "LastModified": "2026-04-28T18:11:02.112Z"
+  },
+  "CopySourceVersionId": null,
+  "Expiration": null,
+  "RequestCharged": "",
+  "SSECustomerAlgorithm": null,
+  "SSECustomerKeyMD5": null,
+  "SSEKMSEncryptionContext": null,
+  "SSEKMSKeyId": null,
+  "ServerSideEncryption": "",
+  "VersionId": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

Implement S3 CopyObject API. Copies an object from one location to another within the same or across buckets.

## Changes

- `handleObjectPut`: dispatch to `CopyObject` when `X-Amz-Copy-Source` header is present
- `CopyObject`: read source object via `GetObject`, write to destination via `PutObject`, return `CopyObjectResult` XML
- `parseCopySource`: parse `/bucket/key` or `bucket/key` format from header value
- `CopyObjectResult` type added to `types.go`
- Emits EventBridge `Object Created` event for the destination object if notification is enabled

## Test plan

- [x] Integration test: `TestS3_CopyObject` (golden)