### PR TITLE
feat(dynamodb): support legacy AttributeUpdates in UpdateItem

### DIFF
--- a/cli/s3api.go
+++ b/cli/s3api.go
@@ -58,6 +58,7 @@ func newS3APIPutObjectCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&bucket, "bucket", "", "Bucket name")
 	cmd.Flags().StringVar(&key, "key", "", "Object key")
+	cmd.Flags().Int64("content-length", 0, "Content length (ignored)")
 
 	return cmd
 }

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -859,6 +859,7 @@ func convertAttributeUpdates(req *UpdateItemRequest) {
 	var setParts, removeParts, addParts []string
 
 	idx := 0
+
 	for attr := range req.AttributeUpdates {
 		update := req.AttributeUpdates[attr]
 		nameKey := fmt.Sprintf("#au%d", idx)

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -857,9 +857,10 @@ func convertAttributeUpdates(req *UpdateItemRequest) {
 	}
 
 	var setParts, removeParts, addParts []string
-	idx := 0
 
-	for attr, update := range req.AttributeUpdates {
+	idx := 0
+	for attr := range req.AttributeUpdates {
+		update := req.AttributeUpdates[attr]
 		nameKey := fmt.Sprintf("#au%d", idx)
 		valueKey := fmt.Sprintf(":au%d", idx)
 		req.ExpressionAttributeNames[nameKey] = attr
@@ -867,11 +868,13 @@ func convertAttributeUpdates(req *UpdateItemRequest) {
 		switch strings.ToUpper(update.Action) {
 		case "PUT", "":
 			req.ExpressionAttributeValues[valueKey] = update.Value
+
 			setParts = append(setParts, nameKey+" = "+valueKey)
 		case "DELETE":
 			removeParts = append(removeParts, nameKey)
 		case "ADD":
 			req.ExpressionAttributeValues[valueKey] = update.Value
+
 			addParts = append(addParts, nameKey+" "+valueKey)
 		}
 
@@ -879,12 +882,15 @@ func convertAttributeUpdates(req *UpdateItemRequest) {
 	}
 
 	var parts []string
+
 	if len(setParts) > 0 {
 		parts = append(parts, "SET "+strings.Join(setParts, ", "))
 	}
+
 	if len(removeParts) > 0 {
 		parts = append(parts, "REMOVE "+strings.Join(removeParts, ", "))
 	}
+
 	if len(addParts) > 0 {
 		parts = append(parts, "ADD "+strings.Join(addParts, ", "))
 	}

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -308,6 +308,11 @@ func (s *Service) UpdateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Convert legacy AttributeUpdates to UpdateExpression if needed.
+	if req.UpdateExpression == "" && len(req.AttributeUpdates) > 0 {
+		convertAttributeUpdates(&req)
+	}
+
 	cond := ConditionInput{
 		Expression: req.ConditionExpression,
 		ExprNames:  req.ExpressionAttributeNames,
@@ -839,4 +844,50 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handler(w, r)
+}
+
+// convertAttributeUpdates converts legacy AttributeUpdates to UpdateExpression.
+func convertAttributeUpdates(req *UpdateItemRequest) {
+	if req.ExpressionAttributeNames == nil {
+		req.ExpressionAttributeNames = make(map[string]string)
+	}
+
+	if req.ExpressionAttributeValues == nil {
+		req.ExpressionAttributeValues = make(map[string]AttributeValue)
+	}
+
+	var setParts, removeParts, addParts []string
+	idx := 0
+
+	for attr, update := range req.AttributeUpdates {
+		nameKey := fmt.Sprintf("#au%d", idx)
+		valueKey := fmt.Sprintf(":au%d", idx)
+		req.ExpressionAttributeNames[nameKey] = attr
+
+		switch strings.ToUpper(update.Action) {
+		case "PUT", "":
+			req.ExpressionAttributeValues[valueKey] = update.Value
+			setParts = append(setParts, nameKey+" = "+valueKey)
+		case "DELETE":
+			removeParts = append(removeParts, nameKey)
+		case "ADD":
+			req.ExpressionAttributeValues[valueKey] = update.Value
+			addParts = append(addParts, nameKey+" "+valueKey)
+		}
+
+		idx++
+	}
+
+	var parts []string
+	if len(setParts) > 0 {
+		parts = append(parts, "SET "+strings.Join(setParts, ", "))
+	}
+	if len(removeParts) > 0 {
+		parts = append(parts, "REMOVE "+strings.Join(removeParts, ", "))
+	}
+	if len(addParts) > 0 {
+		parts = append(parts, "ADD "+strings.Join(addParts, ", "))
+	}
+
+	req.UpdateExpression = strings.Join(parts, " ")
 }

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -332,15 +332,22 @@ type DeleteItemResponse struct {
 	Attributes Item `json:"Attributes,omitempty"`
 }
 
+// AttributeValueUpdate represents a legacy AttributeUpdates entry.
+type AttributeValueUpdate struct {
+	Action string         `json:"Action"` // PUT, DELETE, ADD
+	Value  AttributeValue `json:"Value"`
+}
+
 // UpdateItemRequest is the request for UpdateItem.
 type UpdateItemRequest struct {
-	TableName                 string                    `json:"TableName"`
-	Key                       Item                      `json:"Key"`
-	UpdateExpression          string                    `json:"UpdateExpression,omitempty"`
-	ConditionExpression       string                    `json:"ConditionExpression,omitempty"`
-	ExpressionAttributeNames  map[string]string         `json:"ExpressionAttributeNames,omitempty"`
-	ExpressionAttributeValues map[string]AttributeValue `json:"ExpressionAttributeValues,omitempty"`
-	ReturnValues              string                    `json:"ReturnValues,omitempty"`
+	TableName                 string                          `json:"TableName"`
+	Key                       Item                            `json:"Key"`
+	UpdateExpression          string                          `json:"UpdateExpression,omitempty"`
+	ConditionExpression       string                          `json:"ConditionExpression,omitempty"`
+	ExpressionAttributeNames  map[string]string               `json:"ExpressionAttributeNames,omitempty"`
+	ExpressionAttributeValues map[string]AttributeValue       `json:"ExpressionAttributeValues,omitempty"`
+	AttributeUpdates          map[string]AttributeValueUpdate `json:"AttributeUpdates,omitempty"`
+	ReturnValues              string                          `json:"ReturnValues,omitempty"`
 }
 
 // UpdateItemResponse is the response for UpdateItem.

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -1297,3 +1297,79 @@ func TestDynamoDB_BatchGetItem(t *testing.T) {
 	}
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), result)
 }
+
+func TestDynamoDB_UpdateItem_AttributeUpdates(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-attribute-updates"
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("OwnerId"), KeyType: types.KeyTypeHash},
+			{AttributeName: aws.String("Key"), KeyType: types.KeyTypeRange},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("OwnerId"), AttributeType: types.ScalarAttributeTypeS},
+			{AttributeName: aws.String("Key"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"OwnerId": &types.AttributeValueMemberS{Value: "owner-1"},
+			"Key":     &types.AttributeValueMemberS{Value: "key-1"},
+			"Name":    &types.AttributeValueMemberS{Value: "original"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updateOutput, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]types.AttributeValue{
+			"OwnerId": &types.AttributeValueMemberS{Value: "owner-1"},
+			"Key":     &types.AttributeValueMemberS{Value: "key-1"},
+		},
+		AttributeUpdates: map[string]types.AttributeValueUpdate{
+			"Name": {
+				Action: types.AttributeActionPut,
+				Value:  &types.AttributeValueMemberS{Value: "updated"},
+			},
+		},
+		ReturnValues: types.ReturnValueAllNew,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), updateOutput)
+
+	getOutput, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]types.AttributeValue{
+			"OwnerId": &types.AttributeValueMemberS{Value: "owner-1"},
+			"Key":     &types.AttributeValueMemberS{Value: "key-1"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	name, ok := getOutput.Item["Name"].(*types.AttributeValueMemberS)
+	if !ok || name.Value != "updated" {
+		t.Errorf("expected Name=updated, got %v", getOutput.Item["Name"])
+	}
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_UpdateItem_AttributeUpdates_TestDynamoDB_UpdateItem_AttributeUpdates.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_UpdateItem_AttributeUpdates_TestDynamoDB_UpdateItem_AttributeUpdates.golden.go
@@ -1,0 +1,16 @@
+{
+  "Attributes": {
+    "Key": {
+      "Value": "key-1"
+    },
+    "Name": {
+      "Value": "updated"
+    },
+    "OwnerId": {
+      "Value": "owner-1"
+    }
+  },
+  "ConsumedCapacity": null,
+  "ItemCollectionMetrics": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

Support the legacy `AttributeUpdates` parameter in DynamoDB UpdateItem by converting it to `UpdateExpression` internally.

## Problem

Clients using the legacy API (`AttributeUpdates` with PUT/DELETE/ADD actions) get silently ignored, resulting in no updates being applied.

## Fix

- Add `AttributeValueUpdate` type and `AttributeUpdates` field to `UpdateItemRequest`
- Add `convertAttributeUpdates` function that translates to `UpdateExpression` + `ExpressionAttributeNames` + `ExpressionAttributeValues`
- Also add `--content-length` flag to kumo CLI `s3api put-object` (ignored, for AWS CLI compatibility)

## Test plan

- [x] Integration test: `TestDynamoDB_UpdateItem_AttributeUpdates` (golden)
- [x] Verified locally with layerone `TestUpdateApiKey`