### PR TITLE
fix(dynamodb): return HTTP 400 for ConditionalCheckFailedException

### DIFF
--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -175,9 +175,6 @@ func (s *Service) PutItem(w http.ResponseWriter, r *http.Request) {
 		var tErr *TableError
 		if errors.As(err, &tErr) {
 			status := http.StatusBadRequest
-			if tErr.Code == ErrCodeConditionalCheckFailed {
-				status = http.StatusConflict
-			}
 
 			writeDynamoDBError(w, tErr.Code, tErr.Message, status)
 
@@ -268,9 +265,6 @@ func (s *Service) DeleteItem(w http.ResponseWriter, r *http.Request) {
 		var tErr *TableError
 		if errors.As(err, &tErr) {
 			status := http.StatusBadRequest
-			if tErr.Code == ErrCodeConditionalCheckFailed {
-				status = http.StatusConflict
-			}
 
 			writeDynamoDBError(w, tErr.Code, tErr.Message, status)
 
@@ -333,9 +327,6 @@ func (s *Service) UpdateItem(w http.ResponseWriter, r *http.Request) {
 		var tErr *TableError
 		if errors.As(err, &tErr) {
 			status := http.StatusBadRequest
-			if tErr.Code == ErrCodeConditionalCheckFailed {
-				status = http.StatusConflict
-			}
 
 			writeDynamoDBError(w, tErr.Code, tErr.Message, status)
 


### PR DESCRIPTION
## Summary
Return HTTP 400 (Bad Request) instead of 409 (Conflict) for ConditionalCheckFailedException in PutItem, DeleteItem, and UpdateItem handlers.

## Context
AWS DynamoDB returns HTTP 400 for ConditionalCheckFailedException. The AWS SDK v2 relies on this to deserialize the error into `*types.ConditionalCheckFailedException`. Returning 409 caused `errors.As` to fail, breaking DynamoDB-based distributed locks (dynamodblock) in layerone's sbpsp and docissue services.

## Test plan
- [x] make lint passes
- [x] go build passes
- [ ] CI passes