### PR TITLE
feat(sfn): add SendTaskSuccess, SendTaskFailure, SendTaskHeartbeat stubs

### DIFF
--- a/internal/service/sfn/handlers.go
+++ b/internal/service/sfn/handlers.go
@@ -24,6 +24,9 @@ func (s *Service) getActionHandlers() map[string]handlerFunc {
 		"DescribeExecution":    s.DescribeExecution,
 		"ListExecutions":       s.ListExecutions,
 		"GetExecutionHistory":  s.GetExecutionHistory,
+		"SendTaskSuccess":      s.SendTaskSuccess,
+		"SendTaskFailure":      s.SendTaskFailure,
+		"SendTaskHeartbeat":    s.SendTaskHeartbeat,
 	}
 }
 
@@ -378,4 +381,22 @@ func getErrorStatus(code string) int {
 	default:
 		return http.StatusBadRequest
 	}
+}
+
+// SendTaskSuccess handles the SendTaskSuccess API.
+// Since kumo does not manage task tokens, it always returns InvalidToken.
+func (s *Service) SendTaskSuccess(w http.ResponseWriter, _ *http.Request) {
+	writeError(w, "InvalidToken", "Invalid token", http.StatusBadRequest)
+}
+
+// SendTaskFailure handles the SendTaskFailure API.
+// Since kumo does not manage task tokens, it always returns InvalidToken.
+func (s *Service) SendTaskFailure(w http.ResponseWriter, _ *http.Request) {
+	writeError(w, "InvalidToken", "Invalid token", http.StatusBadRequest)
+}
+
+// SendTaskHeartbeat handles the SendTaskHeartbeat API.
+// Since kumo does not manage task tokens, it always returns InvalidToken.
+func (s *Service) SendTaskHeartbeat(w http.ResponseWriter, _ *http.Request) {
+	writeError(w, "InvalidToken", "Invalid token", http.StatusBadRequest)
 }


### PR DESCRIPTION
## Summary
- Add SendTaskSuccess, SendTaskFailure, SendTaskHeartbeat handlers to SFN service
- All return InvalidToken error since kumo does not manage activity task tokens
- Prevents "InvalidAction" errors when clients call these APIs

## Test plan
- [x] layerone `go/pkg/connect/batch` tests pass locally
- [ ] CI passes