### PR TITLE
fix(ec2): correct InvalidRouteTableID.NotFound error code casing

### DIFF
--- a/internal/service/ec2/storage.go
+++ b/internal/service/ec2/storage.go
@@ -1148,7 +1148,7 @@ func (m *MemoryStorage) DescribeRouteTables(_ context.Context, rtbIDs []string) 
 		rt, exists := m.RouteTables[id]
 		if !exists {
 			return nil, &Error{
-				Code:    "InvalidRouteTableId.NotFound",
+				Code:    "InvalidRouteTableID.NotFound",
 				Message: fmt.Sprintf("The routeTable ID '%s' does not exist", id),
 			}
 		}


### PR DESCRIPTION
## Summary

\`DescribeRouteTables\` returned the error code with lowercase \`d\`:

\`\`\`
InvalidRouteTableId.NotFound
\`\`\`

The AWS spec and the AWS SDK use capital \`D\`:

\`\`\`
InvalidRouteTableID.NotFound
\`\`\`

Every other site in \`internal/service/ec2/storage.go\` that emits route-table errors already uses the capital-D form (lines 1180, 1215, 1689, 1710 in HEAD). This one occurrence at line 1258 is the outlier.

## Why it matters

Clients that match against the exact error code — the typical pattern for SDK-level error handling — treated the lowercase variant as an unknown error instead of the documented "not found" response. That breaks delete-polling: the client expects \`InvalidRouteTableID.NotFound\` to mean "successfully deleted, stop polling" and instead retries until timeout.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] Existing \`TestEC2_*\` integration tests still pass