### PR TITLE
feat(dynamodb): support arithmetic expressions in SET clause

### DIFF
--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -1018,12 +1018,76 @@ func applySetClause(item Item, clause string, exprValues map[string]AttributeVal
 			continue
 		}
 
+		// Handle arithmetic: path + :val or path - :val
+		if val, ok := evaluateSetArithmetic(item, valueExpr, exprValues); ok {
+			item[attrName] = val
+
+			continue
+		}
+
 		if val, ok := exprValues[valueExpr]; ok {
 			item[attrName] = val
 		}
 	}
 
 	return item
+}
+
+// evaluateSetArithmetic handles "path + :val" and "path - :val" expressions.
+func evaluateSetArithmetic(item Item, expr string, exprValues map[string]AttributeValue) (AttributeValue, bool) {
+	for _, op := range []string{" + ", " - "} {
+		idx := strings.Index(expr, op)
+		if idx == -1 {
+			continue
+		}
+
+		leftToken := strings.TrimSpace(expr[:idx])
+		rightToken := strings.TrimSpace(expr[idx+len(op):])
+
+		left := resolveSetOperand(item, leftToken, exprValues)
+		right := resolveSetOperand(item, rightToken, exprValues)
+
+		if left.N == nil || right.N == nil {
+			return AttributeValue{}, false
+		}
+
+		leftNum, err1 := strconv.ParseFloat(*left.N, 64)
+		rightNum, err2 := strconv.ParseFloat(*right.N, 64)
+
+		if err1 != nil || err2 != nil {
+			return AttributeValue{}, false
+		}
+
+		var result float64
+		if op == " + " {
+			result = leftNum + rightNum
+		} else {
+			result = leftNum - rightNum
+		}
+
+		resultStr := strconv.FormatFloat(result, 'f', -1, 64)
+
+		return AttributeValue{N: &resultStr}, true
+	}
+
+	return AttributeValue{}, false
+}
+
+// resolveSetOperand resolves a token to an AttributeValue for SET expressions.
+func resolveSetOperand(item Item, token string, exprValues map[string]AttributeValue) AttributeValue {
+	if strings.HasPrefix(token, ":") {
+		if val, ok := exprValues[token]; ok {
+			return val
+		}
+
+		return AttributeValue{}
+	}
+
+	if val, ok := item[token]; ok {
+		return val
+	}
+
+	return AttributeValue{}
 }
 
 // applyIfNotExists handles the if_not_exists(attr, :val) function within a SET clause.

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -1001,7 +1001,7 @@ func parseUpdateClauses(expr string) []updateClause {
 
 // applySetClause handles SET attr = :val, SET attr = if_not_exists(attr, :val).
 func applySetClause(item Item, clause string, exprValues map[string]AttributeValue) Item {
-	assignments := strings.Split(clause, ",")
+	assignments := splitAssignments(clause)
 	for _, assignment := range assignments {
 		parts := strings.SplitN(strings.TrimSpace(assignment), "=", 2)
 		if len(parts) != 2 {
@@ -1011,14 +1011,14 @@ func applySetClause(item Item, clause string, exprValues map[string]AttributeVal
 		attrName := strings.TrimSpace(parts[0])
 		valueExpr := strings.TrimSpace(parts[1])
 
-		// Handle if_not_exists(attr, :val)
-		if strings.HasPrefix(valueExpr, "if_not_exists(") {
+		// Handle if_not_exists(attr, :val) — but only if not combined with arithmetic.
+		if strings.HasPrefix(valueExpr, "if_not_exists(") && !containsArithmeticOp(valueExpr) {
 			applyIfNotExists(item, attrName, valueExpr, exprValues)
 
 			continue
 		}
 
-		// Handle arithmetic: path + :val or path - :val
+		// Handle arithmetic: path + :val, path - :val, if_not_exists(...) + :val
 		if val, ok := evaluateSetArithmetic(item, valueExpr, exprValues); ok {
 			item[attrName] = val
 
@@ -1031,6 +1031,52 @@ func applySetClause(item Item, clause string, exprValues map[string]AttributeVal
 	}
 
 	return item
+}
+
+// splitAssignments splits a SET clause into individual assignments, respecting parentheses.
+func splitAssignments(clause string) []string {
+	var result []string
+
+	depth := 0
+	start := 0
+
+	for i, ch := range clause {
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				result = append(result, clause[start:i])
+				start = i + 1
+			}
+		}
+	}
+
+	result = append(result, clause[start:])
+
+	return result
+}
+
+// containsArithmeticOp checks if expression contains + or - operators outside of parentheses.
+func containsArithmeticOp(expr string) bool {
+	depth := 0
+
+	for i, ch := range expr {
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case '+', '-':
+			if depth == 0 && i > 0 && expr[i-1] == ' ' {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // evaluateSetArithmetic handles "path + :val" and "path - :val" expressions.
@@ -1074,7 +1120,13 @@ func evaluateSetArithmetic(item Item, expr string, exprValues map[string]Attribu
 }
 
 // resolveSetOperand resolves a token to an AttributeValue for SET expressions.
+// Supports: :placeholder, path, and if_not_exists(path, :default).
 func resolveSetOperand(item Item, token string, exprValues map[string]AttributeValue) AttributeValue {
+	// Handle if_not_exists(path, :default)
+	if strings.HasPrefix(token, "if_not_exists(") {
+		return resolveIfNotExists(item, token, exprValues)
+	}
+
 	if strings.HasPrefix(token, ":") {
 		if val, ok := exprValues[token]; ok {
 			return val
@@ -1084,6 +1136,30 @@ func resolveSetOperand(item Item, token string, exprValues map[string]AttributeV
 	}
 
 	if val, ok := item[token]; ok {
+		return val
+	}
+
+	return AttributeValue{}
+}
+
+// resolveIfNotExists evaluates if_not_exists(path, :default) and returns the resolved value.
+func resolveIfNotExists(item Item, token string, exprValues map[string]AttributeValue) AttributeValue {
+	inner := strings.TrimPrefix(token, "if_not_exists(")
+	inner = strings.TrimSuffix(inner, ")")
+
+	parts := strings.SplitN(inner, ",", 2)
+	if len(parts) != 2 {
+		return AttributeValue{}
+	}
+
+	path := strings.TrimSpace(parts[0])
+	defaultPlaceholder := strings.TrimSpace(parts[1])
+
+	if val, ok := item[path]; ok {
+		return val
+	}
+
+	if val, ok := exprValues[defaultPlaceholder]; ok {
 		return val
 	}
 

--- a/internal/service/dynamodb/storage_set_arithmetic_test.go
+++ b/internal/service/dynamodb/storage_set_arithmetic_test.go
@@ -1,0 +1,159 @@
+package dynamodb
+
+import (
+	"context"
+	"testing"
+)
+
+//nolint:gocognit,cyclop,funlen // Test function exercises multiple SET arithmetic scenarios sequentially.
+func TestSetArithmetic(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := s.CreateTable(ctx, &CreateTableRequest{
+		TableName: "test-arithmetic",
+		KeySchema: []KeySchemaElement{
+			{AttributeName: "pk", KeyType: "HASH"},
+		},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "pk", AttributeType: "S"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("SET path = path + :val", func(t *testing.T) {
+		t.Parallel()
+
+		key := Item{"pk": {S: ptr("arith-add")}}
+
+		// Insert initial item with Counter=5.
+		_, err := s.PutItem(ctx, "test-arithmetic", Item{
+			"pk":      {S: ptr("arith-add")},
+			"Counter": {N: ptr("5")},
+		}, false, ConditionInput{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// UpdateItem: SET Counter = Counter + :incr
+		result, err := s.UpdateItem(ctx, "test-arithmetic", key,
+			"SET Counter = Counter + :incr",
+			nil,
+			map[string]AttributeValue{":incr": {N: ptr("3")}},
+			ReturnValuesAllNew,
+			ConditionInput{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if result["Counter"].N == nil || *result["Counter"].N != "8" {
+			t.Errorf("Counter = %v, want 8", result["Counter"])
+		}
+	})
+
+	t.Run("SET path = path - :val", func(t *testing.T) {
+		t.Parallel()
+
+		key := Item{"pk": {S: ptr("arith-sub")}}
+
+		_, err := s.PutItem(ctx, "test-arithmetic", Item{
+			"pk":      {S: ptr("arith-sub")},
+			"Counter": {N: ptr("10")},
+		}, false, ConditionInput{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := s.UpdateItem(ctx, "test-arithmetic", key,
+			"SET Counter = Counter - :decr",
+			nil,
+			map[string]AttributeValue{":decr": {N: ptr("4")}},
+			ReturnValuesAllNew,
+			ConditionInput{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if result["Counter"].N == nil || *result["Counter"].N != "6" {
+			t.Errorf("Counter = %v, want 6", result["Counter"])
+		}
+	})
+
+	t.Run("SET path = if_not_exists(path, :default) + :incr (new item)", func(t *testing.T) {
+		t.Parallel()
+
+		key := Item{"pk": {S: ptr("arith-ifne-new")}}
+
+		result, err := s.UpdateItem(ctx, "test-arithmetic", key,
+			"SET #count = if_not_exists(#count, :zero) + :incr",
+			map[string]string{"#count": "Counter"},
+			map[string]AttributeValue{
+				":zero": {N: ptr("0")},
+				":incr": {N: ptr("1")},
+			},
+			ReturnValuesAllNew,
+			ConditionInput{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if result["Counter"].N == nil || *result["Counter"].N != "1" {
+			t.Errorf("Counter = %v, want 1", result["Counter"])
+		}
+
+		// Second call should increment to 2.
+		result, err = s.UpdateItem(ctx, "test-arithmetic", key,
+			"SET #count = if_not_exists(#count, :zero) + :incr",
+			map[string]string{"#count": "Counter"},
+			map[string]AttributeValue{
+				":zero": {N: ptr("0")},
+				":incr": {N: ptr("1")},
+			},
+			ReturnValuesAllNew,
+			ConditionInput{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if result["Counter"].N == nil || *result["Counter"].N != "2" {
+			t.Errorf("Counter = %v, want 2", result["Counter"])
+		}
+	})
+
+	t.Run("SET with multiple assignments including if_not_exists + arithmetic", func(t *testing.T) {
+		t.Parallel()
+
+		key := Item{"pk": {S: ptr("arith-multi")}}
+
+		result, err := s.UpdateItem(ctx, "test-arithmetic", key,
+			"SET #count = if_not_exists(#count, :zero) + :incr, ExpiresAt = :exp",
+			map[string]string{"#count": "Counter"},
+			map[string]AttributeValue{
+				":zero": {N: ptr("0")},
+				":incr": {N: ptr("1")},
+				":exp":  {N: ptr("9999")},
+			},
+			ReturnValuesAllNew,
+			ConditionInput{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if result["Counter"].N == nil || *result["Counter"].N != "1" {
+			t.Errorf("Counter = %v, want 1", result["Counter"])
+		}
+
+		if result["ExpiresAt"].N == nil || *result["ExpiresAt"].N != "9999" {
+			t.Errorf("ExpiresAt = %v, want 9999", result["ExpiresAt"])
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Support `path + :val` and `path - :val` arithmetic in UpdateExpression SET clauses
- Previously only direct value assignment (`SET attr = :val`) and `if_not_exists` were handled
- `SET Counter = Counter + :incr` silently did nothing, causing PutItem conditional logic to break in layerone throttle tests

## Test plan
- [ ] Existing integration tests pass
- [ ] layerone throttle store tests pass locally with this fix