### PR TITLE
feat(ec2): VPC/Subnet attribute mutation (Modify/Describe)

### DIFF
--- a/internal/service/ec2/handlers.go
+++ b/internal/service/ec2/handlers.go
@@ -966,6 +966,178 @@ func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ModifyVpcAttribute handles the ModifyVpcAttribute action. AWS modifies one
+// attribute per call; the handler updates only the fields the request supplies.
+func (s *Service) ModifyVpcAttribute(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	vpcID := r.Form.Get("VpcId")
+	if vpcID == "" {
+		writeError(w, errInvalidParameter, "VpcId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.ModifyVpcAttribute(r.Context(), vpcID, vpcAttributeUpdates(r.Form)); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeEC2XMLResponse(w, struct {
+		XMLName   xml.Name `xml:"ModifyVpcAttributeResponse"`
+		Xmlns     string   `xml:"xmlns,attr"`
+		RequestID string   `xml:"requestId"`
+		Return    bool     `xml:"return"`
+	}{Xmlns: ec2XMLNS, RequestID: uuid.New().String(), Return: true})
+}
+
+// DescribeVpcAttribute returns one of EnableDnsHostnames, EnableDnsSupport, or
+// EnableNetworkAddressUsageMetrics. The attribute name in the request uses
+// the AWS lowercase-camel form (e.g. "enableDnsHostnames").
+func (s *Service) DescribeVpcAttribute(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	vpcID := r.Form.Get("VpcId")
+	attribute := r.Form.Get("Attribute")
+
+	if vpcID == "" || attribute == "" {
+		writeError(w, errInvalidParameter, "VpcId and Attribute are required", http.StatusBadRequest)
+
+		return
+	}
+
+	vpcs, err := s.storage.DescribeVpcs(r.Context(), []string{vpcID})
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	if len(vpcs) == 0 {
+		writeError(w, "InvalidVpcID.NotFound", "The vpc ID '"+vpcID+"' does not exist", http.StatusBadRequest)
+
+		return
+	}
+
+	vpc := vpcs[0]
+
+	resp := struct {
+		XMLName                          xml.Name      `xml:"DescribeVpcAttributeResponse"`
+		Xmlns                            string        `xml:"xmlns,attr"`
+		RequestID                        string        `xml:"requestId"`
+		VpcID                            string        `xml:"vpcId"`
+		EnableDNSHostnames               *xmlBoolValue `xml:"enableDnsHostnames,omitempty"`
+		EnableDNSSupport                 *xmlBoolValue `xml:"enableDnsSupport,omitempty"`
+		EnableNetworkAddressUsageMetrics *xmlBoolValue `xml:"enableNetworkAddressUsageMetrics,omitempty"`
+	}{Xmlns: ec2XMLNS, RequestID: uuid.New().String(), VpcID: vpc.VpcID}
+
+	switch attribute {
+	case "enableDnsHostnames":
+		resp.EnableDNSHostnames = &xmlBoolValue{Value: vpc.EnableDNSHostnames}
+	case "enableDnsSupport":
+		resp.EnableDNSSupport = &xmlBoolValue{Value: vpc.EnableDNSSupport}
+	case "enableNetworkAddressUsageMetrics":
+		resp.EnableNetworkAddressUsageMetrics = &xmlBoolValue{Value: false}
+	default:
+		writeError(w, errInvalidParameter, "Unsupported attribute: "+attribute, http.StatusBadRequest)
+
+		return
+	}
+
+	writeEC2XMLResponse(w, resp)
+}
+
+// xmlBoolValue wraps a boolean in the AWS <value>true</value> child shape.
+type xmlBoolValue struct {
+	Value bool `xml:"value"`
+}
+
+// ModifySubnetAttribute handles the ModifySubnetAttribute action.
+func (s *Service) ModifySubnetAttribute(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	subnetID := r.Form.Get("SubnetId")
+	if subnetID == "" {
+		writeError(w, errInvalidParameter, "SubnetId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.ModifySubnetAttribute(r.Context(), subnetID, subnetAttributeUpdates(r.Form)); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeEC2XMLResponse(w, struct {
+		XMLName   xml.Name `xml:"ModifySubnetAttributeResponse"`
+		Xmlns     string   `xml:"xmlns,attr"`
+		RequestID string   `xml:"requestId"`
+		Return    bool     `xml:"return"`
+	}{Xmlns: ec2XMLNS, RequestID: uuid.New().String(), Return: true})
+}
+
+// vpcAttributeUpdates extracts EnableDnsHostnames.Value and EnableDnsSupport.Value
+// from the form, returning a struct with only the supplied fields populated.
+func vpcAttributeUpdates(form map[string][]string) VpcAttributeUpdates {
+	var u VpcAttributeUpdates
+
+	if v := getFormBoolPtr(form, "EnableDnsHostnames.Value"); v != nil {
+		u.EnableDNSHostnames = v
+	}
+
+	if v := getFormBoolPtr(form, "EnableDnsSupport.Value"); v != nil {
+		u.EnableDNSSupport = v
+	}
+
+	return u
+}
+
+// subnetAttributeUpdates extracts MapPublicIpOnLaunch.Value and
+// AssignIpv6AddressOnCreation.Value from the form.
+func subnetAttributeUpdates(form map[string][]string) SubnetAttributeUpdates {
+	var u SubnetAttributeUpdates
+
+	if v := getFormBoolPtr(form, "MapPublicIpOnLaunch.Value"); v != nil {
+		u.MapPublicIPOnLaunch = v
+	}
+
+	if v := getFormBoolPtr(form, "AssignIpv6AddressOnCreation.Value"); v != nil {
+		u.AssignIPv6AddressOnCreation = v
+	}
+
+	return u
+}
+
+// getFormBoolPtr returns a pointer to a parsed bool from the form, or nil
+// if the key is missing or unparseable.
+func getFormBoolPtr(form map[string][]string, key string) *bool {
+	values, ok := form[key]
+	if !ok || len(values) == 0 {
+		return nil
+	}
+
+	b, err := strconv.ParseBool(values[0])
+	if err != nil {
+		return nil
+	}
+
+	return &b
+}
+
 // readTagRequestForm extracts ResourceId.N and Tag.N.Key/Value pairs from the
 // already-parsed AWS Query form. The Query dispatcher calls ParseForm before
 // dispatch, but ParseForm is idempotent, so calling it again is safe.
