### PR TITLE
feat(s3): PublicAccessBlock and BucketEncryption

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -106,6 +106,18 @@ func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, ok := r.URL.Query()["publicAccessBlock"]; ok {
+		s.GetPublicAccessBlock(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["encryption"]; ok {
+		s.GetBucketEncryption(w, r)
+
+		return
+	}
+
 	if _, ok := r.URL.Query()["versions"]; ok {
 		s.ListObjectVersions(w, r)
 
@@ -969,7 +981,204 @@ func (s *Service) handleBucketPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, ok := r.URL.Query()["publicAccessBlock"]; ok {
+		s.PutPublicAccessBlock(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["encryption"]; ok {
+		s.PutBucketEncryption(w, r)
+
+		return
+	}
+
 	s.CreateBucket(w, r)
+}
+
+// handleBucketDelete dispatches DELETE /{bucket} requests based on query parameters.
+func (s *Service) handleBucketDelete(w http.ResponseWriter, r *http.Request) {
+	if _, ok := r.URL.Query()["publicAccessBlock"]; ok {
+		s.DeletePublicAccessBlock(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["encryption"]; ok {
+		s.DeleteBucketEncryption(w, r)
+
+		return
+	}
+
+	s.DeleteBucket(w, r)
+}
+
+// PutPublicAccessBlock handles PUT /{bucket}?publicAccessBlock.
+func (s *Service) PutPublicAccessBlock(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeS3Error(w, r, "InvalidRequest", "Failed to read request body", http.StatusBadRequest)
+
+		return
+	}
+
+	var cfg PublicAccessBlockConfiguration
+	if err := xml.Unmarshal(body, &cfg); err != nil {
+		writeS3Error(w, r, "MalformedXML", "The request body is malformed XML", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.PutPublicAccessBlock(r.Context(), bucket, PublicAccessBlockConfig{
+		BlockPublicAcls:       cfg.BlockPublicAcls,
+		IgnorePublicAcls:      cfg.IgnorePublicAcls,
+		BlockPublicPolicy:     cfg.BlockPublicPolicy,
+		RestrictPublicBuckets: cfg.RestrictPublicBuckets,
+	}); err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetPublicAccessBlock handles GET /{bucket}?publicAccessBlock.
+func (s *Service) GetPublicAccessBlock(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	cfg, err := s.storage.GetPublicAccessBlock(r.Context(), bucket)
+	if err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	writeXMLResponse(w, PublicAccessBlockConfiguration{
+		Xmlns:                 s3Namespace,
+		BlockPublicAcls:       cfg.BlockPublicAcls,
+		IgnorePublicAcls:      cfg.IgnorePublicAcls,
+		BlockPublicPolicy:     cfg.BlockPublicPolicy,
+		RestrictPublicBuckets: cfg.RestrictPublicBuckets,
+	})
+}
+
+// DeletePublicAccessBlock handles DELETE /{bucket}?publicAccessBlock.
+func (s *Service) DeletePublicAccessBlock(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	if err := s.storage.DeletePublicAccessBlock(r.Context(), bucket); err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// PutBucketEncryption handles PUT /{bucket}?encryption.
+func (s *Service) PutBucketEncryption(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeS3Error(w, r, "InvalidRequest", "Failed to read request body", http.StatusBadRequest)
+
+		return
+	}
+
+	var cfg ServerSideEncryptionConfiguration
+	if err := xml.Unmarshal(body, &cfg); err != nil {
+		writeS3Error(w, r, "MalformedXML", "The request body is malformed XML", http.StatusBadRequest)
+
+		return
+	}
+
+	rules := make([]ServerSideEncryptionRule, 0, len(cfg.Rules))
+
+	for _, rule := range cfg.Rules {
+		stored := ServerSideEncryptionRule{BucketKeyEnabled: rule.BucketKeyEnabled}
+		if rule.ApplyServerSideEncryptionByDefault != nil {
+			stored.SSEAlgorithm = rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm
+			stored.KMSMasterKeyID = rule.ApplyServerSideEncryptionByDefault.KMSMasterKeyID
+		}
+
+		rules = append(rules, stored)
+	}
+
+	if err := s.storage.PutBucketEncryption(r.Context(), bucket, ServerSideEncryptionConfig{Rules: rules}); err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetBucketEncryption handles GET /{bucket}?encryption.
+func (s *Service) GetBucketEncryption(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	cfg, err := s.storage.GetBucketEncryption(r.Context(), bucket)
+	if err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	xmlRules := make([]ServerSideEncryptionRuleX, 0, len(cfg.Rules))
+
+	for _, rule := range cfg.Rules {
+		xmlRule := ServerSideEncryptionRuleX{BucketKeyEnabled: rule.BucketKeyEnabled}
+		if rule.SSEAlgorithm != "" {
+			xmlRule.ApplyServerSideEncryptionByDefault = &ApplyServerSideEncryptionByDefault{
+				SSEAlgorithm:   rule.SSEAlgorithm,
+				KMSMasterKeyID: rule.KMSMasterKeyID,
+			}
+		}
+
+		xmlRules = append(xmlRules, xmlRule)
+	}
+
+	writeXMLResponse(w, ServerSideEncryptionConfiguration{
+		Xmlns: s3Namespace,
+		Rules: xmlRules,
+	})
+}
+
+// DeleteBucketEncryption handles DELETE /{bucket}?encryption.
+func (s *Service) DeleteBucketEncryption(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	if err := s.storage.DeleteBucketEncryption(r.Context(), bucket); err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// writeBucketErrorOrInternal maps a BucketError to its HTTP status code,
+// falling back to 500 for non-bucket errors. Used by sub-resource handlers.
+func writeBucketErrorOrInternal(w http.ResponseWriter, r *http.Request, err error) {
+	var bucketErr *BucketError
+	if errors.As(err, &bucketErr) {
+		status := http.StatusBadRequest
+
+		switch bucketErr.Code {
+		case "NoSuchBucket", "NoSuchPublicAccessBlockConfiguration", "ServerSideEncryptionConfigurationNotFoundError":
+			status = http.StatusNotFound
+		}
+
+		writeS3Error(w, r, bucketErr.Code, bucketErr.Message, status)
+
+		return
+	}
+
+	writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
 }
 
 // writeXMLResponse writes an XML response with HTTP 200 OK status.

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -62,7 +62,7 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	// Bucket operations
 	r.Handle("GET", "/", s.ListBuckets)
 	r.Handle("PUT", "/{bucket}", s.handleBucketPut)
-	r.Handle("DELETE", "/{bucket}", s.DeleteBucket)
+	r.Handle("DELETE", "/{bucket}", s.handleBucketDelete)
 	r.Handle("HEAD", "/{bucket}", s.HeadBucket)
 
 	// Bucket-level GET handles ListObjects, ListMultipartUploads, versioning queries

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -61,6 +61,14 @@ type Storage interface {
 	IsEventBridgeEnabled(ctx context.Context, bucket string) bool
 	SetCORSConfiguration(ctx context.Context, bucket string, rules []CORSRule)
 	GetCORSRules(ctx context.Context, bucket string) []CORSRule
+
+	PutPublicAccessBlock(ctx context.Context, bucket string, cfg PublicAccessBlockConfig) error
+	GetPublicAccessBlock(ctx context.Context, bucket string) (*PublicAccessBlockConfig, error)
+	DeletePublicAccessBlock(ctx context.Context, bucket string) error
+
+	PutBucketEncryption(ctx context.Context, bucket string, cfg ServerSideEncryptionConfig) error
+	GetBucketEncryption(ctx context.Context, bucket string) (*ServerSideEncryptionConfig, error)
+	DeleteBucketEncryption(ctx context.Context, bucket string) error
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -90,13 +98,35 @@ type MemoryStorage struct {
 type MemoryBucket struct {
 	Name               string                      `json:"name"`
 	CreationDate       time.Time                   `json:"creationDate"`
-	Objects            map[string]*Object          `json:"objects"`             // current/latest version per key
-	Versions           map[string][]*Object        `json:"versions"`            // all versions per key (newest first)
-	VersioningStatus   string                      `json:"versioningStatus"`    // "", "Enabled", "Suspended"
-	VersionIDCounter   uint64                      `json:"versionIdcounter"`    // counter for generating version IDs
-	MultipartUploads   map[string]*MultipartUpload `json:"-"`                   // uploadID -> MultipartUpload
-	EventBridgeEnabled bool                        `json:"eventBridgeEnabled"`  // EventBridge notification
-	CORSRules          []CORSRule                  `json:"corsRules,omitempty"` // CORS configuration
+	Objects            map[string]*Object          `json:"objects"`                     // current/latest version per key
+	Versions           map[string][]*Object        `json:"versions"`                    // all versions per key (newest first)
+	VersioningStatus   string                      `json:"versioningStatus"`            // "", "Enabled", "Suspended"
+	VersionIDCounter   uint64                      `json:"versionIdcounter"`            // counter for generating version IDs
+	MultipartUploads   map[string]*MultipartUpload `json:"-"`                           // uploadID -> MultipartUpload
+	EventBridgeEnabled bool                        `json:"eventBridgeEnabled"`          // EventBridge notification
+	CORSRules          []CORSRule                  `json:"corsRules,omitempty"`         // CORS configuration
+	PublicAccessBlock  *PublicAccessBlockConfig    `json:"publicAccessBlock,omitempty"` // public access block configuration
+	Encryption         *ServerSideEncryptionConfig `json:"encryption,omitempty"`        // server-side encryption configuration
+}
+
+// PublicAccessBlockConfig stores the four PAB flags.
+type PublicAccessBlockConfig struct {
+	BlockPublicAcls       bool `json:"blockPublicAcls"`
+	IgnorePublicAcls      bool `json:"ignorePublicAcls"`
+	BlockPublicPolicy     bool `json:"blockPublicPolicy"`
+	RestrictPublicBuckets bool `json:"restrictPublicBuckets"`
+}
+
+// ServerSideEncryptionConfig stores the bucket SSE configuration.
+type ServerSideEncryptionConfig struct {
+	Rules []ServerSideEncryptionRule `json:"rules"`
+}
+
+// ServerSideEncryptionRule represents a single SSE rule.
+type ServerSideEncryptionRule struct {
+	SSEAlgorithm     string `json:"sseAlgorithm"`               // AES256 / aws:kms / aws:kms:dsse
+	KMSMasterKeyID   string `json:"kmsMasterKeyId,omitempty"`   // optional KMS key
+	BucketKeyEnabled bool   `json:"bucketKeyEnabled,omitempty"` // S3 Bucket Keys
 }
 
 // NewMemoryStorage creates a new in-memory S3 storage.
@@ -1089,6 +1119,114 @@ func (s *MemoryStorage) GetCORSRules(_ context.Context, bucket string) []CORSRul
 	if b, exists := s.Buckets[bucket]; exists {
 		return b.CORSRules
 	}
+
+	return nil
+}
+
+// PutPublicAccessBlock stores a bucket's public access block configuration.
+func (s *MemoryStorage) PutPublicAccessBlock(_ context.Context, bucket string, cfg PublicAccessBlockConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	c := cfg
+	b.PublicAccessBlock = &c
+
+	return nil
+}
+
+// GetPublicAccessBlock returns a bucket's public access block configuration.
+func (s *MemoryStorage) GetPublicAccessBlock(_ context.Context, bucket string) (*PublicAccessBlockConfig, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if b.PublicAccessBlock == nil {
+		return nil, &BucketError{
+			Code:       "NoSuchPublicAccessBlockConfiguration",
+			Message:    "The public access block configuration was not found",
+			BucketName: bucket,
+		}
+	}
+
+	c := *b.PublicAccessBlock
+
+	return &c, nil
+}
+
+// DeletePublicAccessBlock removes a bucket's public access block configuration.
+func (s *MemoryStorage) DeletePublicAccessBlock(_ context.Context, bucket string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	b.PublicAccessBlock = nil
+
+	return nil
+}
+
+// PutBucketEncryption stores a bucket's server-side encryption configuration.
+func (s *MemoryStorage) PutBucketEncryption(_ context.Context, bucket string, cfg ServerSideEncryptionConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	c := ServerSideEncryptionConfig{Rules: append([]ServerSideEncryptionRule(nil), cfg.Rules...)}
+	b.Encryption = &c
+
+	return nil
+}
+
+// GetBucketEncryption returns a bucket's server-side encryption configuration.
+func (s *MemoryStorage) GetBucketEncryption(_ context.Context, bucket string) (*ServerSideEncryptionConfig, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if b.Encryption == nil {
+		return nil, &BucketError{
+			Code:       "ServerSideEncryptionConfigurationNotFoundError",
+			Message:    "The server side encryption configuration was not found",
+			BucketName: bucket,
+		}
+	}
+
+	c := ServerSideEncryptionConfig{Rules: append([]ServerSideEncryptionRule(nil), b.Encryption.Rules...)}
+
+	return &c, nil
+}
+
+// DeleteBucketEncryption removes a bucket's server-side encryption configuration.
+func (s *MemoryStorage) DeleteBucketEncryption(_ context.Context, bucket string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	b.Encryption = nil
 
 	return nil
 }

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -330,3 +330,36 @@ type CORSRule struct {
 	ExposeHeaders  []string `json:"exposeHeaders,omitempty"  xml:"ExposeHeader"`
 	MaxAgeSeconds  int      `json:"maxAgeSeconds,omitempty"  xml:"MaxAgeSeconds"`
 }
+
+// PublicAccessBlockConfiguration is the request/response body for the
+// public access block APIs.
+type PublicAccessBlockConfiguration struct {
+	XMLName               xml.Name `xml:"PublicAccessBlockConfiguration"`
+	Xmlns                 string   `xml:"xmlns,attr,omitempty"`
+	BlockPublicAcls       bool     `xml:"BlockPublicAcls"`
+	IgnorePublicAcls      bool     `xml:"IgnorePublicAcls"`
+	BlockPublicPolicy     bool     `xml:"BlockPublicPolicy"`
+	RestrictPublicBuckets bool     `xml:"RestrictPublicBuckets"`
+}
+
+// ServerSideEncryptionConfiguration is the request/response body for the
+// bucket-encryption APIs.
+type ServerSideEncryptionConfiguration struct {
+	XMLName xml.Name                    `xml:"ServerSideEncryptionConfiguration"`
+	Xmlns   string                      `xml:"xmlns,attr,omitempty"`
+	Rules   []ServerSideEncryptionRuleX `xml:"Rule"`
+}
+
+// ServerSideEncryptionRuleX is the XML representation of a single SSE rule.
+// (Suffixed with X to avoid colliding with storage's ServerSideEncryptionRule.)
+type ServerSideEncryptionRuleX struct {
+	ApplyServerSideEncryptionByDefault *ApplyServerSideEncryptionByDefault `xml:"ApplyServerSideEncryptionByDefault,omitempty"`
+	BucketKeyEnabled                   bool                                `xml:"BucketKeyEnabled,omitempty"`
+}
+
+// ApplyServerSideEncryptionByDefault holds the default SSE algorithm and
+// optional KMS key id.
+type ApplyServerSideEncryptionByDefault struct {
+	SSEAlgorithm   string `xml:"SSEAlgorithm"`
+	KMSMasterKeyID string `xml:"KMSMasterKeyID,omitempty"`
+}

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1461,3 +1461,99 @@ func TestS3_PutObject_KeyWithLeadingSlash(t *testing.T) {
 		t.Errorf("body = %q, want %q", string(gotBody), "hello")
 	}
 }
+
+func TestS3_PublicAccessBlock(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-pab-bucket"
+
+	if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Fatalf("failed to create bucket: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	})
+
+	if _, err := client.PutPublicAccessBlock(ctx, &s3.PutPublicAccessBlockInput{
+		Bucket: aws.String(bucket),
+		PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{
+			BlockPublicAcls:       aws.Bool(true),
+			IgnorePublicAcls:      aws.Bool(true),
+			BlockPublicPolicy:     aws.Bool(true),
+			RestrictPublicBuckets: aws.Bool(true),
+		},
+	}); err != nil {
+		t.Fatalf("failed to put public access block: %v", err)
+	}
+
+	getResult, err := client.GetPublicAccessBlock(ctx, &s3.GetPublicAccessBlockInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatalf("failed to get public access block: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_get", getResult)
+
+	if _, err := client.DeletePublicAccessBlock(ctx, &s3.DeletePublicAccessBlockInput{
+		Bucket: aws.String(bucket),
+	}); err != nil {
+		t.Fatalf("failed to delete public access block: %v", err)
+	}
+
+	if _, err := client.GetPublicAccessBlock(ctx, &s3.GetPublicAccessBlockInput{
+		Bucket: aws.String(bucket),
+	}); err == nil {
+		t.Fatal("expected NoSuchPublicAccessBlockConfiguration after delete, got nil")
+	}
+}
+
+func TestS3_BucketEncryption(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-sse-bucket"
+
+	if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Fatalf("failed to create bucket: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	})
+
+	if _, err := client.PutBucketEncryption(ctx, &s3.PutBucketEncryptionInput{
+		Bucket: aws.String(bucket),
+		ServerSideEncryptionConfiguration: &types.ServerSideEncryptionConfiguration{
+			Rules: []types.ServerSideEncryptionRule{
+				{
+					ApplyServerSideEncryptionByDefault: &types.ServerSideEncryptionByDefault{
+						SSEAlgorithm: types.ServerSideEncryptionAes256,
+					},
+					BucketKeyEnabled: aws.Bool(true),
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("failed to put bucket encryption: %v", err)
+	}
+
+	getResult, err := client.GetBucketEncryption(ctx, &s3.GetBucketEncryptionInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatalf("failed to get bucket encryption: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_get", getResult)
+
+	if _, err := client.DeleteBucketEncryption(ctx, &s3.DeleteBucketEncryptionInput{
+		Bucket: aws.String(bucket),
+	}); err != nil {
+		t.Fatalf("failed to delete bucket encryption: %v", err)
+	}
+
+	if _, err := client.GetBucketEncryption(ctx, &s3.GetBucketEncryptionInput{
+		Bucket: aws.String(bucket),
+	}); err == nil {
+		t.Fatal("expected ServerSideEncryptionConfigurationNotFoundError after delete, got nil")
+	}
+}

--- a/test/integration/testdata/s3_test_TestS3_BucketEncryption_TestS3_BucketEncryption_get.golden.go
+++ b/test/integration/testdata/s3_test_TestS3_BucketEncryption_TestS3_BucketEncryption_get.golden.go
@@ -1,0 +1,15 @@
+{
+  "ServerSideEncryptionConfiguration": {
+    "Rules": [
+      {
+        "ApplyServerSideEncryptionByDefault": {
+          "SSEAlgorithm": "AES256",
+          "KMSMasterKeyID": null
+        },
+        "BlockedEncryptionTypes": null,
+        "BucketKeyEnabled": true
+      }
+    ]
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/s3_test_TestS3_PublicAccessBlock_TestS3_PublicAccessBlock_get.golden.go
+++ b/test/integration/testdata/s3_test_TestS3_PublicAccessBlock_TestS3_PublicAccessBlock_get.golden.go
@@ -1,0 +1,9 @@
+{
+  "PublicAccessBlockConfiguration": {
+    "BlockPublicAcls": true,
+    "BlockPublicPolicy": true,
+    "IgnorePublicAcls": true,
+    "RestrictPublicBuckets": true
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

Adds bucket-level Put / Get / Delete handlers for the two sub-resources the AWS S3 SDK exposes for public access controls and default server-side encryption.

| Sub-resource | APIs added |
|---|---|
| Public access block | \`PutPublicAccessBlock\`, \`GetPublicAccessBlock\`, \`DeletePublicAccessBlock\` |
| Server-side encryption | \`PutBucketEncryption\`, \`GetBucketEncryption\`, \`DeleteBucketEncryption\` |

## Implementation notes

- A new \`handleBucketDelete\` dispatcher wraps the existing \`DeleteBucket\` handler so \`DELETE ?publicAccessBlock\` and \`DELETE ?encryption\` route without touching the unconditional bucket-delete path.
- The same query-parameter dispatch is added to \`handleBucketPut\` and \`handleBucketGet\` for the corresponding PUT / GET requests.
- Storage adds two optional fields on \`MemoryBucket\` (\`PublicAccessBlock\`, \`Encryption\`), each with its own typed configuration. XML wire types live in \`types.go\` and the handler is the only place that crosses the wire / storage boundary.
- Get handlers return AWS-compatible errors when the configuration is absent: \`NoSuchPublicAccessBlockConfiguration\` and \`ServerSideEncryptionConfigurationNotFoundError\`. The new \`writeBucketErrorOrInternal\` helper maps them to \`404\`.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestS3_*\` integration tests still pass
- [x] New \`TestS3_PublicAccessBlock\` covers the full lifecycle: Put → Get → Delete → Get returns error
- [x] New \`TestS3_BucketEncryption\` covers Put (AES256 + BucketKeyEnabled) → Get → Delete → Get returns error

---

Addresses sivchari/kumo#404 — Medium Priority "GetBucketEncryption / PutBucketEncryption / DeleteBucketEncryption". The PublicAccessBlock triple is not enumerated in #404 but is the natural pair to SSE for any bucket configured with default encryption.
