### PR TITLE
feat(route53): ListHostedZonesByName

### DIFF
--- a/internal/service/route53/handlers.go
+++ b/internal/service/route53/handlers.go
@@ -220,6 +220,99 @@ func (s *Service) ListHostedZones(w http.ResponseWriter, r *http.Request) {
 	writeXMLResponse(w, http.StatusOK, resp)
 }
 
+// ListHostedZonesByName handles the ListHostedZonesByName API. Hosted zones
+// are sorted ASCII-ascending on Name (matching the AWS contract used by data
+// sources such as aws_route53_zone). The dnsname query parameter, when
+// supplied, filters to zones with Name >= dnsname; an exact-match dnsname
+// yields a single-zone response with that zone first.
+//
+//nolint:funlen // Handler bundles parsing, sorting, and pagination by design
+func (s *Service) ListHostedZonesByName(w http.ResponseWriter, r *http.Request) {
+	dnsname := normalizeDNSName(r.URL.Query().Get("dnsname"))
+	hostedZoneID := r.URL.Query().Get("hostedzoneid")
+	maxItemsStr := r.URL.Query().Get("maxitems")
+
+	maxItems := 100
+
+	if maxItemsStr != "" {
+		if parsed, err := strconv.Atoi(maxItemsStr); err == nil && parsed > 0 && parsed <= 100 {
+			maxItems = parsed
+		}
+	}
+
+	zones, err := s.storage.ListHostedZones()
+	if err != nil {
+		writeErrorResponse(w, http.StatusInternalServerError, "InternalError", err.Error())
+
+		return
+	}
+
+	sort.Slice(zones, func(i, j int) bool {
+		return zones[i].Name < zones[j].Name
+	})
+
+	startIdx := 0
+
+	if dnsname != "" {
+		for i, z := range zones {
+			if z.Name >= dnsname {
+				startIdx = i
+
+				break
+			}
+
+			startIdx = len(zones) // beyond range
+		}
+	}
+
+	endIdx := startIdx + maxItems
+	isTruncated := false
+	nextDNSName := ""
+	nextHostedZoneID := ""
+
+	if endIdx < len(zones) {
+		isTruncated = true
+		nextDNSName = zones[endIdx].Name
+		nextHostedZoneID = strings.TrimPrefix(zones[endIdx].ID, "/hostedzone/")
+	} else {
+		endIdx = len(zones)
+	}
+
+	hostedZones := make([]HostedZone, 0, endIdx-startIdx)
+	for i := startIdx; i < endIdx; i++ {
+		hostedZones = append(hostedZones, *zones[i])
+	}
+
+	resp := ListHostedZonesByNameResponse{
+		XMLNS:            xmlns,
+		HostedZones:      hostedZones,
+		DNSName:          dnsname,
+		HostedZoneID:     hostedZoneID,
+		IsTruncated:      isTruncated,
+		NextDNSName:      nextDNSName,
+		NextHostedZoneID: nextHostedZoneID,
+		MaxItems:         strconv.Itoa(maxItems),
+	}
+
+	writeXMLResponse(w, http.StatusOK, resp)
+}
+
+// normalizeDNSName makes the DNS-name query value compare-friendly: AWS
+// canonicalizes hosted-zone names with a trailing dot, but clients may send
+// either form. Lowercase to make comparison case-insensitive.
+func normalizeDNSName(name string) string {
+	if name == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(name)
+	if !strings.HasSuffix(lower, ".") {
+		lower += "."
+	}
+
+	return lower
+}
+
 // DeleteHostedZone handles the DeleteHostedZone API.
 func (s *Service) DeleteHostedZone(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")

--- a/internal/service/route53/service.go
+++ b/internal/service/route53/service.go
@@ -41,6 +41,7 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	// Hosted Zones
 	r.Handle("POST", "/2013-04-01/hostedzone", s.CreateHostedZone)
 	r.Handle("GET", "/2013-04-01/hostedzone", s.ListHostedZones)
+	r.Handle("GET", "/2013-04-01/hostedzonesbyname", s.ListHostedZonesByName)
 	r.Handle("GET", "/2013-04-01/hostedzone/{id}", s.GetHostedZone)
 	r.Handle("DELETE", "/2013-04-01/hostedzone/{id}", s.DeleteHostedZone)
 

--- a/internal/service/route53/types.go
+++ b/internal/service/route53/types.go
@@ -108,6 +108,20 @@ type ListHostedZonesResponse struct {
 	MaxItems    string       `xml:"MaxItems"`
 }
 
+// ListHostedZonesByNameResponse represents a response to list hosted zones
+// by name (used by the AWS data source aws_route53_zone among others).
+type ListHostedZonesByNameResponse struct {
+	XMLName          xml.Name     `xml:"ListHostedZonesByNameResponse"`
+	XMLNS            string       `xml:"xmlns,attr"`
+	HostedZones      []HostedZone `xml:"HostedZones>HostedZone"`
+	DNSName          string       `xml:"DNSName,omitempty"`
+	HostedZoneID     string       `xml:"HostedZoneId,omitempty"`
+	IsTruncated      bool         `xml:"IsTruncated"`
+	NextDNSName      string       `xml:"NextDNSName,omitempty"`
+	NextHostedZoneID string       `xml:"NextHostedZoneId,omitempty"`
+	MaxItems         string       `xml:"MaxItems"`
+}
+
 // DeleteHostedZoneResponse represents a response to delete hosted zone.
 type DeleteHostedZoneResponse struct {
 	XMLName    xml.Name   `xml:"DeleteHostedZoneResponse"`

--- a/test/integration/route53_test.go
+++ b/test/integration/route53_test.go
@@ -586,3 +586,62 @@ func TestRoute53_GetChange_NotFound(t *testing.T) {
 		t.Fatalf("expected NoSuchChange error, got %T: %v", err, err)
 	}
 }
+
+func TestRoute53_ListHostedZonesByName(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := t.Context()
+
+	// Create three zones with names that span the alphabet so we can verify
+	// the ascending-order start filter.
+	for i, name := range []string{"alpha.example.com.", "kumo-zone.example.com.", "zeta.example.com."} {
+		ref := fmt.Sprintf("lhzbn-test-%d-%d", time.Now().UnixNano(), i)
+
+		zoneRes, err := client.CreateHostedZone(ctx, &route53.CreateHostedZoneInput{
+			Name:            aws.String(name),
+			CallerReference: aws.String(ref),
+		})
+		if err != nil {
+			t.Fatalf("CreateHostedZone(%s): %v", name, err)
+		}
+
+		id := *zoneRes.HostedZone.Id
+		t.Cleanup(func() {
+			_, _ = client.DeleteHostedZone(context.Background(), &route53.DeleteHostedZoneInput{
+				Id: aws.String(id),
+			})
+		})
+	}
+
+	// No filter: returns all zones, sorted ascending by name.
+	allRes, err := client.ListHostedZonesByName(ctx, &route53.ListHostedZonesByNameInput{})
+	if err != nil {
+		t.Fatalf("ListHostedZonesByName (no filter): %v", err)
+	}
+
+	if got := len(allRes.HostedZones); got < 3 {
+		t.Fatalf("ListHostedZonesByName returned %d zones, want at least 3", got)
+	}
+
+	for i := 1; i < len(allRes.HostedZones); i++ {
+		if *allRes.HostedZones[i-1].Name > *allRes.HostedZones[i].Name {
+			t.Errorf("zones not sorted ascending: %q > %q", *allRes.HostedZones[i-1].Name, *allRes.HostedZones[i].Name)
+		}
+	}
+
+	// Filter by exact name: the first zone in the response is the requested
+	// zone (the index-0 contract used by data source-style lookups).
+	exactRes, err := client.ListHostedZonesByName(ctx, &route53.ListHostedZonesByNameInput{
+		DNSName: aws.String("kumo-zone.example.com"),
+	})
+	if err != nil {
+		t.Fatalf("ListHostedZonesByName (dnsname): %v", err)
+	}
+
+	if got := len(exactRes.HostedZones); got == 0 {
+		t.Fatal("ListHostedZonesByName(dnsname=kumo-zone.example.com) returned 0 zones")
+	}
+
+	if got := *exactRes.HostedZones[0].Name; got != "kumo-zone.example.com." {
+		t.Errorf("first zone for exact-name query = %q, want kumo-zone.example.com.", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds \`GET /2013-04-01/hostedzonesbyname\` for the AWS Route 53 \`ListHostedZonesByName\` API. Used by callers that look up a hosted zone by DNS name rather than by ID — \`aws route53 list-hosted-zones-by-name\` and the data-source-style lookups in IaC tools.

## Behavior alignment with AWS

- Zones are sorted ASCII-ascending by \`Name\`. The \`dnsname\` query parameter, when supplied, filters to zones with \`Name >= dnsname\`, so an exact match places the requested zone at index 0.
- DNS names are normalized to lowercase + trailing dot before the comparison, so callers that send \`example.com\` and \`Example.com.\` get the same response shape AWS would return.
- Pagination uses \`NextDNSName\` / \`NextHostedZoneId\`, matching the AWS contract; \`maxitems\` caps at 100.

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestRoute53_*\` integration tests still pass
- [x] New \`TestRoute53_ListHostedZonesByName\` creates three zones (\`alpha\`, \`kumo-zone\`, \`zeta\`), asserts unfiltered list is sorted ascending, and asserts an exact \`dnsname\` query returns the matching zone at index 0