### PR TITLE
fix(dynamodb): apply KeyConditionExpression range key filter and add BETWEEN

### DIFF
--- a/charts/kumo/Chart.yaml
+++ b/charts/kumo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kumo
 description: Lightweight AWS service emulator for Kubernetes with automatic AWS_ENDPOINT_URL injection
 type: application
-version: 0.17.0
-appVersion: "0.17.0"
+version: 0.17.1
+appVersion: "0.17.1"

--- a/charts/kumo/values.yaml
+++ b/charts/kumo/values.yaml
@@ -4,7 +4,7 @@ kumo:
     registry: ghcr.io
     repository: sivchari/kumo
     # -- Image tag for kumo. Set to empty to fall back to the chart appVersion.
-    tag: "0.17.0"
+    tag: "0.17.1"
   logLevel: info
   resources:
     requests:

--- a/internal/service/dynamodb/condition.go
+++ b/internal/service/dynamodb/condition.go
@@ -351,6 +351,11 @@ func parseComparison(expr string, item Item, values map[string]AttributeValue) (
 
 	rest = strings.TrimSpace(rest)
 
+	// Handle BETWEEN: operand BETWEEN operand AND operand
+	if startsWithKeyword(rest, "BETWEEN") {
+		return parseBetween(leftToken, strings.TrimSpace(rest[7:]), item, values)
+	}
+
 	op, afterOp, err := parseComparisonOp(rest)
 	if err != nil {
 		return false, "", err
@@ -365,6 +370,35 @@ func parseComparison(expr string, item Item, values map[string]AttributeValue) (
 	right := resolveOperand(rightToken, item, values)
 
 	result := compareAttributeValues(left, right, op)
+
+	return result, finalRest, nil
+}
+
+// parseBetween handles "operand BETWEEN lo AND hi".
+func parseBetween(leftToken, rest string, item Item, values map[string]AttributeValue) (bool, string, error) {
+	loToken, rest := nextToken(strings.TrimSpace(rest))
+	if loToken == "" {
+		return false, "", fmt.Errorf("expected low operand in BETWEEN")
+	}
+
+	rest = strings.TrimSpace(rest)
+	if !startsWithKeyword(rest, "AND") {
+		return false, "", fmt.Errorf("expected AND in BETWEEN expression")
+	}
+
+	rest = strings.TrimSpace(rest[3:])
+
+	hiToken, finalRest := nextToken(rest)
+	if hiToken == "" {
+		return false, "", fmt.Errorf("expected high operand in BETWEEN")
+	}
+
+	val := resolveOperand(leftToken, item, values)
+	lo := resolveOperand(loToken, item, values)
+	hi := resolveOperand(hiToken, item, values)
+
+	// val >= lo AND val <= hi
+	result := compareAttributeValues(val, lo, ">=") && compareAttributeValues(val, hi, "<=")
 
 	return result, finalRest, nil
 }

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -162,7 +162,7 @@ func (s *Service) PutItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	returnOld := req.ReturnValues == "ReturnValuesAllOld"
+	returnOld := req.ReturnValues == ReturnValuesAllOld
 
 	cond := ConditionInput{
 		Expression: req.ConditionExpression,
@@ -255,7 +255,7 @@ func (s *Service) DeleteItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	returnOld := req.ReturnValues == "ReturnValuesAllOld"
+	returnOld := req.ReturnValues == ReturnValuesAllOld
 
 	cond := ConditionInput{
 		Expression: req.ConditionExpression,

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -558,6 +558,12 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 	// Parse key condition to extract partition key value.
 	partitionKeyValue := m.extractPartitionKeyValue(keyCondExpr, partitionKeyName, exprNames, exprValues)
 
+	// Resolve expression attribute names in key condition.
+	resolvedKeyCondExpr := keyCondExpr
+	for placeholder, name := range exprNames {
+		resolvedKeyCondExpr = strings.ReplaceAll(resolvedKeyCondExpr, placeholder, name)
+	}
+
 	// Collect matching items.
 	var results []Item
 
@@ -577,7 +583,20 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 			}
 		}
 
-		// Apply filter expression (simplified).
+		// Evaluate full key condition expression (includes RANGE key conditions like >=, BETWEEN, begins_with).
+		if resolvedKeyCondExpr != "" {
+			keyCond := ConditionInput{
+				Expression: resolvedKeyCondExpr,
+				ExprValues: exprValues,
+			}
+
+			ok, _ := evaluateCondition(item, keyCond)
+			if !ok {
+				continue
+			}
+		}
+
+		// Apply filter expression.
 		if filterExpr != "" && !m.evaluateFilterExpression(item, filterExpr, exprNames, exprValues) {
 			continue
 		}

--- a/internal/service/dynamodb/storage_query_test.go
+++ b/internal/service/dynamodb/storage_query_test.go
@@ -1,0 +1,198 @@
+package dynamodb
+
+import (
+	"context"
+	"testing"
+)
+
+//nolint:funlen // Test function exercises multiple Query scenarios.
+func TestQueryKeyConditionExpression(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := s.CreateTable(ctx, &CreateTableRequest{
+		TableName: "test-query-keycond",
+		KeySchema: []KeySchemaElement{
+			{AttributeName: "PK", KeyType: "HASH"},
+			{AttributeName: "SK", KeyType: "RANGE"},
+		},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "PK", AttributeType: "S"},
+			{AttributeName: "SK", AttributeType: "S"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert items with different SK values.
+	items := []Item{
+		{"PK": {S: ptr("tenant1")}, "SK": {S: ptr("100")}},
+		{"PK": {S: ptr("tenant1")}, "SK": {S: ptr("200")}},
+		{"PK": {S: ptr("tenant1")}, "SK": {S: ptr("300")}},
+		{"PK": {S: ptr("tenant1")}, "SK": {S: ptr("400")}},
+		{"PK": {S: ptr("tenant2")}, "SK": {S: ptr("100")}},
+	}
+	for _, item := range items {
+		if _, err := s.PutItem(ctx, "test-query-keycond", item, false, ConditionInput{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("SK >= :val filters range key", func(t *testing.T) {
+		t.Parallel()
+
+		results, _, _, err := s.Query(ctx, "test-query-keycond", "",
+			"PK = :pk AND SK >= :sk",
+			"",
+			nil,
+			map[string]AttributeValue{
+				":pk": {S: ptr("tenant1")},
+				":sk": {S: ptr("200")},
+			},
+			0, nil, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(results) != 3 {
+			t.Errorf("got %d results, want 3 (SK >= 200 should match 200, 300, 400)", len(results))
+		}
+	})
+
+	t.Run("SK > :val filters range key", func(t *testing.T) {
+		t.Parallel()
+
+		results, _, _, err := s.Query(ctx, "test-query-keycond", "",
+			"PK = :pk AND SK > :sk",
+			"",
+			nil,
+			map[string]AttributeValue{
+				":pk": {S: ptr("tenant1")},
+				":sk": {S: ptr("200")},
+			},
+			0, nil, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(results) != 2 {
+			t.Errorf("got %d results, want 2 (SK > 200 should match 300, 400)", len(results))
+		}
+	})
+
+	t.Run("SK BETWEEN :lo AND :hi filters range key", func(t *testing.T) {
+		t.Parallel()
+
+		results, _, _, err := s.Query(ctx, "test-query-keycond", "",
+			"PK = :pk AND SK BETWEEN :lo AND :hi",
+			"",
+			nil,
+			map[string]AttributeValue{
+				":pk": {S: ptr("tenant1")},
+				":lo": {S: ptr("200")},
+				":hi": {S: ptr("300")},
+			},
+			0, nil, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(results) != 2 {
+			t.Errorf("got %d results, want 2 (SK BETWEEN 200 AND 300 should match 200, 300)", len(results))
+		}
+	})
+
+	t.Run("partition key only returns all items for that key", func(t *testing.T) {
+		t.Parallel()
+
+		results, _, _, err := s.Query(ctx, "test-query-keycond", "",
+			"PK = :pk",
+			"",
+			nil,
+			map[string]AttributeValue{
+				":pk": {S: ptr("tenant1")},
+			},
+			0, nil, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(results) != 4 {
+			t.Errorf("got %d results, want 4 (all tenant1 items)", len(results))
+		}
+	})
+}
+
+//nolint:funlen // Test function with setup and multiple subtests.
+func TestDeleteItemReturnValues(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := s.CreateTable(ctx, &CreateTableRequest{
+		TableName: "test-delete-return",
+		KeySchema: []KeySchemaElement{
+			{AttributeName: "PK", KeyType: "HASH"},
+			{AttributeName: "SK", KeyType: "RANGE"},
+		},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "PK", AttributeType: "S"},
+			{AttributeName: "SK", AttributeType: "S"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert an item.
+	_, err = s.PutItem(ctx, "test-delete-return", Item{
+		"PK":   {S: ptr("pk1")},
+		"SK":   {S: ptr("sk1")},
+		"Data": {S: ptr("value")},
+	}, false, ConditionInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("DeleteItem with ALL_OLD returns old item", func(t *testing.T) {
+		t.Parallel()
+
+		oldItem, err := s.DeleteItem(ctx, "test-delete-return",
+			Item{"PK": {S: ptr("pk1")}, "SK": {S: ptr("sk1")}},
+			true, // returnOld = true (ALL_OLD)
+			ConditionInput{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if oldItem == nil {
+			t.Fatal("oldItem should not be nil when item existed")
+		}
+
+		if oldItem["Data"].S == nil || *oldItem["Data"].S != "value" {
+			t.Errorf("oldItem[Data] = %v, want value", oldItem["Data"])
+		}
+	})
+
+	t.Run("DeleteItem non-existent returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		oldItem, err := s.DeleteItem(ctx, "test-delete-return",
+			Item{"PK": {S: ptr("pk1")}, "SK": {S: ptr("sk-nonexist")}},
+			true,
+			ConditionInput{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if oldItem != nil {
+			t.Errorf("oldItem should be nil for non-existent item, got %v", oldItem)
+		}
+	})
+}

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@
 package kumo
 
 // Version is the current version of kumo.
-const Version = "0.17.0"
+const Version = "0.17.1"


### PR DESCRIPTION
## Summary
- Query now evaluates the full KeyConditionExpression including RANGE key conditions (>=, >, <, <=, BETWEEN) instead of only filtering by HASH key
- Add BETWEEN operator support in condition expression parser
- Fix DeleteItem/PutItem ReturnValues: compare against constant `ALL_OLD` instead of wrong literal `ReturnValuesAllOld`

## Context
fraudguardcore Python tests failed because:
1. Query with `SK >= :timestamp` returned all items for the partition (RANGE key filter was ignored)
2. DeleteItem with `ReturnValues: "ALL_OLD"` never returned the old item (string comparison was wrong)

## Test plan
- [x] Unit tests for Query KeyConditionExpression (>=, >, BETWEEN, partition-only)
- [x] Unit tests for DeleteItem ReturnValues (ALL_OLD returns old item, non-existent returns nil)
- [x] All existing DynamoDB tests pass
- [x] make lint passes
- [ ] CI passes