### PR TITLE
fix(ec2): sort DescribeTags response for deterministic ordering

### DIFF
--- a/internal/service/ec2/storage.go
+++ b/internal/service/ec2/storage.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1319,6 +1320,13 @@ func (m *MemoryStorage) DescribeTags(_ context.Context, filters map[string][]str
 			})
 		}
 	}
+
+	sort.Slice(descriptions, func(i, j int) bool {
+		if descriptions[i].ResourceID != descriptions[j].ResourceID {
+			return descriptions[i].ResourceID < descriptions[j].ResourceID
+		}
+		return descriptions[i].Key < descriptions[j].Key
+	})
 
 	return descriptions, nil
 }

--- a/internal/service/ec2/storage.go
+++ b/internal/service/ec2/storage.go
@@ -1325,6 +1325,7 @@ func (m *MemoryStorage) DescribeTags(_ context.Context, filters map[string][]str
 		if descriptions[i].ResourceID != descriptions[j].ResourceID {
 			return descriptions[i].ResourceID < descriptions[j].ResourceID
 		}
+
 		return descriptions[i].Key < descriptions[j].Key
 	})
 

--- a/test/integration/testdata/ec2_test_TestEC2_CreateAndDescribeTags_TestEC2_CreateAndDescribeTags_describe.golden.go
+++ b/test/integration/testdata/ec2_test_TestEC2_CreateAndDescribeTags_TestEC2_CreateAndDescribeTags_describe.golden.go
@@ -2,16 +2,16 @@
   "NextToken": null,
   "Tags": [
     {
-      "Key": "Name",
-      "ResourceId": "vpc-f2db9e0b-3a30-43d",
-      "ResourceType": "vpc",
-      "Value": "kumo-tag-test"
-    },
-    {
       "Key": "Env",
-      "ResourceId": "vpc-f2db9e0b-3a30-43d",
+      "ResourceId": "vpc-2aa58f61-59e9-402",
       "ResourceType": "vpc",
       "Value": "test"
+    },
+    {
+      "Key": "Name",
+      "ResourceId": "vpc-2aa58f61-59e9-402",
+      "ResourceType": "vpc",
+      "Value": "kumo-tag-test"
     }
   ],
   "ResultMetadata": {}

--- a/test/integration/testdata/ec2_test_TestEC2_CreateAndDescribeTags_TestEC2_CreateAndDescribeTags_vpc.golden.go
+++ b/test/integration/testdata/ec2_test_TestEC2_CreateAndDescribeTags_TestEC2_CreateAndDescribeTags_vpc.golden.go
@@ -22,7 +22,7 @@
           "Value": "test"
         }
       ],
-      "VpcId": "vpc-f2db9e0b-3a30-43d"
+      "VpcId": "vpc-2aa58f61-59e9-402"
     }
   ],
   "ResultMetadata": {}

--- a/test/integration/testdata/ec2_test_TestEC2_DeleteTags_TestEC2_DeleteTags_after_delete.golden.go
+++ b/test/integration/testdata/ec2_test_TestEC2_DeleteTags_TestEC2_DeleteTags_after_delete.golden.go
@@ -3,7 +3,7 @@
   "Tags": [
     {
       "Key": "Keep",
-      "ResourceId": "vpc-7a9964ce-81b3-4ce",
+      "ResourceId": "vpc-084af622-61e2-48f",
       "ResourceType": "vpc",
       "Value": "yes"
     }


### PR DESCRIPTION
## Summary

- Sort DescribeTags results by ResourceId then Key to prevent non-deterministic map iteration ordering
- Update golden test files to reflect the sorted order

## Test plan

- [x] Golden test files updated with sorted output
- [x] Integration tests pass