### PR TITLE
feat(ec2): implement CreateTags / DeleteTags / DescribeTags

### DIFF
--- a/internal/service/ec2/handlers.go
+++ b/internal/service/ec2/handlers.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -843,6 +845,251 @@ func (s *Service) DescribeNatGateways(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// CreateTags handles the CreateTags action.
+func (s *Service) CreateTags(w http.ResponseWriter, r *http.Request) {
+	resources, tags, err := readTagRequestForm(r)
+	if err != nil {
+		writeError(w, errInvalidParameter, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	if len(resources) == 0 {
+		writeError(w, errInvalidParameter, "ResourceId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if len(tags) == 0 {
+		writeError(w, errInvalidParameter, "Tag is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.CreateTags(r.Context(), resources, tags); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeEC2XMLResponse(w, XMLCreateTagsResponse{
+		Xmlns:     ec2XMLNS,
+		RequestID: uuid.New().String(),
+		Return:    true,
+	})
+}
+
+// DeleteTags handles the DeleteTags action.
+func (s *Service) DeleteTags(w http.ResponseWriter, r *http.Request) {
+	resources, tags, err := readTagRequestForm(r)
+	if err != nil {
+		writeError(w, errInvalidParameter, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	if len(resources) == 0 {
+		writeError(w, errInvalidParameter, "ResourceId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteTags(r.Context(), resources, tags); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeEC2XMLResponse(w, XMLDeleteTagsResponse{
+		Xmlns:     ec2XMLNS,
+		RequestID: uuid.New().String(),
+		Return:    true,
+	})
+}
+
+// DescribeTags handles the DescribeTags action.
+func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	filters := parseFiltersFromForm(r.Form)
+
+	descriptions, err := s.storage.DescribeTags(r.Context(), filters)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	items := make([]XMLTagDescription, 0, len(descriptions))
+	for _, d := range descriptions {
+		items = append(items, XMLTagDescription(d))
+	}
+
+	writeEC2XMLResponse(w, XMLDescribeTagsResponse{
+		Xmlns:     ec2XMLNS,
+		RequestID: uuid.New().String(),
+		TagSet:    XMLTagDescriptionSet{Items: items},
+	})
+}
+
+// readTagRequestForm extracts ResourceId.N and Tag.N.Key/Value pairs from the
+// already-parsed AWS Query form. The Query dispatcher calls ParseForm before
+// dispatch, but ParseForm is idempotent, so calling it again is safe.
+func readTagRequestForm(r *http.Request) ([]string, []Tag, error) {
+	if err := r.ParseForm(); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse form: %w", err)
+	}
+
+	resources := parseIndexedListFromForm(r.Form, "ResourceId")
+	tags := parseTagsFromForm(r.Form, "Tag")
+
+	return resources, tags, nil
+}
+
+// parseIndexedListFromForm returns values for keys of the form "<prefix>.N",
+// ordered by N. Indexes start at 1 in AWS Query but we tolerate any positive
+// integer. Missing indexes are skipped.
+func parseIndexedListFromForm(form map[string][]string, prefix string) []string {
+	type entry struct {
+		idx int
+		val string
+	}
+
+	entries := make([]entry, 0)
+
+	for key, values := range form {
+		suffix, ok := strings.CutPrefix(key, prefix+".")
+		if !ok || len(values) == 0 {
+			continue
+		}
+
+		// Reject nested keys like "Tag.1.Key" — only direct numeric suffix counts.
+		if strings.Contains(suffix, ".") {
+			continue
+		}
+
+		n, err := strconv.Atoi(suffix)
+		if err != nil {
+			continue
+		}
+
+		entries = append(entries, entry{idx: n, val: values[0]})
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].idx < entries[j].idx })
+
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.val)
+	}
+
+	return out
+}
+
+// parseTagsFromForm reads "<prefix>.N.Key" and "<prefix>.N.Value" pairs.
+// A missing Value is treated as empty string.
+func parseTagsFromForm(form map[string][]string, prefix string) []Tag {
+	keysByIdx := make(map[int]string)
+	valsByIdx := make(map[int]string)
+
+	for key, values := range form {
+		suffix, ok := strings.CutPrefix(key, prefix+".")
+		if !ok || len(values) == 0 {
+			continue
+		}
+
+		dot := strings.Index(suffix, ".")
+		if dot < 0 {
+			continue
+		}
+
+		n, err := strconv.Atoi(suffix[:dot])
+		if err != nil {
+			continue
+		}
+
+		switch suffix[dot+1:] {
+		case "Key":
+			keysByIdx[n] = values[0]
+		case "Value":
+			valsByIdx[n] = values[0]
+		}
+	}
+
+	indexes := make([]int, 0, len(keysByIdx))
+	for n := range keysByIdx {
+		indexes = append(indexes, n)
+	}
+
+	sort.Ints(indexes)
+
+	tags := make([]Tag, 0, len(indexes))
+	for _, n := range indexes {
+		tags = append(tags, Tag{Key: keysByIdx[n], Value: valsByIdx[n]})
+	}
+
+	return tags
+}
+
+// parseFiltersFromForm reads "Filter.N.Name" and "Filter.N.Value.M" entries
+// into a Name -> []Value map.
+func parseFiltersFromForm(form map[string][]string) map[string][]string {
+	type filterAcc struct {
+		name   string
+		values []string
+	}
+
+	byIdx := make(map[int]*filterAcc)
+
+	for key, values := range form {
+		suffix, ok := strings.CutPrefix(key, "Filter.")
+		if !ok || len(values) == 0 {
+			continue
+		}
+
+		dot := strings.Index(suffix, ".")
+		if dot < 0 {
+			continue
+		}
+
+		n, err := strconv.Atoi(suffix[:dot])
+		if err != nil {
+			continue
+		}
+
+		field := suffix[dot+1:]
+
+		entry, ok := byIdx[n]
+		if !ok {
+			entry = &filterAcc{}
+			byIdx[n] = entry
+		}
+
+		switch {
+		case field == "Name":
+			entry.name = values[0]
+		case strings.HasPrefix(field, "Value."):
+			entry.values = append(entry.values, values[0])
+		}
+	}
+
+	out := make(map[string][]string)
+
+	for _, entry := range byIdx {
+		if entry.name == "" {
+			continue
+		}
+
+		out[entry.name] = append(out[entry.name], entry.values...)
+	}
+
+	return out
+}
+
 // DispatchAction routes the request to the appropriate handler based on Action parameter.
 func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 	action := extractAction(r)
