### PR TITLE
fix(s3): clean URL path to prevent 301 redirects and sort GetObjectTagging response

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"path"
 	"time"
 
 	"github.com/google/uuid"
@@ -156,6 +157,15 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		_, _ = w.Write([]byte(`{"status":"healthy"}`))
 
 		return
+	}
+
+	// Clean the URL path to prevent Go's ServeMux from returning 301 redirects
+	// for paths with double slashes (e.g., /bucket//key). S3 keys can start with
+	// "/" which produces double slashes in path-style URLs. We clean the path
+	// ourselves so the mux sees an already-clean path and serves it directly.
+	if cleaned := path.Clean(req.URL.Path); cleaned != req.URL.Path {
+		req = req.Clone(req.Context())
+		req.URL.Path = cleaned
 	}
 
 	// Check if the request matches a prefix router first.

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1477,8 +1478,16 @@ func (s *Service) GetObjectTagging(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tagging := Tagging{TagSet: TagSet{Tags: make([]Tag, 0, len(tags))}}
-	for k, v := range tags {
-		tagging.TagSet.Tags = append(tagging.TagSet.Tags, Tag{Key: k, Value: v})
+
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		tagging.TagSet.Tags = append(tagging.TagSet.Tags, Tag{Key: k, Value: tags[k]})
 	}
 
 	w.Header().Set("Content-Type", "application/xml")

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1387,7 +1387,7 @@ func TestS3_PutAndGetObjectTagging(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Get tags.
+	// Get tags and verify sorted order via golden test.
 	tagOutput, err := client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -1396,22 +1396,7 @@ func TestS3_PutAndGetObjectTagging(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(tagOutput.TagSet) != 2 {
-		t.Fatalf("expected 2 tags, got %d", len(tagOutput.TagSet))
-	}
-
-	tagMap := make(map[string]string)
-	for _, tag := range tagOutput.TagSet {
-		tagMap[*tag.Key] = *tag.Value
-	}
-
-	if tagMap["env"] != "test" {
-		t.Errorf("tag env = %q, want %q", tagMap["env"], "test")
-	}
-
-	if tagMap["team"] != "platform" {
-		t.Errorf("tag team = %q, want %q", tagMap["team"], "platform")
-	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), tagOutput.TagSet)
 
 	// Verify body not overwritten.
 	getOutput, err := client.GetObject(ctx, &s3.GetObjectInput{
@@ -1425,5 +1410,54 @@ func TestS3_PutAndGetObjectTagging(t *testing.T) {
 	body, _ := io.ReadAll(getOutput.Body)
 	if string(body) != "original-body" {
 		t.Errorf("body = %q, want %q", string(body), "original-body")
+	}
+}
+
+func TestS3_PutObject_KeyWithLeadingSlash(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-leading-slash-bucket"
+	key := "/path/to/object.txt"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+			Bucket: aws.String(bucket),
+		})
+	})
+
+	// PutObject with a key that starts with "/" produces a double slash in
+	// path-style URLs (e.g., /bucket//path/to/object.txt). Go's ServeMux
+	// would return 301 for this without the path cleaning fix.
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   strings.NewReader("hello"),
+	})
+	if err != nil {
+		t.Fatalf("PutObject with leading slash key failed: %v", err)
+	}
+
+	getOutput, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("GetObject with leading slash key failed: %v", err)
+	}
+
+	gotBody, _ := io.ReadAll(getOutput.Body)
+	if string(gotBody) != "hello" {
+		t.Errorf("body = %q, want %q", string(gotBody), "hello")
 	}
 }

--- a/test/integration/testdata/s3_test_TestS3_PutAndGetObjectTagging_TestS3_PutAndGetObjectTagging.golden.go
+++ b/test/integration/testdata/s3_test_TestS3_PutAndGetObjectTagging_TestS3_PutAndGetObjectTagging.golden.go
@@ -1,0 +1,10 @@
+[
+  {
+    "Key": "env",
+    "Value": "test"
+  },
+  {
+    "Key": "team",
+    "Value": "platform"
+  }
+]


### PR DESCRIPTION
## Summary

- Clean URL path in `ServeHTTP` before passing to `http.ServeMux` to prevent 301 redirects for paths with double slashes (e.g., `/bucket//key`). S3 keys can legitimately start with `/`, which produces double slashes in path-style URLs.
- Sort `GetObjectTagging` response tags by key name for deterministic ordering. Previously, iterating over `map[string]string` produced non-deterministic tag order.

## Test plan

- [x] Add golden test for `GetObjectTagging` tag ordering verification
- [x] Add integration test for `PutObject` with leading slash key (`/path/to/object.txt`)
- [x] Existing unit tests pass (`go test -race -shuffle=on ./...`)
- [x] Integration tests pass with kumo server running