### PR TITLE
feat(elbv2): LoadBalancer / TargetGroup attribute APIs (Modify/Describe)

### DIFF
--- a/internal/service/elbv2/handlers.go
+++ b/internal/service/elbv2/handlers.go
@@ -822,21 +822,25 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // getActionHandler returns the handler function for the given action.
 func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *http.Request) {
 	handlers := map[string]func(http.ResponseWriter, *http.Request){
-		"CreateLoadBalancer":    s.CreateLoadBalancer,
-		"DeleteLoadBalancer":    s.DeleteLoadBalancer,
-		"DescribeLoadBalancers": s.DescribeLoadBalancers,
-		"CreateTargetGroup":     s.CreateTargetGroup,
-		"DeleteTargetGroup":     s.DeleteTargetGroup,
-		"DescribeTargetGroups":  s.DescribeTargetGroups,
-		"RegisterTargets":       s.RegisterTargets,
-		"DeregisterTargets":     s.DeregisterTargets,
-		"CreateListener":        s.CreateListener,
-		"DeleteListener":        s.DeleteListener,
-		"CreateRule":            s.CreateRule,
-		"DescribeRules":         s.DescribeRules,
-		"ModifyRule":            s.ModifyRule,
-		"DeleteRule":            s.DeleteRule,
-		"SetRulePriorities":     s.SetRulePriorities,
+		"CreateLoadBalancer":             s.CreateLoadBalancer,
+		"DeleteLoadBalancer":             s.DeleteLoadBalancer,
+		"DescribeLoadBalancers":          s.DescribeLoadBalancers,
+		"CreateTargetGroup":              s.CreateTargetGroup,
+		"DeleteTargetGroup":              s.DeleteTargetGroup,
+		"DescribeTargetGroups":           s.DescribeTargetGroups,
+		"RegisterTargets":                s.RegisterTargets,
+		"DeregisterTargets":              s.DeregisterTargets,
+		"CreateListener":                 s.CreateListener,
+		"DeleteListener":                 s.DeleteListener,
+		"CreateRule":                     s.CreateRule,
+		"DescribeRules":                  s.DescribeRules,
+		"ModifyRule":                     s.ModifyRule,
+		"DeleteRule":                     s.DeleteRule,
+		"SetRulePriorities":              s.SetRulePriorities,
+		"ModifyLoadBalancerAttributes":   s.ModifyLoadBalancerAttributes,
+		"DescribeLoadBalancerAttributes": s.DescribeLoadBalancerAttributes,
+		"ModifyTargetGroupAttributes":    s.ModifyTargetGroupAttributes,
+		"DescribeTargetGroupAttributes":  s.DescribeTargetGroupAttributes,
 	}
 
 	return handlers[action]
@@ -976,4 +980,196 @@ func handleELBError(w http.ResponseWriter, err error) {
 	}
 
 	writeELBError(w, errInternalError, "Internal server error", http.StatusInternalServerError)
+}
+
+// ModifyLoadBalancerAttributes handles the ModifyLoadBalancerAttributes action.
+func (s *Service) ModifyLoadBalancerAttributes(w http.ResponseWriter, r *http.Request) {
+	lbArn, attrs, err := readAttributesRequestForm(r, "LoadBalancerArn")
+	if err != nil {
+		writeELBError(w, errInvalidParameter, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	updated, err := s.storage.ModifyLoadBalancerAttributes(r.Context(), lbArn, attrs)
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	writeELBXMLResponse(w, XMLModifyLoadBalancerAttributesResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLModifyLoadBalancerAttributesResult{Attributes: attributesToXML(updated)},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DescribeLoadBalancerAttributes handles the DescribeLoadBalancerAttributes action.
+func (s *Service) DescribeLoadBalancerAttributes(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	lbArn := r.Form.Get("LoadBalancerArn")
+	if lbArn == "" {
+		writeELBError(w, errInvalidParameter, "LoadBalancerArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	attrs, err := s.storage.DescribeLoadBalancerAttributes(r.Context(), lbArn)
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	writeELBXMLResponse(w, XMLDescribeLoadBalancerAttributesResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLDescribeLoadBalancerAttributesResult{Attributes: attributesToXML(attrs)},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// ModifyTargetGroupAttributes handles the ModifyTargetGroupAttributes action.
+func (s *Service) ModifyTargetGroupAttributes(w http.ResponseWriter, r *http.Request) {
+	tgArn, attrs, err := readAttributesRequestForm(r, "TargetGroupArn")
+	if err != nil {
+		writeELBError(w, errInvalidParameter, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	updated, err := s.storage.ModifyTargetGroupAttributes(r.Context(), tgArn, attrs)
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	writeELBXMLResponse(w, XMLModifyTargetGroupAttributesResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLModifyTargetGroupAttributesResult{Attributes: attributesToXML(updated)},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DescribeTargetGroupAttributes handles the DescribeTargetGroupAttributes action.
+func (s *Service) DescribeTargetGroupAttributes(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	tgArn := r.Form.Get("TargetGroupArn")
+	if tgArn == "" {
+		writeELBError(w, errInvalidParameter, "TargetGroupArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	attrs, err := s.storage.DescribeTargetGroupAttributes(r.Context(), tgArn)
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	writeELBXMLResponse(w, XMLDescribeTargetGroupAttributesResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLDescribeTargetGroupAttributesResult{Attributes: attributesToXML(attrs)},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// readAttributesRequestForm extracts the resource ARN and the
+// Attributes.member.N.{Key,Value} pairs from the AWS Query form.
+func readAttributesRequestForm(r *http.Request, arnField string) (string, map[string]string, error) {
+	if err := r.ParseForm(); err != nil {
+		return "", nil, fmt.Errorf("failed to parse form: %w", err)
+	}
+
+	arn := r.Form.Get(arnField)
+	if arn == "" {
+		return "", nil, fmt.Errorf("%s is required", arnField)
+	}
+
+	return arn, parseAttributePairsFromForm(r.Form), nil
+}
+
+// attributePairAcc accumulates one Attributes.member.N pair being parsed.
+type attributePairAcc struct {
+	key   string
+	value string
+}
+
+// parseAttributePairsFromForm reads Attributes.member.N.Key/Value into a map.
+func parseAttributePairsFromForm(form map[string][]string) map[string]string {
+	byIdx := make(map[int]*attributePairAcc)
+
+	for key, values := range form {
+		applyAttributePairFormEntry(byIdx, key, values)
+	}
+
+	out := make(map[string]string)
+
+	for _, entry := range byIdx {
+		if entry.key != "" {
+			out[entry.key] = entry.value
+		}
+	}
+
+	return out
+}
+
+func applyAttributePairFormEntry(byIdx map[int]*attributePairAcc, key string, values []string) {
+	suffix, ok := strings.CutPrefix(key, "Attributes.member.")
+	if !ok || len(values) == 0 {
+		return
+	}
+
+	dot := strings.Index(suffix, ".")
+	if dot < 0 {
+		return
+	}
+
+	n, err := strconv.Atoi(suffix[:dot])
+	if err != nil {
+		return
+	}
+
+	entry, exists := byIdx[n]
+	if !exists {
+		entry = &attributePairAcc{}
+		byIdx[n] = entry
+	}
+
+	switch suffix[dot+1:] {
+	case "Key":
+		entry.key = values[0]
+	case "Value":
+		entry.value = values[0]
+	}
+}
+
+// attributesToXML converts a name->value map to the XML wire shape, sorted
+// by key for deterministic output.
+func attributesToXML(attrs map[string]string) XMLAttributePairs {
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	members := make([]XMLAttributePair, 0, len(keys))
+	for _, k := range keys {
+		members = append(members, XMLAttributePair{Key: k, Value: attrs[k]})
+	}
+
+	return XMLAttributePairs{Members: members}
 }

--- a/internal/service/elbv2/service.go
+++ b/internal/service/elbv2/service.go
@@ -66,6 +66,10 @@ func (s *Service) Actions() []string {
 		"ModifyRule",
 		"DeleteRule",
 		"SetRulePriorities",
+		"ModifyLoadBalancerAttributes",
+		"DescribeLoadBalancerAttributes",
+		"ModifyTargetGroupAttributes",
+		"DescribeTargetGroupAttributes",
 	}
 }
 

--- a/internal/service/elbv2/storage.go
+++ b/internal/service/elbv2/storage.go
@@ -39,6 +39,11 @@ type Storage interface {
 	ModifyRule(ctx context.Context, ruleArn string, conditions []RuleCondition, actions []Action) (*Rule, error)
 	DeleteRule(ctx context.Context, ruleArn string) error
 	SetRulePriorities(ctx context.Context, priorities map[string]string) ([]Rule, error)
+
+	ModifyLoadBalancerAttributes(ctx context.Context, lbArn string, attrs map[string]string) (map[string]string, error)
+	DescribeLoadBalancerAttributes(ctx context.Context, lbArn string) (map[string]string, error)
+	ModifyTargetGroupAttributes(ctx context.Context, tgArn string, attrs map[string]string) (map[string]string, error)
+	DescribeTargetGroupAttributes(ctx context.Context, tgArn string) (map[string]string, error)
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -769,4 +774,119 @@ func (m *MemoryStorage) SetRulePriorities(_ context.Context, priorities map[stri
 
 func uuidLite() string {
 	return fmt.Sprintf("rule-%d", time.Now().UnixNano())
+}
+
+// defaultLoadBalancerAttributes returns the AWS-default attribute set
+// surfaced on a freshly-created load balancer.
+func defaultLoadBalancerAttributes() map[string]string {
+	return map[string]string{
+		"access_logs.s3.enabled":                          "false",
+		"access_logs.s3.bucket":                           "",
+		"access_logs.s3.prefix":                           "",
+		"deletion_protection.enabled":                     "false",
+		"idle_timeout.timeout_seconds":                    "60",
+		"routing.http2.enabled":                           "true",
+		"routing.http.drop_invalid_header_fields.enabled": "false",
+		"load_balancing.cross_zone.enabled":               "true",
+	}
+}
+
+// defaultTargetGroupAttributes returns the AWS-default attribute set for a
+// freshly-created target group.
+func defaultTargetGroupAttributes() map[string]string {
+	return map[string]string{
+		"deregistration_delay.timeout_seconds":  "300",
+		"stickiness.enabled":                    "false",
+		"stickiness.type":                       "lb_cookie",
+		"stickiness.lb_cookie.duration_seconds": "86400",
+		"slow_start.duration_seconds":           "0",
+		"load_balancing.algorithm.type":         "round_robin",
+		"proxy_protocol_v2.enabled":             "false",
+	}
+}
+
+// ModifyLoadBalancerAttributes upserts attributes on a load balancer.
+func (m *MemoryStorage) ModifyLoadBalancerAttributes(_ context.Context, lbArn string, attrs map[string]string) (map[string]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	lb, ok := m.LoadBalancers[lbArn]
+	if !ok {
+		return nil, &Error{Code: "LoadBalancerNotFound", Message: "Load balancer '" + lbArn + "' not found"}
+	}
+
+	if lb.Attributes == nil {
+		lb.Attributes = defaultLoadBalancerAttributes()
+	}
+
+	for k, v := range attrs {
+		lb.Attributes[k] = v
+	}
+
+	return cloneAttributes(lb.Attributes), nil
+}
+
+// DescribeLoadBalancerAttributes returns the attribute set, lazy-initializing
+// to the AWS defaults if Modify has never been called.
+func (m *MemoryStorage) DescribeLoadBalancerAttributes(_ context.Context, lbArn string) (map[string]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	lb, ok := m.LoadBalancers[lbArn]
+	if !ok {
+		return nil, &Error{Code: "LoadBalancerNotFound", Message: "Load balancer '" + lbArn + "' not found"}
+	}
+
+	if lb.Attributes == nil {
+		lb.Attributes = defaultLoadBalancerAttributes()
+	}
+
+	return cloneAttributes(lb.Attributes), nil
+}
+
+// ModifyTargetGroupAttributes upserts attributes on a target group.
+func (m *MemoryStorage) ModifyTargetGroupAttributes(_ context.Context, tgArn string, attrs map[string]string) (map[string]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tg, ok := m.TargetGroups[tgArn]
+	if !ok {
+		return nil, &Error{Code: "TargetGroupNotFound", Message: "Target group '" + tgArn + "' not found"}
+	}
+
+	if tg.Attributes == nil {
+		tg.Attributes = defaultTargetGroupAttributes()
+	}
+
+	for k, v := range attrs {
+		tg.Attributes[k] = v
+	}
+
+	return cloneAttributes(tg.Attributes), nil
+}
+
+// DescribeTargetGroupAttributes returns the attribute set with AWS defaults.
+func (m *MemoryStorage) DescribeTargetGroupAttributes(_ context.Context, tgArn string) (map[string]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tg, ok := m.TargetGroups[tgArn]
+	if !ok {
+		return nil, &Error{Code: "TargetGroupNotFound", Message: "Target group '" + tgArn + "' not found"}
+	}
+
+	if tg.Attributes == nil {
+		tg.Attributes = defaultTargetGroupAttributes()
+	}
+
+	return cloneAttributes(tg.Attributes), nil
+}
+
+func cloneAttributes(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
 }

--- a/internal/service/elbv2/types.go
+++ b/internal/service/elbv2/types.go
@@ -22,6 +22,7 @@ type LoadBalancer struct {
 	AvailabilityZones     []AvailabilityZone
 	SecurityGroups        []string
 	IPAddressType         string
+	Attributes            map[string]string
 }
 
 // LoadBalancerState represents the state of a load balancer.
@@ -60,6 +61,7 @@ type TargetGroup struct {
 	UnhealthyThresholdCount    int
 	TargetType                 string // instance | ip | lambda | alb
 	LoadBalancerArns           []string
+	Attributes                 map[string]string
 }
 
 // Listener represents an ELB listener.
@@ -528,4 +530,67 @@ type Error struct {
 // Error implements the error interface.
 func (e *Error) Error() string {
 	return e.Code + ": " + e.Message
+}
+
+// XMLAttributePair represents a single attribute key/value entry.
+type XMLAttributePair struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+// XMLAttributePairs contains a list of attribute key/value entries.
+type XMLAttributePairs struct {
+	Members []XMLAttributePair `xml:"member"`
+}
+
+// XMLModifyLoadBalancerAttributesResponse is the XML response.
+type XMLModifyLoadBalancerAttributesResponse struct {
+	XMLName          xml.Name                              `xml:"ModifyLoadBalancerAttributesResponse"`
+	Xmlns            string                                `xml:"xmlns,attr"`
+	Result           XMLModifyLoadBalancerAttributesResult `xml:"ModifyLoadBalancerAttributesResult"`
+	ResponseMetadata XMLResponseMetadata                   `xml:"ResponseMetadata"`
+}
+
+// XMLModifyLoadBalancerAttributesResult contains the updated attributes.
+type XMLModifyLoadBalancerAttributesResult struct {
+	Attributes XMLAttributePairs `xml:"Attributes"`
+}
+
+// XMLDescribeLoadBalancerAttributesResponse is the XML response.
+type XMLDescribeLoadBalancerAttributesResponse struct {
+	XMLName          xml.Name                                `xml:"DescribeLoadBalancerAttributesResponse"`
+	Xmlns            string                                  `xml:"xmlns,attr"`
+	Result           XMLDescribeLoadBalancerAttributesResult `xml:"DescribeLoadBalancerAttributesResult"`
+	ResponseMetadata XMLResponseMetadata                     `xml:"ResponseMetadata"`
+}
+
+// XMLDescribeLoadBalancerAttributesResult contains the requested attributes.
+type XMLDescribeLoadBalancerAttributesResult struct {
+	Attributes XMLAttributePairs `xml:"Attributes"`
+}
+
+// XMLModifyTargetGroupAttributesResponse is the XML response.
+type XMLModifyTargetGroupAttributesResponse struct {
+	XMLName          xml.Name                             `xml:"ModifyTargetGroupAttributesResponse"`
+	Xmlns            string                               `xml:"xmlns,attr"`
+	Result           XMLModifyTargetGroupAttributesResult `xml:"ModifyTargetGroupAttributesResult"`
+	ResponseMetadata XMLResponseMetadata                  `xml:"ResponseMetadata"`
+}
+
+// XMLModifyTargetGroupAttributesResult contains the updated attributes.
+type XMLModifyTargetGroupAttributesResult struct {
+	Attributes XMLAttributePairs `xml:"Attributes"`
+}
+
+// XMLDescribeTargetGroupAttributesResponse is the XML response.
+type XMLDescribeTargetGroupAttributesResponse struct {
+	XMLName          xml.Name                               `xml:"DescribeTargetGroupAttributesResponse"`
+	Xmlns            string                                 `xml:"xmlns,attr"`
+	Result           XMLDescribeTargetGroupAttributesResult `xml:"DescribeTargetGroupAttributesResult"`
+	ResponseMetadata XMLResponseMetadata                    `xml:"ResponseMetadata"`
+}
+
+// XMLDescribeTargetGroupAttributesResult contains the requested attributes.
+type XMLDescribeTargetGroupAttributesResult struct {
+	Attributes XMLAttributePairs `xml:"Attributes"`
 }

--- a/test/integration/elbv2_test.go
+++ b/test/integration/elbv2_test.go
@@ -497,3 +497,138 @@ func TestELBv2_ListenerRuleLifecycle(t *testing.T) {
 		t.Errorf("after delete, DescribeRules returned %d rules, want 1 (default only)", got)
 	}
 }
+
+func TestELBv2_LoadBalancerAttributes(t *testing.T) {
+	client := newELBv2Client(t)
+	ctx := t.Context()
+
+	lbRes, err := client.CreateLoadBalancer(ctx, &elasticloadbalancingv2.CreateLoadBalancerInput{
+		Name:    aws.String("attr-test-lb"),
+		Subnets: []string{"subnet-aaaa1111", "subnet-bbbb2222"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	lbArn := lbRes.LoadBalancers[0].LoadBalancerArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteLoadBalancer(context.Background(), &elasticloadbalancingv2.DeleteLoadBalancerInput{
+			LoadBalancerArn: lbArn,
+		})
+	})
+
+	descBefore, err := client.DescribeLoadBalancerAttributes(ctx, &elasticloadbalancingv2.DescribeLoadBalancerAttributesInput{
+		LoadBalancerArn: lbArn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if found := lookupLBAttr(descBefore.Attributes, "deletion_protection.enabled"); found != "false" {
+		t.Errorf("default deletion_protection.enabled = %q, want %q", found, "false")
+	}
+
+	if found := lookupLBAttr(descBefore.Attributes, "idle_timeout.timeout_seconds"); found != "60" {
+		t.Errorf("default idle_timeout.timeout_seconds = %q, want %q", found, "60")
+	}
+
+	if _, err := client.ModifyLoadBalancerAttributes(ctx, &elasticloadbalancingv2.ModifyLoadBalancerAttributesInput{
+		LoadBalancerArn: lbArn,
+		Attributes: []types.LoadBalancerAttribute{
+			{Key: aws.String("deletion_protection.enabled"), Value: aws.String("true")},
+			{Key: aws.String("idle_timeout.timeout_seconds"), Value: aws.String("120")},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyLoadBalancerAttributes: %v", err)
+	}
+
+	descAfter, err := client.DescribeLoadBalancerAttributes(ctx, &elasticloadbalancingv2.DescribeLoadBalancerAttributesInput{
+		LoadBalancerArn: lbArn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if found := lookupLBAttr(descAfter.Attributes, "deletion_protection.enabled"); found != "true" {
+		t.Errorf("after Modify, deletion_protection.enabled = %q, want %q", found, "true")
+	}
+
+	if found := lookupLBAttr(descAfter.Attributes, "idle_timeout.timeout_seconds"); found != "120" {
+		t.Errorf("after Modify, idle_timeout.timeout_seconds = %q, want %q", found, "120")
+	}
+}
+
+func TestELBv2_TargetGroupAttributes(t *testing.T) {
+	client := newELBv2Client(t)
+	ctx := t.Context()
+
+	tgRes, err := client.CreateTargetGroup(ctx, &elasticloadbalancingv2.CreateTargetGroupInput{
+		Name:     aws.String("attr-test-tg"),
+		Protocol: types.ProtocolEnumHttp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-xxxx"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgArn := tgRes.TargetGroups[0].TargetGroupArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTargetGroup(context.Background(), &elasticloadbalancingv2.DeleteTargetGroupInput{
+			TargetGroupArn: tgArn,
+		})
+	})
+
+	descBefore, err := client.DescribeTargetGroupAttributes(ctx, &elasticloadbalancingv2.DescribeTargetGroupAttributesInput{
+		TargetGroupArn: tgArn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if found := lookupTGAttr(descBefore.Attributes, "deregistration_delay.timeout_seconds"); found != "300" {
+		t.Errorf("default deregistration_delay.timeout_seconds = %q, want %q", found, "300")
+	}
+
+	if _, err := client.ModifyTargetGroupAttributes(ctx, &elasticloadbalancingv2.ModifyTargetGroupAttributesInput{
+		TargetGroupArn: tgArn,
+		Attributes: []types.TargetGroupAttribute{
+			{Key: aws.String("deregistration_delay.timeout_seconds"), Value: aws.String("60")},
+		},
+	}); err != nil {
+		t.Fatalf("ModifyTargetGroupAttributes: %v", err)
+	}
+
+	descAfter, err := client.DescribeTargetGroupAttributes(ctx, &elasticloadbalancingv2.DescribeTargetGroupAttributesInput{
+		TargetGroupArn: tgArn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if found := lookupTGAttr(descAfter.Attributes, "deregistration_delay.timeout_seconds"); found != "60" {
+		t.Errorf("after Modify, deregistration_delay.timeout_seconds = %q, want %q", found, "60")
+	}
+}
+
+func lookupLBAttr(attrs []types.LoadBalancerAttribute, key string) string {
+	for _, a := range attrs {
+		if a.Key != nil && *a.Key == key && a.Value != nil {
+			return *a.Value
+		}
+	}
+
+	return ""
+}
+
+func lookupTGAttr(attrs []types.TargetGroupAttribute, key string) string {
+	for _, a := range attrs {
+		if a.Key != nil && *a.Key == key && a.Value != nil {
+			return *a.Value
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
## Summary

Adds the attribute APIs that AWS clients call after \`CreateLoadBalancer\` and \`CreateTargetGroup\` to read or change per-resource configuration:

| Action | Notes |
|---|---|
| \`ModifyLoadBalancerAttributes\` | Upserts the supplied attributes; returns the merged set. |
| \`DescribeLoadBalancerAttributes\` | Returns all attributes; lazy-initializes to AWS defaults if Modify has never been called. |
| \`ModifyTargetGroupAttributes\` | Same shape for target groups. |
| \`DescribeTargetGroupAttributes\` | Same. |

Without these, any client that sets attributes (\`deletion_protection.enabled\`, \`idle_timeout.timeout_seconds\`, \`deregistration_delay.timeout_seconds\`, \`stickiness.*\`, etc.) hits \`InvalidAction\` immediately after \`Create*\`, and any client that reads state back for drift detection sees an empty attribute set instead of the AWS defaults.

## Behavior alignment with AWS

\`Describe*Attributes\` lazily seeds the AWS-default attribute set so a freshly-created LB / TG reads back the same defaults real AWS surfaces:

| Resource | Default attributes (excerpt) |
|---|---|
| Load balancer | \`deletion_protection.enabled=false\`, \`idle_timeout.timeout_seconds=60\`, \`routing.http2.enabled=true\`, \`load_balancing.cross_zone.enabled=true\` |
| Target group | \`deregistration_delay.timeout_seconds=300\`, \`stickiness.enabled=false\`, \`stickiness.type=lb_cookie\`, \`load_balancing.algorithm.type=round_robin\` |

\`Modify*Attributes\` upserts; subsequent \`Describe\` returns the merged set sorted by key for deterministic output.

## Implementation

\`Attributes.member.N.{Key,Value}\` parsing lives in \`handlers.go\` in the same form-helper style as the existing CreateTags / DescribeTags code (PR #547). No change to the generic Query dispatcher.

\`LoadBalancer\` and \`TargetGroup\` storage types gain \`Attributes map[string]string\`. Defaults are seeded lazily so existing tests that build these resources directly do not need updating.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestELBv2_*\` integration tests still pass
- [x] New \`TestELBv2_LoadBalancerAttributes\` asserts AWS defaults on first Describe, then toggles two attributes and reads them back
- [x] New \`TestELBv2_TargetGroupAttributes\` does the same for the TG side