### PR TITLE
feat(s3): default-response stubs for unconfigured bucket sub-resources

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -130,7 +130,128 @@ func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if handled := s.serveBucketSubresourceStub(w, r); handled {
+		return
+	}
+
 	s.ListObjects(w, r)
+}
+
+// serveBucketSubresourceStub handles GET requests for bucket sub-resources that
+// kumo does not model. Some sub-resources (acl, location, logging, accelerate,
+// requestPayment) always return a default response in real S3; others return a
+// specific NoSuch* error code. Returns true when the request was handled.
+func (s *Service) serveBucketSubresourceStub(w http.ResponseWriter, r *http.Request) bool {
+	q := r.URL.Query()
+
+	switch {
+	case q.Has("acl"):
+		writeXMLResponse(w, defaultBucketACL())
+	case q.Has("location"):
+		writeXMLResponse(w, struct {
+			XMLName xml.Name `xml:"LocationConstraint"`
+			Xmlns   string   `xml:"xmlns,attr,omitempty"`
+			Value   string   `xml:",chardata"`
+		}{Xmlns: s3Namespace, Value: "us-east-1"})
+	case q.Has("logging"):
+		writeXMLResponse(w, struct {
+			XMLName xml.Name `xml:"BucketLoggingStatus"`
+			Xmlns   string   `xml:"xmlns,attr,omitempty"`
+		}{Xmlns: s3Namespace})
+	case q.Has("accelerate"):
+		writeXMLResponse(w, struct {
+			XMLName xml.Name `xml:"AccelerateConfiguration"`
+			Xmlns   string   `xml:"xmlns,attr,omitempty"`
+			Status  string   `xml:"Status,omitempty"`
+		}{Xmlns: s3Namespace})
+	case q.Has("requestPayment"):
+		writeXMLResponse(w, struct {
+			XMLName xml.Name `xml:"RequestPaymentConfiguration"`
+			Xmlns   string   `xml:"xmlns,attr,omitempty"`
+			Payer   string   `xml:"Payer"`
+		}{Xmlns: s3Namespace, Payer: "BucketOwner"})
+	default:
+		errCode, ok := bucketSubresourceErrorCode(q)
+		if !ok {
+			return false
+		}
+
+		writeS3Error(w, r, errCode, "The "+errCode+" sub-resource is not configured", http.StatusNotFound)
+	}
+
+	return true
+}
+
+// bucketSubresourceErrorCode maps a GET ?<sub-resource> query to the AWS error
+// code returned when the sub-resource is unconfigured.
+func bucketSubresourceErrorCode(q map[string][]string) (string, bool) {
+	mapping := map[string]string{
+		"policy":            "NoSuchBucketPolicy",
+		"cors":              "NoSuchCORSConfiguration",
+		"lifecycle":         "NoSuchLifecycleConfiguration",
+		"replication":       "ReplicationConfigurationNotFoundError",
+		"website":           "NoSuchWebsiteConfiguration",
+		"tagging":           "NoSuchTagSet",
+		"object-lock":       "ObjectLockConfigurationNotFoundError",
+		"ownershipControls": "OwnershipControlsNotFoundError",
+	}
+
+	for key, code := range mapping {
+		if _, ok := q[key]; ok {
+			return code, true
+		}
+	}
+
+	return "", false
+}
+
+// defaultBucketACL builds the ACL response real S3 returns when the bucket has
+// no explicit ACL set: owner gets FULL_CONTROL.
+func defaultBucketACL() any {
+	type grantee struct {
+		XMLName     xml.Name `xml:"Grantee"`
+		XSI         string   `xml:"xmlns:xsi,attr"`
+		Type        string   `xml:"xsi:type,attr"`
+		ID          string   `xml:"ID,omitempty"`
+		DisplayName string   `xml:"DisplayName,omitempty"`
+	}
+
+	type grant struct {
+		XMLName    xml.Name `xml:"Grant"`
+		Grantee    grantee
+		Permission string `xml:"Permission"`
+	}
+
+	type owner struct {
+		XMLName     xml.Name `xml:"Owner"`
+		ID          string   `xml:"ID"`
+		DisplayName string   `xml:"DisplayName,omitempty"`
+	}
+
+	return struct {
+		XMLName           xml.Name `xml:"AccessControlPolicy"`
+		Xmlns             string   `xml:"xmlns,attr,omitempty"`
+		Owner             owner
+		AccessControlList struct {
+			Grant grant
+		} `xml:"AccessControlList"`
+	}{
+		Xmlns: s3Namespace,
+		Owner: owner{ID: "owner-id", DisplayName: "owner"},
+		AccessControlList: struct {
+			Grant grant
+		}{
+			Grant: grant{
+				Grantee: grantee{
+					XSI:         "http://www.w3.org/2001/XMLSchema-instance",
+					Type:        "CanonicalUser",
+					ID:          "owner-id",
+					DisplayName: "owner",
+				},
+				Permission: "FULL_CONTROL",
+			},
+		},
+	}
 }
 
 // handleBucketPost dispatches POST /{bucket} requests based on query parameters.

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1557,3 +1557,101 @@ func TestS3_BucketEncryption(t *testing.T) {
 		t.Fatal("expected ServerSideEncryptionConfigurationNotFoundError after delete, got nil")
 	}
 }