@@ -1264,6 +1436,10 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 		"CreateTags":   s.CreateTags,
 		"DeleteTags":   s.DeleteTags,
 		"DescribeTags": s.DescribeTags,
+		// VPC / Subnet attribute mutation
+		"ModifyVpcAttribute":    s.ModifyVpcAttribute,
+		"DescribeVpcAttribute":  s.DescribeVpcAttribute,
+		"ModifySubnetAttribute": s.ModifySubnetAttribute,
 	}
 
 	return handlers[action]

--- a/internal/service/ec2/service.go
+++ b/internal/service/ec2/service.go
@@ -93,6 +93,10 @@ func (s *Service) Actions() []string {
 		"CreateTags",
 		"DeleteTags",
 		"DescribeTags",
+		// VPC / Subnet attribute mutation
+		"ModifyVpcAttribute",
+		"DescribeVpcAttribute",
+		"ModifySubnetAttribute",
 	}
 }
 

--- a/internal/service/ec2/storage.go
+++ b/internal/service/ec2/storage.go
@@ -83,11 +83,13 @@ type Storage interface {
 	CreateVpc(ctx context.Context, req *CreateVpcRequest) (*Vpc, error)
 	DeleteVpc(ctx context.Context, vpcID string) error
 	DescribeVpcs(ctx context.Context, vpcIDs []string) ([]*Vpc, error)
+	ModifyVpcAttribute(ctx context.Context, vpcID string, updates VpcAttributeUpdates) error
 
 	// Subnet operations
 	CreateSubnet(ctx context.Context, req *CreateSubnetRequest) (*Subnet, error)
 	DeleteSubnet(ctx context.Context, subnetID string) error
 	DescribeSubnets(ctx context.Context, subnetIDs []string, filters map[string][]string) ([]*Subnet, error)
+	ModifySubnetAttribute(ctx context.Context, subnetID string, updates SubnetAttributeUpdates) error
 
 	// Internet Gateway operations
 	CreateInternetGateway(ctx context.Context, req *CreateInternetGatewayRequest) (*InternetGateway, error)
@@ -762,12 +764,14 @@ func (m *MemoryStorage) CreateVpc(_ context.Context, req *CreateVpcRequest) (*Vp
 	defer m.mu.Unlock()
 
 	vpc := &Vpc{
-		VpcID:           "vpc-" + generateID(),
-		CidrBlock:       req.CidrBlock,
-		State:           "available",
-		IsDefault:       false,
-		InstanceTenancy: req.InstanceTenancy,
-		Tags:            []Tag{},
+		VpcID:              "vpc-" + generateID(),
+		CidrBlock:          req.CidrBlock,
+		State:              "available",
+		IsDefault:          false,
+		InstanceTenancy:    req.InstanceTenancy,
+		EnableDNSSupport:   true, // matches AWS default
+		EnableDNSHostnames: false,
+		Tags:               []Tag{},
 	}
 
 	if vpc.InstanceTenancy == "" {
@@ -1258,6 +1262,53 @@ func (m *MemoryStorage) CreateTags(_ context.Context, resourceIDs []string, tags
 			return err
 		}
 	}
+
+	return nil
+}
+
+// ModifyVpcAttribute applies VPC attribute updates. Only set (non-nil) fields
+// are touched, matching the AWS one-attribute-per-call semantics.
+func (m *MemoryStorage) ModifyVpcAttribute(_ context.Context, vpcID string, updates VpcAttributeUpdates) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	vpc, ok := m.Vpcs[vpcID]
+	if !ok {
+		return &Error{
+			Code:    "InvalidVpcID.NotFound",
+			Message: fmt.Sprintf("The vpc ID '%s' does not exist", vpcID),
+		}
+	}
+
+	if updates.EnableDNSHostnames != nil {
+		vpc.EnableDNSHostnames = *updates.EnableDNSHostnames
+	}
+
+	if updates.EnableDNSSupport != nil {
+		vpc.EnableDNSSupport = *updates.EnableDNSSupport
+	}
+
+	return nil
+}
+
+// ModifySubnetAttribute applies subnet attribute updates.
+func (m *MemoryStorage) ModifySubnetAttribute(_ context.Context, subnetID string, updates SubnetAttributeUpdates) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	subnet, ok := m.Subnets[subnetID]
+	if !ok {
+		return &Error{
+			Code:    "InvalidSubnetID.NotFound",
+			Message: fmt.Sprintf("The subnet ID '%s' does not exist", subnetID),
+		}
+	}
+
+	if updates.MapPublicIPOnLaunch != nil {
+		subnet.MapPublicIPOnLaunch = *updates.MapPublicIPOnLaunch
+	}
+
+	_ = updates.AssignIPv6AddressOnCreation // accepted but not modeled
 
 	return nil
 }

