### PR TITLE
feat(elbv2): DescribeListeners / ModifyListener / DescribeTargetHealth

### DIFF
--- a/internal/service/elbv2/handlers.go
+++ b/internal/service/elbv2/handlers.go
@@ -841,6 +841,9 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 		"DescribeLoadBalancerAttributes": s.DescribeLoadBalancerAttributes,
 		"ModifyTargetGroupAttributes":    s.ModifyTargetGroupAttributes,
 		"DescribeTargetGroupAttributes":  s.DescribeTargetGroupAttributes,
+		"DescribeListeners":              s.DescribeListeners,
+		"ModifyListener":                 s.ModifyListener,
+		"DescribeTargetHealth":           s.DescribeTargetHealth,
 	}
 
 	return handlers[action]
@@ -1172,4 +1175,215 @@ func attributesToXML(attrs map[string]string) XMLAttributePairs {
 	}
 
 	return XMLAttributePairs{Members: members}
+}
+
+// DescribeListeners handles the DescribeListeners action.
+func (s *Service) DescribeListeners(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	listenerArns := parseELBMemberListFromForm(r.Form, "ListenerArns")
+	lbArn := r.Form.Get("LoadBalancerArn")
+
+	listeners, err := s.storage.DescribeListeners(r.Context(), listenerArns, lbArn)
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	xmlListeners := make([]XMLListener, 0, len(listeners))
+	for _, l := range listeners {
+		xmlListeners = append(xmlListeners, convertToXMLListener(l))
+	}
+
+	writeELBXMLResponse(w, XMLDescribeListenersResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLDescribeListenersResult{Listeners: XMLListeners{Members: xmlListeners}},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// ModifyListener handles the ModifyListener action.
+func (s *Service) ModifyListener(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	listenerArn := r.Form.Get("ListenerArn")
+	if listenerArn == "" {
+		writeELBError(w, errInvalidParameter, "ListenerArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	port := 0
+
+	if p := r.Form.Get("Port"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			port = v
+		}
+	}
+
+	protocol := r.Form.Get("Protocol")
+
+	defaultActions := parseELBActionsFromForm(r.Form, "DefaultActions")
+	if len(defaultActions) == 0 {
+		defaultActions = nil
+	}
+
+	listener, err := s.storage.ModifyListener(r.Context(), listenerArn, port, protocol, defaultActions)
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	writeELBXMLResponse(w, XMLModifyListenerResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLModifyListenerResult{Listeners: XMLListeners{Members: []XMLListener{convertToXMLListener(listener)}}},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// DescribeTargetHealth handles the DescribeTargetHealth action.
+func (s *Service) DescribeTargetHealth(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	tgArn := r.Form.Get("TargetGroupArn")
+	if tgArn == "" {
+		writeELBError(w, errInvalidParameter, "TargetGroupArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	targets := parseELBTargetsFromForm(r.Form)
+
+	descriptions, err := s.storage.DescribeTargetHealth(r.Context(), tgArn, targets)
+	if err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
+	members := make([]XMLTargetHealthDescription, 0, len(descriptions))
+	for _, d := range descriptions {
+		members = append(members, XMLTargetHealthDescription{
+			Target: XMLTargetForHealth{
+				ID:               d.Target.ID,
+				Port:             d.Target.Port,
+				AvailabilityZone: d.Target.AvailabilityZone,
+			},
+			TargetHealth: XMLTargetHealth{State: d.HealthState},
+		})
+	}
+
+	writeELBXMLResponse(w, XMLDescribeTargetHealthResponse{
+		Xmlns:            elbXMLNS,
+		Result:           XMLDescribeTargetHealthResult{TargetHealthDescriptions: XMLTargetHealthDescriptions{Members: members}},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// parseELBMemberListFromForm reads <prefix>.member.N entries.
+func parseELBMemberListFromForm(form map[string][]string, prefix string) []string {
+	type entry struct {
+		idx int
+		val string
+	}
+
+	entries := make([]entry, 0)
+
+	for key, values := range form {
+		suffix, ok := strings.CutPrefix(key, prefix+".member.")
+		if !ok || len(values) == 0 {
+			continue
+		}
+
+		if strings.Contains(suffix, ".") {
+			continue
+		}
+
+		n, err := strconv.Atoi(suffix)
+		if err != nil {
+			continue
+		}
+
+		entries = append(entries, entry{idx: n, val: values[0]})
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].idx < entries[j].idx })
+
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.val)
+	}
+
+	return out
+}
+
+// parseELBActionsFromForm reads <prefix>.member.N.{Type,TargetGroupArn,Order}.
+func parseELBActionsFromForm(form map[string][]string, prefix string) []Action {
+	byIdx := make(map[int]*Action)
+
+	for key, values := range form {
+		applyELBActionFormEntry(byIdx, prefix, key, values)
+	}
+
+	indexes := make([]int, 0, len(byIdx))
+	for n := range byIdx {
+		indexes = append(indexes, n)
+	}
+
+	sort.Ints(indexes)
+
+	out := make([]Action, 0, len(indexes))
+	for _, n := range indexes {
+		out = append(out, *byIdx[n])
+	}
+
+	return out
+}
+
+func applyELBActionFormEntry(byIdx map[int]*Action, prefix, key string, values []string) {
+	suffix, ok := strings.CutPrefix(key, prefix+".member.")
+	if !ok || len(values) == 0 {
+		return
+	}
+
+	dot := strings.Index(suffix, ".")
+	if dot < 0 {
+		return
+	}
+
+	n, err := strconv.Atoi(suffix[:dot])
+	if err != nil {
+		return
+	}
+
+	entry, exists := byIdx[n]
+	if !exists {
+		entry = &Action{}
+		byIdx[n] = entry
+	}
+
+	switch suffix[dot+1:] {
+	case "Type":
+		entry.Type = values[0]
+	case "TargetGroupArn":
+		entry.TargetGroupArn = values[0]
+	case "Order":
+		if v, err := strconv.Atoi(values[0]); err == nil {
+			entry.Order = v
+		}
+	}
 }

--- a/internal/service/elbv2/service.go
+++ b/internal/service/elbv2/service.go
@@ -70,6 +70,13 @@ func (s *Service) Actions() []string {
 		"DescribeLoadBalancerAttributes",
 		"ModifyTargetGroupAttributes",
 		"DescribeTargetGroupAttributes",
+		"DescribeTargetHealth",
+		"ModifyListener",
+		"DescribeListeners",
+		"github.com/sivchari/kumo/internal/service",
+		"os",
+		"io",
+		"fmt",
 	}
 }
 

--- a/internal/service/elbv2/storage.go
+++ b/internal/service/elbv2/storage.go
@@ -44,6 +44,10 @@ type Storage interface {
 	DescribeLoadBalancerAttributes(ctx context.Context, lbArn string) (map[string]string, error)
 	ModifyTargetGroupAttributes(ctx context.Context, tgArn string, attrs map[string]string) (map[string]string, error)
 	DescribeTargetGroupAttributes(ctx context.Context, tgArn string) (map[string]string, error)
+
+	DescribeListeners(ctx context.Context, listenerArns []string, lbArn string) ([]*Listener, error)
+	ModifyListener(ctx context.Context, listenerArn string, port int, protocol string, defaultActions []Action) (*Listener, error)
+	DescribeTargetHealth(ctx context.Context, targetGroupArn string, targets []Target) ([]TargetDescription, error)
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -889,4 +893,103 @@ func cloneAttributes(in map[string]string) map[string]string {
 	}
 
 	return out
+}
+
+// DescribeListeners returns listeners by ARN list or by parent load balancer.
+func (m *MemoryStorage) DescribeListeners(_ context.Context, listenerArns []string, lbArn string) ([]*Listener, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make([]*Listener, 0)
+
+	if len(listenerArns) > 0 {
+		for _, arn := range listenerArns {
+			listener, ok := m.Listeners[arn]
+			if !ok {
+				return nil, &Error{Code: "ListenerNotFound", Message: "Listener '" + arn + "' not found"}
+			}
+
+			out = append(out, listener)
+		}
+
+		return out, nil
+	}
+
+	for _, listener := range m.Listeners {
+		if lbArn == "" || listener.LoadBalancerArn == lbArn {
+			out = append(out, listener)
+		}
+	}
+
+	return out, nil
+}
+
+// ModifyListener replaces port / protocol / default actions on a listener.
+// A zero port means "do not change"; an empty protocol or nil DefaultActions
+// likewise.
+func (m *MemoryStorage) ModifyListener(_ context.Context, listenerArn string, port int, protocol string, defaultActions []Action) (*Listener, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	listener, ok := m.Listeners[listenerArn]
+	if !ok {
+		return nil, &Error{Code: "ListenerNotFound", Message: "Listener '" + listenerArn + "' not found"}
+	}
+
+	if port != 0 {
+		listener.Port = port
+	}
+
+	if protocol != "" {
+		listener.Protocol = protocol
+	}
+
+	if defaultActions != nil {
+		listener.DefaultActions = append([]Action(nil), defaultActions...)
+	}
+
+	return listener, nil
+}
+
+// DescribeTargetHealth returns the health of registered targets in a target
+// group. kumo does not run real health checks, so every registered target is
+// reported as "healthy". An empty Targets request returns the full set; a
+// non-empty Targets request filters to those exact targets and reports
+// "unused" for any target not currently registered.
+func (m *MemoryStorage) DescribeTargetHealth(_ context.Context, targetGroupArn string, targets []Target) ([]TargetDescription, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if _, ok := m.TargetGroups[targetGroupArn]; !ok {
+		return nil, &Error{Code: "TargetGroupNotFound", Message: "Target group '" + targetGroupArn + "' not found"}
+	}
+
+	registered := m.Targets[targetGroupArn]
+
+	if len(targets) == 0 {
+		out := make([]TargetDescription, 0, len(registered))
+		for _, t := range registered {
+			out = append(out, TargetDescription{Target: t, HealthState: "healthy"})
+		}
+
+		return out, nil
+	}
+
+	out := make([]TargetDescription, 0, len(targets))
+
+	for _, want := range targets {
+		state := "unused"
+
+		for _, t := range registered {
+			if t.ID == want.ID && (want.Port == 0 || t.Port == want.Port) {
+				state = "healthy"
+
+				break
+			}
+		}
+
+		out = append(out, TargetDescription{Target: want, HealthState: state})
+	}
+
+	return out, nil
 }

--- a/internal/service/elbv2/types.go
+++ b/internal/service/elbv2/types.go
@@ -594,3 +594,67 @@ type XMLDescribeTargetGroupAttributesResponse struct {
 type XMLDescribeTargetGroupAttributesResult struct {
 	Attributes XMLAttributePairs `xml:"Attributes"`
 }
+
+// XMLDescribeTargetHealthResponse is the XML response for DescribeTargetHealth.
+type XMLDescribeTargetHealthResponse struct {
+	XMLName          xml.Name                      `xml:"DescribeTargetHealthResponse"`
+	Xmlns            string                        `xml:"xmlns,attr"`
+	Result           XMLDescribeTargetHealthResult `xml:"DescribeTargetHealthResult"`
+	ResponseMetadata XMLResponseMetadata           `xml:"ResponseMetadata"`
+}
+
+// XMLDescribeTargetHealthResult contains the per-target health.
+type XMLDescribeTargetHealthResult struct {
+	TargetHealthDescriptions XMLTargetHealthDescriptions `xml:"TargetHealthDescriptions"`
+}
+
+// XMLTargetHealthDescriptions contains a list of target health descriptions.
+type XMLTargetHealthDescriptions struct {
+	Members []XMLTargetHealthDescription `xml:"member"`
+}
+
+// XMLTargetHealthDescription represents one target's health.
+type XMLTargetHealthDescription struct {
+	Target       XMLTargetForHealth `xml:"Target"`
+	TargetHealth XMLTargetHealth    `xml:"TargetHealth"`
+}
+
+// XMLTargetForHealth is the Target as wrapped inside a health description.
+type XMLTargetForHealth struct {
+	ID               string `xml:"Id"`
+	Port             int    `xml:"Port"`
+	AvailabilityZone string `xml:"AvailabilityZone,omitempty"`
+}
+
+// XMLTargetHealth represents a target's health state.
+type XMLTargetHealth struct {
+	State       string `xml:"State"`
+	Reason      string `xml:"Reason,omitempty"`
+	Description string `xml:"Description,omitempty"`
+}
+
+// XMLDescribeListenersResponse is the XML response for DescribeListeners.
+type XMLDescribeListenersResponse struct {
+	XMLName          xml.Name                   `xml:"DescribeListenersResponse"`
+	Xmlns            string                     `xml:"xmlns,attr"`
+	Result           XMLDescribeListenersResult `xml:"DescribeListenersResult"`
+	ResponseMetadata XMLResponseMetadata        `xml:"ResponseMetadata"`
+}
+
+// XMLDescribeListenersResult contains the listed listeners.
+type XMLDescribeListenersResult struct {
+	Listeners XMLListeners `xml:"Listeners"`
+}
+
+// XMLModifyListenerResponse is the XML response for ModifyListener.
+type XMLModifyListenerResponse struct {
+	XMLName          xml.Name                `xml:"ModifyListenerResponse"`
+	Xmlns            string                  `xml:"xmlns,attr"`
+	Result           XMLModifyListenerResult `xml:"ModifyListenerResult"`
+	ResponseMetadata XMLResponseMetadata     `xml:"ResponseMetadata"`
+}
+
+// XMLModifyListenerResult contains the modified listener.
+type XMLModifyListenerResult struct {
+	Listeners XMLListeners `xml:"Listeners"`
+}

--- a/test/integration/elbv2_test.go
+++ b/test/integration/elbv2_test.go
@@ -632,3 +632,148 @@ func lookupTGAttr(attrs []types.TargetGroupAttribute, key string) string {
 
 	return ""
 }
+
+func TestELBv2_DescribeListenersAndModify(t *testing.T) {
+	client := newELBv2Client(t)
+	ctx := t.Context()
+
+	lbRes, err := client.CreateLoadBalancer(ctx, &elasticloadbalancingv2.CreateLoadBalancerInput{
+		Name:    aws.String("listener-mod-lb"),
+		Subnets: []string{"subnet-aaaa1111"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	lbArn := lbRes.LoadBalancers[0].LoadBalancerArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteLoadBalancer(context.Background(), &elasticloadbalancingv2.DeleteLoadBalancerInput{
+			LoadBalancerArn: lbArn,
+		})
+	})
+
+	tgRes, err := client.CreateTargetGroup(ctx, &elasticloadbalancingv2.CreateTargetGroupInput{
+		Name:     aws.String("listener-mod-tg"),
+		Protocol: types.ProtocolEnumHttp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-x"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgArn := tgRes.TargetGroups[0].TargetGroupArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTargetGroup(context.Background(), &elasticloadbalancingv2.DeleteTargetGroupInput{
+			TargetGroupArn: tgArn,
+		})
+	})
+
+	listenerRes, err := client.CreateListener(ctx, &elasticloadbalancingv2.CreateListenerInput{
+		LoadBalancerArn: lbArn,
+		Protocol:        types.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []types.Action{
+			{Type: types.ActionTypeEnumForward, TargetGroupArn: tgArn},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	listenerArn := listenerRes.Listeners[0].ListenerArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteListener(context.Background(), &elasticloadbalancingv2.DeleteListenerInput{
+			ListenerArn: listenerArn,
+		})
+	})
+
+	descRes, err := client.DescribeListeners(ctx, &elasticloadbalancingv2.DescribeListenersInput{
+		LoadBalancerArn: lbArn,
+	})
+	if err != nil {
+		t.Fatalf("DescribeListeners: %v", err)
+	}
+
+	if got := len(descRes.Listeners); got != 1 {
+		t.Errorf("DescribeListeners returned %d listeners, want 1", got)
+	}
+
+	if _, err := client.ModifyListener(ctx, &elasticloadbalancingv2.ModifyListenerInput{
+		ListenerArn: listenerArn,
+		Port:        aws.Int32(8080),
+	}); err != nil {
+		t.Fatalf("ModifyListener: %v", err)
+	}
+
+	descAfter, err := client.DescribeListeners(ctx, &elasticloadbalancingv2.DescribeListenersInput{
+		ListenerArns: []string{*listenerArn},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := *descAfter.Listeners[0].Port; got != 8080 {
+		t.Errorf("after Modify, listener.Port = %d, want 8080", got)
+	}
+}
+
+func TestELBv2_DescribeTargetHealth(t *testing.T) {
+	client := newELBv2Client(t)
+	ctx := t.Context()
+
+	tgRes, err := client.CreateTargetGroup(ctx, &elasticloadbalancingv2.CreateTargetGroupInput{
+		Name:     aws.String("health-test-tg"),
+		Protocol: types.ProtocolEnumHttp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-x"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgArn := tgRes.TargetGroups[0].TargetGroupArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTargetGroup(context.Background(), &elasticloadbalancingv2.DeleteTargetGroupInput{
+			TargetGroupArn: tgArn,
+		})
+	})
+
+	// On a freshly-created target group with no registered targets, the
+	// unfiltered call returns an empty list.
+	healthRes, err := client.DescribeTargetHealth(ctx, &elasticloadbalancingv2.DescribeTargetHealthInput{
+		TargetGroupArn: tgArn,
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth: %v", err)
+	}
+
+	if got := len(healthRes.TargetHealthDescriptions); got != 0 {
+		t.Errorf("on empty target group, DescribeTargetHealth returned %d entries, want 0", got)
+	}
+
+	// A request with explicit Targets returns one entry per requested target,
+	// reporting "unused" for any target that is not currently registered. This
+	// matches AWS behavior for the read-side query.
+	healthFiltered, err := client.DescribeTargetHealth(ctx, &elasticloadbalancingv2.DescribeTargetHealthInput{
+		TargetGroupArn: tgArn,
+		Targets: []types.TargetDescription{
+			{Id: aws.String("10.0.0.99"), Port: aws.Int32(80)},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := len(healthFiltered.TargetHealthDescriptions); got != 1 {
+		t.Fatalf("filtered DescribeTargetHealth returned %d entries, want 1", got)
+	}
+
+	if got := string(healthFiltered.TargetHealthDescriptions[0].TargetHealth.State); got != "unused" {
+		t.Errorf("non-registered target state = %q, want unused", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds three read/update operations the AWS ELBv2 SDK relies on once a listener and target group are in place:

| Action | Notes |
|---|---|
| \`DescribeListeners\` | By \`ListenerArns\` list or by parent \`LoadBalancerArn\`. |
| \`ModifyListener\` | Replaces \`Port\` / \`Protocol\` / \`DefaultActions\` on an existing listener. Zero / empty / nil means "leave as-is", matching AWS one-attribute-per-call style. |
| \`DescribeTargetHealth\` | Per-target state lookup. Reports \`healthy\` for registered targets and \`unused\` for explicit \`Targets\` filter entries that name a target not currently registered. |

Without \`DescribeListeners\` and \`DescribeTargetHealth\`, any client that does state read-back after Create / Register hits \`InvalidAction\`. Without \`ModifyListener\`, any client that changes a listener attribute (e.g. switching the default action to a new target group as part of a rollout) cannot do so via the emulator.

## Behavior alignment with AWS

- kumo does not run real health checks, so registered targets are always reported \`healthy\`. The state machine for transient \`initial\` / \`draining\` / \`unhealthy\` is intentionally not modeled.
- The \`Targets\` filter on \`DescribeTargetHealth\` is honored: an explicit query for a non-registered target returns one description with state \`unused\`, mirroring AWS behavior for "is this target known to me?" probes.
- \`ModifyListener\` does not synthesize a \`Reason\`/\`Description\` on the listener state; the listener stays in the same state code AWS uses for active listeners.

## Form parsing

Form parsers for \`Targets.member.N.{Id,Port,AvailabilityZone}\`, \`DefaultActions.member.N.{Type,TargetGroupArn,Order}\`, and \`ListenerArns.member.N\` live alongside the existing tag/filter helpers in \`handlers.go\`. No change to the generic Query dispatcher.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestELBv2_*\` integration tests still pass
- [x] New \`TestELBv2_DescribeListenersAndModify\` exercises Describe → Modify (port change) → Describe by ARN list, asserting the new port persists
- [x] New \`TestELBv2_DescribeTargetHealth\` asserts an empty list on a fresh target group, and \`unused\` on a request for an unknown target

## Note

\`RegisterTargets\` uses the existing JSON-converted body path, which does not currently parse the \`Targets.member.N.{Id,Port}\` Query-protocol form correctly. That is a separate pre-existing issue and is out of scope here. The new test for \`DescribeTargetHealth\` therefore verifies the empty / filtered paths rather than the round-trip "register N targets, then describe and assert N" path.