@@ -895,6 +1142,10 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 		// NAT gateway operations
 		"CreateNatGateway":    s.CreateNatGateway,
 		"DescribeNatGateways": s.DescribeNatGateways,
+		// Tag operations
+		"CreateTags":   s.CreateTags,
+		"DeleteTags":   s.DeleteTags,
+		"DescribeTags": s.DescribeTags,
 	}
 
 	return handlers[action]

--- a/internal/service/ec2/service.go
+++ b/internal/service/ec2/service.go
@@ -89,6 +89,10 @@ func (s *Service) Actions() []string {
 		// NAT Gateway operations
 		"CreateNatGateway",
 		"DescribeNatGateways",
+		// Tag operations
+		"CreateTags",
+		"DeleteTags",
+		"DescribeTags",
 	}
 }
 

--- a/internal/service/ec2/storage.go
+++ b/internal/service/ec2/storage.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -101,6 +102,11 @@ type Storage interface {
 	// NAT Gateway operations
 	CreateNatGateway(ctx context.Context, req *CreateNatGatewayRequest) (*NatGateway, error)
 	DescribeNatGateways(ctx context.Context, natgwIDs []string) ([]*NatGateway, error)
+
+	// Tag operations
+	CreateTags(ctx context.Context, resourceIDs []string, tags []Tag) error
+	DeleteTags(ctx context.Context, resourceIDs []string, tags []Tag) error
+	DescribeTags(ctx context.Context, filters map[string][]string) ([]TagDescription, error)
 }
 
 // InstanceStateChange represents an instance state change.
@@ -1232,4 +1238,257 @@ func containsString(slice []string, s string) bool {
 	}
 
 	return false
