### PR TITLE
fix(server): fallback Query protocol routing when User-Agent lacks service identifier

### DIFF
--- a/internal/server/awsquery.go
+++ b/internal/server/awsquery.go
@@ -76,28 +76,50 @@ func (d *QueryProtocolDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Reque
 
 	// Identify the target service from User-Agent header.
 	svcID := parseServiceFromUserAgent(r.Header.Get("User-Agent"))
-	if svcID == "" {
-		writeQueryError(w, "MissingServiceIdentifier",
-			"User-Agent header with api/ identifier is required for Query protocol routing")
 
-		return
-	}
+	var entry queryHandlerEntry
 
-	// Look up handler by service identifier and action.
-	actions, ok := d.actionHandlers[svcID]
-	if !ok {
-		writeQueryError(w, "UnknownService",
-			"Unknown service: "+svcID)
+	if svcID != "" {
+		// Look up handler by service identifier and action.
+		actions, ok := d.actionHandlers[svcID]
+		if !ok {
+			writeQueryError(w, "UnknownService",
+				"Unknown service: "+svcID)
 
-		return
-	}
+			return
+		}
 
-	entry, ok := actions[action]
-	if !ok {
-		writeQueryError(w, "UnknownAction",
-			"Action "+action+" is not supported for service "+svcID)
+		entry, ok = actions[action]
+		if !ok {
+			writeQueryError(w, "UnknownAction",
+				"Action "+action+" is not supported for service "+svcID)
 
-		return
+			return
+		}
+	} else {
+		// Fallback: search all services for a unique action match.
+		var found bool
+
+		for _, actions := range d.actionHandlers {
+			if e, ok := actions[action]; ok {
+				if found {
+					writeQueryError(w, "AmbiguousAction",
+						"Action "+action+" matches multiple services; send a User-Agent with api/ identifier")
+
+					return
+				}
+
+				entry = e
+				found = true
+			}
+		}
+
+		if !found {
+			writeQueryError(w, "UnknownAction",
+				"Action "+action+" is not supported")
+
+			return
+		}
 	}
 
 	// Convert form data to JSON and dispatch.

--- a/internal/server/awsquery.go
+++ b/internal/server/awsquery.go
@@ -77,49 +77,11 @@ func (d *QueryProtocolDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	// Identify the target service from User-Agent header.
 	svcID := parseServiceFromUserAgent(r.Header.Get("User-Agent"))
 
-	var entry queryHandlerEntry
+	entry, err := d.resolveHandler(svcID, action)
+	if err != nil {
+		writeQueryError(w, err.code, err.message)
 
-	if svcID != "" {
-		// Look up handler by service identifier and action.
-		actions, ok := d.actionHandlers[svcID]
-		if !ok {
-			writeQueryError(w, "UnknownService",
-				"Unknown service: "+svcID)
-
-			return
-		}
-
-		entry, ok = actions[action]
-		if !ok {
-			writeQueryError(w, "UnknownAction",
-				"Action "+action+" is not supported for service "+svcID)
-
-			return
-		}
-	} else {
-		// Fallback: search all services for a unique action match.
-		var found bool
-
-		for _, actions := range d.actionHandlers {
-			if e, ok := actions[action]; ok {
-				if found {
-					writeQueryError(w, "AmbiguousAction",
-						"Action "+action+" matches multiple services; send a User-Agent with api/ identifier")
-
-					return
-				}
-
-				entry = e
-				found = true
-			}
-		}
-
-		if !found {
-			writeQueryError(w, "UnknownAction",
-				"Action "+action+" is not supported")
-
-			return
-		}
+		return
 	}
 
 	// Convert form data to JSON and dispatch.
@@ -129,6 +91,58 @@ func (d *QueryProtocolDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	r.Header.Set("Content-Type", "application/x-amz-json-1.0")
 	r.Header.Set("X-Amz-Target", entry.servicePrefix+"."+action)
 	entry.handler(w, r)
+}
+
+// queryResolveError represents an error during handler resolution.
+type queryResolveError struct {
+	code    string
+	message string
+}
+
+// resolveHandler finds the handler for the given service ID and action.
+func (d *QueryProtocolDispatcher) resolveHandler(svcID, action string) (queryHandlerEntry, *queryResolveError) {
+	if svcID != "" {
+		return d.resolveByService(svcID, action)
+	}
+
+	return d.resolveByFallback(action)
+}
+
+func (d *QueryProtocolDispatcher) resolveByService(svcID, action string) (queryHandlerEntry, *queryResolveError) {
+	actions, ok := d.actionHandlers[svcID]
+	if !ok {
+		return queryHandlerEntry{}, &queryResolveError{"UnknownService", "Unknown service: " + svcID}
+	}
+
+	entry, ok := actions[action]
+	if !ok {
+		return queryHandlerEntry{}, &queryResolveError{"UnknownAction", "Action " + action + " is not supported for service " + svcID}
+	}
+
+	return entry, nil
+}
+
+func (d *QueryProtocolDispatcher) resolveByFallback(action string) (queryHandlerEntry, *queryResolveError) {
+	var entry queryHandlerEntry
+
+	var found bool
+
+	for _, actions := range d.actionHandlers {
+		if e, ok := actions[action]; ok {
+			if found {
+				return queryHandlerEntry{}, &queryResolveError{"AmbiguousAction", "Action " + action + " matches multiple services; send a User-Agent with api/ identifier"}
+			}
+
+			entry = e
+			found = true
+		}
+	}
+
+	if !found {
+		return queryHandlerEntry{}, &queryResolveError{"UnknownAction", "Action " + action + " is not supported"}
+	}
+
+	return entry, nil
 }
 
 // parseServiceFromUserAgent extracts the service identifier from the AWS SDK v2 User-Agent header.

--- a/internal/server/awsquery_test.go
+++ b/internal/server/awsquery_test.go
@@ -128,12 +128,48 @@ func TestQueryDispatcher_DisambiguatesOverlappingActions(t *testing.T) {
 	}
 }
 
-func TestQueryDispatcher_MissingUserAgent(t *testing.T) {
+func TestQueryDispatcher_MissingUserAgent_UniqueAction(t *testing.T) {
+	t.Parallel()
+
+	d := NewQueryProtocolDispatcher()
+
+	called := false
+
+	d.RegisterAction("CreateDBCluster", "AmazonRDSv19", "rds", func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	body := strings.NewReader("Action=CreateDBCluster&Version=2014-10-31")
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rec := httptest.NewRecorder()
+
+	d.ServeHTTP(rec, req)
+
+	// When the action is unique across all services, the dispatcher should
+	// fall back to action-based lookup even without a User-Agent header.
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	if !called {
+		t.Error("expected handler to be called via fallback")
+	}
+}
+
+func TestQueryDispatcher_MissingUserAgent_AmbiguousAction(t *testing.T) {
 	t.Parallel()
 
 	d := NewQueryProtocolDispatcher()
 
 	d.RegisterAction("CreateDBCluster", "AmazonRDSv19", "rds", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	d.RegisterAction("CreateDBCluster", "AmazonNeptuneDataService", "neptune", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -150,8 +186,8 @@ func TestQueryDispatcher_MissingUserAgent(t *testing.T) {
 		t.Errorf("expected status 400, got %d", rec.Code)
 	}
 
-	if !strings.Contains(rec.Body.String(), "MissingServiceIdentifier") {
-		t.Errorf("expected MissingServiceIdentifier error, got %s", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "AmbiguousAction") {
+		t.Errorf("expected AmbiguousAction error, got %s", rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix STS GetCallerIdentity failures from clients that don't include `api/sts` in User-Agent header.

## Problem

The Query protocol dispatcher required `api/{service}` in User-Agent to route requests. AWS CLI and some SDKs don't always include this, causing STS calls to fail with `MissingServiceIdentifier`.

## Fix

When User-Agent doesn't contain a service identifier, search all registered Query protocol services for a matching action name. If the action is unique across services, dispatch to that service.

## Test plan

- [x] Unit test: unique action fallback
- [x] Unit test: ambiguous action error