--- a/internal/service/ec2/types.go
+++ b/internal/service/ec2/types.go
@@ -355,12 +355,27 @@ func (e *Error) Error() string {
 
 // Vpc represents a VPC.
 type Vpc struct {
-	VpcID           string
-	CidrBlock       string
-	State           string
-	IsDefault       bool
-	InstanceTenancy string
-	Tags            []Tag
+	VpcID              string
+	CidrBlock          string
+	State              string
+	IsDefault          bool
+	InstanceTenancy    string
+	EnableDNSHostnames bool
+	EnableDNSSupport   bool
+	Tags               []Tag
+}
+
+// VpcAttributeUpdates carries optional VPC attribute changes. nil pointers
+// mean "leave as-is" since AWS modifies one attribute per call.
+type VpcAttributeUpdates struct {
+	EnableDNSHostnames *bool
+	EnableDNSSupport   *bool
+}
+
+// SubnetAttributeUpdates is the subnet equivalent.
+type SubnetAttributeUpdates struct {
+	MapPublicIPOnLaunch         *bool
+	AssignIPv6AddressOnCreation *bool
 }
 
 // Subnet represents a subnet.

--- a/test/integration/ec2_test.go
+++ b/test/integration/ec2_test.go
@@ -753,3 +753,114 @@ func TestEC2_CreateVpc_WithTagSpecifications(t *testing.T) {
 		t.Errorf("DescribeTags = %d entries, want 2", got)
 	}
 }
