### PR TITLE
feat(elbv2): empty-payload stubs for read-only metadata APIs

### DIFF
--- a/internal/service/elbv2/handlers.go
+++ b/internal/service/elbv2/handlers.go
@@ -844,9 +844,129 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 		"DescribeListeners":              s.DescribeListeners,
 		"ModifyListener":                 s.ModifyListener,
 		"DescribeTargetHealth":           s.DescribeTargetHealth,
+		"DescribeTags":                   s.DescribeTags,
+		"AddTags":                        s.tagsNoOp,
+		"RemoveTags":                     s.tagsNoOp,
+		"DescribeCapacityReservation":    s.DescribeCapacityReservation,
+		"DescribeListenerAttributes":     s.DescribeListenerAttributes,
+		"ModifyListenerAttributes":       s.DescribeListenerAttributes,
 	}
 
 	return handlers[action]
+}
+
+// xmlDescribeTagsResponse is the wire shape for DescribeTags.
+type xmlDescribeTagsResponse struct {
+	XMLName            xml.Name              `xml:"DescribeTagsResponse"`
+	Xmlns              string                `xml:"xmlns,attr"`
+	DescribeTagsResult xmlDescribeTagsResult `xml:"DescribeTagsResult"`
+	ResponseMetadata   XMLResponseMetadata   `xml:"ResponseMetadata"`
+}
+
+type xmlDescribeTagsResult struct {
+	TagDescriptions xmlTagDescriptions `xml:"TagDescriptions"`
+}
+
+type xmlTagDescriptions struct {
+	Members []xmlTagDescription `xml:"member"`
+}
+
+type xmlTagDescription struct {
+	ResourceArn string          `xml:"ResourceArn"`
+	Tags        xmlEmptyMembers `xml:"Tags"`
+}
+
+type xmlEmptyMembers struct {
+	Members []struct{} `xml:"member"`
+}
+
+// DescribeTags returns empty tag descriptions for each ResourceArn.N. The
+// AWS provider calls this on every read to surface tags to the user; we
+// don't model them yet but must echo the requested ARNs back.
+func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseForm()
+
+	descs := make([]xmlTagDescription, 0)
+
+	for i := 1; ; i++ {
+		key := fmt.Sprintf("ResourceArns.member.%d", i)
+
+		arn := r.Form.Get(key)
+		if arn == "" {
+			break
+		}
+
+		descs = append(descs, xmlTagDescription{ResourceArn: arn})
+	}
+
+	writeELBXMLResponse(w, xmlDescribeTagsResponse{
+		Xmlns:              elbXMLNS,
+		DescribeTagsResult: xmlDescribeTagsResult{TagDescriptions: xmlTagDescriptions{Members: descs}},
+		ResponseMetadata:   XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// xmlDescribeCapacityReservationResponse mirrors the wire shape AWS returns
+// when no capacity reservation is configured.
+type xmlDescribeCapacityReservationResponse struct {
+	XMLName                           xml.Name                     `xml:"DescribeCapacityReservationResponse"`
+	Xmlns                             string                       `xml:"xmlns,attr"`
+	DescribeCapacityReservationResult xmlCapacityReservationResult `xml:"DescribeCapacityReservationResult"`
+	ResponseMetadata                  XMLResponseMetadata          `xml:"ResponseMetadata"`
+}
+
+type xmlCapacityReservationResult struct {
+	LastModifiedTime          string          `xml:"LastModifiedTime,omitempty"`
+	DecreaseRequestsRemaining int             `xml:"DecreaseRequestsRemaining"`
+	CapacityReservationState  xmlEmptyMembers `xml:"CapacityReservationState"`
+}
+
+// DescribeCapacityReservation returns an empty capacity reservation block.
+// The AWS provider reads this on every load balancer read; we don't model
+// reserved capacity, so we omit MinimumLoadBalancerCapacity entirely (a
+// CapacityUnits=0 child block triggers perpetual drift).
+func (s *Service) DescribeCapacityReservation(w http.ResponseWriter, _ *http.Request) {
+	writeELBXMLResponse(w, xmlDescribeCapacityReservationResponse{
+		Xmlns:            elbXMLNS,
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// xmlDescribeListenerAttrResponse is shared by Describe and Modify
+// ListenerAttributes; the wrapping element name differs but the body shape
+// is identical.
+type xmlDescribeListenerAttrResponse struct {
+	XMLName          xml.Name              `xml:"DescribeListenerAttributesResponse"`
+	Xmlns            string                `xml:"xmlns,attr"`
+	Result           xmlListenerAttrResult `xml:"DescribeListenerAttributesResult"`
+	ResponseMetadata XMLResponseMetadata   `xml:"ResponseMetadata"`
+}
+
+type xmlListenerAttrResult struct {
+	Attributes XMLAttributePairs `xml:"Attributes"`
+}
+
+// DescribeListenerAttributes returns an empty attribute set. Listener
+// attributes are not modeled but the AWS provider reads them on every
+// listener refresh.
+func (s *Service) DescribeListenerAttributes(w http.ResponseWriter, _ *http.Request) {
+	writeELBXMLResponse(w, xmlDescribeListenerAttrResponse{
+		Xmlns:            elbXMLNS,
+		Result:           xmlListenerAttrResult{Attributes: XMLAttributePairs{Members: []XMLAttributePair{}}},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// tagsNoOp accepts AddTags / RemoveTags as a no-op success response.
+func (s *Service) tagsNoOp(w http.ResponseWriter, _ *http.Request) {
+	writeELBXMLResponse(w, struct {
+		XMLName          xml.Name            `xml:"AddTagsResponse"`
+		Xmlns            string              `xml:"xmlns,attr"`
+		ResponseMetadata XMLResponseMetadata `xml:"ResponseMetadata"`
+	}{
+		Xmlns:            elbXMLNS,
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
 }
 
 // Helper functions.

--- a/internal/service/elbv2/handlers.go
+++ b/internal/service/elbv2/handlers.go
@@ -845,8 +845,8 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 		"ModifyListener":                 s.ModifyListener,
 		"DescribeTargetHealth":           s.DescribeTargetHealth,
 		"DescribeTags":                   s.DescribeTags,
-		"AddTags":                        s.tagsNoOp,
-		"RemoveTags":                     s.tagsNoOp,
+		"AddTags":                        s.addTagsNoOp,
+		"RemoveTags":                     s.removeTagsNoOp,
 		"DescribeCapacityReservation":    s.DescribeCapacityReservation,
 		"DescribeListenerAttributes":     s.DescribeListenerAttributes,
 		"ModifyListenerAttributes":       s.DescribeListenerAttributes,
@@ -855,38 +855,13 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 	return handlers[action]
 }
 
-// xmlDescribeTagsResponse is the wire shape for DescribeTags.
-type xmlDescribeTagsResponse struct {
-	XMLName            xml.Name              `xml:"DescribeTagsResponse"`
-	Xmlns              string                `xml:"xmlns,attr"`
-	DescribeTagsResult xmlDescribeTagsResult `xml:"DescribeTagsResult"`
-	ResponseMetadata   XMLResponseMetadata   `xml:"ResponseMetadata"`
-}
-
-type xmlDescribeTagsResult struct {
-	TagDescriptions xmlTagDescriptions `xml:"TagDescriptions"`
-}
-
-type xmlTagDescriptions struct {
-	Members []xmlTagDescription `xml:"member"`
-}
-
-type xmlTagDescription struct {
-	ResourceArn string          `xml:"ResourceArn"`
-	Tags        xmlEmptyMembers `xml:"Tags"`
-}
-
-type xmlEmptyMembers struct {
-	Members []struct{} `xml:"member"`
-}
-
 // DescribeTags returns empty tag descriptions for each ResourceArn.N. The
 // AWS provider calls this on every read to surface tags to the user; we
 // don't model them yet but must echo the requested ARNs back.
 func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
 	_ = r.ParseForm()
 
-	descs := make([]xmlTagDescription, 0)
+	descs := make([]XMLTagDescription, 0)
 
 	for i := 1; ; i++ {
 		key := fmt.Sprintf("ResourceArns.member.%d", i)
@@ -896,29 +871,14 @@ func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		descs = append(descs, xmlTagDescription{ResourceArn: arn})
+		descs = append(descs, XMLTagDescription{ResourceArn: arn})
 	}
 
-	writeELBXMLResponse(w, xmlDescribeTagsResponse{
+	writeELBXMLResponse(w, XMLDescribeTagsResponse{
 		Xmlns:              elbXMLNS,
-		DescribeTagsResult: xmlDescribeTagsResult{TagDescriptions: xmlTagDescriptions{Members: descs}},
+		DescribeTagsResult: XMLDescribeTagsResult{TagDescriptions: XMLTagDescriptions{Members: descs}},
 		ResponseMetadata:   XMLResponseMetadata{RequestID: uuid.New().String()},
 	})
-}
-
-// xmlDescribeCapacityReservationResponse mirrors the wire shape AWS returns
-// when no capacity reservation is configured.
-type xmlDescribeCapacityReservationResponse struct {
-	XMLName                           xml.Name                     `xml:"DescribeCapacityReservationResponse"`
-	Xmlns                             string                       `xml:"xmlns,attr"`
-	DescribeCapacityReservationResult xmlCapacityReservationResult `xml:"DescribeCapacityReservationResult"`
-	ResponseMetadata                  XMLResponseMetadata          `xml:"ResponseMetadata"`
-}
-
-type xmlCapacityReservationResult struct {
-	LastModifiedTime          string          `xml:"LastModifiedTime,omitempty"`
-	DecreaseRequestsRemaining int             `xml:"DecreaseRequestsRemaining"`
-	CapacityReservationState  xmlEmptyMembers `xml:"CapacityReservationState"`
 }
 
 // DescribeCapacityReservation returns an empty capacity reservation block.
@@ -926,44 +886,34 @@ type xmlCapacityReservationResult struct {
 // reserved capacity, so we omit MinimumLoadBalancerCapacity entirely (a
 // CapacityUnits=0 child block triggers perpetual drift).
 func (s *Service) DescribeCapacityReservation(w http.ResponseWriter, _ *http.Request) {
-	writeELBXMLResponse(w, xmlDescribeCapacityReservationResponse{
+	writeELBXMLResponse(w, XMLDescribeCapacityReservationResponse{
 		Xmlns:            elbXMLNS,
 		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
 	})
-}
-
-// xmlDescribeListenerAttrResponse is shared by Describe and Modify
-// ListenerAttributes; the wrapping element name differs but the body shape
-// is identical.
-type xmlDescribeListenerAttrResponse struct {
-	XMLName          xml.Name              `xml:"DescribeListenerAttributesResponse"`
-	Xmlns            string                `xml:"xmlns,attr"`
-	Result           xmlListenerAttrResult `xml:"DescribeListenerAttributesResult"`
-	ResponseMetadata XMLResponseMetadata   `xml:"ResponseMetadata"`
-}
-
-type xmlListenerAttrResult struct {
-	Attributes XMLAttributePairs `xml:"Attributes"`
 }
 
 // DescribeListenerAttributes returns an empty attribute set. Listener
 // attributes are not modeled but the AWS provider reads them on every
 // listener refresh.
 func (s *Service) DescribeListenerAttributes(w http.ResponseWriter, _ *http.Request) {
-	writeELBXMLResponse(w, xmlDescribeListenerAttrResponse{
+	writeELBXMLResponse(w, XMLDescribeListenerAttributesResponse{
 		Xmlns:            elbXMLNS,
-		Result:           xmlListenerAttrResult{Attributes: XMLAttributePairs{Members: []XMLAttributePair{}}},
+		Result:           XMLListenerAttributesResult{Attributes: XMLAttributePairs{Members: []XMLAttributePair{}}},
 		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
 	})
 }
 
-// tagsNoOp accepts AddTags / RemoveTags as a no-op success response.
-func (s *Service) tagsNoOp(w http.ResponseWriter, _ *http.Request) {
-	writeELBXMLResponse(w, struct {
-		XMLName          xml.Name            `xml:"AddTagsResponse"`
-		Xmlns            string              `xml:"xmlns,attr"`
-		ResponseMetadata XMLResponseMetadata `xml:"ResponseMetadata"`
-	}{
+// addTagsNoOp accepts AddTags as a no-op success response.
+func (s *Service) addTagsNoOp(w http.ResponseWriter, _ *http.Request) {
+	writeELBXMLResponse(w, XMLAddTagsResponse{
+		Xmlns:            elbXMLNS,
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// removeTagsNoOp accepts RemoveTags as a no-op success response.
+func (s *Service) removeTagsNoOp(w http.ResponseWriter, _ *http.Request) {
+	writeELBXMLResponse(w, XMLRemoveTagsResponse{
 		Xmlns:            elbXMLNS,
 		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
 	})

--- a/internal/service/elbv2/handlers_test.go
+++ b/internal/service/elbv2/handlers_test.go
@@ -1,0 +1,40 @@
+package elbv2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTagNoOpResponsesUseMatchingActionRoot(t *testing.T) {
+	t.Parallel()
+
+	service := New(NewMemoryStorage())
+
+	for _, tc := range []struct {
+		action string
+		root   string
+	}{
+		{action: "AddTags", root: "<AddTagsResponse"},
+		{action: "RemoveTags", root: "<RemoveTagsResponse"},
+	} {
+		t.Run(tc.action, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+			rec := httptest.NewRecorder()
+
+			req.Header.Set("X-Amz-Target", "ElasticLoadBalancing."+tc.action)
+			service.DispatchAction(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+
+			if !strings.Contains(rec.Body.String(), tc.root) {
+				t.Fatalf("response body = %q, want root %s", rec.Body.String(), tc.root)
+			}
+		})
+	}
+}

--- a/internal/service/elbv2/service.go
+++ b/internal/service/elbv2/service.go
@@ -73,10 +73,12 @@ func (s *Service) Actions() []string {
 		"DescribeTargetHealth",
 		"ModifyListener",
 		"DescribeListeners",
-		"github.com/sivchari/kumo/internal/service",
-		"os",
-		"io",
-		"fmt",
+		"DescribeTags",
+		"AddTags",
+		"RemoveTags",
+		"DescribeCapacityReservation",
+		"DescribeListenerAttributes",
+		"ModifyListenerAttributes",
 	}
 }
 

--- a/internal/service/elbv2/types.go
+++ b/internal/service/elbv2/types.go
@@ -658,3 +658,74 @@ type XMLModifyListenerResponse struct {
 type XMLModifyListenerResult struct {
 	Listeners XMLListeners `xml:"Listeners"`
 }
+
+// XMLDescribeTagsResponse is the XML response for DescribeTags.
+type XMLDescribeTagsResponse struct {
+	XMLName            xml.Name              `xml:"DescribeTagsResponse"`
+	Xmlns              string                `xml:"xmlns,attr"`
+	DescribeTagsResult XMLDescribeTagsResult `xml:"DescribeTagsResult"`
+	ResponseMetadata   XMLResponseMetadata   `xml:"ResponseMetadata"`
+}
+
+// XMLDescribeTagsResult contains tag descriptions.
+type XMLDescribeTagsResult struct {
+	TagDescriptions XMLTagDescriptions `xml:"TagDescriptions"`
+}
+
+// XMLTagDescriptions contains a list of tag descriptions.
+type XMLTagDescriptions struct {
+	Members []XMLTagDescription `xml:"member"`
+}
+
+// XMLTagDescription represents tags attached to a resource.
+type XMLTagDescription struct {
+	ResourceArn string          `xml:"ResourceArn"`
+	Tags        XMLEmptyMembers `xml:"Tags"`
+}
+
+// XMLEmptyMembers represents an empty AWS Query member list.
+type XMLEmptyMembers struct {
+	Members []struct{} `xml:"member"`
+}
+
+// XMLDescribeCapacityReservationResponse is the XML response for DescribeCapacityReservation.
+type XMLDescribeCapacityReservationResponse struct {
+	XMLName                           xml.Name                     `xml:"DescribeCapacityReservationResponse"`
+	Xmlns                             string                       `xml:"xmlns,attr"`
+	DescribeCapacityReservationResult XMLCapacityReservationResult `xml:"DescribeCapacityReservationResult"`
+	ResponseMetadata                  XMLResponseMetadata          `xml:"ResponseMetadata"`
+}
+
+// XMLCapacityReservationResult contains capacity reservation metadata.
+type XMLCapacityReservationResult struct {
+	LastModifiedTime          string          `xml:"LastModifiedTime,omitempty"`
+	DecreaseRequestsRemaining int             `xml:"DecreaseRequestsRemaining"`
+	CapacityReservationState  XMLEmptyMembers `xml:"CapacityReservationState"`
+}
+
+// XMLDescribeListenerAttributesResponse is the XML response for DescribeListenerAttributes.
+type XMLDescribeListenerAttributesResponse struct {
+	XMLName          xml.Name                    `xml:"DescribeListenerAttributesResponse"`
+	Xmlns            string                      `xml:"xmlns,attr"`
+	Result           XMLListenerAttributesResult `xml:"DescribeListenerAttributesResult"`
+	ResponseMetadata XMLResponseMetadata         `xml:"ResponseMetadata"`
+}
+
+// XMLListenerAttributesResult contains listener attributes.
+type XMLListenerAttributesResult struct {
+	Attributes XMLAttributePairs `xml:"Attributes"`
+}
+
+// XMLAddTagsResponse is the XML response for AddTags.
+type XMLAddTagsResponse struct {
+	XMLName          xml.Name            `xml:"AddTagsResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata XMLResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// XMLRemoveTagsResponse is the XML response for RemoveTags.
+type XMLRemoveTagsResponse struct {
+	XMLName          xml.Name            `xml:"RemoveTagsResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata XMLResponseMetadata `xml:"ResponseMetadata"`
+}


### PR DESCRIPTION
## Summary

The AWS provider's \`aws_lb\` / \`aws_lb_listener\` / \`aws_lb_target_group\` resources call several metadata APIs on every refresh that kumo does not implement yet. Without them, a freshly-created resource fails its very first read with \`api error UnknownError: UnknownError\` (the SDK's catch-all for InvalidAction-shaped XML errors). In the capacity-reservation case, an under-modeled response surfaces as perpetual drift.

This adds minimal handlers that respond with the AWS-default empty shape:

- \`DescribeTags\` — echoes each requested \`ResourceArn\` back with an empty \`<Tags/>\` child
- \`AddTags\` / \`RemoveTags\` — accept the request and return an empty body
- \`DescribeCapacityReservation\` — returns \`DecreaseRequestsRemaining=0\` and an empty \`CapacityReservationState\`. \`MinimumLoadBalancerCapacity\` is omitted on purpose: emitting it with \`CapacityUnits=0\` triggers perpetual drift in the provider.
- \`DescribeListenerAttributes\` / \`ModifyListenerAttributes\` — empty \`Attributes\` member list (both share the same handler since the wire shapes are identical)

## Why

These are pure wire-level read-path fixes. Tag and capacity state are not modeled by kumo; per-attribute / per-tag behaviour can be added later without changing the wire shape.

Caught while running \`terraform-provider-aws\` (5.x) end-to-end against kumo. With the handlers in place, an ALB lifecycle (\`apply\` → \`plan\` shows no drift → \`destroy\`) completes against kumo without intervention.

## Test plan

- [x] \`go build ./...\` passes
- [x] Existing ELBv2 integration tests still pass
- [ ] Reviewer: confirm the empty-payload shapes match what the SDK expects (especially \`DescribeCapacityReservation\` — see comment about omitting \`MinimumLoadBalancerCapacity\`)