### PR TITLE
fix(dynamodb): handle space between function name and parenthesis in ConditionExpression

### DIFF
--- a/internal/service/dynamodb/condition.go
+++ b/internal/service/dynamodb/condition.go
@@ -132,6 +132,11 @@ func parsePrimary(expr string, item Item, values map[string]AttributeValue) (boo
 		if strings.HasPrefix(trimmed, fn+"(") {
 			return parseFunctionCall(fn, trimmed[len(fn):], item, values)
 		}
+
+		// Handle optional space between function name and parenthesis: fn (args).
+		if strings.HasPrefix(trimmed, fn+" (") {
+			return parseFunctionCall(fn, strings.TrimSpace(trimmed[len(fn):]), item, values)
+		}
 	}
 
 	// size() function used in comparison: size(path) op value


### PR DESCRIPTION
## Summary

Fix ConditionExpression parsing failure for patterns like `attribute_not_exists (pKey)` where a space exists between the function name and opening parenthesis.

## Problem

Error: `Invalid ConditionExpression: failed to evaluate condition: expected comparison operator, got: (pKey)`

The parser only matched `fn(` (no space) but not `fn (` (with space), causing the expression to fall through to comparison parsing which failed.

## Fix

Add `fn + " ("` pattern matching in `parsePrimary` alongside the existing `fn + "("` check.