### PR TITLE
feat(secretsmanager): support partial ARN lookup per AWS spec

### DIFF
--- a/charts/kumo/Chart.yaml
+++ b/charts/kumo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kumo
 description: Lightweight AWS service emulator for Kubernetes with automatic AWS_ENDPOINT_URL injection
 type: application
-version: 0.17.1
-appVersion: "0.17.1"
+version: 0.17.2
+appVersion: "0.17.2"

--- a/charts/kumo/values.yaml
+++ b/charts/kumo/values.yaml
@@ -4,7 +4,7 @@ kumo:
     registry: ghcr.io
     repository: sivchari/kumo
     # -- Image tag for kumo. Set to empty to fall back to the chart appVersion.
-    tag: "0.17.1"
+    tag: "0.17.2"
   logLevel: info
   resources:
     requests:

--- a/internal/service/secretsmanager/storage.go
+++ b/internal/service/secretsmanager/storage.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -485,6 +486,19 @@ func (m *MemoryStorage) findSecret(secretID string) *Secret {
 	for _, secret := range m.Secrets {
 		if secret.ARN == secretID {
 			return secret
+		}
+	}
+
+	// Try by partial ARN (without random suffix).
+	// AWS allows GetSecretValue with "arn:aws:secretsmanager:REGION:ACCOUNT:secret:NAME"
+	// even though the full ARN is "arn:aws:secretsmanager:REGION:ACCOUNT:secret:NAME-SUFFIX".
+	if strings.HasPrefix(secretID, "arn:aws:secretsmanager:") {
+		parts := strings.SplitN(secretID, ":secret:", 2)
+		if len(parts) == 2 {
+			name := parts[1]
+			if secret, exists := m.Secrets[name]; exists {
+				return secret
+			}
 		}
 	}
 

--- a/test/integration/secretsmanager_test.go
+++ b/test/integration/secretsmanager_test.go
@@ -453,6 +453,71 @@ func TestSecretsManager_VersionStages(t *testing.T) {
 	}
 }
 
+func TestSecretsManager_GetSecretValueByPartialARN(t *testing.T) {
+	client := newSecretsManagerClient(t)
+	ctx := t.Context()
+	secretName := "test-secret-partial-arn"
+	secretValue := "partial-arn-value"
+
+	// Create secret.
+	_, err := client.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
+		Name:         aws.String(secretName),
+		SecretString: aws.String(secretValue),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{
+			SecretId:                   aws.String(secretName),
+			ForceDeleteWithoutRecovery: aws.Bool(true),
+		})
+	})
+
+	// Get by partial ARN (without the random suffix that AWS appends).
+	partialARN := "arn:aws:secretsmanager:us-east-1:000000000000:secret:" + secretName
+	getOutput, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(partialARN),
+	})
+	if err != nil {
+		t.Fatalf("GetSecretValue with partial ARN failed: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ARN", "VersionId", "CreatedDate", "ResultMetadata")).Assert(t.Name(), getOutput)
+}
+
+func TestSecretsManager_GetSecretValueByExactARN(t *testing.T) {
+	client := newSecretsManagerClient(t)
+	ctx := t.Context()
+	secretName := "test-secret-exact-arn"
+	secretValue := "exact-arn-value"
+
+	// Create secret and capture the ARN.
+	createOutput, err := client.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
+		Name:         aws.String(secretName),
+		SecretString: aws.String(secretValue),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteSecret(context.Background(), &secretsmanager.DeleteSecretInput{
+			SecretId:                   aws.String(secretName),
+			ForceDeleteWithoutRecovery: aws.Bool(true),
+		})
+	})
+
+	// Get by exact ARN (with the random suffix).
+	getOutput, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: createOutput.ARN,
+	})
+	if err != nil {
+		t.Fatalf("GetSecretValue with exact ARN failed: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ARN", "VersionId", "CreatedDate", "ResultMetadata")).Assert(t.Name(), getOutput)
+}
+
 func TestSecretsManager_GetRandomPassword(t *testing.T) {
 	client := newSecretsManagerClient(t)
 	ctx := t.Context()

--- a/test/integration/testdata/secretsmanager_test_TestSecretsManager_GetSecretValueByExactARN_TestSecretsManager_GetSecretValueByExactARN.golden.go
+++ b/test/integration/testdata/secretsmanager_test_TestSecretsManager_GetSecretValueByExactARN_TestSecretsManager_GetSecretValueByExactARN.golden.go
@@ -1,0 +1,12 @@
+{
+  "ARN": "arn:aws:secretsmanager:ap-northeast-1:000000000000:secret:test-secret-exact-arn-4e357d",
+  "CreatedDate": "2026-05-07T04:29:24Z",
+  "Name": "test-secret-exact-arn",
+  "SecretBinary": null,
+  "SecretString": "exact-arn-value",
+  "VersionId": "372701e2-fa34-43de-ac41-3078f1419a26",
+  "VersionStages": [
+    "AWSCURRENT"
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/secretsmanager_test_TestSecretsManager_GetSecretValueByPartialARN_TestSecretsManager_GetSecretValueByPartialARN.golden.go
+++ b/test/integration/testdata/secretsmanager_test_TestSecretsManager_GetSecretValueByPartialARN_TestSecretsManager_GetSecretValueByPartialARN.golden.go
@@ -1,0 +1,12 @@
+{
+  "ARN": "arn:aws:secretsmanager:ap-northeast-1:000000000000:secret:test-secret-partial-arn-220a83",
+  "CreatedDate": "2026-05-07T04:29:24Z",
+  "Name": "test-secret-partial-arn",
+  "SecretBinary": null,
+  "SecretString": "partial-arn-value",
+  "VersionId": "a9f8bb59-64a9-4ceb-a149-cd6c42ae3f76",
+  "VersionStages": [
+    "AWSCURRENT"
+  ],
+  "ResultMetadata": {}
+}

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@
 package kumo
 
 // Version is the current version of kumo.
-const Version = "0.17.1"
+const Version = "0.17.2"


### PR DESCRIPTION
## Summary
- Support partial ARN (without random suffix) in GetSecretValue lookup
- AWS spec allows `arn:aws:secretsmanager:REGION:ACCOUNT:secret:NAME` without the 6-char suffix

## Ref
https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html

## Test plan
- [x] Integration test: GetSecretValue by partial ARN (golden)
- [x] Integration test: GetSecretValue by exact ARN (golden)
- [x] layerone `go/pkg/aws/secrets` tests pass locally
- [ ] CI passes