### PR TITLE
feat(cli): add AppSync subcommands

### DIFF
--- a/cli/appsync.go
+++ b/cli/appsync.go
@@ -1,0 +1,314 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/appsync"
+	appsyncTypes "github.com/aws/aws-sdk-go-v2/service/appsync/types"
+	"github.com/spf13/cobra"
+)
+
+func newAppSyncCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "appsync",
+		Short: "AppSync commands",
+	}
+
+	cmd.AddCommand(
+		newAppSyncCreateGraphqlAPICmd(),
+		newAppSyncGetGraphqlAPICmd(),
+		newAppSyncListGraphqlAPIsCmd(),
+		newAppSyncDeleteGraphqlAPICmd(),
+		newAppSyncCreateDataSourceCmd(),
+		newAppSyncCreateResolverCmd(),
+		newAppSyncStartSchemaCreationCmd(),
+	)
+
+	return cmd
+}
+
+func newAppSyncCreateGraphqlAPICmd() *cobra.Command {
+	var name, authType string
+
+	cmd := &cobra.Command{
+		Use:   "create-graphql-api",
+		Short: "Create a GraphQL API",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := appsync.NewFromConfig(cfg, func(o *appsync.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &appsync.CreateGraphqlApiInput{
+				Name:               aws.String(name),
+				AuthenticationType: appsyncTypes.AuthenticationType(authType),
+			}
+
+			out, err := client.CreateGraphqlApi(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("create-graphql-api failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "API name")
+	cmd.Flags().StringVar(&authType, "authentication-type", "", "Authentication type (API_KEY, AWS_IAM, etc.)")
+
+	return cmd
+}
+
+func newAppSyncGetGraphqlAPICmd() *cobra.Command {
+	var apiID string
+
+	cmd := &cobra.Command{
+		Use:   "get-graphql-api",
+		Short: "Get a GraphQL API",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := appsync.NewFromConfig(cfg, func(o *appsync.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.GetGraphqlApi(cmd.Context(), &appsync.GetGraphqlApiInput{
+				ApiId: aws.String(apiID),
+			})
+			if err != nil {
+				return fmt.Errorf("get-graphql-api failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&apiID, "api-id", "", "API ID")
+
+	return cmd
+}
+
+func newAppSyncListGraphqlAPIsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-graphql-apis",
+		Short: "List GraphQL APIs",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := appsync.NewFromConfig(cfg, func(o *appsync.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.ListGraphqlApis(cmd.Context(), &appsync.ListGraphqlApisInput{})
+			if err != nil {
+				return fmt.Errorf("list-graphql-apis failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newAppSyncDeleteGraphqlAPICmd() *cobra.Command {
+	var apiID string
+
+	cmd := &cobra.Command{
+		Use:   "delete-graphql-api",
+		Short: "Delete a GraphQL API",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := appsync.NewFromConfig(cfg, func(o *appsync.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			_, err = client.DeleteGraphqlApi(cmd.Context(), &appsync.DeleteGraphqlApiInput{
+				ApiId: aws.String(apiID),
+			})
+			if err != nil {
+				return fmt.Errorf("delete-graphql-api failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&apiID, "api-id", "", "API ID")
+
+	return cmd
+}
+
+func newAppSyncCreateDataSourceCmd() *cobra.Command {
+	var apiID, name, dsType, description, serviceRoleArn string
+
+	cmd := &cobra.Command{
+		Use:   "create-data-source",
+		Short: "Create a data source",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := appsync.NewFromConfig(cfg, func(o *appsync.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &appsync.CreateDataSourceInput{
+				ApiId: aws.String(apiID),
+				Name:  aws.String(name),
+				Type:  appsyncTypes.DataSourceType(dsType),
+			}
+
+			if description != "" {
+				input.Description = aws.String(description)
+			}
+
+			if serviceRoleArn != "" {
+				input.ServiceRoleArn = aws.String(serviceRoleArn)
+			}
+
+			out, err := client.CreateDataSource(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("create-data-source failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&apiID, "api-id", "", "API ID")
+	cmd.Flags().StringVar(&name, "name", "", "Data source name")
+	cmd.Flags().StringVar(&dsType, "type", "", "Data source type (NONE, AMAZON_DYNAMODB, AWS_LAMBDA, etc.)")
+	cmd.Flags().StringVar(&description, "description", "", "Data source description")
+	cmd.Flags().StringVar(&serviceRoleArn, "service-role-arn", "", "Service role ARN")
+
+	return cmd
+}
+
+func newAppSyncCreateResolverCmd() *cobra.Command {
+	var apiID, typeName, fieldName, dataSourceName, requestTemplate, responseTemplate string
+
+	cmd := &cobra.Command{
+		Use:   "create-resolver",
+		Short: "Create a resolver",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := appsync.NewFromConfig(cfg, func(o *appsync.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &appsync.CreateResolverInput{
+				ApiId:     aws.String(apiID),
+				TypeName:  aws.String(typeName),
+				FieldName: aws.String(fieldName),
+			}
+
+			if dataSourceName != "" {
+				input.DataSourceName = aws.String(dataSourceName)
+			}
+
+			if requestTemplate != "" {
+				input.RequestMappingTemplate = aws.String(requestTemplate)
+			}
+
+			if responseTemplate != "" {
+				input.ResponseMappingTemplate = aws.String(responseTemplate)
+			}
+
+			out, err := client.CreateResolver(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("create-resolver failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&apiID, "api-id", "", "API ID")
+	cmd.Flags().StringVar(&typeName, "type-name", "", "Type name")
+	cmd.Flags().StringVar(&fieldName, "field-name", "", "Field name")
+	cmd.Flags().StringVar(&dataSourceName, "data-source-name", "", "Data source name")
+	cmd.Flags().StringVar(&requestTemplate, "request-mapping-template", "", "Request mapping template")
+	cmd.Flags().StringVar(&responseTemplate, "response-mapping-template", "", "Response mapping template")
+
+	return cmd
+}
+
+func newAppSyncStartSchemaCreationCmd() *cobra.Command {
+	var apiID, definition string
+
+	cmd := &cobra.Command{
+		Use:   "start-schema-creation",
+		Short: "Start schema creation",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := appsync.NewFromConfig(cfg, func(o *appsync.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.StartSchemaCreation(cmd.Context(), &appsync.StartSchemaCreationInput{
+				ApiId:      aws.String(apiID),
+				Definition: []byte(definition),
+			})
+			if err != nil {
+				return fmt.Errorf("start-schema-creation failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&apiID, "api-id", "", "API ID")
+	cmd.Flags().StringVar(&definition, "definition", "", "Schema definition (SDL)")
+
+	return cmd
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -31,6 +31,7 @@ func NewRootCmd() *cobra.Command {
 		newAmplifyCmd(),
 		newAPIGatewayCmd(),
 		newAppMeshCmd(),
+		newAppSyncCmd(),
 		newS3Cmd(),
 		newS3APICmd(),
 		newDynamoDBCmd(),

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14 // indirect
+	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3 h1:7MJlB7KGFd+KNKtnPgoFW
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3/go.mod h1:MwilTAruv11x8EFjsk1R0VfjMdCxB6JHVtanCqsTR5o=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14 h1:31mnzduRd3FyuGCwgdMfPAu6MG1XnQf4zJrPjpZvnbM=
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14/go.mod h1:u/RTn1872BcpTxDnsQXi0AO8nxMch/46nlr3/loCpu8=
+github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 h1:SjkXYNc15FoovS9k6ML7dO7pkXE3ns66RXwL+rfQVl8=
+github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7/go.mod h1:RcoBov7Pw38ViMxlthKRr1GLgHPPseA+kY2bupWVm10=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 h1:XgjzLEE8CrNYnr4Xmi1W5PfKsKMjp4Pu1rWkJNO43JI=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3/go.mod h1:r7sfLXEN8RUA89tAHy1E7lCtVOOWIkqVy/FbnUdxW1E=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 h1:9PZbyFSCN/E0TnqXqnvYJRhu7yQJv31vHG/vyuirbCY=


### PR DESCRIPTION
## Summary
- Add AppSync CLI subcommands: create-graphql-api, get-graphql-api, list-graphql-apis, delete-graphql-api, create-data-source, create-resolver, start-schema-creation
- Register appsync command in root command

## Test plan
- [ ] Build passes
- [ ] All 7 AppSync subcommands are accessible via `kumo appsync --help`