+}
+
+// CreateTags adds or overwrites tags on the listed resources.
+func (m *MemoryStorage) CreateTags(_ context.Context, resourceIDs []string, tags []Tag) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, id := range resourceIDs {
+		current, _, err := m.lookupTagsLocked(id)
+		if err != nil {
+			return err
+		}
+
+		updated := mergeTags(current, tags)
+
+		if err := m.setTagsLocked(id, updated); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DeleteTags removes the listed tags from the resources. An empty tag list
+// removes all tags. A tag with an empty Value matches any value.
+func (m *MemoryStorage) DeleteTags(_ context.Context, resourceIDs []string, tags []Tag) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, id := range resourceIDs {
+		current, _, err := m.lookupTagsLocked(id)
+		if err != nil {
+			return err
+		}
+
+		var updated []Tag
+		if len(tags) == 0 {
+			updated = nil
+		} else {
+			updated = removeTags(current, tags)
+		}
+
+		if err := m.setTagsLocked(id, updated); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DescribeTags returns all tags across all resources, optionally filtered by
+// resource-id or key. Other filters are accepted for compatibility but ignored.
+func (m *MemoryStorage) DescribeTags(_ context.Context, filters map[string][]string) ([]TagDescription, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	resourceIDs := filters["resource-id"]
+	keys := filters["key"]
+
+	descriptions := make([]TagDescription, 0)
+
+	for id, getTags := range m.tagSourcesLocked() {
+		if len(resourceIDs) > 0 && !containsString(resourceIDs, id) {
+			continue
+		}
+
+		resourceType := resourceTypeForID(id)
+
+		for _, t := range getTags() {
+			if len(keys) > 0 && !containsString(keys, t.Key) {
+				continue
+			}
+
+			descriptions = append(descriptions, TagDescription{
+				ResourceID:   id,
+				ResourceType: resourceType,
+				Key:          t.Key,
+				Value:        t.Value,
+			})
+		}
+	}
+
+	return descriptions, nil
+}
+
+// lookupTagsLocked returns the current tags and a setter for the resource ID.
+// The caller must hold the appropriate lock.
+func (m *MemoryStorage) lookupTagsLocked(id string) ([]Tag, func([]Tag), error) {
+	if vpc, ok := m.Vpcs[id]; ok {
+		return vpc.Tags, func(t []Tag) { vpc.Tags = t }, nil
+	}
+
+	if subnet, ok := m.Subnets[id]; ok {
+		return subnet.Tags, func(t []Tag) { subnet.Tags = t }, nil
+	}
+
+	if igw, ok := m.InternetGateways[id]; ok {
+		return igw.Tags, func(t []Tag) { igw.Tags = t }, nil
+	}
+
+	if rt, ok := m.RouteTables[id]; ok {
+		return rt.Tags, func(t []Tag) { rt.Tags = t }, nil
+	}
+
+	if natgw, ok := m.NatGateways[id]; ok {
+		return natgw.Tags, func(t []Tag) { natgw.Tags = t }, nil
+	}
+
+	if inst, ok := m.Instances[id]; ok {
+		return inst.Tags, func(t []Tag) { inst.Tags = t }, nil
+	}
+
+	if sg, ok := m.SecurityGroups[id]; ok {
+		return sg.Tags, func(t []Tag) { sg.Tags = t }, nil
+	}
+
+	if kp, ok := m.KeyPairs[id]; ok {
+		return kp.Tags, func(t []Tag) { kp.Tags = t }, nil
+	}
+
+	return nil, nil, &Error{
+		Code:    "InvalidID",
+		Message: fmt.Sprintf("The ID '%s' is not valid", id),
+	}
+}
+
+func (m *MemoryStorage) setTagsLocked(id string, tags []Tag) error {
+	_, set, err := m.lookupTagsLocked(id)
+	if err != nil {
+		return err
+	}
+
+	set(tags)
+
+	return nil
+}
+
+// tagSourcesLocked returns a map of resource-id to a closure returning that
+// resource's tag list. Used to iterate every taggable resource.
+func (m *MemoryStorage) tagSourcesLocked() map[string]func() []Tag {
+	out := make(map[string]func() []Tag)
+
+	for id, v := range m.Vpcs {
+		out[id] = func() []Tag { return v.Tags }
+	}
+
+	for id, v := range m.Subnets {
+		out[id] = func() []Tag { return v.Tags }
+	}
+
+	for id, v := range m.InternetGateways {
+		out[id] = func() []Tag { return v.Tags }
+	}
+
+	for id, v := range m.RouteTables {
+		out[id] = func() []Tag { return v.Tags }
+	}
+
+	for id, v := range m.NatGateways {
+		out[id] = func() []Tag { return v.Tags }
+	}
+
+	for id, v := range m.Instances {
+		out[id] = func() []Tag { return v.Tags }
+	}
+
+	for id, v := range m.SecurityGroups {
+		out[id] = func() []Tag { return v.Tags }
+	}
+
+	for id, v := range m.KeyPairs {
+		out[id] = func() []Tag { return v.Tags }
+	}
+
+	return out
+}
+
+// resourceTypePrefixes maps EC2 resource ID prefixes to their resource-type
+// strings. Order does not matter; longer-prefix matches are not required since
+// EC2 prefixes do not collide.
+var resourceTypePrefixes = map[string]string{
+	"vpc-":    "vpc",
+	"subnet-": "subnet",
+	"igw-":    "internet-gateway",
+	"rtb-":    "route-table",
+	"nat-":    "natgateway",
+	"i-":      "instance",
+	"sg-":     "security-group",
+	"key-":    "key-pair",
+}
+
+// resourceTypeForID maps an EC2 resource ID prefix to its resource-type string.
+func resourceTypeForID(id string) string {
+	for prefix, rtype := range resourceTypePrefixes {
+		if strings.HasPrefix(id, prefix) {
+			return rtype
+		}
+	}
+
+	return ""
+}
+
+// mergeTags upserts new tags into existing, replacing values for matching keys.
+func mergeTags(existing, incoming []Tag) []Tag {
+	merged := make([]Tag, 0, len(existing)+len(incoming))
+	merged = append(merged, existing...)
+
+	for _, t := range incoming {
+		replaced := false
+
+		for i, e := range merged {
+			if e.Key == t.Key {
+				merged[i].Value = t.Value
+				replaced = true
+
+				break
+			}
+		}
+
+		if !replaced {
+			merged = append(merged, t)
+		}
+	}
+
+	return merged
+}
+
+// removeTags returns existing minus any matches in toRemove. A toRemove entry
+// with an empty Value matches all values for that key.
+func removeTags(existing, toRemove []Tag) []Tag {
+	out := make([]Tag, 0, len(existing))
+
+	for _, e := range existing {
+		drop := false
+
+		for _, r := range toRemove {
+			if r.Key != e.Key {
+				continue
+			}
+
+			if r.Value == "" || r.Value == e.Value {
+				drop = true
+
+				break
+			}
+		}
+
+		if !drop {
+			out = append(out, e)
+		}
+	}
+
+	return out
 }

--- a/internal/service/ec2/types.go
+++ b/internal/service/ec2/types.go
@@ -753,3 +753,70 @@ type XMLDescribeNatGatewaysResponse struct {
 type XMLNatGatewaySet struct {
 	Items []XMLNatGateway `xml:"item"`
 }
+
+// TagDescription represents a tag association with a resource.
+type TagDescription struct {
+	ResourceID   string
+	ResourceType string
+	Key          string
+	Value        string
+}
+
+// CreateTagsRequest represents a CreateTags request.
+type CreateTagsRequest struct {
+	Resources []string
+	Tags      []Tag
+}
+
+// DeleteTagsRequest represents a DeleteTags request.
+type DeleteTagsRequest struct {
+	Resources []string
+	// Tags lists the tags to remove. An empty slice removes all tags from the
+	// listed resources. A tag with an empty Value removes the tag for any value.
+	Tags []Tag
+}
+
+// DescribeTagsRequest represents a DescribeTags request.
+type DescribeTagsRequest struct {
+	// Filters supports the standard EC2 tag filters: resource-id, resource-type,
+	// key, value, tag:<key>. Only resource-id and key are honored today; the rest
+	// are accepted but ignored.
+	Filters map[string][]string
+}
+
+// XMLCreateTagsResponse is the XML response for CreateTags.
+type XMLCreateTagsResponse struct {
+	XMLName   xml.Name `xml:"CreateTagsResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+// XMLDeleteTagsResponse is the XML response for DeleteTags.
+type XMLDeleteTagsResponse struct {
+	XMLName   xml.Name `xml:"DeleteTagsResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+// XMLDescribeTagsResponse is the XML response for DescribeTags.
+type XMLDescribeTagsResponse struct {
+	XMLName   xml.Name             `xml:"DescribeTagsResponse"`
+	Xmlns     string               `xml:"xmlns,attr"`
+	RequestID string               `xml:"requestId"`
+	TagSet    XMLTagDescriptionSet `xml:"tagSet"`
+}
+
+// XMLTagDescriptionSet contains a list of tag descriptions.
+type XMLTagDescriptionSet struct {
+	Items []XMLTagDescription `xml:"item"`
+}
+
+// XMLTagDescription represents a tag description in XML format.
+type XMLTagDescription struct {
+	ResourceID   string `xml:"resourceId"`
+	ResourceType string `xml:"resourceType"`
+	Key          string `xml:"key"`
+	Value        string `xml:"value"`
+}

--- a/test/integration/ec2_test.go
+++ b/test/integration/ec2_test.go
@@ -602,3 +602,101 @@ func TestEC2_CreateNatGateway(t *testing.T) {
 	}
 	golden.New(t, golden.WithIgnoreFields("NatGatewayId", "SubnetId", "VpcId", "CreateTime", "ResultMetadata")).Assert(t.Name()+"_describe", descResult)
 }
+
+func TestEC2_CreateAndDescribeTags(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := t.Context()
+
+	vpcResult, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{
+		CidrBlock: aws.String("10.42.0.0/16"),
+	})
+	if err != nil {
+		t.Fatalf("failed to create vpc: %v", err)
+	}
+
+	vpcID := *vpcResult.Vpc.VpcId
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteVpc(context.Background(), &ec2.DeleteVpcInput{
+			VpcId: aws.String(vpcID),
+		})
+	})
+
+	if _, err := client.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{vpcID},
+		Tags: []types.Tag{
+			{Key: aws.String("Name"), Value: aws.String("kumo-tag-test")},
+			{Key: aws.String("Env"), Value: aws.String("test")},
+		},
+	}); err != nil {
+		t.Fatalf("failed to create tags: %v", err)
+	}
+
+	descResult, err := client.DescribeTags(ctx, &ec2.DescribeTagsInput{
+		Filters: []types.Filter{
+			{Name: aws.String("resource-id"), Values: []string{vpcID}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to describe tags: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResourceId", "ResultMetadata")).Assert(t.Name()+"_describe", descResult)
+
+	vpcDescResult, err := client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+		VpcIds: []string{vpcID},
+	})
+	if err != nil {
+		t.Fatalf("failed to describe vpc: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("VpcId", "OwnerId", "ResultMetadata")).Assert(t.Name()+"_vpc", vpcDescResult)
+}
+
+func TestEC2_DeleteTags(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := t.Context()
+
+	vpcResult, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{
+		CidrBlock: aws.String("10.43.0.0/16"),
+	})
+	if err != nil {
+		t.Fatalf("failed to create vpc: %v", err)
+	}
+
+	vpcID := *vpcResult.Vpc.VpcId
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteVpc(context.Background(), &ec2.DeleteVpcInput{
+			VpcId: aws.String(vpcID),
+		})
+	})
+
+	if _, err := client.CreateTags(ctx, &ec2.CreateTagsInput{
+		Resources: []string{vpcID},
+		Tags: []types.Tag{
+			{Key: aws.String("Name"), Value: aws.String("to-delete")},
+			{Key: aws.String("Keep"), Value: aws.String("yes")},
+		},
+	}); err != nil {
+		t.Fatalf("failed to create tags: %v", err)
+	}
+
+	// Delete a single tag by key (Value omitted = remove regardless of value).
+	if _, err := client.DeleteTags(ctx, &ec2.DeleteTagsInput{
+		Resources: []string{vpcID},
+		Tags: []types.Tag{
+			{Key: aws.String("Name")},
+		},
+	}); err != nil {
+		t.Fatalf("failed to delete tags: %v", err)
+	}
+
+	descResult, err := client.DescribeTags(ctx, &ec2.DescribeTagsInput{
+		Filters: []types.Filter{
+			{Name: aws.String("resource-id"), Values: []string{vpcID}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to describe tags: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResourceId", "ResultMetadata")).Assert(t.Name()+"_after_delete", descResult)
+}

--- a/test/integration/testdata/ec2_test_TestEC2_CreateAndDescribeTags_TestEC2_CreateAndDescribeTags_describe.golden.go
+++ b/test/integration/testdata/ec2_test_TestEC2_CreateAndDescribeTags_TestEC2_CreateAndDescribeTags_describe.golden.go
@@ -1,0 +1,18 @@
+{
+  "NextToken": null,
+  "Tags": [
+    {
+      "Key": "Name",
+      "ResourceId": "vpc-f2db9e0b-3a30-43d",
+      "ResourceType": "vpc",
+      "Value": "kumo-tag-test"
+    },
+    {
+      "Key": "Env",
+      "ResourceId": "vpc-f2db9e0b-3a30-43d",
+      "ResourceType": "vpc",
+      "Value": "test"
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ec2_test_TestEC2_CreateAndDescribeTags_TestEC2_CreateAndDescribeTags_vpc.golden.go
+++ b/test/integration/testdata/ec2_test_TestEC2_CreateAndDescribeTags_TestEC2_CreateAndDescribeTags_vpc.golden.go
@@ -1,0 +1,29 @@
+{
+  "NextToken": null,
+  "Vpcs": [
+    {
+      "BlockPublicAccessStates": null,
+      "CidrBlock": "10.42.0.0/16",
+      "CidrBlockAssociationSet": null,
+      "DhcpOptionsId": null,
+      "EncryptionControl": null,
+      "InstanceTenancy": "default",
+      "Ipv6CidrBlockAssociationSet": null,
+      "IsDefault": false,
+      "OwnerId": null,
+      "State": "available",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "kumo-tag-test"
+        },
+        {
+          "Key": "Env",
+          "Value": "test"
+        }
+      ],
+      "VpcId": "vpc-f2db9e0b-3a30-43d"
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ec2_test_TestEC2_DeleteTags_TestEC2_DeleteTags_after_delete.golden.go
+++ b/test/integration/testdata/ec2_test_TestEC2_DeleteTags_TestEC2_DeleteTags_after_delete.golden.go
@@ -1,0 +1,12 @@
+{
+  "NextToken": null,
+  "Tags": [
+    {
+      "Key": "Keep",
+      "ResourceId": "vpc-7a9964ce-81b3-4ce",
+      "ResourceType": "vpc",
+      "Value": "yes"
+    }
+  ],
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

Adds the cross-resource tag APIs that the AWS EC2 SDK exposes. Tag operations dispatch by resource ID prefix and cover every taggable resource currently modeled in kumo: VPC, Subnet, InternetGateway, RouteTable, NatGateway, Instance, SecurityGroup, and KeyPair.

## Behavior

- \`CreateTags\` upserts by key (replaces value if the key already exists).
- \`DeleteTags\` follows AWS semantics: an empty \`Value\` matches any value for the key, and an empty \`Tags\` list removes all tags from the listed resources.
- \`DescribeTags\` supports the \`resource-id\` and \`key\` filters; other filters are accepted for SDK compatibility but ignored.
- Tags written via \`CreateTags\` are reflected through the existing \`Describe*\` responses (verified in the test by \`DescribeVpcs\` returning the tags set via \`CreateTags\`).

## Implementation notes

The Query protocol form-to-JSON converter does not understand the \`Tag.N.Key\` / \`Tag.N.Value\` and \`Filter.N.Name\` / \`Filter.N.Value.M\` patterns, so the new handlers parse them directly from \`r.Form\`. \`r.Form\` is already populated by the dispatcher's \`ParseForm\` call, and \`ParseForm\` is idempotent.

Tag dispatch by ID prefix is centralized in \`resourceTypePrefixes\`. Adding a new taggable resource is one line in that map plus an entry in \`lookupTagsLocked\` / \`tagSourcesLocked\`.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] \`make test\`
- [x] Existing \`TestEC2_*\` integration tests still pass
- [x] New \`TestEC2_CreateAndDescribeTags\` exercises CreateTags + DescribeTags + ensures tags are reflected by DescribeVpcs
- [x] New \`TestEC2_DeleteTags\` exercises DeleteTags by-key (with omitted value)

---

Addresses sivchari/kumo#409 — High Priority "CreateTags / DeleteTags / DescribeTags".
