### PR TITLE
feat(iam): instance profile lifecycle (Create/Get/Delete/List + AddRole/RemoveRole)

### DIFF
--- a/internal/service/iam/handlers.go
+++ b/internal/service/iam/handlers.go
@@ -485,6 +485,151 @@ func (s *Service) ListAccessKeys(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ListInstanceProfilesForRole returns the profiles attached to a role.
+func (s *Service) ListInstanceProfilesForRole(w http.ResponseWriter, r *http.Request) {
+	roleName := getFormValue(r, "RoleName")
+	if roleName == "" {
+		writeIAMError(w, errInvalidParameter, "RoleName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	profiles, err := s.storage.ListInstanceProfilesForRoleReal(r.Context(), roleName)
+	if err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, ListInstanceProfilesForRoleResponseV2{
+		ListInstanceProfilesForRoleResult: ListInstanceProfilesForRoleResultV2{InstanceProfiles: profiles},
+		ResponseMetadata:                  ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// CreateInstanceProfile handles the CreateInstanceProfile action.
+func (s *Service) CreateInstanceProfile(w http.ResponseWriter, r *http.Request) {
+	name := getFormValue(r, "InstanceProfileName")
+	if name == "" {
+		writeIAMError(w, errInvalidParameter, "InstanceProfileName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	profile, err := s.storage.CreateInstanceProfile(r.Context(), name, getFormValue(r, "Path"))
+	if err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, CreateInstanceProfileResponse{
+		CreateInstanceProfileResult: CreateInstanceProfileResult{InstanceProfile: *profile},
+		ResponseMetadata:            ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DeleteInstanceProfile handles the DeleteInstanceProfile action.
+func (s *Service) DeleteInstanceProfile(w http.ResponseWriter, r *http.Request) {
+	name := getFormValue(r, "InstanceProfileName")
+	if name == "" {
+		writeIAMError(w, errInvalidParameter, "InstanceProfileName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteInstanceProfile(r.Context(), name); err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, DeleteInstanceProfileResponse{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// GetInstanceProfile handles the GetInstanceProfile action.
+func (s *Service) GetInstanceProfile(w http.ResponseWriter, r *http.Request) {
+	name := getFormValue(r, "InstanceProfileName")
+	if name == "" {
+		writeIAMError(w, errInvalidParameter, "InstanceProfileName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	profile, err := s.storage.GetInstanceProfile(r.Context(), name)
+	if err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, GetInstanceProfileResponse{
+		GetInstanceProfileResult: GetInstanceProfileResult{InstanceProfile: *profile},
+		ResponseMetadata:         ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// ListInstanceProfiles handles the ListInstanceProfiles action.
+func (s *Service) ListInstanceProfiles(w http.ResponseWriter, r *http.Request) {
+	profiles, err := s.storage.ListInstanceProfiles(r.Context(), getFormValue(r, "PathPrefix"), parseMaxItems(r))
+	if err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, ListInstanceProfilesResponse{
+		ListInstanceProfilesResult: ListInstanceProfilesResult{InstanceProfiles: profiles},
+		ResponseMetadata:           ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// AddRoleToInstanceProfile handles the AddRoleToInstanceProfile action.
+func (s *Service) AddRoleToInstanceProfile(w http.ResponseWriter, r *http.Request) {
+	profileName := getFormValue(r, "InstanceProfileName")
+	roleName := getFormValue(r, "RoleName")
+
+	if profileName == "" || roleName == "" {
+		writeIAMError(w, errInvalidParameter, "InstanceProfileName and RoleName are required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.AddRoleToInstanceProfile(r.Context(), profileName, roleName); err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, AddRoleToInstanceProfileResponse{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// RemoveRoleFromInstanceProfile handles the RemoveRoleFromInstanceProfile action.
+func (s *Service) RemoveRoleFromInstanceProfile(w http.ResponseWriter, r *http.Request) {
+	profileName := getFormValue(r, "InstanceProfileName")
+	roleName := getFormValue(r, "RoleName")
+
+	if profileName == "" || roleName == "" {
+		writeIAMError(w, errInvalidParameter, "InstanceProfileName and RoleName are required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.RemoveRoleFromInstanceProfile(r.Context(), profileName, roleName); err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, RemoveRoleFromInstanceProfileResponse{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
 // PutRolePolicy handles the PutRolePolicy action.
 func (s *Service) PutRolePolicy(w http.ResponseWriter, r *http.Request) {
 	roleName := getFormValue(r, "RoleName")

--- a/internal/service/iam/service.go
+++ b/internal/service/iam/service.go
@@ -66,17 +66,25 @@ func (s *Service) initActionHandlers() {
 		"DeleteAccessKey": s.DeleteAccessKey,
 		"ListAccessKeys":  s.ListAccessKeys,
 		// Inline role policies
-		"PutRolePolicy":            s.PutRolePolicy,
-		"GetRolePolicy":            s.GetRolePolicy,
-		"DeleteRolePolicy":         s.DeleteRolePolicy,
-		"ListRolePolicies":         s.ListRolePolicies,
-		"ListAttachedRolePolicies": s.ListAttachedRolePolicies,
+		"PutRolePolicy":               s.PutRolePolicy,
+		"GetRolePolicy":               s.GetRolePolicy,
+		"DeleteRolePolicy":            s.DeleteRolePolicy,
+		"ListRolePolicies":            s.ListRolePolicies,
+		"ListAttachedRolePolicies":    s.ListAttachedRolePolicies,
+		"ListInstanceProfilesForRole": s.ListInstanceProfilesForRole,
 		// OpenID Connect provider
 		"CreateOpenIDConnectProvider":           s.CreateOpenIDConnectProvider,
 		"GetOpenIDConnectProvider":              s.GetOpenIDConnectProvider,
 		"DeleteOpenIDConnectProvider":           s.DeleteOpenIDConnectProvider,
 		"ListOpenIDConnectProviders":            s.ListOpenIDConnectProviders,
 		"UpdateOpenIDConnectProviderThumbprint": s.UpdateOpenIDConnectProviderThumbprint,
+		// Instance profiles
+		"CreateInstanceProfile":         s.CreateInstanceProfile,
+		"DeleteInstanceProfile":         s.DeleteInstanceProfile,
+		"GetInstanceProfile":            s.GetInstanceProfile,
+		"ListInstanceProfiles":          s.ListInstanceProfiles,
+		"AddRoleToInstanceProfile":      s.AddRoleToInstanceProfile,
+		"RemoveRoleFromInstanceProfile": s.RemoveRoleFromInstanceProfile,
 	}
 }
 

--- a/internal/service/iam/storage.go
+++ b/internal/service/iam/storage.go
@@ -67,6 +67,14 @@ type Storage interface {
 	CreateAccessKey(ctx context.Context, userName string) (*AccessKey, error)
 	DeleteAccessKey(ctx context.Context, userName, accessKeyID string) error
 	ListAccessKeys(ctx context.Context, userName string, maxItems int) ([]AccessKeyMetadata, error)
+
+	CreateInstanceProfile(ctx context.Context, name, path string) (*InstanceProfile, error)
+	DeleteInstanceProfile(ctx context.Context, name string) error
+	GetInstanceProfile(ctx context.Context, name string) (*InstanceProfile, error)
+	ListInstanceProfiles(ctx context.Context, pathPrefix string, maxItems int) ([]InstanceProfile, error)
+	ListInstanceProfilesForRoleReal(ctx context.Context, roleName string) ([]InstanceProfile, error)
+	AddRoleToInstanceProfile(ctx context.Context, profileName, roleName string) error
+	RemoveRoleFromInstanceProfile(ctx context.Context, profileName, roleName string) error
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -87,25 +95,27 @@ var (
 
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu            sync.RWMutex                     `json:"-"`
-	Users         map[string]*User                 `json:"users"`
-	Roles         map[string]*Role                 `json:"roles"`
-	Policies      map[string]*Policy               `json:"policies"`      // key is ARN
-	AccessKeys    map[string]map[string]*AccessKey `json:"accessKeys"`    // userName -> accessKeyID -> AccessKey
-	OIDCProviders map[string]*OIDCProvider         `json:"oidcProviders"` // key is ARN
-	accountID     string
-	dataDir       string
+	mu               sync.RWMutex                     `json:"-"`
+	Users            map[string]*User                 `json:"users"`
+	Roles            map[string]*Role                 `json:"roles"`
+	Policies         map[string]*Policy               `json:"policies"`         // key is ARN
+	AccessKeys       map[string]map[string]*AccessKey `json:"accessKeys"`       // userName -> accessKeyID -> AccessKey
+	OIDCProviders    map[string]*OIDCProvider         `json:"oidcProviders"`    // key is ARN
+	InstanceProfiles map[string]*InstanceProfile      `json:"instanceProfiles"` // key is name
+	accountID        string
+	dataDir          string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	s := &MemoryStorage{
-		Users:         make(map[string]*User),
-		Roles:         make(map[string]*Role),
-		Policies:      make(map[string]*Policy),
-		AccessKeys:    make(map[string]map[string]*AccessKey),
-		OIDCProviders: make(map[string]*OIDCProvider),
-		accountID:     "123456789012",
+		Users:            make(map[string]*User),
+		Roles:            make(map[string]*Role),
+		Policies:         make(map[string]*Policy),
+		AccessKeys:       make(map[string]map[string]*AccessKey),
+		OIDCProviders:    make(map[string]*OIDCProvider),
+		InstanceProfiles: make(map[string]*InstanceProfile),
+		accountID:        "123456789012",
 	}
 	for _, o := range opts {
 		o(s)
@@ -164,6 +174,10 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 
 	if s.OIDCProviders == nil {
 		s.OIDCProviders = make(map[string]*OIDCProvider)
+	}
+
+	if s.InstanceProfiles == nil {
+		s.InstanceProfiles = make(map[string]*InstanceProfile)
 	}
 
 	return nil
@@ -1011,4 +1025,153 @@ func stripScheme(url string) string {
 	}
 
 	return url
+}
+
+// CreateInstanceProfile creates a new instance profile.
+func (s *MemoryStorage) CreateInstanceProfile(_ context.Context, name, path string) (*InstanceProfile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.InstanceProfiles[name]; exists {
+		return nil, &Error{
+			Code:    errEntityAlreadyExists,
+			Message: fmt.Sprintf("Instance profile with name %s already exists.", name),
+		}
+	}
+
+	if path == "" {
+		path = defaultPath
+	}
+
+	profile := &InstanceProfile{
+		InstanceProfileName: name,
+		InstanceProfileID:   generateID("AIP"),
+		Arn:                 fmt.Sprintf("arn:aws:iam::%s:instance-profile%s%s", s.accountID, path, name),
+		Path:                path,
+		CreateDate:          time.Now().UTC(),
+	}
+	s.InstanceProfiles[name] = profile
+
+	return profile, nil
+}
+
+// DeleteInstanceProfile removes an instance profile by name.
+func (s *MemoryStorage) DeleteInstanceProfile(_ context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	profile, ok := s.InstanceProfiles[name]
+	if !ok {
+		return &Error{Code: errNoSuchEntity, Message: fmt.Sprintf("Instance profile %s does not exist.", name)}
+	}
+
+	if len(profile.Roles) > 0 {
+		return &Error{Code: errDeleteConflict, Message: fmt.Sprintf("Cannot delete instance profile %s; remove roles first.", name)}
+	}
+
+	delete(s.InstanceProfiles, name)
+
+	return nil
+}
+
+// GetInstanceProfile returns the instance profile by name.
+func (s *MemoryStorage) GetInstanceProfile(_ context.Context, name string) (*InstanceProfile, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	profile, ok := s.InstanceProfiles[name]
+	if !ok {
+		return nil, &Error{Code: errNoSuchEntity, Message: fmt.Sprintf("Instance profile %s does not exist.", name)}
+	}
+
+	return profile, nil
+}
+
+// ListInstanceProfiles returns all instance profiles, optionally filtered by path prefix.
+func (s *MemoryStorage) ListInstanceProfiles(_ context.Context, pathPrefix string, _ int) ([]InstanceProfile, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]InstanceProfile, 0, len(s.InstanceProfiles))
+
+	for _, p := range s.InstanceProfiles {
+		if pathPrefix != "" && !strings.HasPrefix(p.Path, pathPrefix) {
+			continue
+		}
+
+		out = append(out, *p)
+	}
+
+	return out, nil
+}
+
+// ListInstanceProfilesForRoleReal returns all profiles that contain the role.
+// (Suffix Real to avoid collision with the existing stub method that returns
+// an empty list — the stub is kept for backward-compat with the original PR.)
+func (s *MemoryStorage) ListInstanceProfilesForRoleReal(_ context.Context, roleName string) ([]InstanceProfile, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if _, ok := s.Roles[roleName]; !ok {
+		return nil, &Error{Code: errNoSuchEntity, Message: fmt.Sprintf("The role with name %s cannot be found.", roleName)}
+	}
+
+	out := make([]InstanceProfile, 0)
+
+	for _, p := range s.InstanceProfiles {
+		for i := range p.Roles {
+			if p.Roles[i].RoleName == roleName {
+				out = append(out, *p)
+
+				break
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// AddRoleToInstanceProfile attaches a role to a profile.
+func (s *MemoryStorage) AddRoleToInstanceProfile(_ context.Context, profileName, roleName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	profile, ok := s.InstanceProfiles[profileName]
+	if !ok {
+		return &Error{Code: errNoSuchEntity, Message: fmt.Sprintf("Instance profile %s does not exist.", profileName)}
+	}
+
+	if len(profile.Roles) > 0 {
+		return &Error{Code: errLimitExceeded, Message: fmt.Sprintf("Instance profile %s already has a role attached.", profileName)}
+	}
+
+	role, ok := s.Roles[roleName]
+	if !ok {
+		return &Error{Code: errNoSuchEntity, Message: fmt.Sprintf("The role with name %s cannot be found.", roleName)}
+	}
+
+	profile.Roles = append(profile.Roles, *role)
+
+	return nil
+}
+
+// RemoveRoleFromInstanceProfile detaches a role from a profile.
+func (s *MemoryStorage) RemoveRoleFromInstanceProfile(_ context.Context, profileName, roleName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	profile, ok := s.InstanceProfiles[profileName]
+	if !ok {
+		return &Error{Code: errNoSuchEntity, Message: fmt.Sprintf("Instance profile %s does not exist.", profileName)}
+	}
+
+	for i := range profile.Roles {
+		if profile.Roles[i].RoleName == roleName {
+			profile.Roles = append(profile.Roles[:i], profile.Roles[i+1:]...)
+
+			return nil
+		}
+	}
+
+	return &Error{Code: errNoSuchEntity, Message: fmt.Sprintf("Role %s is not attached to instance profile %s.", roleName, profileName)}
 }

--- a/internal/service/iam/types.go
+++ b/internal/service/iam/types.go
@@ -38,6 +38,82 @@ type OIDCProvider struct {
 	CreateDate     time.Time `xml:"CreateDate"`
 }
 
+// InstanceProfile represents an IAM instance profile.
+type InstanceProfile struct {
+	InstanceProfileName string    `xml:"InstanceProfileName"`
+	InstanceProfileID   string    `xml:"InstanceProfileId"`
+	Arn                 string    `xml:"Arn"`
+	Path                string    `xml:"Path"`
+	CreateDate          time.Time `xml:"CreateDate"`
+	Roles               []Role    `xml:"Roles>member,omitempty"`
+	Tags                []Tag     `xml:"Tags>member,omitempty"`
+}
+
+// CreateInstanceProfileResponse is the response for CreateInstanceProfile.
+type CreateInstanceProfileResponse struct {
+	CreateInstanceProfileResult CreateInstanceProfileResult `xml:"CreateInstanceProfileResult"`
+	ResponseMetadata            ResponseMetadata            `xml:"ResponseMetadata"`
+}
+
+// CreateInstanceProfileResult contains the new InstanceProfile.
+type CreateInstanceProfileResult struct {
+	InstanceProfile InstanceProfile `xml:"InstanceProfile"`
+}
+
+// GetInstanceProfileResponse is the response for GetInstanceProfile.
+type GetInstanceProfileResponse struct {
+	GetInstanceProfileResult GetInstanceProfileResult `xml:"GetInstanceProfileResult"`
+	ResponseMetadata         ResponseMetadata         `xml:"ResponseMetadata"`
+}
+
+// GetInstanceProfileResult contains the looked-up InstanceProfile.
+type GetInstanceProfileResult struct {
+	InstanceProfile InstanceProfile `xml:"InstanceProfile"`
+}
+
+// DeleteInstanceProfileResponse is the response for DeleteInstanceProfile.
+type DeleteInstanceProfileResponse struct {
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// ListInstanceProfilesResponse is the response for ListInstanceProfiles.
+type ListInstanceProfilesResponse struct {
+	ListInstanceProfilesResult ListInstanceProfilesResult `xml:"ListInstanceProfilesResult"`
+	ResponseMetadata           ResponseMetadata           `xml:"ResponseMetadata"`
+}
+
+// ListInstanceProfilesResult contains the list of InstanceProfiles.
+type ListInstanceProfilesResult struct {
+	InstanceProfiles []InstanceProfile `xml:"InstanceProfiles>member"`
+	IsTruncated      bool              `xml:"IsTruncated"`
+	Marker           string            `xml:"Marker,omitempty"`
+}
+
+// ListInstanceProfilesForRoleResultV2 is the real response for
+// ListInstanceProfilesForRole replacing the empty stub.
+type ListInstanceProfilesForRoleResultV2 struct {
+	InstanceProfiles []InstanceProfile `xml:"InstanceProfiles>member"`
+	IsTruncated      bool              `xml:"IsTruncated"`
+	Marker           string            `xml:"Marker,omitempty"`
+}
+
+// ListInstanceProfilesForRoleResponseV2 wraps the real response.
+type ListInstanceProfilesForRoleResponseV2 struct {
+	ListInstanceProfilesForRoleResult ListInstanceProfilesForRoleResultV2 `xml:"ListInstanceProfilesForRoleResult"`
+	ResponseMetadata                  ResponseMetadata                    `xml:"ResponseMetadata"`
+}
+
+// AddRoleToInstanceProfileResponse is the response for AddRoleToInstanceProfile.
+type AddRoleToInstanceProfileResponse struct {
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// RemoveRoleFromInstanceProfileResponse is the response for
+// RemoveRoleFromInstanceProfile.
+type RemoveRoleFromInstanceProfileResponse struct {
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
 // Policy represents an IAM policy.
 type Policy struct {
 	PolicyName       string    `xml:"PolicyName"`

--- a/test/integration/iam_test.go
+++ b/test/integration/iam_test.go
@@ -789,3 +789,81 @@ func TestIAM_OpenIDConnectProvider(t *testing.T) {
 	}
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "CreateDate")).Assert(t.Name()+"_get_after_update", getAfter)
 }
+
+func TestIAM_InstanceProfileLifecycle(t *testing.T) {
+	client := newIAMClient(t)
+	ctx := t.Context()
+	roleName := "test-ip-role"
+	profileName := "test-ip-profile"
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteRole(context.Background(), &iam.DeleteRoleInput{
+			RoleName: aws.String(roleName),
+		})
+	})
+
+	createRes, err := client.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	})
+	if err != nil {
+		t.Fatalf("CreateInstanceProfile: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "InstanceProfileId", "Arn", "CreateDate")).Assert(t.Name()+"_create", createRes)
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteInstanceProfile(context.Background(), &iam.DeleteInstanceProfileInput{
+			InstanceProfileName: aws.String(profileName),
+		})
+	})
+
+	if _, err := client.AddRoleToInstanceProfile(ctx, &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+		RoleName:            aws.String(roleName),
+	}); err != nil {
+		t.Fatalf("AddRoleToInstanceProfile: %v", err)
+	}
+
+	getRes, err := client.GetInstanceProfile(ctx, &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(getRes.InstanceProfile.Roles); got != 1 || *getRes.InstanceProfile.Roles[0].RoleName != roleName {
+		t.Errorf("after AddRole, profile.Roles = %d entries, want 1 with name %q", got, roleName)
+	}
+
+	listRes, err := client.ListInstanceProfilesForRole(ctx, &iam.ListInstanceProfilesForRoleInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(listRes.InstanceProfiles); got != 1 || *listRes.InstanceProfiles[0].InstanceProfileName != profileName {
+		t.Errorf("ListInstanceProfilesForRole returned %d entries, want 1 with profile %q", got, profileName)
+	}
+
+	if _, err := client.RemoveRoleFromInstanceProfile(ctx, &iam.RemoveRoleFromInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+		RoleName:            aws.String(roleName),
+	}); err != nil {
+		t.Fatalf("RemoveRoleFromInstanceProfile: %v", err)
+	}
+
+	getAfter, err := client.GetInstanceProfile(ctx, &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(getAfter.InstanceProfile.Roles); got != 0 {
+		t.Errorf("after RemoveRole, profile.Roles = %d entries, want 0", got)
+	}
+}

--- a/test/integration/testdata/iam_test_TestIAM_InstanceProfileLifecycle_TestIAM_InstanceProfileLifecycle_create.golden.go
+++ b/test/integration/testdata/iam_test_TestIAM_InstanceProfileLifecycle_TestIAM_InstanceProfileLifecycle_create.golden.go
@@ -1,0 +1,12 @@
+{
+  "InstanceProfile": {
+    "Arn": "arn:aws:iam::123456789012:instance-profile/test-ip-profile",
+    "CreateDate": "2026-05-08T10:08:35.563325Z",
+    "InstanceProfileId": "AIP39D121CD-9DBA-405",
+    "InstanceProfileName": "test-ip-profile",
+    "Path": "/",
+    "Roles": [],
+    "Tags": []
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

Adds the IAM instance profile lifecycle. AWS uses \`InstanceProfile\` as the addressable identity that an EC2 instance assumes a role through, so without it any client that creates a profile, attaches a role, and queries it back fails immediately with \`InvalidAction\`.

| Operation | Notes |
|---|---|
| \`CreateInstanceProfile\` | Generates ARN as \`arn:aws:iam::<account>:instance-profile<path><name>\`. |
| \`DeleteInstanceProfile\` | Returns \`DeleteConflict\` if a role is still attached, matching AWS. |
| \`GetInstanceProfile\` | Returns the full profile including its current \`Roles\` list. |
| \`ListInstanceProfiles\` | Supports the \`PathPrefix\` filter; pagination not modeled. |
| \`ListInstanceProfilesForRole\` | Real implementation — returns profiles that contain the role. (Supersedes the empty stub in #551.) |
| \`AddRoleToInstanceProfile\` | Rejects a second role with \`LimitExceeded\` — AWS allows at most one role per profile. |
| \`RemoveRoleFromInstanceProfile\` | Plain detach. |

## Storage

\`MemoryStorage\` gains an \`InstanceProfiles map[string]*InstanceProfile\` keyed by name. Roles are referenced inline in the \`Roles []Role\` field on \`InstanceProfile\` (matching the AWS API shape, not normalized).

## Relationship to #551

#551 adds a stand-alone empty-list stub of \`ListInstanceProfilesForRole\` so role tear-down works in environments that never created a profile. This PR replaces the stub with a real implementation. If #551 lands first, this PR resolves the conflict by overriding the handler. If this lands first, #551 becomes a no-op and can be closed.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestIAM_*\` integration tests still pass
- [x] New \`TestIAM_InstanceProfileLifecycle\` exercises Create → AddRole → GetInstanceProfile (asserts the role appears) → ListInstanceProfilesForRole (asserts the profile appears) → RemoveRole → GetInstanceProfile (asserts empty Roles)

---

Addresses sivchari/kumo#408 — High Priority "CreateInstanceProfile / DeleteInstanceProfile / GetInstanceProfile / ListInstanceProfiles" and "AddRoleToInstanceProfile / RemoveRoleFromInstanceProfile". Also covers the Medium Priority "ListInstanceProfilesForRole" via the real implementation.