### PR TITLE
feat(elbv2): listener rule lifecycle (Create/Describe/Modify/Delete + SetRulePriorities)

### DIFF
--- a/internal/service/elbv2/handlers.go
+++ b/internal/service/elbv2/handlers.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -323,6 +325,428 @@ func (s *Service) DeleteListener(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// CreateRule handles the CreateRule action.
+func (s *Service) CreateRule(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	listenerArn := r.Form.Get("ListenerArn")
+	priority := r.Form.Get("Priority")
+
+	if listenerArn == "" || priority == "" {
+		writeELBError(w, errInvalidParameter, "ListenerArn and Priority are required", http.StatusBadRequest)
+
+		return
+	}
+
+	rule, err := s.storage.CreateRule(r.Context(), listenerArn, priority,
+		parseRuleConditionsFromForm(r.Form), parseActionsFromForm(r.Form, "Actions"))
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	writeELBXMLResponse(w, XMLCreateRuleResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLCreateRuleResult{Rules: XMLRules{Members: []XMLRule{convertRuleToXML(rule)}}},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DescribeRules handles the DescribeRules action.
+func (s *Service) DescribeRules(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	listenerArn := r.Form.Get("ListenerArn")
+	ruleArns := parseMemberListFromForm(r.Form, "RuleArns")
+
+	rules, err := s.storage.DescribeRules(r.Context(), listenerArn, ruleArns)
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	writeELBXMLResponse(w, XMLDescribeRulesResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLDescribeRulesResult{Rules: XMLRules{Members: convertRulesToXML(rules)}},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// ModifyRule handles the ModifyRule action.
+func (s *Service) ModifyRule(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	ruleArn := r.Form.Get("RuleArn")
+	if ruleArn == "" {
+		writeELBError(w, errInvalidParameter, "RuleArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	conds := parseRuleConditionsFromForm(r.Form)
+	actions := parseActionsFromForm(r.Form, "Actions")
+
+	if len(conds) == 0 {
+		conds = nil
+	}
+
+	if len(actions) == 0 {
+		actions = nil
+	}
+
+	rule, err := s.storage.ModifyRule(r.Context(), ruleArn, conds, actions)
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	writeELBXMLResponse(w, XMLModifyRuleResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLModifyRuleResult{Rules: XMLRules{Members: []XMLRule{convertRuleToXML(rule)}}},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DeleteRule handles the DeleteRule action.
+func (s *Service) DeleteRule(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	ruleArn := r.Form.Get("RuleArn")
+	if ruleArn == "" {
+		writeELBError(w, errInvalidParameter, "RuleArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteRule(r.Context(), ruleArn); err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	writeELBXMLResponse(w, XMLDeleteRuleResponse{
+		Xmlns:            elbXMLNS,
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// SetRulePriorities handles the SetRulePriorities action.
+func (s *Service) SetRulePriorities(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	priorities := parseRulePrioritiesFromForm(r.Form)
+	if len(priorities) == 0 {
+		writeELBError(w, errInvalidParameter, "RulePriorities is required", http.StatusBadRequest)
+
+		return
+	}
+
+	rules, err := s.storage.SetRulePriorities(r.Context(), priorities)
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	writeELBXMLResponse(w, XMLSetRulePrioritiesResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLSetRulePrioritiesResult{Rules: XMLRules{Members: convertRulesToXML(rules)}},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// parseMemberListFromForm reads <prefix>.member.N entries into a list,
+// preserving the index order.
+func parseMemberListFromForm(form map[string][]string, prefix string) []string {
+	type entry struct {
+		idx int
+		val string
+	}
+
+	entries := make([]entry, 0)
+
+	for key, values := range form {
+		suffix, ok := strings.CutPrefix(key, prefix+".member.")
+		if !ok || len(values) == 0 {
+			continue
+		}
+
+		if strings.Contains(suffix, ".") {
+			continue
+		}
+
+		n, err := strconv.Atoi(suffix)
+		if err != nil {
+			continue
+		}
+
+		entries = append(entries, entry{idx: n, val: values[0]})
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].idx < entries[j].idx })
+
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.val)
+	}
+
+	return out
+}
+
+// parseActionsFromForm reads <prefix>.member.N.{Type,TargetGroupArn,Order}.
+func parseActionsFromForm(form map[string][]string, prefix string) []Action {
+	byIdx := make(map[int]*Action)
+
+	for key, values := range form {
+		suffix, ok := strings.CutPrefix(key, prefix+".member.")
+		if !ok || len(values) == 0 {
+			continue
+		}
+
+		dot := strings.Index(suffix, ".")
+		if dot < 0 {
+			continue
+		}
+
+		n, err := strconv.Atoi(suffix[:dot])
+		if err != nil {
+			continue
+		}
+
+		entry, exists := byIdx[n]
+		if !exists {
+			entry = &Action{}
+			byIdx[n] = entry
+		}
+
+		switch suffix[dot+1:] {
+		case "Type":
+			entry.Type = values[0]
+		case "TargetGroupArn":
+			entry.TargetGroupArn = values[0]
+		case "Order":
+			if v, err := strconv.Atoi(values[0]); err == nil {
+				entry.Order = v
+			}
+		}
+	}
+
+	indexes := make([]int, 0, len(byIdx))
+	for n := range byIdx {
+		indexes = append(indexes, n)
+	}
+
+	sort.Ints(indexes)
+
+	out := make([]Action, 0, len(indexes))
+	for _, n := range indexes {
+		out = append(out, *byIdx[n])
+	}
+
+	return out
+}
+
+// ruleConditionAcc accumulates one Conditions.member.N entry being parsed.
+type ruleConditionAcc struct {
+	field  string
+	values map[int]string
+}
+
+// parseRuleConditionsFromForm reads Conditions.member.N.Field and either
+// Conditions.member.N.Values.member.M (legacy) or
+// Conditions.member.N.<Field>Config.Values.member.M (modern). Both are
+// stored as Field + Values.
+func parseRuleConditionsFromForm(form map[string][]string) []RuleCondition {
+	byIdx := make(map[int]*ruleConditionAcc)
+
+	for key, values := range form {
+		suffix, ok := strings.CutPrefix(key, "Conditions.member.")
+		if !ok || len(values) == 0 {
+			continue
+		}
+
+		dot := strings.Index(suffix, ".")
+		if dot < 0 {
+			continue
+		}
+
+		n, err := strconv.Atoi(suffix[:dot])
+		if err != nil {
+			continue
+		}
+
+		entry, exists := byIdx[n]
+		if !exists {
+			entry = &ruleConditionAcc{values: make(map[int]string)}
+			byIdx[n] = entry
+		}
+
+		applyRuleConditionField(entry, suffix[dot+1:], values[0])
+	}
+
+	indexes := make([]int, 0, len(byIdx))
+	for n := range byIdx {
+		indexes = append(indexes, n)
+	}
+
+	sort.Ints(indexes)
+
+	out := make([]RuleCondition, 0, len(indexes))
+
+	for _, n := range indexes {
+		entry := byIdx[n]
+		vals := flattenValuesMap(entry.values)
+		out = append(out, RuleCondition{Field: entry.field, Values: vals})
+	}
+
+	return out
+}
+
+func applyRuleConditionField(entry *ruleConditionAcc, field, value string) {
+	switch {
+	case field == "Field":
+		entry.field = value
+	case strings.HasPrefix(field, "Values.member."):
+		recordIndexedValue(entry.values, strings.TrimPrefix(field, "Values.member."), value)
+	default:
+		// Modern <Field>Config.Values.member.N pattern.
+		if i := strings.Index(field, "Config.Values.member."); i > 0 {
+			recordIndexedValue(entry.values, field[i+len("Config.Values.member."):], value)
+		}
+	}
+}
+
+func recordIndexedValue(m map[int]string, suffix, value string) {
+	n, err := strconv.Atoi(suffix)
+	if err != nil {
+		return
+	}
+
+	m[n] = value
+}
+
+func flattenValuesMap(m map[int]string) []string {
+	indexes := make([]int, 0, len(m))
+	for n := range m {
+		indexes = append(indexes, n)
+	}
+
+	sort.Ints(indexes)
+
+	out := make([]string, 0, len(indexes))
+	for _, n := range indexes {
+		out = append(out, m[n])
+	}
+
+	return out
+}
+
+// parseRulePrioritiesFromForm reads RulePriorities.member.N.{RuleArn,Priority}.
+func parseRulePrioritiesFromForm(form map[string][]string) map[string]string {
+	type entry struct {
+		arn      string
+		priority string
+	}
+
+	byIdx := make(map[int]*entry)
+
+	for key, values := range form {
+		suffix, ok := strings.CutPrefix(key, "RulePriorities.member.")
+		if !ok || len(values) == 0 {
+			continue
+		}
+
+		dot := strings.Index(suffix, ".")
+		if dot < 0 {
+			continue
+		}
+
+		n, err := strconv.Atoi(suffix[:dot])
+		if err != nil {
+			continue
+		}
+
+		ent, exists := byIdx[n]
+		if !exists {
+			ent = &entry{}
+			byIdx[n] = ent
+		}
+
+		switch suffix[dot+1:] {
+		case "RuleArn":
+			ent.arn = values[0]
+		case "Priority":
+			ent.priority = values[0]
+		}
+	}
+
+	out := make(map[string]string)
+
+	for _, ent := range byIdx {
+		if ent.arn != "" {
+			out[ent.arn] = ent.priority
+		}
+	}
+
+	return out
+}
+
+// convertRuleToXML converts a Rule to its XML form.
+func convertRuleToXML(rule *Rule) XMLRule {
+	conds := make([]XMLRuleCondition, 0, len(rule.Conditions))
+	for _, c := range rule.Conditions {
+		conds = append(conds, XMLRuleCondition{
+			Field:  c.Field,
+			Values: XMLRuleValues{Members: append([]string(nil), c.Values...)},
+		})
+	}
+
+	actions := make([]XMLAction, 0, len(rule.Actions))
+	for _, a := range rule.Actions {
+		actions = append(actions, XMLAction(a))
+	}
+
+	return XMLRule{
+		RuleArn:    rule.RuleArn,
+		Priority:   rule.Priority,
+		Conditions: XMLRuleConditions{Members: conds},
+		Actions:    XMLActions{Members: actions},
+		IsDefault:  rule.IsDefault,
+	}
+}
+
+func convertRulesToXML(rules []Rule) []XMLRule {
+	out := make([]XMLRule, 0, len(rules))
+	for i := range rules {
+		out = append(out, convertRuleToXML(&rules[i]))
+	}
+
+	return out
+}
+
 // DispatchAction routes the request to the appropriate handler based on Action parameter.
 func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 	action := extractAction(r)
@@ -350,6 +774,11 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 		"DeregisterTargets":     s.DeregisterTargets,
 		"CreateListener":        s.CreateListener,
 		"DeleteListener":        s.DeleteListener,
+		"CreateRule":            s.CreateRule,
+		"DescribeRules":         s.DescribeRules,
+		"ModifyRule":            s.ModifyRule,
+		"DeleteRule":            s.DeleteRule,
+		"SetRulePriorities":     s.SetRulePriorities,
 	}
 
 	return handlers[action]

--- a/internal/service/elbv2/service.go
+++ b/internal/service/elbv2/service.go
@@ -61,6 +61,11 @@ func (s *Service) Actions() []string {
 		"DeregisterTargets",
 		"CreateListener",
 		"DeleteListener",
+		"CreateRule",
+		"DescribeRules",
+		"ModifyRule",
+		"DeleteRule",
+		"SetRulePriorities",
 	}
 }
 

--- a/internal/service/elbv2/storage.go
+++ b/internal/service/elbv2/storage.go
@@ -33,6 +33,12 @@ type Storage interface {
 
 	CreateListener(ctx context.Context, req *CreateListenerRequest) (*Listener, error)
 	DeleteListener(ctx context.Context, listenerArn string) error
+
+	CreateRule(ctx context.Context, listenerArn, priority string, conditions []RuleCondition, actions []Action) (*Rule, error)
+	DescribeRules(ctx context.Context, listenerArn string, ruleArns []string) ([]Rule, error)
+	ModifyRule(ctx context.Context, ruleArn string, conditions []RuleCondition, actions []Action) (*Rule, error)
+	DeleteRule(ctx context.Context, ruleArn string) error
+	SetRulePriorities(ctx context.Context, priorities map[string]string) ([]Rule, error)
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -609,4 +615,158 @@ func (m *MemoryStorage) DeleteListener(_ context.Context, listenerArn string) er
 	delete(m.Listeners, listenerArn)
 
 	return nil
+}
+
+// CreateRule attaches a new rule to a listener.
+func (m *MemoryStorage) CreateRule(_ context.Context, listenerArn, priority string, conditions []RuleCondition, actions []Action) (*Rule, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	listener, ok := m.Listeners[listenerArn]
+	if !ok {
+		return nil, &Error{Code: "ListenerNotFound", Message: "Listener '" + listenerArn + "' not found"}
+	}
+
+	rule := Rule{
+		RuleArn:    listenerArn + "/" + uuidLite(),
+		Priority:   priority,
+		Conditions: append([]RuleCondition(nil), conditions...),
+		Actions:    append([]Action(nil), actions...),
+		IsDefault:  false,
+	}
+	listener.Rules = append(listener.Rules, rule)
+
+	return &listener.Rules[len(listener.Rules)-1], nil
+}
+
+// DescribeRules returns rules for a listener (or specific rule ARNs across
+// all listeners).
+func (m *MemoryStorage) DescribeRules(_ context.Context, listenerArn string, ruleArns []string) ([]Rule, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make([]Rule, 0)
+
+	if listenerArn != "" {
+		listener, ok := m.Listeners[listenerArn]
+		if !ok {
+			return nil, &Error{Code: "ListenerNotFound", Message: "Listener '" + listenerArn + "' not found"}
+		}
+
+		out = append(out, defaultRuleFor(listener))
+		out = append(out, listener.Rules...)
+
+		return out, nil
+	}
+
+	if len(ruleArns) == 0 {
+		return out, nil
+	}
+
+	for _, listener := range m.Listeners {
+		for _, rule := range listener.Rules {
+			for _, want := range ruleArns {
+				if rule.RuleArn == want {
+					out = append(out, rule)
+				}
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// defaultRuleFor synthesizes the implicit default rule that AWS surfaces
+// alongside explicitly-created rules.
+func defaultRuleFor(listener *Listener) Rule {
+	return Rule{
+		RuleArn:   listener.ListenerArn + "/default",
+		Priority:  "default",
+		Actions:   append([]Action(nil), listener.DefaultActions...),
+		IsDefault: true,
+	}
+}
+
+// ModifyRule replaces the conditions and/or actions on a rule. nil slices
+// leave the corresponding field as-is, matching AWS one-field-per-call
+// semantics.
+func (m *MemoryStorage) ModifyRule(_ context.Context, ruleArn string, conditions []RuleCondition, actions []Action) (*Rule, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, listener := range m.Listeners {
+		for i := range listener.Rules {
+			if listener.Rules[i].RuleArn != ruleArn {
+				continue
+			}
+
+			if conditions != nil {
+				listener.Rules[i].Conditions = append([]RuleCondition(nil), conditions...)
+			}
+
+			if actions != nil {
+				listener.Rules[i].Actions = append([]Action(nil), actions...)
+			}
+
+			return &listener.Rules[i], nil
+		}
+	}
+
+	return nil, &Error{Code: "RuleNotFound", Message: "Rule '" + ruleArn + "' not found"}
+}
+
+// DeleteRule removes a rule by ARN.
+func (m *MemoryStorage) DeleteRule(_ context.Context, ruleArn string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, listener := range m.Listeners {
+		for i := range listener.Rules {
+			if listener.Rules[i].RuleArn == ruleArn {
+				listener.Rules = append(listener.Rules[:i], listener.Rules[i+1:]...)
+
+				return nil
+			}
+		}
+	}
+
+	return &Error{Code: "RuleNotFound", Message: "Rule '" + ruleArn + "' not found"}
+}
+
+// SetRulePriorities updates the priorities of one or more rules atomically.
+func (m *MemoryStorage) SetRulePriorities(_ context.Context, priorities map[string]string) ([]Rule, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	updated := make([]Rule, 0, len(priorities))
+
+	for arn, prio := range priorities {
+		found := false
+
+		for _, listener := range m.Listeners {
+			for i := range listener.Rules {
+				if listener.Rules[i].RuleArn == arn {
+					listener.Rules[i].Priority = prio
+					updated = append(updated, listener.Rules[i])
+					found = true
+
+					break
+				}
+			}
+
+			if found {
+				break
+			}
+		}
+
+		if !found {
+			return nil, &Error{Code: "RuleNotFound", Message: "Rule '" + arn + "' not found"}
+		}
+	}
+
+	return updated, nil
+}
+
+func uuidLite() string {
+	return fmt.Sprintf("rule-%d", time.Now().UnixNano())
 }

--- a/internal/service/elbv2/types.go
+++ b/internal/service/elbv2/types.go
@@ -69,6 +69,7 @@ type Listener struct {
 	Port            int
 	Protocol        string
 	DefaultActions  []Action
+	Rules           []Rule
 }
 
 // Action represents a listener action.
@@ -76,6 +77,24 @@ type Action struct {
 	Type           string
 	TargetGroupArn string
 	Order          int
+}
+
+// Rule represents a listener rule for path/host-based routing.
+type Rule struct {
+	RuleArn    string
+	Priority   string // AWS treats priority as string ("default" or 1-50000)
+	Conditions []RuleCondition
+	Actions    []Action
+	IsDefault  bool
+}
+
+// RuleCondition represents one condition on a rule (host-header,
+// path-pattern, http-header, etc.). Field + Values is the legacy form;
+// modern SDKs may also send <Field>Config.Values.member.N. The handler
+// accepts both and stores them in Field/Values.
+type RuleCondition struct {
+	Field  string
+	Values []string
 }
 
 // Target represents a target in a target group.
@@ -386,6 +405,99 @@ type XMLAction struct {
 	Type           string `xml:"Type"`
 	TargetGroupArn string `xml:"TargetGroupArn,omitempty"`
 	Order          int    `xml:"Order,omitempty"`
+}
+
+// XMLCreateRuleResponse is the XML response for CreateRule.
+type XMLCreateRuleResponse struct {
+	XMLName          xml.Name            `xml:"CreateRuleResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	Result           XMLCreateRuleResult `xml:"CreateRuleResult"`
+	ResponseMetadata XMLResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// XMLCreateRuleResult contains the created rules.
+type XMLCreateRuleResult struct {
+	Rules XMLRules `xml:"Rules"`
+}
+
+// XMLDescribeRulesResponse is the XML response for DescribeRules.
+type XMLDescribeRulesResponse struct {
+	XMLName          xml.Name               `xml:"DescribeRulesResponse"`
+	Xmlns            string                 `xml:"xmlns,attr"`
+	Result           XMLDescribeRulesResult `xml:"DescribeRulesResult"`
+	ResponseMetadata XMLResponseMetadata    `xml:"ResponseMetadata"`
+}
+
+// XMLDescribeRulesResult contains the listed rules.
+type XMLDescribeRulesResult struct {
+	Rules XMLRules `xml:"Rules"`
+}
+
+// XMLModifyRuleResponse is the XML response for ModifyRule.
+type XMLModifyRuleResponse struct {
+	XMLName          xml.Name            `xml:"ModifyRuleResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	Result           XMLModifyRuleResult `xml:"ModifyRuleResult"`
+	ResponseMetadata XMLResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// XMLModifyRuleResult contains the modified rule.
+type XMLModifyRuleResult struct {
+	Rules XMLRules `xml:"Rules"`
+}
+
+// XMLDeleteRuleResponse is the XML response for DeleteRule.
+type XMLDeleteRuleResponse struct {
+	XMLName          xml.Name            `xml:"DeleteRuleResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	Result           XMLDeleteRuleResult `xml:"DeleteRuleResult"`
+	ResponseMetadata XMLResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// XMLDeleteRuleResult is an empty result for DeleteRule.
+type XMLDeleteRuleResult struct{}
+
+// XMLSetRulePrioritiesResponse is the XML response for SetRulePriorities.
+type XMLSetRulePrioritiesResponse struct {
+	XMLName          xml.Name                   `xml:"SetRulePrioritiesResponse"`
+	Xmlns            string                     `xml:"xmlns,attr"`
+	Result           XMLSetRulePrioritiesResult `xml:"SetRulePrioritiesResult"`
+	ResponseMetadata XMLResponseMetadata        `xml:"ResponseMetadata"`
+}
+
+// XMLSetRulePrioritiesResult contains the rules with their new priorities.
+type XMLSetRulePrioritiesResult struct {
+	Rules XMLRules `xml:"Rules"`
+}
+
+// XMLRules contains a list of rules.
+type XMLRules struct {
+	Members []XMLRule `xml:"member"`
+}
+
+// XMLRule represents a rule in XML format.
+type XMLRule struct {
+	RuleArn    string            `xml:"RuleArn"`
+	Priority   string            `xml:"Priority"`
+	Conditions XMLRuleConditions `xml:"Conditions"`
+	Actions    XMLActions        `xml:"Actions"`
+	IsDefault  bool              `xml:"IsDefault"`
+}
+
+// XMLRuleConditions contains a list of conditions.
+type XMLRuleConditions struct {
+	Members []XMLRuleCondition `xml:"member"`
+}
+
+// XMLRuleCondition represents a condition in XML format.
+type XMLRuleCondition struct {
+	Field  string        `xml:"Field"`
+	Values XMLRuleValues `xml:"Values"`
+}
+
+// XMLRuleValues contains a list of values for a condition.
+type XMLRuleValues struct {
+	Members []string `xml:"member"`
 }
 
 // XMLResponseMetadata contains response metadata.

--- a/test/integration/elbv2_test.go
+++ b/test/integration/elbv2_test.go
@@ -380,3 +380,120 @@ func TestELBv2_LoadBalancerWithTargetGroupAndListener(t *testing.T) {
 
 	golden.New(t, golden.WithIgnoreFields("TargetGroupArn", "LoadBalancerArns", "ResultMetadata")).Assert(t.Name()+"_describe_tg", descTgResult)
 }
+
+func TestELBv2_ListenerRuleLifecycle(t *testing.T) {
+	client := newELBv2Client(t)
+	ctx := t.Context()
+
+	lbRes, err := client.CreateLoadBalancer(ctx, &elasticloadbalancingv2.CreateLoadBalancerInput{
+		Name:    aws.String("rule-test-lb"),
+		Subnets: []string{"subnet-aaaa1111", "subnet-bbbb2222"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	lbArn := lbRes.LoadBalancers[0].LoadBalancerArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteLoadBalancer(context.Background(), &elasticloadbalancingv2.DeleteLoadBalancerInput{
+			LoadBalancerArn: lbArn,
+		})
+	})
+
+	tgRes, err := client.CreateTargetGroup(ctx, &elasticloadbalancingv2.CreateTargetGroupInput{
+		Name:     aws.String("rule-test-tg"),
+		Protocol: types.ProtocolEnumHttp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-xxxx"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgArn := tgRes.TargetGroups[0].TargetGroupArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTargetGroup(context.Background(), &elasticloadbalancingv2.DeleteTargetGroupInput{
+			TargetGroupArn: tgArn,
+		})
+	})
+
+	listenerRes, err := client.CreateListener(ctx, &elasticloadbalancingv2.CreateListenerInput{
+		LoadBalancerArn: lbArn,
+		Protocol:        types.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []types.Action{
+			{Type: types.ActionTypeEnumForward, TargetGroupArn: tgArn},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	listenerArn := listenerRes.Listeners[0].ListenerArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteListener(context.Background(), &elasticloadbalancingv2.DeleteListenerInput{
+			ListenerArn: listenerArn,
+		})
+	})
+
+	createRuleRes, err := client.CreateRule(ctx, &elasticloadbalancingv2.CreateRuleInput{
+		ListenerArn: listenerArn,
+		Priority:    aws.Int32(100),
+		Conditions: []types.RuleCondition{
+			{
+				Field: aws.String("path-pattern"),
+				PathPatternConfig: &types.PathPatternConditionConfig{
+					Values: []string{"/api/*"},
+				},
+			},
+		},
+		Actions: []types.Action{
+			{Type: types.ActionTypeEnumForward, TargetGroupArn: tgArn},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	ruleArn := createRuleRes.Rules[0].RuleArn
+
+	if got := len(createRuleRes.Rules[0].Conditions); got != 1 {
+		t.Errorf("created rule has %d conditions, want 1", got)
+	}
+
+	if got := len(createRuleRes.Rules[0].Conditions[0].Values); got != 1 || createRuleRes.Rules[0].Conditions[0].Values[0] != "/api/*" {
+		t.Errorf("rule.Conditions[0].Values = %v, want [/api/*]", createRuleRes.Rules[0].Conditions[0].Values)
+	}
+
+	descRes, err := client.DescribeRules(ctx, &elasticloadbalancingv2.DescribeRulesInput{
+		ListenerArn: listenerArn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Default rule + the rule we created.
+	if got := len(descRes.Rules); got != 2 {
+		t.Errorf("DescribeRules returned %d rules, want 2 (default + created)", got)
+	}
+
+	if _, err := client.DeleteRule(ctx, &elasticloadbalancingv2.DeleteRuleInput{
+		RuleArn: ruleArn,
+	}); err != nil {
+		t.Fatalf("DeleteRule: %v", err)
+	}
+
+	descAfter, err := client.DescribeRules(ctx, &elasticloadbalancingv2.DescribeRulesInput{
+		ListenerArn: listenerArn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := len(descAfter.Rules); got != 1 {
+		t.Errorf("after delete, DescribeRules returned %d rules, want 1 (default only)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the ALB listener rule APIs that drive path-based and host-based routing on top of an existing listener.

| Action | Notes |
|---|---|
| \`CreateRule\` | Accepts conditions and forward actions on a listener. |
| \`DescribeRules\` | Per listener (returns the implicit default rule synthesized from \`Listener.DefaultActions\` alongside explicitly-created rules) or by \`RuleArns\`. |
| \`ModifyRule\` | Replaces conditions and/or actions on a rule (nil = leave as-is). |
| \`DeleteRule\` | Removes a rule by ARN. |
| \`SetRulePriorities\` | Atomic priority updates across multiple rules. |

Without these, any client that creates a listener and then attaches even a single \`forward\` rule on a path pattern hits \`InvalidAction\` immediately after \`CreateListener\`.

## Wire format compatibility

Conditions accept both shapes the AWS SDK emits:

- Legacy: \`Conditions.member.N.Field=path-pattern\` + \`Conditions.member.N.Values.member.M=/foo\`
- Modern: \`Conditions.member.N.Field=path-pattern\` + \`Conditions.member.N.PathPatternConfig.Values.member.M=/foo\`

Both are flattened to the storage \`RuleCondition{Field, Values}\` shape, and emitted in the legacy \`Field + Values\` form on the response. The form-level parsers live in \`handlers.go\` alongside the existing tag/filter helpers; no change to the generic Query dispatcher.

## Storage shape

\`Listener\` gains a \`Rules []Rule\` slice. The implicit default rule is not stored — it is synthesized at \`DescribeRules\` time from \`Listener.DefaultActions\` so the response shape matches AWS without duplicating state.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestELBv2_*\` integration tests still pass
- [x] New \`TestELBv2_ListenerRuleLifecycle\` exercises Create (with \`PathPatternConfig\`) → DescribeRules (asserts default + created rule) → DeleteRule → DescribeRules (asserts default only)