### PR TITLE
feat(ec2): tags-on-create via TagSpecifications on Create* actions

### DIFF
--- a/internal/service/ec2/handlers.go
+++ b/internal/service/ec2/handlers.go
@@ -213,6 +213,8 @@ func (s *Service) CreateSecurityGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	applyTagsOnCreate(r, s.storage, sg.GroupID, "security-group")
+
 	writeEC2XMLResponse(w, XMLCreateSecurityGroupResponse{
 		Xmlns:     ec2XMLNS,
 		RequestID: uuid.New().String(),
@@ -423,11 +425,33 @@ func (s *Service) CreateVpc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	applyTagsOnCreate(r, s.storage, vpc.VpcID, "vpc")
+
 	writeEC2XMLResponse(w, XMLCreateVpcResponse{
 		Xmlns:     ec2XMLNS,
 		RequestID: uuid.New().String(),
 		Vpc:       convertToXMLVpc(vpc),
 	})
+}
+
+// applyTagsOnCreate copies TagSpecifications from the form (if any) onto the
+// just-created resource via the storage tag API. Storage.CreateTags upserts in
+// place, and the existing Storage.Create* methods return the storage-owned
+// pointer, so the caller's resource value reflects the new tags by the time
+// this returns — no further mutation needed. resourceType matches the AWS
+// TagSpecifications.ResourceType values: "vpc", "subnet", "internet-gateway",
+// "route-table", "security-group".
+func applyTagsOnCreate(r *http.Request, storage Storage, resourceID, resourceType string) {
+	if err := r.ParseForm(); err != nil {
+		return
+	}
+
+	tags := parseTagSpecificationsForResourceType(r.Form, resourceType)
+	if len(tags) == 0 {
+		return
+	}
+
+	_ = storage.CreateTags(r.Context(), []string{resourceID}, tags)
 }
 
 // DeleteVpc handles the DeleteVpc action.
@@ -514,6 +538,8 @@ func (s *Service) CreateSubnet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	applyTagsOnCreate(r, s.storage, subnet.SubnetID, "subnet")
+
 	writeEC2XMLResponse(w, XMLCreateSubnetResponse{
 		Xmlns:     ec2XMLNS,
 		RequestID: uuid.New().String(),
@@ -592,6 +618,8 @@ func (s *Service) CreateInternetGateway(w http.ResponseWriter, r *http.Request) 
 
 		return
 	}
+
+	applyTagsOnCreate(r, s.storage, igw.InternetGatewayID, "internet-gateway")
 
 	writeEC2XMLResponse(w, XMLCreateInternetGatewayResponse{
 		Xmlns:           ec2XMLNS,
@@ -683,6 +711,8 @@ func (s *Service) CreateRouteTable(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
+
+	applyTagsOnCreate(r, s.storage, rt.RouteTableID, "route-table")
 
 	writeEC2XMLResponse(w, XMLCreateRouteTableResponse{
 		Xmlns:      ec2XMLNS,
@@ -1088,6 +1118,94 @@ func parseFiltersFromForm(form map[string][]string) map[string][]string {
 	}
 
 	return out
+}
+
+// tagSpec accumulates one TagSpecification.N entry being parsed from form data.
+type tagSpec struct {
+	resourceType string
+	tags         []Tag
+}
+
+// parseTagSpecificationsForResourceType reads TagSpecifications.N.ResourceType
+// and TagSpecifications.N.Tag.M.{Key,Value} from form data, returning the
+// tags whose ResourceType matches `resourceType` (e.g. "vpc", "subnet").
+// The Query form-to-JSON converter does not understand this nested pattern,
+// so callers parse from r.Form directly.
+func parseTagSpecificationsForResourceType(form map[string][]string, resourceType string) []Tag {
+	specs := make(map[int]*tagSpec)
+
+	for key, values := range form {
+		applyTagSpecFormEntry(specs, key, values)
+	}
+
+	for _, sp := range specs {
+		if sp.resourceType == resourceType {
+			return sp.tags
+		}
+	}
+
+	return nil
+}
+
+func applyTagSpecFormEntry(specs map[int]*tagSpec, key string, values []string) {
+	suffix, ok := strings.CutPrefix(key, "TagSpecification.")
+	if !ok || len(values) == 0 {
+		return
+	}
+
+	dot := strings.Index(suffix, ".")
+	if dot < 0 {
+		return
+	}
+
+	n, err := strconv.Atoi(suffix[:dot])
+	if err != nil {
+		return
+	}
+
+	entry, exists := specs[n]
+	if !exists {
+		entry = &tagSpec{}
+		specs[n] = entry
+	}
+
+	setTagSpecField(entry, suffix[dot+1:], values[0])
+}
+
+func setTagSpecField(entry *tagSpec, field, value string) {
+	switch {
+	case field == "ResourceType":
+		entry.resourceType = value
+	case strings.HasPrefix(field, "Tag."):
+		applyTagFromTagSpec(entry, strings.TrimPrefix(field, "Tag."), value)
+	}
+}
+
+func applyTagFromTagSpec(entry *tagSpec, suffix, value string) {
+	tdot := strings.Index(suffix, ".")
+	if tdot < 0 {
+		return
+	}
+
+	m, err := strconv.Atoi(suffix[:tdot])
+	if err != nil {
+		return
+	}
+
+	ensureTag(&entry.tags, m)
+
+	switch suffix[tdot+1:] {
+	case "Key":
+		entry.tags[m-1].Key = value
+	case "Value":
+		entry.tags[m-1].Value = value
+	}
+}
+
+func ensureTag(tags *[]Tag, n int) {
+	for len(*tags) < n {
+		*tags = append(*tags, Tag{})
+	}
 }
 
 // DispatchAction routes the request to the appropriate handler based on Action parameter.

--- a/test/integration/ec2_test.go
+++ b/test/integration/ec2_test.go
@@ -700,3 +700,56 @@ func TestEC2_DeleteTags(t *testing.T) {
 	}
 	golden.New(t, golden.WithIgnoreFields("ResourceId", "ResultMetadata")).Assert(t.Name()+"_after_delete", descResult)
 }
+
+func TestEC2_CreateVpc_WithTagSpecifications(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := t.Context()
+
+	createResult, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{
+		CidrBlock: aws.String("10.55.0.0/16"),
+		TagSpecifications: []types.TagSpecification{
+			{
+				ResourceType: types.ResourceTypeVpc,
+				Tags: []types.Tag{
+					{Key: aws.String("Name"), Value: aws.String("tagspec-vpc")},
+					{Key: aws.String("Env"), Value: aws.String("test")},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateVpc with TagSpecifications failed: %v", err)
+	}
+
+	vpcID := *createResult.Vpc.VpcId
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteVpc(context.Background(), &ec2.DeleteVpcInput{
+			VpcId: aws.String(vpcID),
+		})
+	})
+
+	if got := len(createResult.Vpc.Tags); got != 2 {
+		t.Errorf("create response Tags = %d entries, want 2", got)
+	}
+
+	descResult, err := client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+		VpcIds: []string{vpcID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("VpcId", "OwnerId", "ResultMetadata")).Assert(t.Name()+"_describe", descResult)
+
+	tagsResult, err := client.DescribeTags(ctx, &ec2.DescribeTagsInput{
+		Filters: []types.Filter{
+			{Name: aws.String("resource-id"), Values: []string{vpcID}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(tagsResult.Tags); got != 2 {
+		t.Errorf("DescribeTags = %d entries, want 2", got)
+	}
+}

--- a/test/integration/testdata/ec2_test_TestEC2_CreateVpc_WithTagSpecifications_TestEC2_CreateVpc_WithTagSpecifications_describe.golden.go
+++ b/test/integration/testdata/ec2_test_TestEC2_CreateVpc_WithTagSpecifications_TestEC2_CreateVpc_WithTagSpecifications_describe.golden.go
@@ -1,0 +1,29 @@
+{
+  "NextToken": null,
+  "Vpcs": [
+    {
+      "BlockPublicAccessStates": null,
+      "CidrBlock": "10.55.0.0/16",
+      "CidrBlockAssociationSet": null,
+      "DhcpOptionsId": null,
+      "EncryptionControl": null,
+      "InstanceTenancy": "default",
+      "Ipv6CidrBlockAssociationSet": null,
+      "IsDefault": false,
+      "OwnerId": null,
+      "State": "available",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "tagspec-vpc"
+        },
+        {
+          "Key": "Env",
+          "Value": "test"
+        }
+      ],
+      "VpcId": "vpc-f34a2881-2c22-4db"
+    }
+  ],
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

The AWS EC2 SDK accepts a \`TagSpecifications\` parameter on the \`Create*\` actions so callers can tag a resource in the same call that creates it. Adds parsing + forwarding for this pattern on the five Create handlers that currently model taggable resources.

| Action | Resource type accepted in \`TagSpecifications\` |
|---|---|
| \`CreateVpc\` | \`vpc\` |
| \`CreateSubnet\` | \`subnet\` |
| \`CreateInternetGateway\` | \`internet-gateway\` |
| \`CreateRouteTable\` | \`route-table\` |
| \`CreateSecurityGroup\` | \`security-group\` |

Without this, tags from the create call were silently dropped: a subsequent \`Describe*\` showed an empty \`TagSet\`, which downstream parity checks (re-applying the same config, or comparing CloudFormation drift) flag as a difference.

## Implementation

- \`applyTagsOnCreate\` helper called after each \`Create*\`: parses \`TagSpecifications\` from the form and forwards to \`storage.CreateTags\`. Since the existing \`storage.Create*\` methods return the storage-owned pointer, and \`storage.CreateTags\` writes through that pointer, the response struct reflects the tags by the time the handler builds the XML response — no separate response-mutation step needed.
- \`parseTagSpecificationsForResourceType\` reads the \`TagSpecifications.N.ResourceType\` / \`.Tag.M.{Key,Value}\` pattern directly from \`r.Form\`. The Query form-to-JSON converter does not understand this nested pattern, so this mirrors the approach already used by \`CreateTags\` / \`DescribeTags\` in #547.

## Stacking

This branch is based on \`feat/ec2-tag-apis\` (PR #547) because it calls \`storage.CreateTags\` introduced there. If #547 lands first, this rebases cleanly.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestEC2_*\` integration tests still pass
- [x] New \`TestEC2_CreateVpc_WithTagSpecifications\` exercises the full path: tags supplied to \`CreateVpc\` are reflected in the create response, in \`DescribeVpcs\`, and in \`DescribeTags\` filtered by \`resource-id\`