### PR TITLE
feat(iam): ListInstanceProfilesForRole stub for role tear-down

### DIFF
--- a/internal/service/iam/handlers.go
+++ b/internal/service/iam/handlers.go
@@ -485,6 +485,22 @@ func (s *Service) ListAccessKeys(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ListInstanceProfilesForRole returns an empty list. Instance profiles are
+// not modeled; AWS clients call this during role tear-down to detach profiles
+// before deletion, so an empty list is the correct "no profiles" response.
+func (s *Service) ListInstanceProfilesForRole(w http.ResponseWriter, _ *http.Request) {
+	writeIAMXMLResponse(w, struct {
+		XMLName                           xml.Name `xml:"ListInstanceProfilesForRoleResponse"`
+		ListInstanceProfilesForRoleResult struct {
+			InstanceProfiles struct{} `xml:"InstanceProfiles"`
+			IsTruncated      bool     `xml:"IsTruncated"`
+		} `xml:"ListInstanceProfilesForRoleResult"`
+		ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+	}{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
 // DispatchAction routes the request to the appropriate handler based on Action parameter.
 func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 	action := extractAction(r)

--- a/internal/service/iam/service.go
+++ b/internal/service/iam/service.go
@@ -65,6 +65,8 @@ func (s *Service) initActionHandlers() {
 		"CreateAccessKey": s.CreateAccessKey,
 		"DeleteAccessKey": s.DeleteAccessKey,
 		"ListAccessKeys":  s.ListAccessKeys,
+		// Role tear-down support
+		"ListInstanceProfilesForRole": s.ListInstanceProfilesForRole,
 	}
 }
 

--- a/test/integration/iam_test.go
+++ b/test/integration/iam_test.go
@@ -610,3 +610,33 @@ func TestIAM_CreateUserWithTags(t *testing.T) {
 
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "UserId", "Arn", "CreateDate")).Assert(t.Name()+"_get", getResult)
 }
+
+func TestIAM_ListInstanceProfilesForRole(t *testing.T) {
+	client := newIAMClient(t)
+	ctx := t.Context()
+	roleName := "test-instance-profiles-role"
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	}); err != nil {
+		t.Fatalf("failed to create role: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteRole(context.Background(), &iam.DeleteRoleInput{
+			RoleName: aws.String(roleName),
+		})
+	})
+
+	result, err := client.ListInstanceProfilesForRole(ctx, &iam.ListInstanceProfilesForRoleInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		t.Fatalf("ListInstanceProfilesForRole failed: %v", err)
+	}
+
+	if len(result.InstanceProfiles) != 0 {
+		t.Errorf("expected empty InstanceProfiles list, got %d entries", len(result.InstanceProfiles))
+	}
+}


### PR DESCRIPTION
## Summary

Adds an empty-list \`ListInstanceProfilesForRole\` handler. AWS clients call this during role deletion to detach any instance profiles before issuing \`DeleteRole\`. kumo does not model instance profiles, so the correct emulator response is an empty list — the same response real IAM gives for a role that never had a profile.

Without this, a role created via kumo cannot be cleanly deleted by clients that follow the standard tear-down idiom: the list call returns \`InvalidAction\` and the client aborts before reaching \`DeleteRole\`.

## Implementation

- One handler (\`ListInstanceProfilesForRole\`) with the AWS-spec XML response shape (\`<InstanceProfiles>\` with no members, \`<IsTruncated>false</IsTruncated>\`).
- One register entry in \`initActionHandlers\`.
- No storage changes — instance profiles are still not modeled, by design.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestIAM_*\` integration tests still pass
- [x] New \`TestIAM_ListInstanceProfilesForRole\` creates a role, calls the new action, and asserts the returned list is empty

---

Related to sivchari/kumo#408 — High Priority "CreateInstanceProfile / DeleteInstanceProfile / GetInstanceProfile / ListInstanceProfiles" / "AddRoleToInstanceProfile / RemoveRoleFromInstanceProfile". This PR only adds the read-side stub used during role tear-down. The full instance-profile lifecycle is a separate follow-up.
