### PR TITLE
feat(cli): add Athena subcommands

### DIFF
--- a/cli/athena.go
+++ b/cli/athena.go
@@ -1,0 +1,307 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/athena"
+	athenaTypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
+	"github.com/spf13/cobra"
+)
+
+func newAthenaCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "athena",
+		Short: "Athena commands",
+	}
+
+	cmd.AddCommand(
+		newAthenaCreateWorkGroupCmd(),
+		newAthenaDeleteWorkGroupCmd(),
+		newAthenaStartQueryExecutionCmd(),
+		newAthenaStopQueryExecutionCmd(),
+		newAthenaGetQueryExecutionCmd(),
+		newAthenaGetQueryResultsCmd(),
+		newAthenaListQueryExecutionsCmd(),
+	)
+
+	return cmd
+}
+
+func newAthenaCreateWorkGroupCmd() *cobra.Command {
+	var name, description string
+
+	cmd := &cobra.Command{
+		Use:   "create-work-group",
+		Short: "Create a workgroup",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := athena.NewFromConfig(cfg, func(o *athena.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &athena.CreateWorkGroupInput{
+				Name: aws.String(name),
+			}
+
+			if description != "" {
+				input.Description = aws.String(description)
+			}
+
+			out, err := client.CreateWorkGroup(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("create-work-group failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Work group name")
+	cmd.Flags().StringVar(&description, "description", "", "Work group description")
+
+	return cmd
+}
+
+func newAthenaDeleteWorkGroupCmd() *cobra.Command {
+	var name string
+
+	cmd := &cobra.Command{
+		Use:   "delete-work-group",
+		Short: "Delete a workgroup",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := athena.NewFromConfig(cfg, func(o *athena.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			_, err = client.DeleteWorkGroup(cmd.Context(), &athena.DeleteWorkGroupInput{
+				WorkGroup: aws.String(name),
+			})
+			if err != nil {
+				return fmt.Errorf("delete-work-group failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "work-group", "", "Work group name")
+
+	return cmd
+}
+
+func newAthenaStartQueryExecutionCmd() *cobra.Command {
+	var queryString, database, workGroup, outputLocation string
+
+	cmd := &cobra.Command{
+		Use:   "start-query-execution",
+		Short: "Start a query execution",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := athena.NewFromConfig(cfg, func(o *athena.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &athena.StartQueryExecutionInput{
+				QueryString: aws.String(queryString),
+			}
+
+			if database != "" {
+				input.QueryExecutionContext = &athenaTypes.QueryExecutionContext{
+					Database: aws.String(database),
+				}
+			}
+
+			if workGroup != "" {
+				input.WorkGroup = aws.String(workGroup)
+			}
+
+			if outputLocation != "" {
+				input.ResultConfiguration = &athenaTypes.ResultConfiguration{
+					OutputLocation: aws.String(outputLocation),
+				}
+			}
+
+			out, err := client.StartQueryExecution(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("start-query-execution failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&queryString, "query-string", "", "SQL query string")
+	cmd.Flags().StringVar(&database, "database", "", "Database name")
+	cmd.Flags().StringVar(&workGroup, "work-group", "", "Work group name")
+	cmd.Flags().StringVar(&outputLocation, "output-location", "", "S3 output location")
+
+	return cmd
+}
+
+func newAthenaStopQueryExecutionCmd() *cobra.Command {
+	var queryExecutionID string
+
+	cmd := &cobra.Command{
+		Use:   "stop-query-execution",
+		Short: "Stop a query execution",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := athena.NewFromConfig(cfg, func(o *athena.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			_, err = client.StopQueryExecution(cmd.Context(), &athena.StopQueryExecutionInput{
+				QueryExecutionId: aws.String(queryExecutionID),
+			})
+			if err != nil {
+				return fmt.Errorf("stop-query-execution failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&queryExecutionID, "query-execution-id", "", "Query execution ID")
+
+	return cmd
+}
+
+func newAthenaGetQueryExecutionCmd() *cobra.Command {
+	var queryExecutionID string
+
+	cmd := &cobra.Command{
+		Use:   "get-query-execution",
+		Short: "Get a query execution",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := athena.NewFromConfig(cfg, func(o *athena.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.GetQueryExecution(cmd.Context(), &athena.GetQueryExecutionInput{
+				QueryExecutionId: aws.String(queryExecutionID),
+			})
+			if err != nil {
+				return fmt.Errorf("get-query-execution failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&queryExecutionID, "query-execution-id", "", "Query execution ID")
+
+	return cmd
+}
+
+func newAthenaGetQueryResultsCmd() *cobra.Command {
+	var queryExecutionID string
+
+	cmd := &cobra.Command{
+		Use:   "get-query-results",
+		Short: "Get query results",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := athena.NewFromConfig(cfg, func(o *athena.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.GetQueryResults(cmd.Context(), &athena.GetQueryResultsInput{
+				QueryExecutionId: aws.String(queryExecutionID),
+			})
+			if err != nil {
+				return fmt.Errorf("get-query-results failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&queryExecutionID, "query-execution-id", "", "Query execution ID")
+
+	return cmd
+}
+
+func newAthenaListQueryExecutionsCmd() *cobra.Command {
+	var workGroup string
+
+	cmd := &cobra.Command{
+		Use:   "list-query-executions",
+		Short: "List query executions",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := athena.NewFromConfig(cfg, func(o *athena.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &athena.ListQueryExecutionsInput{}
+
+			if workGroup != "" {
+				input.WorkGroup = aws.String(workGroup)
+			}
+
+			out, err := client.ListQueryExecutions(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("list-query-executions failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&workGroup, "work-group", "", "Work group name")
+
+	return cmd
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -32,6 +32,7 @@ func NewRootCmd() *cobra.Command {
 		newAPIGatewayCmd(),
 		newAppMeshCmd(),
 		newAppSyncCmd(),
+		newAthenaCmd(),
 		newS3Cmd(),
 		newS3APICmd(),
 		newDynamoDBCmd(),

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/athena v1.57.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14 h1:31mnzduRd3FyuGCwgdMfPAu
 github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14/go.mod h1:u/RTn1872BcpTxDnsQXi0AO8nxMch/46nlr3/loCpu8=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 h1:SjkXYNc15FoovS9k6ML7dO7pkXE3ns66RXwL+rfQVl8=
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7/go.mod h1:RcoBov7Pw38ViMxlthKRr1GLgHPPseA+kY2bupWVm10=
+github.com/aws/aws-sdk-go-v2/service/athena v1.57.6 h1:QPDxHlfHmozXUj9rmUyxQiOLVEJL3qX4x56CrwAtytM=
+github.com/aws/aws-sdk-go-v2/service/athena v1.57.6/go.mod h1:3QLTFWWkK+tGp4LD0ClX5Ib75MWE5H66vBat1N9f8Os=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 h1:XgjzLEE8CrNYnr4Xmi1W5PfKsKMjp4Pu1rWkJNO43JI=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3/go.mod h1:r7sfLXEN8RUA89tAHy1E7lCtVOOWIkqVy/FbnUdxW1E=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 h1:9PZbyFSCN/E0TnqXqnvYJRhu7yQJv31vHG/vyuirbCY=


### PR DESCRIPTION
## Summary
- Add Athena CLI subcommands: create-work-group, delete-work-group, start-query-execution, stop-query-execution, get-query-execution, get-query-results, list-query-executions
- Register athena command in root command

## Test plan
- [ ] Build passes
- [ ] All 7 Athena subcommands are accessible via `kumo athena --help`