### PR TITLE
feat(iam): inline role policies, ListAttachedRolePolicies, OIDC provider

### DIFF
--- a/internal/service/iam/handlers.go
+++ b/internal/service/iam/handlers.go
@@ -485,6 +485,276 @@ func (s *Service) ListAccessKeys(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// PutRolePolicy handles the PutRolePolicy action.
+func (s *Service) PutRolePolicy(w http.ResponseWriter, r *http.Request) {
+	roleName := getFormValue(r, "RoleName")
+	policyName := getFormValue(r, "PolicyName")
+	policyDoc := getFormValue(r, "PolicyDocument")
+
+	switch {
+	case roleName == "":
+		writeIAMError(w, errInvalidParameter, "RoleName is required", http.StatusBadRequest)
+
+		return
+	case policyName == "":
+		writeIAMError(w, errInvalidParameter, "PolicyName is required", http.StatusBadRequest)
+
+		return
+	case policyDoc == "":
+		writeIAMError(w, errInvalidParameter, "PolicyDocument is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.PutRolePolicy(r.Context(), roleName, policyName, policyDoc); err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, PutRolePolicyResponse{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// GetRolePolicy handles the GetRolePolicy action.
+func (s *Service) GetRolePolicy(w http.ResponseWriter, r *http.Request) {
+	roleName := getFormValue(r, "RoleName")
+	policyName := getFormValue(r, "PolicyName")
+
+	if roleName == "" || policyName == "" {
+		writeIAMError(w, errInvalidParameter, "RoleName and PolicyName are required", http.StatusBadRequest)
+
+		return
+	}
+
+	doc, err := s.storage.GetRolePolicy(r.Context(), roleName, policyName)
+	if err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, GetRolePolicyResponse{
+		GetRolePolicyResult: GetRolePolicyResult{
+			RoleName:       roleName,
+			PolicyName:     policyName,
+			PolicyDocument: doc,
+		},
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DeleteRolePolicy handles the DeleteRolePolicy action.
+func (s *Service) DeleteRolePolicy(w http.ResponseWriter, r *http.Request) {
+	roleName := getFormValue(r, "RoleName")
+	policyName := getFormValue(r, "PolicyName")
+
+	if roleName == "" || policyName == "" {
+		writeIAMError(w, errInvalidParameter, "RoleName and PolicyName are required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteRolePolicy(r.Context(), roleName, policyName); err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, DeleteRolePolicyResponse{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// ListRolePolicies handles the ListRolePolicies action.
+func (s *Service) ListRolePolicies(w http.ResponseWriter, r *http.Request) {
+	roleName := getFormValue(r, "RoleName")
+	if roleName == "" {
+		writeIAMError(w, errInvalidParameter, "RoleName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	names, err := s.storage.ListRolePolicies(r.Context(), roleName)
+	if err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, ListRolePoliciesResponse{
+		ListRolePoliciesResult: ListRolePoliciesResult{PolicyNames: names, IsTruncated: false},
+		ResponseMetadata:       ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// ListAttachedRolePolicies handles the ListAttachedRolePolicies action.
+func (s *Service) ListAttachedRolePolicies(w http.ResponseWriter, r *http.Request) {
+	roleName := getFormValue(r, "RoleName")
+	if roleName == "" {
+		writeIAMError(w, errInvalidParameter, "RoleName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	attached, err := s.storage.ListAttachedRolePolicies(r.Context(), roleName)
+	if err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, ListAttachedRolePoliciesResponse{
+		ListAttachedRolePoliciesResult: ListAttachedRolePoliciesResult{
+			AttachedPolicies: attached,
+			IsTruncated:      false,
+		},
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// CreateOpenIDConnectProvider handles the CreateOpenIDConnectProvider action.
+func (s *Service) CreateOpenIDConnectProvider(w http.ResponseWriter, r *http.Request) {
+	url := getFormValue(r, "Url")
+	if url == "" {
+		writeIAMError(w, errInvalidParameter, "Url is required", http.StatusBadRequest)
+
+		return
+	}
+
+	clientIDs := parseStringList(r, "ClientIDList")
+	thumbprints := parseStringList(r, "ThumbprintList")
+
+	provider, err := s.storage.CreateOIDCProvider(r.Context(), url, clientIDs, thumbprints)
+	if err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, CreateOpenIDConnectProviderResponse{
+		CreateOpenIDConnectProviderResult: CreateOpenIDConnectProviderResult{
+			OpenIDConnectProviderArn: provider.Arn,
+		},
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// GetOpenIDConnectProvider handles the GetOpenIDConnectProvider action.
+func (s *Service) GetOpenIDConnectProvider(w http.ResponseWriter, r *http.Request) {
+	arn := getFormValue(r, "OpenIDConnectProviderArn")
+	if arn == "" {
+		writeIAMError(w, errInvalidParameter, "OpenIDConnectProviderArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	provider, err := s.storage.GetOIDCProvider(r.Context(), arn)
+	if err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, GetOpenIDConnectProviderResponse{
+		GetOpenIDConnectProviderResult: GetOpenIDConnectProviderResult{
+			URL:            provider.URL,
+			ClientIDList:   provider.ClientIDList,
+			ThumbprintList: provider.ThumbprintList,
+			CreateDate:     provider.CreateDate,
+		},
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DeleteOpenIDConnectProvider handles the DeleteOpenIDConnectProvider action.
+func (s *Service) DeleteOpenIDConnectProvider(w http.ResponseWriter, r *http.Request) {
+	arn := getFormValue(r, "OpenIDConnectProviderArn")
+	if arn == "" {
+		writeIAMError(w, errInvalidParameter, "OpenIDConnectProviderArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteOIDCProvider(r.Context(), arn); err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, DeleteOpenIDConnectProviderResponse{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// ListOpenIDConnectProviders handles the ListOpenIDConnectProviders action.
+func (s *Service) ListOpenIDConnectProviders(w http.ResponseWriter, r *http.Request) {
+	arns, err := s.storage.ListOIDCProviders(r.Context())
+	if err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	entries := make([]OIDCProviderEntry, 0, len(arns))
+	for _, arn := range arns {
+		entries = append(entries, OIDCProviderEntry{Arn: arn})
+	}
+
+	writeIAMXMLResponse(w, ListOpenIDConnectProvidersResponse{
+		ListOpenIDConnectProvidersResult: ListOpenIDConnectProvidersResult{
+			OpenIDConnectProviderList: entries,
+		},
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// UpdateOpenIDConnectProviderThumbprint handles the
+// UpdateOpenIDConnectProviderThumbprint action.
+func (s *Service) UpdateOpenIDConnectProviderThumbprint(w http.ResponseWriter, r *http.Request) {
+	arn := getFormValue(r, "OpenIDConnectProviderArn")
+	if arn == "" {
+		writeIAMError(w, errInvalidParameter, "OpenIDConnectProviderArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	thumbprints := parseStringList(r, "ThumbprintList")
+	if len(thumbprints) == 0 {
+		writeIAMError(w, errInvalidParameter, "ThumbprintList is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.UpdateOIDCProviderThumbprint(r.Context(), arn, thumbprints); err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, UpdateOpenIDConnectProviderThumbprintResponse{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// parseStringList reads "<name>.member.N" entries (the IAM convention) into a
+// list, stopping at the first missing index.
+func parseStringList(r *http.Request, name string) []string {
+	var out []string
+
+	for i := 1; ; i++ {
+		v := getFormValue(r, fmt.Sprintf("%s.member.%d", name, i))
+		if v == "" {
+			break
+		}
+
+		out = append(out, v)
+	}
+
+	return out
+}
+
 // DispatchAction routes the request to the appropriate handler based on Action parameter.
 func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 	action := extractAction(r)

--- a/internal/service/iam/service.go
+++ b/internal/service/iam/service.go
@@ -65,6 +65,18 @@ func (s *Service) initActionHandlers() {
 		"CreateAccessKey": s.CreateAccessKey,
 		"DeleteAccessKey": s.DeleteAccessKey,
 		"ListAccessKeys":  s.ListAccessKeys,
+		// Inline role policies
+		"PutRolePolicy":            s.PutRolePolicy,
+		"GetRolePolicy":            s.GetRolePolicy,
+		"DeleteRolePolicy":         s.DeleteRolePolicy,
+		"ListRolePolicies":         s.ListRolePolicies,
+		"ListAttachedRolePolicies": s.ListAttachedRolePolicies,
+		// OpenID Connect provider
+		"CreateOpenIDConnectProvider":           s.CreateOpenIDConnectProvider,
+		"GetOpenIDConnectProvider":              s.GetOpenIDConnectProvider,
+		"DeleteOpenIDConnectProvider":           s.DeleteOpenIDConnectProvider,
+		"ListOpenIDConnectProviders":            s.ListOpenIDConnectProviders,
+		"UpdateOpenIDConnectProviderThumbprint": s.UpdateOpenIDConnectProviderThumbprint,
 	}
 }
 

--- a/internal/service/iam/storage.go
+++ b/internal/service/iam/storage.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -50,6 +51,18 @@ type Storage interface {
 	DetachUserPolicy(ctx context.Context, userName, policyArn string) error
 	AttachRolePolicy(ctx context.Context, roleName, policyArn string) error
 	DetachRolePolicy(ctx context.Context, roleName, policyArn string) error
+	ListAttachedRolePolicies(ctx context.Context, roleName string) ([]AttachedPolicy, error)
+
+	PutRolePolicy(ctx context.Context, roleName, policyName, policyDocument string) error
+	GetRolePolicy(ctx context.Context, roleName, policyName string) (string, error)
+	DeleteRolePolicy(ctx context.Context, roleName, policyName string) error
+	ListRolePolicies(ctx context.Context, roleName string) ([]string, error)
+
+	CreateOIDCProvider(ctx context.Context, url string, clientIDs, thumbprints []string) (*OIDCProvider, error)
+	GetOIDCProvider(ctx context.Context, arn string) (*OIDCProvider, error)
+	DeleteOIDCProvider(ctx context.Context, arn string) error
+	ListOIDCProviders(ctx context.Context) ([]string, error)
+	UpdateOIDCProviderThumbprint(ctx context.Context, arn string, thumbprints []string) error
 
 	CreateAccessKey(ctx context.Context, userName string) (*AccessKey, error)
 	DeleteAccessKey(ctx context.Context, userName, accessKeyID string) error
@@ -74,23 +87,25 @@ var (
 
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu         sync.RWMutex                     `json:"-"`
-	Users      map[string]*User                 `json:"users"`
-	Roles      map[string]*Role                 `json:"roles"`
-	Policies   map[string]*Policy               `json:"policies"`   // key is ARN
-	AccessKeys map[string]map[string]*AccessKey `json:"accessKeys"` // userName -> accessKeyID -> AccessKey
-	accountID  string
-	dataDir    string
+	mu            sync.RWMutex                     `json:"-"`
+	Users         map[string]*User                 `json:"users"`
+	Roles         map[string]*Role                 `json:"roles"`
+	Policies      map[string]*Policy               `json:"policies"`      // key is ARN
+	AccessKeys    map[string]map[string]*AccessKey `json:"accessKeys"`    // userName -> accessKeyID -> AccessKey
+	OIDCProviders map[string]*OIDCProvider         `json:"oidcProviders"` // key is ARN
+	accountID     string
+	dataDir       string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	s := &MemoryStorage{
-		Users:      make(map[string]*User),
-		Roles:      make(map[string]*Role),
-		Policies:   make(map[string]*Policy),
-		AccessKeys: make(map[string]map[string]*AccessKey),
-		accountID:  "123456789012",
+		Users:         make(map[string]*User),
+		Roles:         make(map[string]*Role),
+		Policies:      make(map[string]*Policy),
+		AccessKeys:    make(map[string]map[string]*AccessKey),
+		OIDCProviders: make(map[string]*OIDCProvider),
+		accountID:     "123456789012",
 	}
 	for _, o := range opts {
 		o(s)
@@ -145,6 +160,10 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 
 	if s.AccessKeys == nil {
 		s.AccessKeys = make(map[string]map[string]*AccessKey)
+	}
+
+	if s.OIDCProviders == nil {
+		s.OIDCProviders = make(map[string]*OIDCProvider)
 	}
 
 	return nil
@@ -774,4 +793,222 @@ func generateSecretAccessKey() string {
 	_, _ = rand.Read(b)
 
 	return hex.EncodeToString(b)[:40]
+}
+
+// PutRolePolicy upserts an inline policy on a role.
+func (s *MemoryStorage) PutRolePolicy(_ context.Context, roleName, policyName, policyDocument string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	role, ok := s.Roles[roleName]
+	if !ok {
+		return &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("The role with name %s cannot be found.", roleName),
+		}
+	}
+
+	if role.InlinePolicies == nil {
+		role.InlinePolicies = make(map[string]string)
+	}
+
+	role.InlinePolicies[policyName] = policyDocument
+
+	return nil
+}
+
+// GetRolePolicy returns the document for an inline policy on a role.
+func (s *MemoryStorage) GetRolePolicy(_ context.Context, roleName, policyName string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	role, ok := s.Roles[roleName]
+	if !ok {
+		return "", &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("The role with name %s cannot be found.", roleName),
+		}
+	}
+
+	doc, ok := role.InlinePolicies[policyName]
+	if !ok {
+		return "", &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("The role policy with name %s cannot be found.", policyName),
+		}
+	}
+
+	return doc, nil
+}
+
+// DeleteRolePolicy removes an inline policy from a role.
+func (s *MemoryStorage) DeleteRolePolicy(_ context.Context, roleName, policyName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	role, ok := s.Roles[roleName]
+	if !ok {
+		return &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("The role with name %s cannot be found.", roleName),
+		}
+	}
+
+	if _, ok := role.InlinePolicies[policyName]; !ok {
+		return &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("The role policy with name %s cannot be found.", policyName),
+		}
+	}
+
+	delete(role.InlinePolicies, policyName)
+
+	return nil
+}
+
+// ListRolePolicies returns the names of inline policies attached to a role.
+func (s *MemoryStorage) ListRolePolicies(_ context.Context, roleName string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	role, ok := s.Roles[roleName]
+	if !ok {
+		return nil, &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("The role with name %s cannot be found.", roleName),
+		}
+	}
+
+	names := make([]string, 0, len(role.InlinePolicies))
+	for name := range role.InlinePolicies {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names, nil
+}
+
+// ListAttachedRolePolicies returns managed policies attached to a role.
+func (s *MemoryStorage) ListAttachedRolePolicies(_ context.Context, roleName string) ([]AttachedPolicy, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	role, ok := s.Roles[roleName]
+	if !ok {
+		return nil, &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("The role with name %s cannot be found.", roleName),
+		}
+	}
+
+	out := make([]AttachedPolicy, len(role.AttachedPolicies))
+	copy(out, role.AttachedPolicies)
+
+	return out, nil
+}
+
+// CreateOIDCProvider stores a new OpenID Connect provider.
+// The provider ARN is derived from the URL by stripping the scheme, matching
+// the AWS IAM convention: arn:aws:iam::<account>:oidc-provider/<host>/<path>.
+func (s *MemoryStorage) CreateOIDCProvider(_ context.Context, url string, clientIDs, thumbprints []string) (*OIDCProvider, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	host := stripScheme(url)
+	arn := fmt.Sprintf("arn:aws:iam::%s:oidc-provider/%s", s.accountID, host)
+
+	if _, exists := s.OIDCProviders[arn]; exists {
+		return nil, &Error{
+			Code:    errEntityAlreadyExists,
+			Message: fmt.Sprintf("OpenID Connect provider %s already exists.", arn),
+		}
+	}
+
+	provider := &OIDCProvider{
+		Arn:            arn,
+		URL:            url,
+		ClientIDList:   append([]string(nil), clientIDs...),
+		ThumbprintList: append([]string(nil), thumbprints...),
+		CreateDate:     time.Now().UTC(),
+	}
+	s.OIDCProviders[arn] = provider
+
+	return provider, nil
+}
+
+// GetOIDCProvider returns the provider with the given ARN.
+func (s *MemoryStorage) GetOIDCProvider(_ context.Context, arn string) (*OIDCProvider, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	provider, ok := s.OIDCProviders[arn]
+	if !ok {
+		return nil, &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("OpenID Connect provider %s does not exist.", arn),
+		}
+	}
+
+	return provider, nil
+}
+
+// DeleteOIDCProvider removes a provider by ARN.
+func (s *MemoryStorage) DeleteOIDCProvider(_ context.Context, arn string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.OIDCProviders[arn]; !ok {
+		return &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("OpenID Connect provider %s does not exist.", arn),
+		}
+	}
+
+	delete(s.OIDCProviders, arn)
+
+	return nil
+}
+
+// ListOIDCProviders returns all provider ARNs.
+func (s *MemoryStorage) ListOIDCProviders(_ context.Context) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	arns := make([]string, 0, len(s.OIDCProviders))
+	for arn := range s.OIDCProviders {
+		arns = append(arns, arn)
+	}
+
+	sort.Strings(arns)
+
+	return arns, nil
+}
+
+// UpdateOIDCProviderThumbprint replaces the thumbprint list of a provider.
+func (s *MemoryStorage) UpdateOIDCProviderThumbprint(_ context.Context, arn string, thumbprints []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	provider, ok := s.OIDCProviders[arn]
+	if !ok {
+		return &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("OpenID Connect provider %s does not exist.", arn),
+		}
+	}
+
+	provider.ThumbprintList = append([]string(nil), thumbprints...)
+
+	return nil
+}
+
+func stripScheme(url string) string {
+	for _, prefix := range []string{"https://", "http://"} {
+		if rest, ok := strings.CutPrefix(url, prefix); ok {
+			return rest
+		}
+	}
+
+	return url
 }

--- a/internal/service/iam/types.go
+++ b/internal/service/iam/types.go
@@ -16,16 +16,26 @@ type User struct {
 
 // Role represents an IAM role.
 type Role struct {
-	RoleName                 string           `xml:"RoleName"`
-	RoleID                   string           `xml:"RoleId"`
-	Arn                      string           `xml:"Arn"`
-	Path                     string           `xml:"Path"`
-	CreateDate               time.Time        `xml:"CreateDate"`
-	AssumeRolePolicyDocument string           `xml:"AssumeRolePolicyDocument"`
-	Description              string           `xml:"Description,omitempty"`
-	MaxSessionDuration       int              `xml:"MaxSessionDuration,omitempty"`
-	Tags                     []Tag            `xml:"Tags>member,omitempty"`
-	AttachedPolicies         []AttachedPolicy `xml:"-"`
+	RoleName                 string            `xml:"RoleName"`
+	RoleID                   string            `xml:"RoleId"`
+	Arn                      string            `xml:"Arn"`
+	Path                     string            `xml:"Path"`
+	CreateDate               time.Time         `xml:"CreateDate"`
+	AssumeRolePolicyDocument string            `xml:"AssumeRolePolicyDocument"`
+	Description              string            `xml:"Description,omitempty"`
+	MaxSessionDuration       int               `xml:"MaxSessionDuration,omitempty"`
+	Tags                     []Tag             `xml:"Tags>member,omitempty"`
+	AttachedPolicies         []AttachedPolicy  `xml:"-"`
+	InlinePolicies           map[string]string `xml:"-"`
+}
+
+// OIDCProvider represents an IAM OpenID Connect provider.
+type OIDCProvider struct {
+	Arn            string    `xml:"Arn"`
+	URL            string    `xml:"Url"`
+	ClientIDList   []string  `xml:"ClientIDList>member,omitempty"`
+	ThumbprintList []string  `xml:"ThumbprintList>member,omitempty"`
+	CreateDate     time.Time `xml:"CreateDate"`
 }
 
 // Policy represents an IAM policy.
@@ -366,6 +376,114 @@ type ListAccessKeysResult struct {
 	AccessKeyMetadata []AccessKeyMetadata `xml:"AccessKeyMetadata>member"`
 	IsTruncated       bool                `xml:"IsTruncated"`
 	Marker            string              `xml:"Marker,omitempty"`
+}
+
+// PutRolePolicyRequest represents a PutRolePolicy request.
+type PutRolePolicyRequest struct {
+	RoleName       string `xml:"RoleName"`
+	PolicyName     string `xml:"PolicyName"`
+	PolicyDocument string `xml:"PolicyDocument"`
+}
+
+// PutRolePolicyResponse represents a PutRolePolicy response.
+type PutRolePolicyResponse struct {
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// GetRolePolicyResponse represents a GetRolePolicy response.
+type GetRolePolicyResponse struct {
+	GetRolePolicyResult GetRolePolicyResult `xml:"GetRolePolicyResult"`
+	ResponseMetadata    ResponseMetadata    `xml:"ResponseMetadata"`
+}
+
+// GetRolePolicyResult contains the result of GetRolePolicy.
+type GetRolePolicyResult struct {
+	RoleName       string `xml:"RoleName"`
+	PolicyName     string `xml:"PolicyName"`
+	PolicyDocument string `xml:"PolicyDocument"`
+}
+
+// DeleteRolePolicyResponse represents a DeleteRolePolicy response.
+type DeleteRolePolicyResponse struct {
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// ListRolePoliciesResponse represents a ListRolePolicies response.
+type ListRolePoliciesResponse struct {
+	ListRolePoliciesResult ListRolePoliciesResult `xml:"ListRolePoliciesResult"`
+	ResponseMetadata       ResponseMetadata       `xml:"ResponseMetadata"`
+}
+
+// ListRolePoliciesResult contains the result of ListRolePolicies.
+type ListRolePoliciesResult struct {
+	PolicyNames []string `xml:"PolicyNames>member"`
+	IsTruncated bool     `xml:"IsTruncated"`
+	Marker      string   `xml:"Marker,omitempty"`
+}
+
+// ListAttachedRolePoliciesResponse represents a ListAttachedRolePolicies response.
+type ListAttachedRolePoliciesResponse struct {
+	ListAttachedRolePoliciesResult ListAttachedRolePoliciesResult `xml:"ListAttachedRolePoliciesResult"`
+	ResponseMetadata               ResponseMetadata               `xml:"ResponseMetadata"`
+}
+
+// ListAttachedRolePoliciesResult contains the result of ListAttachedRolePolicies.
+type ListAttachedRolePoliciesResult struct {
+	AttachedPolicies []AttachedPolicy `xml:"AttachedPolicies>member"`
+	IsTruncated      bool             `xml:"IsTruncated"`
+	Marker           string           `xml:"Marker,omitempty"`
+}
+
+// CreateOpenIDConnectProviderResponse is the response for CreateOpenIDConnectProvider.
+type CreateOpenIDConnectProviderResponse struct {
+	CreateOpenIDConnectProviderResult CreateOpenIDConnectProviderResult `xml:"CreateOpenIDConnectProviderResult"`
+	ResponseMetadata                  ResponseMetadata                  `xml:"ResponseMetadata"`
+}
+
+// CreateOpenIDConnectProviderResult contains the OIDC provider ARN.
+type CreateOpenIDConnectProviderResult struct {
+	OpenIDConnectProviderArn string `xml:"OpenIDConnectProviderArn"`
+}
+
+// GetOpenIDConnectProviderResponse is the response for GetOpenIDConnectProvider.
+type GetOpenIDConnectProviderResponse struct {
+	GetOpenIDConnectProviderResult GetOpenIDConnectProviderResult `xml:"GetOpenIDConnectProviderResult"`
+	ResponseMetadata               ResponseMetadata               `xml:"ResponseMetadata"`
+}
+
+// GetOpenIDConnectProviderResult contains the OIDC provider details.
+type GetOpenIDConnectProviderResult struct {
+	URL            string    `xml:"Url"`
+	ClientIDList   []string  `xml:"ClientIDList>member,omitempty"`
+	ThumbprintList []string  `xml:"ThumbprintList>member,omitempty"`
+	CreateDate     time.Time `xml:"CreateDate"`
+}
+
+// DeleteOpenIDConnectProviderResponse is the response for DeleteOpenIDConnectProvider.
+type DeleteOpenIDConnectProviderResponse struct {
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// ListOpenIDConnectProvidersResponse is the response for ListOpenIDConnectProviders.
+type ListOpenIDConnectProvidersResponse struct {
+	ListOpenIDConnectProvidersResult ListOpenIDConnectProvidersResult `xml:"ListOpenIDConnectProvidersResult"`
+	ResponseMetadata                 ResponseMetadata                 `xml:"ResponseMetadata"`
+}
+
+// ListOpenIDConnectProvidersResult contains the list of OIDC provider ARNs.
+type ListOpenIDConnectProvidersResult struct {
+	OpenIDConnectProviderList []OIDCProviderEntry `xml:"OpenIDConnectProviderList>member"`
+}
+
+// OIDCProviderEntry is a single entry in the OIDC provider list.
+type OIDCProviderEntry struct {
+	Arn string `xml:"Arn"`
+}
+
+// UpdateOpenIDConnectProviderThumbprintResponse is the response for
+// UpdateOpenIDConnectProviderThumbprint.
+type UpdateOpenIDConnectProviderThumbprintResponse struct {
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
 }
 
 // ResponseMetadata contains the request ID.

--- a/test/integration/iam_test.go
+++ b/test/integration/iam_test.go
@@ -610,3 +610,182 @@ func TestIAM_CreateUserWithTags(t *testing.T) {
 
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "UserId", "Arn", "CreateDate")).Assert(t.Name()+"_get", getResult)
 }
+
+func TestIAM_PutGetListDeleteRolePolicy(t *testing.T) {
+	client := newIAMClient(t)
+	ctx := t.Context()
+	roleName := "test-inline-policy-role"
+	policyName := "test-inline-policy"
+	policyDoc := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	}); err != nil {
+		t.Fatalf("failed to create role: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteRole(context.Background(), &iam.DeleteRoleInput{
+			RoleName: aws.String(roleName),
+		})
+	})
+
+	if _, err := client.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		RoleName:       aws.String(roleName),
+		PolicyName:     aws.String(policyName),
+		PolicyDocument: aws.String(policyDoc),
+	}); err != nil {
+		t.Fatalf("failed to put role policy: %v", err)
+	}
+
+	listResult, err := client.ListRolePolicies(ctx, &iam.ListRolePoliciesInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		t.Fatalf("failed to list role policies: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_list", listResult)
+
+	getResult, err := client.GetRolePolicy(ctx, &iam.GetRolePolicyInput{
+		RoleName:   aws.String(roleName),
+		PolicyName: aws.String(policyName),
+	})
+	if err != nil {
+		t.Fatalf("failed to get role policy: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_get", getResult)
+
+	if _, err := client.DeleteRolePolicy(ctx, &iam.DeleteRolePolicyInput{
+		RoleName:   aws.String(roleName),
+		PolicyName: aws.String(policyName),
+	}); err != nil {
+		t.Fatalf("failed to delete role policy: %v", err)
+	}
+
+	listAfter, err := client.ListRolePolicies(ctx, &iam.ListRolePoliciesInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_list_after_delete", listAfter)
+}
+
+func TestIAM_ListAttachedRolePolicies(t *testing.T) {
+	client := newIAMClient(t)
+	ctx := t.Context()
+	roleName := "test-attached-list-role"
+	policyName := "test-list-managed-policy"
+
+	policyResult, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String(policyName),
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+
+	policyArn := *policyResult.Policy.Arn
+
+	t.Cleanup(func() {
+		_, _ = client.DeletePolicy(context.Background(), &iam.DeletePolicyInput{
+			PolicyArn: aws.String(policyArn),
+		})
+	})
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	}); err != nil {
+		t.Fatalf("failed to create role: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DetachRolePolicy(context.Background(), &iam.DetachRolePolicyInput{
+			RoleName:  aws.String(roleName),
+			PolicyArn: aws.String(policyArn),
+		})
+		_, _ = client.DeleteRole(context.Background(), &iam.DeleteRoleInput{
+			RoleName: aws.String(roleName),
+		})
+	})
+
+	if _, err := client.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+		RoleName:  aws.String(roleName),
+		PolicyArn: aws.String(policyArn),
+	}); err != nil {
+		t.Fatalf("failed to attach role policy: %v", err)
+	}
+
+	listResult, err := client.ListAttachedRolePolicies(ctx, &iam.ListAttachedRolePoliciesInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		t.Fatalf("failed to list attached role policies: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "PolicyArn")).Assert(t.Name(), listResult)
+}
+
+func TestIAM_OpenIDConnectProvider(t *testing.T) {
+	client := newIAMClient(t)
+	ctx := t.Context()
+
+	createResult, err := client.CreateOpenIDConnectProvider(ctx, &iam.CreateOpenIDConnectProviderInput{
+		Url:            aws.String("https://token.actions.githubusercontent.com"),
+		ClientIDList:   []string{"sts.amazonaws.com"},
+		ThumbprintList: []string{"6938fd4d98bab03faadb97b34396831e3780aea1"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create OIDC provider: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "OpenIDConnectProviderArn")).Assert(t.Name()+"_create", createResult)
+
+	arn := *createResult.OpenIDConnectProviderArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteOpenIDConnectProvider(context.Background(), &iam.DeleteOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: aws.String(arn),
+		})
+	})
+
+	getResult, err := client.GetOpenIDConnectProvider(ctx, &iam.GetOpenIDConnectProviderInput{
+		OpenIDConnectProviderArn: aws.String(arn),
+	})
+	if err != nil {
+		t.Fatalf("failed to get OIDC provider: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "CreateDate")).Assert(t.Name()+"_get", getResult)
+
+	listResult, err := client.ListOpenIDConnectProviders(ctx, &iam.ListOpenIDConnectProvidersInput{})
+	if err != nil {
+		t.Fatalf("failed to list OIDC providers: %v", err)
+	}
+
+	found := false
+	for _, p := range listResult.OpenIDConnectProviderList {
+		if p.Arn != nil && *p.Arn == arn {
+			found = true
+
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("created OIDC provider %s not present in list", arn)
+	}
+
+	if _, err := client.UpdateOpenIDConnectProviderThumbprint(ctx, &iam.UpdateOpenIDConnectProviderThumbprintInput{
+		OpenIDConnectProviderArn: aws.String(arn),
+		ThumbprintList:           []string{"a031c46782e6e6c662c2c87c76da9aa62ccabd8e"},
+	}); err != nil {
+		t.Fatalf("failed to update thumbprint: %v", err)
+	}
+
+	getAfter, err := client.GetOpenIDConnectProvider(ctx, &iam.GetOpenIDConnectProviderInput{
+		OpenIDConnectProviderArn: aws.String(arn),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "CreateDate")).Assert(t.Name()+"_get_after_update", getAfter)
+}

--- a/test/integration/testdata/iam_test_TestIAM_ListAttachedRolePolicies_TestIAM_ListAttachedRolePolicies.golden.go
+++ b/test/integration/testdata/iam_test_TestIAM_ListAttachedRolePolicies_TestIAM_ListAttachedRolePolicies.golden.go
@@ -1,0 +1,11 @@
+{
+  "AttachedPolicies": [
+    {
+      "PolicyArn": "arn:aws:iam::123456789012:policy/test-list-managed-policy",
+      "PolicyName": "test-list-managed-policy"
+    }
+  ],
+  "IsTruncated": false,
+  "Marker": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/iam_test_TestIAM_OpenIDConnectProvider_TestIAM_OpenIDConnectProvider_create.golden.go
+++ b/test/integration/testdata/iam_test_TestIAM_OpenIDConnectProvider_TestIAM_OpenIDConnectProvider_create.golden.go
@@ -1,0 +1,5 @@
+{
+  "OpenIDConnectProviderArn": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com",
+  "Tags": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/iam_test_TestIAM_OpenIDConnectProvider_TestIAM_OpenIDConnectProvider_get.golden.go
+++ b/test/integration/testdata/iam_test_TestIAM_OpenIDConnectProvider_TestIAM_OpenIDConnectProvider_get.golden.go
@@ -1,0 +1,12 @@
+{
+  "ClientIDList": [
+    "sts.amazonaws.com"
+  ],
+  "CreateDate": "2026-05-08T07:35:36.882021Z",
+  "Tags": null,
+  "ThumbprintList": [
+    "6938fd4d98bab03faadb97b34396831e3780aea1"
+  ],
+  "Url": "https://token.actions.githubusercontent.com",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/iam_test_TestIAM_OpenIDConnectProvider_TestIAM_OpenIDConnectProvider_get_after_update.golden.go
+++ b/test/integration/testdata/iam_test_TestIAM_OpenIDConnectProvider_TestIAM_OpenIDConnectProvider_get_after_update.golden.go
@@ -1,0 +1,12 @@
+{
+  "ClientIDList": [
+    "sts.amazonaws.com"
+  ],
+  "CreateDate": "2026-05-08T07:35:36.882021Z",
+  "Tags": null,
+  "ThumbprintList": [
+    "a031c46782e6e6c662c2c87c76da9aa62ccabd8e"
+  ],
+  "Url": "https://token.actions.githubusercontent.com",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/iam_test_TestIAM_PutGetListDeleteRolePolicy_TestIAM_PutGetListDeleteRolePolicy_get.golden.go
+++ b/test/integration/testdata/iam_test_TestIAM_PutGetListDeleteRolePolicy_TestIAM_PutGetListDeleteRolePolicy_get.golden.go
@@ -1,0 +1,6 @@
+{
+  "PolicyDocument": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"s3:GetObject\",\"Resource\":\"*\"}]}",
+  "PolicyName": "test-inline-policy",
+  "RoleName": "test-inline-policy-role",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/iam_test_TestIAM_PutGetListDeleteRolePolicy_TestIAM_PutGetListDeleteRolePolicy_list.golden.go
+++ b/test/integration/testdata/iam_test_TestIAM_PutGetListDeleteRolePolicy_TestIAM_PutGetListDeleteRolePolicy_list.golden.go
@@ -1,0 +1,8 @@
+{
+  "PolicyNames": [
+    "test-inline-policy"
+  ],
+  "IsTruncated": false,
+  "Marker": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/iam_test_TestIAM_PutGetListDeleteRolePolicy_TestIAM_PutGetListDeleteRolePolicy_list_after_delete.golden.go
+++ b/test/integration/testdata/iam_test_TestIAM_PutGetListDeleteRolePolicy_TestIAM_PutGetListDeleteRolePolicy_list_after_delete.golden.go
@@ -1,0 +1,6 @@
+{
+  "PolicyNames": [],
+  "IsTruncated": false,
+  "Marker": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

Adds three groups of IAM APIs that the AWS SDK exposes. Without these, any code that creates an IAM role with policies, lists managed-policy attachments, or sets up OIDC federation hits \`InvalidAction\`.

| Category | APIs added |
|---|---|
| Inline role policies | \`PutRolePolicy\`, \`GetRolePolicy\`, \`DeleteRolePolicy\`, \`ListRolePolicies\` |
| Managed-policy readback | \`ListAttachedRolePolicies\` |
| OpenID Connect provider | \`CreateOpenIDConnectProvider\`, \`GetOpenIDConnectProvider\`, \`DeleteOpenIDConnectProvider\`, \`ListOpenIDConnectProviders\`, \`UpdateOpenIDConnectProviderThumbprint\` |

OIDC support enables tests for federated-credential setups (GitHub Actions OIDC → AWS, EKS service accounts, etc.) without touching real AWS.

## Implementation notes

- Inline policies are stored on the existing \`Role\` struct as a \`PolicyName -> PolicyDocument\` map. \`CreateRole\` is unchanged.
- Managed-policy attachments were already tracked on \`Role.AttachedPolicies\` by the existing \`AttachRolePolicy\` / \`DetachRolePolicy\` handlers; the new \`ListAttachedRolePolicies\` simply exposes them through a handler.
- The OIDC provider ARN is derived from the URL by stripping the scheme, matching AWS IAM's convention: \`arn:aws:iam::<account>:oidc-provider/<host>/<path>\`. This is the same shape the AWS SDK expects.
- A small \`parseStringList\` helper reads the IAM \`<name>.member.N\` form pattern used by \`ClientIDList\` / \`ThumbprintList\`.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestIAM_*\` integration tests still pass
- [x] New \`TestIAM_PutGetListDeleteRolePolicy\` exercises the full lifecycle of an inline role policy, including verifying the empty list after delete
- [x] New \`TestIAM_ListAttachedRolePolicies\` exercises managed-policy attachment readback
- [x] New \`TestIAM_OpenIDConnectProvider\` exercises Create / Get / List / UpdateThumbprint / Delete

---

Addresses sivchari/kumo#408:
- Medium Priority "PutRolePolicy / GetRolePolicy / DeleteRolePolicy / ListRolePolicies"
- Medium Priority "ListAttachedRolePolicies"

OIDC provider operations are not enumerated in #408 but commonly needed alongside the inline-policy work for OIDC federation tests.
