### PR TITLE
feat(logs): no-op stubs for ListTagsForResource / TagResource / UntagResource

### DIFF
--- a/internal/service/cloudwatchlogs/handlers.go
+++ b/internal/service/cloudwatchlogs/handlers.go
@@ -322,6 +322,12 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 		s.PutRetentionPolicy(w, r)
 	case "DeleteRetentionPolicy":
 		s.DeleteRetentionPolicy(w, r)
+	case "ListTagsForResource", "ListTagsLogGroup",
+		"TagResource", "UntagResource",
+		"TagLogGroup", "UntagLogGroup":
+		// Tags are not modeled; respond as no-op so AWS SDK clients
+		// reading state after CreateLogGroup do not see InvalidAction.
+		writeEmptyResponse(w)
 	default:
 		writeLogsError(w, errInvalidAction, "The action "+action+" is not valid for this web service", http.StatusBadRequest)
 	}


### PR DESCRIPTION
## Summary

CloudWatch Logs tags are not modeled today, but AWS SDK clients call \`ListTagsForResource\` on every log group read. Without that action, any client that reads logs state back after \`CreateLogGroup\` immediately fails with:

\`\`\`
UnrecognizedClientException: The action ListTagsForResource is not valid for this web service
\`\`\`

This adds six tag operations as no-ops, returning an empty response body:

- \`ListTagsForResource\` / \`ListTagsLogGroup\` (legacy)
- \`TagResource\` / \`TagLogGroup\` (legacy)
- \`UntagResource\` / \`UntagLogGroup\` (legacy)

## Why

Caught while running \`terraform-provider-aws\` (5.x) end-to-end against kumo: the provider's read path for \`aws_cloudwatch_log_group\` calls \`ListTagsForResource\` on every refresh, so even a freshly-created log group surfaces the error above on the next plan.

## Test plan

- [x] \`go build ./...\` passes
- [x] Existing CW Logs integration tests still pass
- [ ] Reviewer: confirm the empty-body response satisfies the SDK's expected shape