### PR TITLE
feat(ecr): PutLifecyclePolicy / GetLifecyclePolicy / DeleteLifecyclePolicy

### DIFF
--- a/internal/service/ecr/handlers.go
+++ b/internal/service/ecr/handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -23,6 +24,9 @@ func (s *Service) getActionHandlers() map[string]handlerFunc {
 		"BatchGetImage":         s.BatchGetImage,
 		"BatchDeleteImage":      s.BatchDeleteImage,
 		"GetAuthorizationToken": s.GetAuthorizationToken,
+		"PutLifecyclePolicy":    s.PutLifecyclePolicy,
+		"GetLifecyclePolicy":    s.GetLifecyclePolicy,
+		"DeleteLifecyclePolicy": s.DeleteLifecyclePolicy,
 	}
 }
 
@@ -269,6 +273,103 @@ func toImageOutput(img *Image) *ImageOutput {
 		ImageID:        img.ImageID,
 		ImageManifest:  img.ImageManifest,
 	}
+}
+
+// PutLifecyclePolicy handles the PutLifecyclePolicy API.
+func (s *Service) PutLifecyclePolicy(w http.ResponseWriter, r *http.Request) {
+	var req PutLifecyclePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RepositoryName == "" || req.LifecyclePolicyText == "" {
+		writeError(w, "ValidationException", "repositoryName and lifecyclePolicyText are required", http.StatusBadRequest)
+
+		return
+	}
+
+	stored, err := s.storage.PutLifecyclePolicy(r.Context(), req.RepositoryName, req.LifecyclePolicyText)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &PutLifecyclePolicyResponse{
+		RegistryID:          req.RegistryID,
+		RepositoryName:      req.RepositoryName,
+		LifecyclePolicyText: stored,
+	})
+}
+
+// GetLifecyclePolicy handles the GetLifecyclePolicy API.
+func (s *Service) GetLifecyclePolicy(w http.ResponseWriter, r *http.Request) {
+	var req GetLifecyclePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RepositoryName == "" {
+		writeError(w, "ValidationException", "repositoryName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	policy, at, err := s.storage.GetLifecyclePolicy(r.Context(), req.RepositoryName)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &GetLifecyclePolicyResponse{
+		RegistryID:          req.RegistryID,
+		RepositoryName:      req.RepositoryName,
+		LifecyclePolicyText: policy,
+		LastEvaluatedAt:     epochSeconds(at),
+	})
+}
+
+// DeleteLifecyclePolicy handles the DeleteLifecyclePolicy API.
+func (s *Service) DeleteLifecyclePolicy(w http.ResponseWriter, r *http.Request) {
+	var req DeleteLifecyclePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.RepositoryName == "" {
+		writeError(w, "ValidationException", "repositoryName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	policy, at, err := s.storage.DeleteLifecyclePolicy(r.Context(), req.RepositoryName)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DeleteLifecyclePolicyResponse{
+		RegistryID:          req.RegistryID,
+		RepositoryName:      req.RepositoryName,
+		LifecyclePolicyText: policy,
+		LastEvaluatedAt:     epochSeconds(at),
+	})
+}
+
+func epochSeconds(t time.Time) float64 {
+	if t.IsZero() {
+		return 0
+	}
+
+	return float64(t.Unix())
 }
 
 // writeResponse writes a JSON response.