+
+func TestS3_BucketSubresourceStubs_DefaultResponses(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-subresource-defaults"
+
+	if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Fatalf("failed to create bucket: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	})
+
+	if _, err := client.GetBucketAcl(ctx, &s3.GetBucketAclInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Errorf("GetBucketAcl: unexpected error: %v", err)
+	}
+
+	loc, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		t.Errorf("GetBucketLocation: unexpected error: %v", err)
+	} else if string(loc.LocationConstraint) != "us-east-1" {
+		t.Errorf("LocationConstraint = %q, want %q", loc.LocationConstraint, "us-east-1")
+	}
+
+	if _, err := client.GetBucketLogging(ctx, &s3.GetBucketLoggingInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Errorf("GetBucketLogging: unexpected error: %v", err)
+	}
+
+	if _, err := client.GetBucketAccelerateConfiguration(ctx, &s3.GetBucketAccelerateConfigurationInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Errorf("GetBucketAccelerateConfiguration: unexpected error: %v", err)
+	}
+
+	pay, err := client.GetBucketRequestPayment(ctx, &s3.GetBucketRequestPaymentInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		t.Errorf("GetBucketRequestPayment: unexpected error: %v", err)
+	} else if string(pay.Payer) != "BucketOwner" {
+		t.Errorf("Payer = %q, want %q", pay.Payer, "BucketOwner")
+	}
+}
+
+func TestS3_BucketSubresourceStubs_NoSuchErrors(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-subresource-nosuch"
+
+	if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Fatalf("failed to create bucket: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	})
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"GetBucketPolicy", func() error {
+			_, err := client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: aws.String(bucket)})
+
+			return err
+		}},
+		{"GetBucketCors", func() error {
+			_, err := client.GetBucketCors(ctx, &s3.GetBucketCorsInput{Bucket: aws.String(bucket)})
+
+			return err
+		}},
+		{"GetBucketLifecycleConfiguration", func() error {
+			_, err := client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{Bucket: aws.String(bucket)})
+
+			return err
+		}},
+		{"GetBucketWebsite", func() error {
+			_, err := client.GetBucketWebsite(ctx, &s3.GetBucketWebsiteInput{Bucket: aws.String(bucket)})
+
+			return err
+		}},
+		{"GetBucketReplication", func() error {
+			_, err := client.GetBucketReplication(ctx, &s3.GetBucketReplicationInput{Bucket: aws.String(bucket)})
+
+			return err
+		}},
+		{"GetBucketTagging", func() error {
+			_, err := client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{Bucket: aws.String(bucket)})
+
+			return err
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.call(); err == nil {
+				t.Fatalf("%s: expected NoSuch* error, got nil", tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds GET stubs for the bucket sub-resources that AWS clients read in the natural Create/Read/Update/Destroy lifecycle of an S3 bucket.

| Behavior | Sub-resources | Reason |
|---|---|---|
| Always present in real S3 (return defaults) | \`acl\`, \`location\`, \`logging\`, \`accelerate\`, \`requestPayment\` | Real S3 always returns one of these, even on a brand-new bucket |
| Optional in real S3 (return \`NoSuch*\` / \`NotFoundError\`) | \`policy\`, \`cors\`, \`lifecycle\`, \`replication\`, \`website\`, \`tagging\`, \`object-lock\`, \`ownershipControls\` | Real S3 returns 404 with a specific code when the sub-resource has not been configured |

Without these, \`GET /bucket?<sub-resource>\` falls through to \`ListObjects\` and returns a \`ListBucketResult\` XML body. Downstream parsers either reject the unexpected XML shape or, if expecting JSON, fail with \`invalid character '<' looking for beginning of value\`.

## Implementation

- One new dispatcher (\`serveBucketSubresourceStub\`) called from \`handleBucketGet\` after the modeled sub-resources but before the \`ListObjects\` fallback.
- One map (\`bucketSubresourceErrorCode\`) for the \`NoSuch*\` cases — adding a new error-style sub-resource is one line.
- One helper (\`defaultBucketACL\`) for the canonical \`AccessControlPolicy\` shape (owner gets \`FULL_CONTROL\`).
- All in \`internal/service/s3/handlers.go\`. No storage changes.

## Stacking

This branch is based on \`feat/s3-pab-and-sse\` (PR #549) because it shares \`handleBucketGet\`. If #549 lands first, this rebases cleanly; if this lands first, #549 needs a trivial rebase.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestS3_*\` integration tests still pass
- [x] New \`TestS3_BucketSubresourceStubs_DefaultResponses\` exercises acl / location / logging / accelerate / requestPayment and asserts the documented defaults
- [x] New \`TestS3_BucketSubresourceStubs_NoSuchErrors\` exercises 6 of the optional sub-resources and asserts each returns an error

---

Addresses sivchari/kumo#404:
- Medium Priority "GetBucketCors", "GetBucketAcl", "GetBucketLifecycleConfiguration"
- Low Priority "GetBucketWebsite", "GetBucketLocation"

This PR covers the read-side stubs only. Full Put/Delete implementations for policy/cors/lifecycle/tagging remain as separate follow-ups.
