### PR TITLE
feat(ecr): no-op stubs for ListTagsForResource / TagResource / UntagResource

### DIFF
--- a/internal/service/ecr/handlers.go
+++ b/internal/service/ecr/handlers.go
@@ -27,7 +27,19 @@ func (s *Service) getActionHandlers() map[string]handlerFunc {
 		"PutLifecyclePolicy":    s.PutLifecyclePolicy,
 		"GetLifecyclePolicy":    s.GetLifecyclePolicy,
 		"DeleteLifecyclePolicy": s.DeleteLifecyclePolicy,
+		"ListTagsForResource":   s.tagsNoOp,
+		"TagResource":           s.tagsNoOp,
+		"UntagResource":         s.tagsNoOp,
 	}
+}
+
+// tagsNoOp returns an empty success response. ECR tags are not modeled but
+// AWS SDK clients call ListTagsForResource on every read; returning empty
+// keeps the read path from hitting InvalidAction.
+func (s *Service) tagsNoOp(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(w, struct {
+		Tags []any `json:"tags"`
+	}{Tags: []any{}})
 }
 
 // DispatchAction dispatches the request to the appropriate handler.


### PR DESCRIPTION
## Summary

ECR tags are not modeled today, but AWS SDK clients call `ListTagsForResource` on every repository read. Without that action, any client that reads ECR state back after `CreateRepository` immediately fails with:

\`\`\`
api error InvalidAction: The action ListTagsForResource is not valid for this endpoint
\`\`\`

This adds three tag operations as no-ops:

- `ListTagsForResource` — returns an empty \`tags\` list
- `TagResource` / `UntagResource` — accept the request and return an empty body

The actual tag store can be added later without changing the wire shape.

## Why

This came up while running `terraform-provider-aws` (5.x) end-to-end against kumo: the provider's read path for `aws_ecr_repository` calls `ListTagsForResource` on every refresh, so even a freshly-created repository shows the error above on the very next plan.

## Test plan

- [x] \`go build ./...\` passes
- [x] Existing ECR integration tests still pass
- [ ] Reviewer: confirm the no-op responses match what the AWS SDK expects (empty \`tags\` array, no error)