### PR TITLE
fix(dynamodb): use pointer types for M and L fields in AttributeValue

### DIFF
--- a/internal/service/dynamodb/condition.go
+++ b/internal/service/dynamodb/condition.go
@@ -245,7 +245,7 @@ func evalContains(av AttributeValue, operand AttributeValue) bool {
 	// List contains value.
 	if av.L != nil {
 		for _, elem := range av.L {
-			if attributeValuesEqualStatic(elem, operand) {
+			if attributeValuesEqualStatic(*elem, operand) {
 				return true
 			}
 		}
@@ -474,10 +474,12 @@ func resolveItemPath(item Item, path string) (AttributeValue, bool) {
 			return AttributeValue{}, false
 		}
 
-		val, ok = val.M[part]
-		if !ok {
+		ptr, ok := val.M[part]
+		if !ok || ptr == nil {
 			return AttributeValue{}, false
 		}
+
+		val = *ptr
 	}
 
 	return val, true

--- a/internal/service/dynamodb/condition_test.go
+++ b/internal/service/dynamodb/condition_test.go
@@ -562,7 +562,7 @@ func TestEvaluateCondition(t *testing.T) {
 		},
 		{
 			name: "size comparison",
-			item: Item{"pk": {S: ptr("1")}, "items": {L: []AttributeValue{{S: ptr("a")}, {S: ptr("b")}, {S: ptr("c")}}}},
+			item: Item{"pk": {S: ptr("1")}, "items": {L: []*AttributeValue{{S: ptr("a")}, {S: ptr("b")}, {S: ptr("c")}}}},
 			cond: ConditionInput{
 				Expression: "size(items) > :min",
 				ExprValues: map[string]AttributeValue{
@@ -573,7 +573,7 @@ func TestEvaluateCondition(t *testing.T) {
 		},
 		{
 			name: "size comparison fails",
-			item: Item{"pk": {S: ptr("1")}, "items": {L: []AttributeValue{{S: ptr("a")}}}},
+			item: Item{"pk": {S: ptr("1")}, "items": {L: []*AttributeValue{{S: ptr("a")}}}},
 			cond: ConditionInput{
 				Expression: "size(items) > :min",
 				ExprValues: map[string]AttributeValue{
@@ -604,7 +604,7 @@ func TestEvaluateCondition(t *testing.T) {
 		},
 		{
 			name: "nested path attribute_exists",
-			item: Item{"pk": {S: ptr("1")}, "meta": {M: map[string]AttributeValue{"version": {N: ptr("1")}}}},
+			item: Item{"pk": {S: ptr("1")}, "meta": {M: map[string]*AttributeValue{"version": {N: ptr("1")}}}},
 			cond: ConditionInput{
 				Expression: "attribute_exists(meta.version)",
 			},

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -794,7 +794,7 @@ func (m *MemoryStorage) copyAttributeValue(av AttributeValue) AttributeValue {
 
 		for k, v := range av.M {
 			copied := m.copyAttributeValue(*v)
-			mapCopy[k] = &copied //nolint:gosec // copied is a fresh value per iteration
+			mapCopy[k] = &copied
 		}
 
 		result.M = mapCopy
@@ -805,7 +805,7 @@ func (m *MemoryStorage) copyAttributeValue(av AttributeValue) AttributeValue {
 
 		for i, v := range av.L {
 			copied := m.copyAttributeValue(*v)
-			listCopy[i] = &copied //nolint:gosec // copied is a fresh value per iteration
+			listCopy[i] = &copied
 		}
 
 		result.L = listCopy

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -790,20 +790,22 @@ func (m *MemoryStorage) copyAttributeValue(av AttributeValue) AttributeValue {
 	}
 
 	if av.M != nil {
-		mapCopy := make(map[string]AttributeValue)
+		mapCopy := make(map[string]*AttributeValue)
 
 		for k, v := range av.M {
-			mapCopy[k] = m.copyAttributeValue(v)
+			copied := m.copyAttributeValue(*v)
+			mapCopy[k] = &copied //nolint:gosec // copied is a fresh value per iteration
 		}
 
 		result.M = mapCopy
 	}
 
 	if av.L != nil {
-		listCopy := make([]AttributeValue, len(av.L))
+		listCopy := make([]*AttributeValue, len(av.L))
 
 		for i, v := range av.L {
-			listCopy[i] = m.copyAttributeValue(v)
+			copied := m.copyAttributeValue(*v)
+			listCopy[i] = &copied //nolint:gosec // copied is a fresh value per iteration
 		}
 
 		result.L = listCopy

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -3,7 +3,6 @@ package dynamodb
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 )
 
@@ -39,7 +38,7 @@ type AttributeValue struct {
 }
 
 // MarshalJSON serializes AttributeValue, preserving empty slices/maps.
-func (av *AttributeValue) MarshalJSON() ([]byte, error) {
+func (av AttributeValue) MarshalJSON() ([]byte, error) {
 	m := make(map[string]any)
 
 	if av.S != nil {
@@ -82,12 +81,7 @@ func (av *AttributeValue) MarshalJSON() ([]byte, error) {
 		m["BOOL"] = av.BOOL
 	}
 
-	data, err := json.Marshal(m)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal attribute value: %w", err)
-	}
-
-	return data, nil
+	return json.Marshal(m)
 }
 
 // UnmarshalJSON deserializes AttributeValue.

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -21,21 +21,19 @@ const (
 )
 
 // AttributeValue represents a DynamoDB attribute value.
-// Only one field should be set at a time.
-// AttributeValue represents a DynamoDB attribute value.
-// Custom MarshalJSON preserves empty lists/maps/sets (e.g. "L": []) instead of
-// omitting them, which is required for correct round-trip serialization.
+// Custom MarshalJSON/UnmarshalJSON handle serialization to preserve empty
+// collections (e.g. "L": [], "SS": []) and omit nil fields.
 type AttributeValue struct {
-	S    *string                   `json:"S,omitempty"`
-	N    *string                   `json:"N,omitempty"`
-	B    []byte                    `json:"B,omitempty"`
-	SS   []string                  `json:"-"`
-	NS   []string                  `json:"-"`
-	BS   [][]byte                  `json:"-"`
-	M    map[string]AttributeValue `json:"-"`
-	L    []AttributeValue          `json:"-"`
-	NULL *bool                     `json:"NULL,omitempty"`
-	BOOL *bool                     `json:"BOOL,omitempty"`
+	S    *string
+	N    *string
+	B    []byte
+	SS   []string
+	NS   []string
+	BS   [][]byte
+	M    map[string]*AttributeValue
+	L    []*AttributeValue
+	NULL *bool
+	BOOL *bool
 }
 
 // MarshalJSON serializes AttributeValue, preserving empty slices/maps.
@@ -92,18 +90,17 @@ func (av *AttributeValue) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON deserializes AttributeValue.
 func (av *AttributeValue) UnmarshalJSON(data []byte) error {
-	// Use a raw struct to avoid infinite recursion.
 	var raw struct {
-		S    *string                   `json:"S"`
-		N    *string                   `json:"N"`
-		B    []byte                    `json:"B"`
-		SS   []string                  `json:"SS"`
-		NS   []string                  `json:"NS"`
-		BS   [][]byte                  `json:"BS"`
-		M    map[string]AttributeValue `json:"M"`
-		L    []AttributeValue          `json:"L"`
-		NULL *bool                     `json:"NULL"`
-		BOOL *bool                     `json:"BOOL"`
+		S    *string                    `json:"S"`
+		N    *string                    `json:"N"`
+		B    []byte                     `json:"B"`
+		SS   []string                   `json:"SS"`
+		NS   []string                   `json:"NS"`
+		BS   [][]byte                   `json:"BS"`
+		M    map[string]*AttributeValue `json:"M"`
+		L    []*AttributeValue          `json:"L"`
+		NULL *bool                      `json:"NULL"`
+		BOOL *bool                      `json:"BOOL"`
 	}
 
 	if err := json.Unmarshal(data, &raw); err != nil {

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -3,6 +3,7 @@ package dynamodb
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -38,7 +39,7 @@ type AttributeValue struct {
 }
 
 // MarshalJSON serializes AttributeValue, preserving empty slices/maps.
-func (av AttributeValue) MarshalJSON() ([]byte, error) {
+func (av *AttributeValue) MarshalJSON() ([]byte, error) {
 	m := make(map[string]any)
 
 	if av.S != nil {
@@ -81,7 +82,12 @@ func (av AttributeValue) MarshalJSON() ([]byte, error) {
 		m["BOOL"] = av.BOOL
 	}
 
-	return json.Marshal(m)
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal attribute value: %w", err)
+	}
+
+	return data, nil
 }
 
 // UnmarshalJSON deserializes AttributeValue.


### PR DESCRIPTION
## Summary

Fix empty attribute serialization for DynamoDB round-trip operations by using pointer types for nested collection fields.

## Problem

`dynamo: cannot unmarshal <empty> attribute value` when clients write items with SS/L/M fields and read them back. The root cause was that `map[string]AttributeValue` (value type) prevented the pointer-receiver `MarshalJSON` from being called for nested values.

## Fix

- Change `M` from `map[string]AttributeValue` to `map[string]*AttributeValue`
- Change `L` from `[]AttributeValue` to `[]*AttributeValue`
- Remove json struct tags (custom MarshalJSON/UnmarshalJSON handle all serialization)
- Update `copyAttributeValue`, `condition.go`, and tests accordingly

## Verified locally

All layerone Go tests pass with this fix:
- `go/pkg/storage/temporary` (S3 CopyObject)
- `go/repos/layerone-ocr/internal/repository` (DynamoDB SS round-trip)
- `go/services/docissue/v1/document/internal/test/integration` (DynamoDB ConditionExpression)
- `go/repos/layerone-workflow/internal/service` (EventBridge PutEvents + DynamoDB)