### PR TITLE
feat(cli): add Amplify subcommands

### DIFF
--- a/cli/amplify.go
+++ b/cli/amplify.go
@@ -1,0 +1,406 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/amplify"
+	amplifyTypes "github.com/aws/aws-sdk-go-v2/service/amplify/types"
+	"github.com/spf13/cobra"
+)
+
+func newAmplifyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "amplify",
+		Short: "Amplify commands",
+	}
+
+	cmd.AddCommand(
+		newAmplifyCreateAppCmd(),
+		newAmplifyGetAppCmd(),
+		newAmplifyListAppsCmd(),
+		newAmplifyUpdateAppCmd(),
+		newAmplifyDeleteAppCmd(),
+		newAmplifyCreateBranchCmd(),
+		newAmplifyGetBranchCmd(),
+		newAmplifyListBranchesCmd(),
+		newAmplifyDeleteBranchCmd(),
+	)
+
+	return cmd
+}
+
+func newAmplifyCreateAppCmd() *cobra.Command {
+	var name, description, repository, platform string
+
+	cmd := &cobra.Command{
+		Use:   "create-app",
+		Short: "Create an Amplify app",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := amplify.NewFromConfig(cfg, func(o *amplify.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &amplify.CreateAppInput{
+				Name: aws.String(name),
+			}
+
+			if description != "" {
+				input.Description = aws.String(description)
+			}
+
+			if repository != "" {
+				input.Repository = aws.String(repository)
+			}
+
+			if platform != "" {
+				input.Platform = amplifyPlatform(platform)
+			}
+
+			out, err := client.CreateApp(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("create-app failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "App name")
+	cmd.Flags().StringVar(&description, "description", "", "App description")
+	cmd.Flags().StringVar(&repository, "repository", "", "Repository URL")
+	cmd.Flags().StringVar(&platform, "platform", "", "Platform (WEB, WEB_DYNAMIC, WEB_COMPUTE)")
+
+	return cmd
+}
+
+func newAmplifyGetAppCmd() *cobra.Command {
+	var appID string
+
+	cmd := &cobra.Command{
+		Use:   "get-app",
+		Short: "Get an Amplify app",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := amplify.NewFromConfig(cfg, func(o *amplify.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.GetApp(cmd.Context(), &amplify.GetAppInput{
+				AppId: aws.String(appID),
+			})
+			if err != nil {
+				return fmt.Errorf("get-app failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&appID, "app-id", "", "App ID")
+
+	return cmd
+}
+
+func newAmplifyListAppsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-apps",
+		Short: "List Amplify apps",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := amplify.NewFromConfig(cfg, func(o *amplify.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.ListApps(cmd.Context(), &amplify.ListAppsInput{})
+			if err != nil {
+				return fmt.Errorf("list-apps failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newAmplifyUpdateAppCmd() *cobra.Command {
+	var appID, name, description, platform string
+
+	cmd := &cobra.Command{
+		Use:   "update-app",
+		Short: "Update an Amplify app",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := amplify.NewFromConfig(cfg, func(o *amplify.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &amplify.UpdateAppInput{
+				AppId: aws.String(appID),
+			}
+
+			if name != "" {
+				input.Name = aws.String(name)
+			}
+
+			if description != "" {
+				input.Description = aws.String(description)
+			}
+
+			if platform != "" {
+				input.Platform = amplifyPlatform(platform)
+			}
+
+			out, err := client.UpdateApp(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("update-app failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&appID, "app-id", "", "App ID")
+	cmd.Flags().StringVar(&name, "name", "", "App name")
+	cmd.Flags().StringVar(&description, "description", "", "App description")
+	cmd.Flags().StringVar(&platform, "platform", "", "Platform")
+
+	return cmd
+}
+
+func newAmplifyDeleteAppCmd() *cobra.Command {
+	var appID string
+
+	cmd := &cobra.Command{
+		Use:   "delete-app",
+		Short: "Delete an Amplify app",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := amplify.NewFromConfig(cfg, func(o *amplify.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			_, err = client.DeleteApp(cmd.Context(), &amplify.DeleteAppInput{
+				AppId: aws.String(appID),
+			})
+			if err != nil {
+				return fmt.Errorf("delete-app failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&appID, "app-id", "", "App ID")
+
+	return cmd
+}
+
+func newAmplifyCreateBranchCmd() *cobra.Command {
+	var appID, branchName, description, framework, stage string
+
+	cmd := &cobra.Command{
+		Use:   "create-branch",
+		Short: "Create an Amplify branch",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := amplify.NewFromConfig(cfg, func(o *amplify.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &amplify.CreateBranchInput{
+				AppId:      aws.String(appID),
+				BranchName: aws.String(branchName),
+			}
+
+			if description != "" {
+				input.Description = aws.String(description)
+			}
+
+			if framework != "" {
+				input.Framework = aws.String(framework)
+			}
+
+			if stage != "" {
+				input.Stage = amplifyStage(stage)
+			}
+
+			out, err := client.CreateBranch(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("create-branch failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&appID, "app-id", "", "App ID")
+	cmd.Flags().StringVar(&branchName, "branch-name", "", "Branch name")
+	cmd.Flags().StringVar(&description, "description", "", "Branch description")
+	cmd.Flags().StringVar(&framework, "framework", "", "Framework")
+	cmd.Flags().StringVar(&stage, "stage", "", "Stage (PRODUCTION, BETA, DEVELOPMENT, etc.)")
+
+	return cmd
+}
+
+func newAmplifyGetBranchCmd() *cobra.Command {
+	var appID, branchName string
+
+	cmd := &cobra.Command{
+		Use:   "get-branch",
+		Short: "Get an Amplify branch",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := amplify.NewFromConfig(cfg, func(o *amplify.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.GetBranch(cmd.Context(), &amplify.GetBranchInput{
+				AppId:      aws.String(appID),
+				BranchName: aws.String(branchName),
+			})
+			if err != nil {
+				return fmt.Errorf("get-branch failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&appID, "app-id", "", "App ID")
+	cmd.Flags().StringVar(&branchName, "branch-name", "", "Branch name")
+
+	return cmd
+}
+
+func newAmplifyListBranchesCmd() *cobra.Command {
+	var appID string
+
+	cmd := &cobra.Command{
+		Use:   "list-branches",
+		Short: "List Amplify branches",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := amplify.NewFromConfig(cfg, func(o *amplify.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.ListBranches(cmd.Context(), &amplify.ListBranchesInput{
+				AppId: aws.String(appID),
+			})
+			if err != nil {
+				return fmt.Errorf("list-branches failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&appID, "app-id", "", "App ID")
+
+	return cmd
+}
+
+func newAmplifyDeleteBranchCmd() *cobra.Command {
+	var appID, branchName string
+
+	cmd := &cobra.Command{
+		Use:   "delete-branch",
+		Short: "Delete an Amplify branch",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := amplify.NewFromConfig(cfg, func(o *amplify.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			_, err = client.DeleteBranch(cmd.Context(), &amplify.DeleteBranchInput{
+				AppId:      aws.String(appID),
+				BranchName: aws.String(branchName),
+			})
+			if err != nil {
+				return fmt.Errorf("delete-branch failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&appID, "app-id", "", "App ID")
+	cmd.Flags().StringVar(&branchName, "branch-name", "", "Branch name")
+
+	return cmd
+}
+
+func amplifyPlatform(s string) amplifyTypes.Platform {
+	return amplifyTypes.Platform(s)
+}
+
+func amplifyStage(s string) amplifyTypes.Stage {
+	return amplifyTypes.Stage(s)
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -28,6 +28,7 @@ func NewRootCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		newACMCmd(),
+		newAmplifyCmd(),
 		newS3Cmd(),
 		newS3APICmd(),
 		newDynamoDBCmd(),

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
 	github.com/aws/aws-sdk-go-v2/service/acm v1.38.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
 github.com/aws/aws-sdk-go-v2/service/acm v1.38.3 h1:Fzab84hCu3rw9R9Y3mH7SHfr/cSEHnCB0Mq1JCdr9t0=
 github.com/aws/aws-sdk-go-v2/service/acm v1.38.3/go.mod h1:yCteizCNPaHt0SnNusoGGHvy0JDB0tvGDTVhEt5anZM=
+github.com/aws/aws-sdk-go-v2/service/amplify v1.38.16 h1:gzzIbyyvOBH5LroqCzPbeVXvYATG1E6giLukqFrTAR8=
+github.com/aws/aws-sdk-go-v2/service/amplify v1.38.16/go.mod h1:Cpr737zpOuoLZ137MQ5iImlVxP5A3pdKkVwgOBATy04=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 h1:XgjzLEE8CrNYnr4Xmi1W5PfKsKMjp4Pu1rWkJNO43JI=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3/go.mod h1:r7sfLXEN8RUA89tAHy1E7lCtVOOWIkqVy/FbnUdxW1E=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 h1:9PZbyFSCN/E0TnqXqnvYJRhu7yQJv31vHG/vyuirbCY=


### PR DESCRIPTION
## Summary
- Add Amplify CLI subcommands: create-app, get-app, list-apps, update-app, delete-app, create-branch, get-branch, list-branches, delete-branch
- Register Amplify command in root command

## Test plan
- [ ] Build passes
- [ ] All 9 Amplify subcommands are accessible via `kumo amplify --help`