+
+func TestEC2_ModifyAndDescribeVpcAttribute(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := t.Context()
+
+	createResult, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{
+		CidrBlock: aws.String("10.60.0.0/16"),
+	})
+	if err != nil {
+		t.Fatalf("CreateVpc failed: %v", err)
+	}
+
+	vpcID := *createResult.Vpc.VpcId
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteVpc(context.Background(), &ec2.DeleteVpcInput{
+			VpcId: aws.String(vpcID),
+		})
+	})
+
+	supportRes, err := client.DescribeVpcAttribute(ctx, &ec2.DescribeVpcAttributeInput{
+		VpcId:     aws.String(vpcID),
+		Attribute: types.VpcAttributeNameEnableDnsSupport,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if supportRes.EnableDnsSupport == nil || !*supportRes.EnableDnsSupport.Value {
+		t.Errorf("default EnableDnsSupport = false, want true")
+	}
+
+	hostRes, err := client.DescribeVpcAttribute(ctx, &ec2.DescribeVpcAttributeInput{
+		VpcId:     aws.String(vpcID),
+		Attribute: types.VpcAttributeNameEnableDnsHostnames,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hostRes.EnableDnsHostnames != nil && hostRes.EnableDnsHostnames.Value != nil && *hostRes.EnableDnsHostnames.Value {
+		t.Errorf("default EnableDnsHostnames = true, want false")
+	}
+
+	if _, err := client.ModifyVpcAttribute(ctx, &ec2.ModifyVpcAttributeInput{
+		VpcId:              aws.String(vpcID),
+		EnableDnsHostnames: &types.AttributeBooleanValue{Value: aws.Bool(true)},
+	}); err != nil {
+		t.Fatalf("ModifyVpcAttribute failed: %v", err)
+	}
+
+	hostRes2, err := client.DescribeVpcAttribute(ctx, &ec2.DescribeVpcAttributeInput{
+		VpcId:     aws.String(vpcID),
+		Attribute: types.VpcAttributeNameEnableDnsHostnames,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hostRes2.EnableDnsHostnames == nil || !*hostRes2.EnableDnsHostnames.Value {
+		t.Errorf("after Modify, EnableDnsHostnames = false, want true")
+	}
+}
+
+func TestEC2_ModifySubnetAttribute(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := t.Context()
+
+	vpcResult, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{
+		CidrBlock: aws.String("10.61.0.0/16"),
+	})
+	if err != nil {
+		t.Fatalf("CreateVpc failed: %v", err)
+	}
+
+	vpcID := *vpcResult.Vpc.VpcId
+
+	subnetResult, err := client.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("10.61.1.0/24"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSubnet failed: %v", err)
+	}
+
+	subnetID := *subnetResult.Subnet.SubnetId
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteSubnet(context.Background(), &ec2.DeleteSubnetInput{
+			SubnetId: aws.String(subnetID),
+		})
+		_, _ = client.DeleteVpc(context.Background(), &ec2.DeleteVpcInput{
+			VpcId: aws.String(vpcID),
+		})
+	})
+
+	if _, err := client.ModifySubnetAttribute(ctx, &ec2.ModifySubnetAttributeInput{
+		SubnetId:            aws.String(subnetID),
+		MapPublicIpOnLaunch: &types.AttributeBooleanValue{Value: aws.Bool(true)},
+	}); err != nil {
+		t.Fatalf("ModifySubnetAttribute failed: %v", err)
+	}
+
+	descResult, err := client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+		SubnetIds: []string{subnetID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := descResult.Subnets[0].MapPublicIpOnLaunch; got == nil || !*got {
+		t.Errorf("after Modify, MapPublicIpOnLaunch = %v, want true", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the attribute APIs the AWS EC2 SDK uses to read and toggle per-VPC and per-Subnet flags:

| Action | Attribute(s) |
|---|---|
| \`ModifyVpcAttribute\` | \`EnableDnsHostnames\`, \`EnableDnsSupport\` |
| \`DescribeVpcAttribute\` | same plus \`enableNetworkAddressUsageMetrics\` (returns \`false\` — not modeled) |
| \`ModifySubnetAttribute\` | \`MapPublicIpOnLaunch\` (\`AssignIpv6AddressOnCreation\` accepted but not modeled) |

These are required for any client that wants to confirm or change the \`EnableDnsHostnames\` flag on a freshly-created VPC, or set \`MapPublicIpOnLaunch\` on a subnet that should auto-assign public IPs.

## Behavior alignment with AWS

- The \`Vpc\` struct gains \`EnableDNSHostnames\` and \`EnableDNSSupport\` fields. \`CreateVpc\` defaults \`EnableDNSSupport=true\` to match real AWS — without this, clients that call \`DescribeVpcAttribute\` immediately after \`CreateVpc\` see a VPC that drifts from a real one (\`enable_dns_support\` reads back \`false\` instead of \`true\`).
- AWS modifies one attribute per call. \`VpcAttributeUpdates\` / \`SubnetAttributeUpdates\` use \`*bool\` pointers so storage applies only what the request supplied.
- Form keys (\`EnableDnsHostnames.Value\` etc.) follow the AWS wire format. The Go struct fields use \`EnableDNS*\` per Go naming conventions.
- \`enableNetworkAddressUsageMetrics\` is queried by recent SDKs even on plain VPCs; this returns \`false\` rather than an error, mirroring a non-NAUM-enabled real VPC.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestEC2_*\` integration tests still pass
- [x] New \`TestEC2_ModifyAndDescribeVpcAttribute\` asserts the AWS-default \`EnableDnsSupport=true\` / \`EnableDnsHostnames=false\` on \`CreateVpc\`, then toggles \`EnableDnsHostnames\` and reads it back
- [x] New \`TestEC2_ModifySubnetAttribute\` toggles \`MapPublicIpOnLaunch\` and reads it back via \`DescribeSubnets\`

---

Addresses sivchari/kumo#409 — Low Priority "ModifyVpcAttribute / DescribeVpcAttribute" and "ModifySubnetAttribute".
