### PR TITLE
feat(s3): implement PutObjectTagging and GetObjectTagging

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -135,6 +135,12 @@ func (s *Service) handleBucketPost(w http.ResponseWriter, r *http.Request) {
 func (s *Service) handleObjectPut(w http.ResponseWriter, r *http.Request) {
 	s.applyCORSHeaders(w, r, r.PathValue("bucket"))
 
+	if r.URL.Query().Has("tagging") {
+		s.PutObjectTagging(w, r)
+
+		return
+	}
+
 	if r.URL.Query().Get("uploadId") != "" && r.URL.Query().Get("partNumber") != "" {
 		s.UploadPart(w, r)
 
@@ -153,6 +159,12 @@ func (s *Service) handleObjectPut(w http.ResponseWriter, r *http.Request) {
 // handleObjectGet dispatches GET /{bucket}/{key} requests based on query parameters.
 func (s *Service) handleObjectGet(w http.ResponseWriter, r *http.Request) {
 	s.applyCORSHeaders(w, r, r.PathValue("bucket"))
+
+	if r.URL.Query().Has("tagging") {
+		s.GetObjectTagging(w, r)
+
+		return
+	}
 
 	if r.URL.Query().Get("uploadId") != "" {
 		s.ListParts(w, r)
@@ -1403,4 +1415,74 @@ func handleMultipartError(w http.ResponseWriter, r *http.Request, err error) {
 	}
 
 	writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+}
+
+// PutObjectTagging handles PUT /{bucket}/{key}?tagging.
+func (s *Service) PutObjectTagging(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+	key := r.PathValue("key")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeS3Error(w, r, "InternalError", "Failed to read request body", http.StatusInternalServerError)
+
+		return
+	}
+
+	var tagging Tagging
+	if err := xml.Unmarshal(body, &tagging); err != nil {
+		writeS3Error(w, r, "MalformedXML", "Invalid XML in request body", http.StatusBadRequest)
+
+		return
+	}
+
+	tags := make(map[string]string, len(tagging.TagSet.Tags))
+	for _, tag := range tagging.TagSet.Tags {
+		tags[tag.Key] = tag.Value
+	}
+
+	if err := s.storage.PutObjectTagging(r.Context(), bucket, key, tags); err != nil {
+		var bErr *BucketError
+		if errors.As(err, &bErr) {
+			writeS3Error(w, r, bErr.Code, bErr.Message, http.StatusNotFound)
+
+			return
+		}
+
+		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetObjectTagging handles GET /{bucket}/{key}?tagging.
+func (s *Service) GetObjectTagging(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+	key := r.PathValue("key")
+
+	tags, err := s.storage.GetObjectTagging(r.Context(), bucket, key)
+	if err != nil {
+		var bErr *BucketError
+		if errors.As(err, &bErr) {
+			writeS3Error(w, r, bErr.Code, bErr.Message, http.StatusNotFound)
+
+			return
+		}
+
+		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	tagging := Tagging{TagSet: TagSet{Tags: make([]Tag, 0, len(tags))}}
+	for k, v := range tags {
+		tagging.TagSet.Tags = append(tagging.TagSet.Tags, Tag{Key: k, Value: v})
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+
+	resp, _ := xml.Marshal(tagging)
+	_, _ = w.Write(resp)
 }

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -52,6 +52,10 @@ type Storage interface {
 	ListMultipartUploads(ctx context.Context, bucket, prefix string, maxUploads int) ([]*MultipartUpload, error)
 	ListParts(ctx context.Context, bucket, key, uploadID string, maxParts int) ([]*Part, error)
 
+	// Object tagging
+	PutObjectTagging(ctx context.Context, bucket, key string, tags map[string]string) error
+	GetObjectTagging(ctx context.Context, bucket, key string) (map[string]string, error)
+
 	// Notification and CORS
 	SetEventBridgeNotification(ctx context.Context, bucket string, enabled bool)
 	IsEventBridgeEnabled(ctx context.Context, bucket string) bool
@@ -343,6 +347,49 @@ func (s *MemoryStorage) GetObjectVersion(_ context.Context, bucket, key, version
 	}
 
 	return nil, &ObjectError{Code: "NoSuchVersion", Message: "The specified version does not exist.", Key: key}
+}
+
+// PutObjectTagging sets tags on an object.
+func (s *MemoryStorage) PutObjectTagging(_ context.Context, bucket, key string, tags map[string]string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	bd, exists := s.Buckets[bucket]
+	if !exists {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist"}
+	}
+
+	obj, exists := bd.Objects[key]
+	if !exists {
+		return &BucketError{Code: "NoSuchKey", Message: "The specified key does not exist."}
+	}
+
+	obj.Tags = tags
+	bd.Objects[key] = obj
+
+	return nil
+}
+
+// GetObjectTagging retrieves tags from an object.
+func (s *MemoryStorage) GetObjectTagging(_ context.Context, bucket, key string) (map[string]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	bd, exists := s.Buckets[bucket]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist"}
+	}
+
+	obj, exists := bd.Objects[key]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchKey", Message: "The specified key does not exist."}
+	}
+
+	if obj.Tags == nil {
+		return map[string]string{}, nil
+	}
+
+	return obj.Tags, nil
 }
 
 // DeleteObject deletes an object.

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -21,8 +21,26 @@ type Object struct {
 	LastModified   time.Time
 	ContentType    string
 	Metadata       map[string]string
+	Tags           map[string]string
 	VersionID      string
 	IsDeleteMarker bool
+}
+
+// Tagging represents the XML structure for S3 object tagging.
+type Tagging struct {
+	XMLName xml.Name `xml:"Tagging"`
+	TagSet  TagSet   `xml:"TagSet"`
+}
+
+// TagSet represents a set of tags.
+type TagSet struct {
+	Tags []Tag `xml:"Tag"`
+}
+
+// Tag represents a single tag key-value pair.
+type Tag struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
 }
 
 // XML Response Types

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1337,3 +1337,93 @@ func TestS3_CopyObject(t *testing.T) {
 		"ServerSideEncryption", "CopySourceVersionId",
 	)).Assert(t.Name(), copyOutput)
 }
+
+func TestS3_PutAndGetObjectTagging(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-tagging-bucket"
+	key := "test-object"
+
+	// Create bucket.
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+			Bucket: aws.String(bucket),
+		})
+	})
+
+	// Put object.
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   strings.NewReader("original-body"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put tags.
+	_, err = client.PutObjectTagging(ctx, &s3.PutObjectTaggingInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Tagging: &types.Tagging{
+			TagSet: []types.Tag{
+				{Key: aws.String("env"), Value: aws.String("test")},
+				{Key: aws.String("team"), Value: aws.String("platform")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get tags.
+	tagOutput, err := client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tagOutput.TagSet) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(tagOutput.TagSet))
+	}
+
+	tagMap := make(map[string]string)
+	for _, tag := range tagOutput.TagSet {
+		tagMap[*tag.Key] = *tag.Value
+	}
+
+	if tagMap["env"] != "test" {
+		t.Errorf("tag env = %q, want %q", tagMap["env"], "test")
+	}
+
+	if tagMap["team"] != "platform" {
+		t.Errorf("tag team = %q, want %q", tagMap["team"], "platform")
+	}
+
+	// Verify body not overwritten.
+	getOutput, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := io.ReadAll(getOutput.Body)
+	if string(body) != "original-body" {
+		t.Errorf("body = %q, want %q", string(body), "original-body")
+	}
+}


### PR DESCRIPTION
## Summary
- Add PutObjectTagging and GetObjectTagging API support
- Route `?tagging` query parameter in PUT/GET object handlers
- Store tags per-object independently from object body

## Context
Previously `PUT /{bucket}/{key}?tagging` was handled as PutObject, overwriting the object body with tag XML. This caused antivirus tests in layerone to fail because test data was corrupted between test cases.

## Test plan
- [x] Integration test: PutObjectTagging + GetObjectTagging + verify body intact
- [x] make lint passes
- [ ] CI passes