### PR TITLE
ci: replace manual actions/cache with setup-go built-in cache

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -23,13 +23,9 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
-
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache-dependency-path: |
+            go.sum
+            test/go.sum
 
       - name: Build with coverage
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,12 +18,9 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache-dependency-path: |
+            go.sum
+            test/go.sum
       - name: golangci-lint
         run: |
           go mod download

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -18,13 +18,8 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: |
-          go mod download
+          cache-dependency-path: |
+            go.sum
+            test/go.sum
       - name: Run tests
         run: make test


### PR DESCRIPTION
## Summary

- Replace manual `actions/cache` steps with `actions/setup-go`'s built-in `cache-dependency-path` parameter in all CI workflows (lint, unit-test, integration-test)
- Explicitly list both `go.sum` and `test/go.sum` so the integration test module's dependencies are properly cached
- Remove the now-redundant `go mod download` step from the unit-test workflow

## Test plan

- [ ] Verify lint workflow caches Go modules correctly
- [ ] Verify unit-test workflow caches Go modules correctly
- [ ] Verify integration-test workflow caches Go modules for both root and test modules