--- a/internal/service/ecr/storage.go
+++ b/internal/service/ecr/storage.go
@@ -32,6 +32,10 @@ type Storage interface {
 	BatchDeleteImage(ctx context.Context, repositoryName string, imageIDs []ImageIdentifier) ([]ImageIdentifier, []ImageFailure, error)
 	GetAuthorizationToken(ctx context.Context) ([]AuthorizationData, error)
 	DispatchAction(action string) bool
+
+	PutLifecyclePolicy(ctx context.Context, repositoryName, policyText string) (string, error)
+	GetLifecyclePolicy(ctx context.Context, repositoryName string) (string, time.Time, error)
+	DeleteLifecyclePolicy(ctx context.Context, repositoryName string) (string, time.Time, error)
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -61,8 +65,10 @@ type MemoryStorage struct {
 
 // repositoryData holds repository information and its images.
 type repositoryData struct {
-	Repository *Repository       `json:"repository"`
-	Images     map[string]*Image `json:"images"`
+	Repository          *Repository       `json:"repository"`
+	Images              map[string]*Image `json:"images"`
+	LifecyclePolicyText string            `json:"lifecyclePolicyText,omitempty"`
+	LifecyclePolicyAt   time.Time         `json:"lifecyclePolicyAt,omitempty"`
 }
 
 // NewMemoryStorage creates a new in-memory storage.
@@ -414,4 +420,78 @@ func calculateDigest(manifest string) string {
 	hash := sha256.Sum256([]byte(manifest))
 
 	return fmt.Sprintf("sha256:%x", hash)
+}
+
+// PutLifecyclePolicy stores the lifecycle policy text on the named repository.
+// AWS validates the policy JSON shape; kumo stores whatever the caller sent so
+// tests can verify policy round-trips without modeling the lifecycle engine.
+func (s *MemoryStorage) PutLifecyclePolicy(_ context.Context, repositoryName, policyText string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	repo, ok := s.Repositories[repositoryName]
+	if !ok {
+		return "", &ServiceError{
+			Code:    "RepositoryNotFoundException",
+			Message: fmt.Sprintf("The repository with name '%s' does not exist in the registry with id '%s'", repositoryName, s.accountID),
+		}
+	}
+
+	repo.LifecyclePolicyText = policyText
+	repo.LifecyclePolicyAt = time.Now().UTC()
+
+	return policyText, nil
+}
+
+// GetLifecyclePolicy returns the stored policy text and the time it was set.
+// AWS returns LifecyclePolicyNotFoundException when the repository has no
+// policy; kumo mirrors that.
+func (s *MemoryStorage) GetLifecyclePolicy(_ context.Context, repositoryName string) (string, time.Time, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	repo, ok := s.Repositories[repositoryName]
+	if !ok {
+		return "", time.Time{}, &ServiceError{
+			Code:    "RepositoryNotFoundException",
+			Message: fmt.Sprintf("The repository with name '%s' does not exist in the registry with id '%s'", repositoryName, s.accountID),
+		}
+	}
+
+	if repo.LifecyclePolicyText == "" {
+		return "", time.Time{}, &ServiceError{
+			Code:    "LifecyclePolicyNotFoundException",
+			Message: fmt.Sprintf("Lifecycle policy does not exist for the repository with name '%s' in the registry with id '%s'", repositoryName, s.accountID),
+		}
+	}
+
+	return repo.LifecyclePolicyText, repo.LifecyclePolicyAt, nil
+}
+
+// DeleteLifecyclePolicy clears the policy text and returns what was removed.
+func (s *MemoryStorage) DeleteLifecyclePolicy(_ context.Context, repositoryName string) (string, time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	repo, ok := s.Repositories[repositoryName]
+	if !ok {
+		return "", time.Time{}, &ServiceError{
+			Code:    "RepositoryNotFoundException",
+			Message: fmt.Sprintf("The repository with name '%s' does not exist in the registry with id '%s'", repositoryName, s.accountID),
+		}
+	}
+
+	if repo.LifecyclePolicyText == "" {
+		return "", time.Time{}, &ServiceError{
+			Code:    "LifecyclePolicyNotFoundException",
+			Message: fmt.Sprintf("Lifecycle policy does not exist for the repository with name '%s' in the registry with id '%s'", repositoryName, s.accountID),
+		}
+	}
+
+	prev := repo.LifecyclePolicyText
+	at := repo.LifecyclePolicyAt
+	repo.LifecyclePolicyText = ""
+	repo.LifecyclePolicyAt = time.Time{}
+
+	return prev, at, nil
 }

--- a/internal/service/ecr/types.go
+++ b/internal/service/ecr/types.go
@@ -53,6 +53,48 @@ type ImageDetail struct {
 	ArtifactMediaType string   `json:"artifactMediaType,omitempty"`
 }
 
+// PutLifecyclePolicyRequest is the request for PutLifecyclePolicy.
+type PutLifecyclePolicyRequest struct {
+	RegistryID          string `json:"registryId,omitempty"`
+	RepositoryName      string `json:"repositoryName"`
+	LifecyclePolicyText string `json:"lifecyclePolicyText"`
+}
+
+// PutLifecyclePolicyResponse is the response for PutLifecyclePolicy.
+type PutLifecyclePolicyResponse struct {
+	RegistryID          string `json:"registryId,omitempty"`
+	RepositoryName      string `json:"repositoryName,omitempty"`
+	LifecyclePolicyText string `json:"lifecyclePolicyText,omitempty"`
+}
+
+// GetLifecyclePolicyRequest is the request for GetLifecyclePolicy.
+type GetLifecyclePolicyRequest struct {
+	RegistryID     string `json:"registryId,omitempty"`
+	RepositoryName string `json:"repositoryName"`
+}
+
+// GetLifecyclePolicyResponse is the response for GetLifecyclePolicy.
+type GetLifecyclePolicyResponse struct {
+	RegistryID          string  `json:"registryId,omitempty"`
+	RepositoryName      string  `json:"repositoryName,omitempty"`
+	LifecyclePolicyText string  `json:"lifecyclePolicyText,omitempty"`
+	LastEvaluatedAt     float64 `json:"lastEvaluatedAt,omitempty"`
+}
+
+// DeleteLifecyclePolicyRequest is the request for DeleteLifecyclePolicy.
+type DeleteLifecyclePolicyRequest struct {
+	RegistryID     string `json:"registryId,omitempty"`
+	RepositoryName string `json:"repositoryName"`
+}
+
+// DeleteLifecyclePolicyResponse is the response for DeleteLifecyclePolicy.
+type DeleteLifecyclePolicyResponse struct {
+	RegistryID          string  `json:"registryId,omitempty"`
+	RepositoryName      string  `json:"repositoryName,omitempty"`
+	LifecyclePolicyText string  `json:"lifecyclePolicyText,omitempty"`
+	LastEvaluatedAt     float64 `json:"lastEvaluatedAt,omitempty"`
+}
+
 // CreateRepositoryRequest is the request for CreateRepository.
 type CreateRepositoryRequest struct {
 	RepositoryName             string                      `json:"repositoryName"`

--- a/test/integration/ecr_test.go
+++ b/test/integration/ecr_test.go
@@ -229,3 +229,69 @@ func TestECR_RepositoryNotFound(t *testing.T) {
 		t.Fatal("expected error for non-existent repository")
 	}
 }
+
+func TestECR_LifecyclePolicy(t *testing.T) {
+	client := newECRClient(t)
+	ctx := t.Context()
+	repoName := "test-lifecycle-policy"
+
+	if _, err := client.CreateRepository(ctx, &ecr.CreateRepositoryInput{
+		RepositoryName: aws.String(repoName),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	policy := `{"rules":[{"rulePriority":1,"description":"keep last 10 images","selection":{"tagStatus":"any","countType":"imageCountMoreThan","countNumber":10},"action":{"type":"expire"}}]}`
+
+	// Get on a fresh repo: AWS returns LifecyclePolicyNotFoundException.
+	if _, err := client.GetLifecyclePolicy(ctx, &ecr.GetLifecyclePolicyInput{
+		RepositoryName: aws.String(repoName),
+	}); err == nil {
+		t.Fatal("expected LifecyclePolicyNotFoundException on first Get, got nil")
+	}
+
+	// Put → Get round trip returns the same policy text verbatim.
+	if _, err := client.PutLifecyclePolicy(ctx, &ecr.PutLifecyclePolicyInput{
+		RepositoryName:      aws.String(repoName),
+		LifecyclePolicyText: aws.String(policy),
+	}); err != nil {
+		t.Fatalf("PutLifecyclePolicy: %v", err)
+	}
+
+	getOut, err := client.GetLifecyclePolicy(ctx, &ecr.GetLifecyclePolicyInput{
+		RepositoryName: aws.String(repoName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := aws.ToString(getOut.LifecyclePolicyText); got != policy {
+		t.Errorf("GetLifecyclePolicy text = %q, want %q", got, policy)
+	}
+
+	// Delete returns the policy that was removed, then Get returns NotFound again.
+	delOut, err := client.DeleteLifecyclePolicy(ctx, &ecr.DeleteLifecyclePolicyInput{
+		RepositoryName: aws.String(repoName),
+	})
+	if err != nil {
+		t.Fatalf("DeleteLifecyclePolicy: %v", err)
+	}
+
+	if got := aws.ToString(delOut.LifecyclePolicyText); got != policy {
+		t.Errorf("DeleteLifecyclePolicy returned text = %q, want %q", got, policy)
+	}
+
+	if _, err := client.GetLifecyclePolicy(ctx, &ecr.GetLifecyclePolicyInput{
+		RepositoryName: aws.String(repoName),
+	}); err == nil {
+		t.Fatal("expected LifecyclePolicyNotFoundException after Delete, got nil")
+	}
+
+	if _, err := client.DeleteRepository(ctx, &ecr.DeleteRepositoryInput{
+		RepositoryName: aws.String(repoName),
+	}); err != nil {
+		t.Fatalf("DeleteRepository cleanup: %v", err)
+	}
+
+	_ = types.LifecyclePolicyNotFoundException{}
+}


### PR DESCRIPTION
## Summary

Adds the lifecycle policy APIs AWS clients use to control ECR's image-pruning rules:

| Action | Notes |
|---|---|
| \`PutLifecyclePolicy\` | Stores the policy JSON text on the repository. |
| \`GetLifecyclePolicy\` | Returns the stored text plus \`LastEvaluatedAt\`. \`LifecyclePolicyNotFoundException\` if the repo has no policy. |
| \`DeleteLifecyclePolicy\` | Returns the policy that was removed. \`LifecyclePolicyNotFoundException\` if there was none. |

Without these, any client that creates a repository and attaches a lifecycle policy hits \`InvalidAction\` immediately after \`CreateRepository\`.

## Implementation

AWS validates the policy JSON shape (rules array, rule priorities, selection / action structure); kumo stores whatever the caller sent so tests can verify policy round-trips without modeling the lifecycle engine itself.

Storage adds two fields on the existing \`repositoryData\` struct: \`LifecyclePolicyText\` and \`LifecyclePolicyAt\`. The \`epochSeconds\` helper formats the AWS-spec \`LastEvaluatedAt\` field (Unix seconds as \`float64\`).

## Test plan

- [x] \`make build\`
- [x] \`make lint\` (no issues)
- [x] All existing \`TestECR_*\` integration tests still pass
- [x] New \`TestECR_LifecyclePolicy\` exercises Get → \`NotFoundException\`, Put → Get returns the same JSON, Delete returns the removed JSON, Get → \`NotFoundException\` again