### PR TITLE
feat(cli): add Backup subcommands

### DIFF
--- a/cli/backup.go
+++ b/cli/backup.go
@@ -1,0 +1,454 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/backup"
+	backupTypes "github.com/aws/aws-sdk-go-v2/service/backup/types"
+	"github.com/spf13/cobra"
+)
+
+func newBackupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backup",
+		Short: "AWS Backup commands",
+	}
+
+	cmd.AddCommand(
+		newBackupCreateBackupVaultCmd(),
+		newBackupDescribeBackupVaultCmd(),
+		newBackupListBackupVaultsCmd(),
+		newBackupDeleteBackupVaultCmd(),
+		newBackupCreateBackupPlanCmd(),
+		newBackupGetBackupPlanCmd(),
+		newBackupListBackupPlansCmd(),
+		newBackupDeleteBackupPlanCmd(),
+		newBackupCreateBackupSelectionCmd(),
+		newBackupGetBackupSelectionCmd(),
+		newBackupListBackupSelectionsCmd(),
+		newBackupDeleteBackupSelectionCmd(),
+	)
+
+	return cmd
+}
+
+func newBackupCreateBackupVaultCmd() *cobra.Command {
+	var vaultName string
+
+	cmd := &cobra.Command{
+		Use:   "create-backup-vault",
+		Short: "Create a backup vault",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.CreateBackupVault(cmd.Context(), &backup.CreateBackupVaultInput{
+				BackupVaultName: aws.String(vaultName),
+			})
+			if err != nil {
+				return fmt.Errorf("create-backup-vault failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&vaultName, "backup-vault-name", "", "Backup vault name")
+
+	return cmd
+}
+
+func newBackupDescribeBackupVaultCmd() *cobra.Command {
+	var vaultName string
+
+	cmd := &cobra.Command{
+		Use:   "describe-backup-vault",
+		Short: "Describe a backup vault",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.DescribeBackupVault(cmd.Context(), &backup.DescribeBackupVaultInput{
+				BackupVaultName: aws.String(vaultName),
+			})
+			if err != nil {
+				return fmt.Errorf("describe-backup-vault failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&vaultName, "backup-vault-name", "", "Backup vault name")
+
+	return cmd
+}
+
+func newBackupListBackupVaultsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-backup-vaults",
+		Short: "List backup vaults",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.ListBackupVaults(cmd.Context(), &backup.ListBackupVaultsInput{})
+			if err != nil {
+				return fmt.Errorf("list-backup-vaults failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newBackupDeleteBackupVaultCmd() *cobra.Command {
+	var vaultName string
+
+	cmd := &cobra.Command{
+		Use:   "delete-backup-vault",
+		Short: "Delete a backup vault",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			_, err = client.DeleteBackupVault(cmd.Context(), &backup.DeleteBackupVaultInput{
+				BackupVaultName: aws.String(vaultName),
+			})
+			if err != nil {
+				return fmt.Errorf("delete-backup-vault failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&vaultName, "backup-vault-name", "", "Backup vault name")
+
+	return cmd
+}
+
+func newBackupCreateBackupPlanCmd() *cobra.Command {
+	var planJSON string
+
+	cmd := &cobra.Command{
+		Use:   "create-backup-plan",
+		Short: "Create a backup plan",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			var plan backupTypes.BackupPlanInput
+
+			_ = json.Unmarshal([]byte(planJSON), &plan)
+
+			out, err := client.CreateBackupPlan(cmd.Context(), &backup.CreateBackupPlanInput{
+				BackupPlan: &plan,
+			})
+			if err != nil {
+				return fmt.Errorf("create-backup-plan failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&planJSON, "backup-plan", "", "Backup plan (JSON)")
+
+	return cmd
+}
+
+func newBackupGetBackupPlanCmd() *cobra.Command {
+	var planID string
+
+	cmd := &cobra.Command{
+		Use:   "get-backup-plan",
+		Short: "Get a backup plan",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.GetBackupPlan(cmd.Context(), &backup.GetBackupPlanInput{
+				BackupPlanId: aws.String(planID),
+			})
+			if err != nil {
+				return fmt.Errorf("get-backup-plan failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&planID, "backup-plan-id", "", "Backup plan ID")
+
+	return cmd
+}
+
+func newBackupListBackupPlansCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-backup-plans",
+		Short: "List backup plans",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.ListBackupPlans(cmd.Context(), &backup.ListBackupPlansInput{})
+			if err != nil {
+				return fmt.Errorf("list-backup-plans failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func newBackupDeleteBackupPlanCmd() *cobra.Command {
+	var planID string
+
+	cmd := &cobra.Command{
+		Use:   "delete-backup-plan",
+		Short: "Delete a backup plan",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			_, err = client.DeleteBackupPlan(cmd.Context(), &backup.DeleteBackupPlanInput{
+				BackupPlanId: aws.String(planID),
+			})
+			if err != nil {
+				return fmt.Errorf("delete-backup-plan failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&planID, "backup-plan-id", "", "Backup plan ID")
+
+	return cmd
+}
+
+func newBackupCreateBackupSelectionCmd() *cobra.Command {
+	var planID, selectionJSON string
+
+	cmd := &cobra.Command{
+		Use:   "create-backup-selection",
+		Short: "Create a backup selection",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			var selection backupTypes.BackupSelection
+
+			_ = json.Unmarshal([]byte(selectionJSON), &selection)
+
+			out, err := client.CreateBackupSelection(cmd.Context(), &backup.CreateBackupSelectionInput{
+				BackupPlanId:    aws.String(planID),
+				BackupSelection: &selection,
+			})
+			if err != nil {
+				return fmt.Errorf("create-backup-selection failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&planID, "backup-plan-id", "", "Backup plan ID")
+	cmd.Flags().StringVar(&selectionJSON, "backup-selection", "", "Backup selection (JSON)")
+
+	return cmd
+}
+
+func newBackupGetBackupSelectionCmd() *cobra.Command {
+	var planID, selectionID string
+
+	cmd := &cobra.Command{
+		Use:   "get-backup-selection",
+		Short: "Get a backup selection",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.GetBackupSelection(cmd.Context(), &backup.GetBackupSelectionInput{
+				BackupPlanId: aws.String(planID),
+				SelectionId:  aws.String(selectionID),
+			})
+			if err != nil {
+				return fmt.Errorf("get-backup-selection failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&planID, "backup-plan-id", "", "Backup plan ID")
+	cmd.Flags().StringVar(&selectionID, "selection-id", "", "Selection ID")
+
+	return cmd
+}
+
+func newBackupListBackupSelectionsCmd() *cobra.Command {
+	var planID string
+
+	cmd := &cobra.Command{
+		Use:   "list-backup-selections",
+		Short: "List backup selections",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.ListBackupSelections(cmd.Context(), &backup.ListBackupSelectionsInput{
+				BackupPlanId: aws.String(planID),
+			})
+			if err != nil {
+				return fmt.Errorf("list-backup-selections failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&planID, "backup-plan-id", "", "Backup plan ID")
+
+	return cmd
+}
+
+func newBackupDeleteBackupSelectionCmd() *cobra.Command {
+	var planID, selectionID string
+
+	cmd := &cobra.Command{
+		Use:   "delete-backup-selection",
+		Short: "Delete a backup selection",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := backup.NewFromConfig(cfg, func(o *backup.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			_, err = client.DeleteBackupSelection(cmd.Context(), &backup.DeleteBackupSelectionInput{
+				BackupPlanId: aws.String(planID),
+				SelectionId:  aws.String(selectionID),
+			})
+			if err != nil {
+				return fmt.Errorf("delete-backup-selection failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&planID, "backup-plan-id", "", "Backup plan ID")
+	cmd.Flags().StringVar(&selectionID, "selection-id", "", "Selection ID")
+
+	return cmd
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -33,6 +33,7 @@ func NewRootCmd() *cobra.Command {
 		newAppMeshCmd(),
 		newAppSyncCmd(),
 		newAthenaCmd(),
+		newBackupCmd(),
 		newS3Cmd(),
 		newS3APICmd(),
 		newDynamoDBCmd(),

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.35.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/athena v1.57.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7 h1:SjkXYNc15FoovS9k6ML7dO7p
 github.com/aws/aws-sdk-go-v2/service/appsync v1.53.7/go.mod h1:RcoBov7Pw38ViMxlthKRr1GLgHPPseA+kY2bupWVm10=
 github.com/aws/aws-sdk-go-v2/service/athena v1.57.6 h1:QPDxHlfHmozXUj9rmUyxQiOLVEJL3qX4x56CrwAtytM=
 github.com/aws/aws-sdk-go-v2/service/athena v1.57.6/go.mod h1:3QLTFWWkK+tGp4LD0ClX5Ib75MWE5H66vBat1N9f8Os=
+github.com/aws/aws-sdk-go-v2/service/backup v1.55.2 h1:WhdT1PwOjTjKLGuD9lJDyNMgYmVaZgTHK06ioJKMBYE=
+github.com/aws/aws-sdk-go-v2/service/backup v1.55.2/go.mod h1:uMh3ZDoLKhXldYL1qcBYy1HsNQfKgL/w8iF2onOyoKY=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 h1:XgjzLEE8CrNYnr4Xmi1W5PfKsKMjp4Pu1rWkJNO43JI=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3/go.mod h1:r7sfLXEN8RUA89tAHy1E7lCtVOOWIkqVy/FbnUdxW1E=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.45.25 h1:9PZbyFSCN/E0TnqXqnvYJRhu7yQJv31vHG/vyuirbCY=


### PR DESCRIPTION
## Summary
- Add AWS Backup CLI subcommands for vault, plan, and selection operations (12 commands total)
- Register backup command in root command

## Test plan
- [ ] Build passes
- [ ] All 12 Backup subcommands are accessible via `kumo backup --help`