### PR TITLE
fix(dynamodb): sort Query results by sort key and fix MarshalJSON for Item type

### DIFF
--- a/charts/kumo/Chart.yaml
+++ b/charts/kumo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kumo
 description: Lightweight AWS service emulator for Kubernetes with automatic AWS_ENDPOINT_URL injection
 type: application
-version: 0.16.0
-appVersion: "0.16.0"
+version: 0.16.1
+appVersion: "0.16.1"

--- a/charts/kumo/values.yaml
+++ b/charts/kumo/values.yaml
@@ -4,7 +4,7 @@ kumo:
     registry: ghcr.io
     repository: sivchari/kumo
     # -- Image tag for kumo. Set to empty to fall back to the chart appVersion.
-    tag: "0.16.0"
+    tag: "0.16.1"
   logLevel: info
   resources:
     requests:

--- a/cli/dynamodb.go
+++ b/cli/dynamodb.go
@@ -30,8 +30,8 @@ func newDynamoDBCmd() *cobra.Command {
 func newDynamoDBCreateTableCmd() *cobra.Command {
 	var (
 		tableName      string
-		attrDefs       string
-		keySchema      string
+		attrDefs       []string
+		keySchema      []string
 		billingMode    string
 		provThroughput string
 		gsiJSON        string
@@ -88,8 +88,8 @@ func newDynamoDBCreateTableCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&tableName, "table-name", "", "Table name")
-	cmd.Flags().StringVar(&attrDefs, "attribute-definitions", "", "Attribute definitions (space-separated key=value pairs)")
-	cmd.Flags().StringVar(&keySchema, "key-schema", "", "Key schema (space-separated key=value pairs)")
+	cmd.Flags().StringArrayVar(&attrDefs, "attribute-definitions", nil, "Attribute definitions (key=value pairs)")
+	cmd.Flags().StringArrayVar(&keySchema, "key-schema", nil, "Key schema (key=value pairs)")
 	cmd.Flags().StringVar(&billingMode, "billing-mode", "", "Billing mode (PROVISIONED or PAY_PER_REQUEST)")
 	cmd.Flags().StringVar(&provThroughput, "provisioned-throughput", "", "Provisioned throughput (key=value)")
 	cmd.Flags().StringVar(&gsiJSON, "global-secondary-indexes", "", "Global secondary indexes (JSON)")
@@ -147,12 +147,11 @@ func newDynamoDBUpdateTimeToLiveCmd() *cobra.Command {
 	return cmd
 }
 
-func parseAttributeDefinitions(s string) []ddbTypes.AttributeDefinition {
-	fields := strings.Fields(s)
-	defs := make([]ddbTypes.AttributeDefinition, 0, len(fields))
+func parseAttributeDefinitions(args []string) []ddbTypes.AttributeDefinition {
+	defs := make([]ddbTypes.AttributeDefinition, 0, len(args))
 
-	for _, field := range fields {
-		m := parseKV(field)
+	for _, arg := range args {
+		m := parseKV(arg)
 		defs = append(defs, ddbTypes.AttributeDefinition{
 			AttributeName: aws.String(m["AttributeName"]),
 			AttributeType: ddbTypes.ScalarAttributeType(m["AttributeType"]),
@@ -162,12 +161,11 @@ func parseAttributeDefinitions(s string) []ddbTypes.AttributeDefinition {
 	return defs
 }
 
-func parseKeySchema(s string) []ddbTypes.KeySchemaElement {
-	fields := strings.Fields(s)
-	schema := make([]ddbTypes.KeySchemaElement, 0, len(fields))
+func parseKeySchema(args []string) []ddbTypes.KeySchemaElement {
+	schema := make([]ddbTypes.KeySchemaElement, 0, len(args))
 
-	for _, field := range fields {
-		m := parseKV(field)
+	for _, arg := range args {
+		m := parseKV(arg)
 		schema = append(schema, ddbTypes.KeySchemaElement{
 			AttributeName: aws.String(m["AttributeName"]),
 			KeyType:       ddbTypes.KeyType(m["KeyType"]),

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -601,7 +601,7 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 			vi := results[i][sortKeyName]
 			vj := results[j][sortKeyName]
 
-			return m.compareForSort(vi, vj)
+			return m.compareForSort(&vi, &vj)
 		})
 	}
 
@@ -1486,7 +1486,7 @@ func (m *MemoryStorage) DescribeTimeToLive(_ context.Context, tableName string) 
 }
 
 // compareForSort compares two AttributeValues for sorting (S or N type).
-func (m *MemoryStorage) compareForSort(a, b AttributeValue) bool {
+func (m *MemoryStorage) compareForSort(a, b *AttributeValue) bool {
 	if a.S != nil && b.S != nil {
 		return *a.S < *b.S
 	}

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -585,9 +585,27 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 		results = append(results, m.copyItem(item))
 	}
 
-	// Sort results.
+	// Sort results by sort key (DynamoDB Query always returns sorted by sort key).
+	var sortKeyName string
+
+	for _, ks := range keySchema {
+		if ks.KeyType == "RANGE" {
+			sortKeyName = ks.AttributeName
+
+			break
+		}
+	}
+
+	if sortKeyName != "" {
+		sort.Slice(results, func(i, j int) bool {
+			vi := results[i][sortKeyName]
+			vj := results[j][sortKeyName]
+
+			return m.compareForSort(vi, vj)
+		})
+	}
+
 	if !scanForward {
-		// Reverse order.
 		for i, j := 0, len(results)-1; i < j; i, j = i+1, j-1 {
 			results[i], results[j] = results[j], results[i]
 		}
@@ -1465,4 +1483,22 @@ func (m *MemoryStorage) DescribeTimeToLive(_ context.Context, tableName string) 
 	}
 
 	return td.Table.TTLAttributeName, td.Table.TTLEnabled, nil
+}
+
+// compareForSort compares two AttributeValues for sorting (S or N type).
+func (m *MemoryStorage) compareForSort(a, b AttributeValue) bool {
+	if a.S != nil && b.S != nil {
+		return *a.S < *b.S
+	}
+
+	if a.N != nil && b.N != nil {
+		var an, bn float64
+
+		_, _ = fmt.Sscanf(*a.N, "%f", &an)
+		_, _ = fmt.Sscanf(*b.N, "%f", &bn)
+
+		return an < bn
+	}
+
+	return false
 }

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -37,7 +37,9 @@ type AttributeValue struct {
 }
 
 // MarshalJSON serializes AttributeValue, preserving empty slices/maps.
-func (av *AttributeValue) MarshalJSON() ([]byte, error) {
+//
+//nolint:gocritic // hugeParam: value receiver is required so json.Marshal works on map[string]AttributeValue (Item type).
+func (av AttributeValue) MarshalJSON() ([]byte, error) {
 	m := make(map[string]any)
 
 	if av.S != nil {

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@
 package kumo
 
 // Version is the current version of kumo.
-const Version = "0.16.0"
+const Version = "0.16.1"


### PR DESCRIPTION
## Summary

Fix DynamoDB Query result ordering and AttributeValue JSON serialization for map values.

## Changes

1. **Query sort by sort key**: Query results are now sorted by the RANGE key attribute (string or number comparison). Previously results were returned in arbitrary map iteration order.

2. **MarshalJSON value receiver**: Change from pointer to value receiver so `json.Marshal` works correctly on `map[string]AttributeValue` (the `Item` type). Pointer receiver was not called for map values, causing null fields in responses.

3. **CLI StringArrayVar**: Change `--attribute-definitions` and `--key-schema` from `StringVar` to `StringArrayVar` to support repeated flags (`--key-schema Val1 --key-schema Val2`).

## Verified locally

All layerone Go tests pass with these fixes:
- workflow repository (form BatchGetItem + sort order)
- workflow service (DynamoDB operations)
- apikey (AttributeUpdates + Query)
- docissue integration
- OCR, storage/temporary, kumo health