### PR TITLE
fix(elbv2): align listener-rule wire format with AWS (ARN segment + condition typed configs)

### DIFF
--- a/internal/service/elbv2/handlers.go
+++ b/internal/service/elbv2/handlers.go
@@ -776,10 +776,7 @@ func parseRulePrioritiesFromForm(form map[string][]string) map[string]string {
 func convertRuleToXML(rule *Rule) XMLRule {
 	conds := make([]XMLRuleCondition, 0, len(rule.Conditions))
 	for _, c := range rule.Conditions {
-		conds = append(conds, XMLRuleCondition{
-			Field:  c.Field,
-			Values: XMLRuleValues{Members: append([]string(nil), c.Values...)},
-		})
+		conds = append(conds, conditionToXML(c))
 	}
 
 	actions := make([]XMLAction, 0, len(rule.Actions))
@@ -794,6 +791,35 @@ func convertRuleToXML(rule *Rule) XMLRule {
 		Actions:    XMLActions{Members: actions},
 		IsDefault:  rule.IsDefault,
 	}
+}
+
+// conditionToXML serializes one condition with both the legacy Values field
+// and the typed config child the AWS provider expects to be non-nil.
+func conditionToXML(c RuleCondition) XMLRuleCondition {
+	values := XMLRuleValues{Members: append([]string(nil), c.Values...)}
+	cfg := &XMLRuleValuesConfig{Values: values}
+	out := XMLRuleCondition{Field: c.Field, Values: values}
+
+	switch c.Field {
+	case "host-header":
+		out.HostHeaderConfig = cfg
+	case "path-pattern":
+		out.PathPatternConfig = cfg
+	case "http-request-method":
+		out.HTTPRequestMethodConfig = cfg
+	case "source-ip":
+		out.SourceIPConfig = cfg
+	case "http-header":
+		out.HTTPHeaderConfig = &XMLHTTPHeaderConfig{Values: values}
+	case "query-string":
+		// Query-string values are key/value pairs; we don't model the
+		// per-pair structure yet, so emit an empty members list rather
+		// than passing the raw strings through (which would mislead the
+		// SDK into expecting Key/Value children).
+		out.QueryStringConfig = &XMLQueryStringConfig{}
+	}
+
+	return out
 }
 
 func convertRulesToXML(rules []Rule) []XMLRule {

--- a/internal/service/elbv2/storage.go
+++ b/internal/service/elbv2/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -636,8 +637,11 @@ func (m *MemoryStorage) CreateRule(_ context.Context, listenerArn, priority stri
 		return nil, &Error{Code: "ListenerNotFound", Message: "Listener '" + listenerArn + "' not found"}
 	}
 
+	// AWS rule ARNs replace ":listener/" with ":listener-rule/" and append
+	// a unique rule id; reproducing that format keeps the AWS provider's
+	// ARN parser from mis-routing the parent listener ARN.
 	rule := Rule{
-		RuleArn:    listenerArn + "/" + uuidLite(),
+		RuleArn:    ruleArnFromListenerArn(listenerArn) + "/" + uuidLite(),
 		Priority:   priority,
 		Conditions: append([]RuleCondition(nil), conditions...),
 		Actions:    append([]Action(nil), actions...),
@@ -689,7 +693,7 @@ func (m *MemoryStorage) DescribeRules(_ context.Context, listenerArn string, rul
 // alongside explicitly-created rules.
 func defaultRuleFor(listener *Listener) Rule {
 	return Rule{
-		RuleArn:   listener.ListenerArn + "/default",
+		RuleArn:   ruleArnFromListenerArn(listener.ListenerArn) + "/default",
 		Priority:  "default",
 		Actions:   append([]Action(nil), listener.DefaultActions...),
 		IsDefault: true,
@@ -992,4 +996,18 @@ func (m *MemoryStorage) DescribeTargetHealth(_ context.Context, targetGroupArn s
 	}
 
 	return out, nil
+}
+
+// ruleArnFromListenerArn rewrites ":listener/" to ":listener-rule/" so the
+// generated rule ARN matches the AWS-published wire format. Any input that
+// doesn't contain that segment is returned unchanged.
+func ruleArnFromListenerArn(listenerArn string) string {
+	const segment = ":listener/"
+
+	idx := strings.Index(listenerArn, segment)
+	if idx < 0 {
+		return listenerArn
+	}
+
+	return listenerArn[:idx] + ":listener-rule/" + listenerArn[idx+len(segment):]
 }

--- a/internal/service/elbv2/types.go
+++ b/internal/service/elbv2/types.go
@@ -491,15 +491,54 @@ type XMLRuleConditions struct {
 	Members []XMLRuleCondition `xml:"member"`
 }
 
-// XMLRuleCondition represents a condition in XML format.
+// XMLRuleCondition represents a condition in XML format. AWS returns each
+// condition with both the legacy Values element AND a typed config child
+// (PathPatternConfig, HostHeaderConfig, …). The AWS provider dereferences
+// the typed config without nil-checking, so we surface a non-nil pointer
+// for whichever field matches the condition's Field, even when its values
+// are empty.
 type XMLRuleCondition struct {
-	Field  string        `xml:"Field"`
-	Values XMLRuleValues `xml:"Values"`
+	Field                   string                `xml:"Field"`
+	Values                  XMLRuleValues         `xml:"Values"`
+	HostHeaderConfig        *XMLRuleValuesConfig  `xml:"HostHeaderConfig,omitempty"`
+	PathPatternConfig       *XMLRuleValuesConfig  `xml:"PathPatternConfig,omitempty"`
+	HTTPHeaderConfig        *XMLHTTPHeaderConfig  `xml:"HttpHeaderConfig,omitempty"`
+	HTTPRequestMethodConfig *XMLRuleValuesConfig  `xml:"HttpRequestMethodConfig,omitempty"`
+	QueryStringConfig       *XMLQueryStringConfig `xml:"QueryStringConfig,omitempty"`
+	SourceIPConfig          *XMLRuleValuesConfig  `xml:"SourceIpConfig,omitempty"`
 }
 
 // XMLRuleValues contains a list of values for a condition.
 type XMLRuleValues struct {
 	Members []string `xml:"member"`
+}
+
+// XMLRuleValuesConfig is the typed value-list wrapper used by the
+// host-header / path-pattern / http-request-method / source-ip configs.
+type XMLRuleValuesConfig struct {
+	Values XMLRuleValues `xml:"Values"`
+}
+
+// XMLHTTPHeaderConfig is the typed config for http-header conditions.
+type XMLHTTPHeaderConfig struct {
+	HTTPHeaderName string        `xml:"HttpHeaderName"`
+	Values         XMLRuleValues `xml:"Values"`
+}
+
+// XMLQueryStringConfig is the typed config for query-string conditions.
+type XMLQueryStringConfig struct {
+	Values XMLQueryStringKVPairs `xml:"Values"`
+}
+
+// XMLQueryStringKVPairs holds the key/value pairs for a query-string match.
+type XMLQueryStringKVPairs struct {
+	Members []XMLQueryStringKV `xml:"member"`
+}
+
+// XMLQueryStringKV is one key=value pair in a query-string condition.
+type XMLQueryStringKV struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
 }
 
 // XMLResponseMetadata contains response metadata.


### PR DESCRIPTION
## Summary

Two listener-rule wire-shape mismatches that make the AWS provider's \`aws_lb_listener_rule\` resource crash on the very first read after \`CreateRule\`:

### 1. Rule ARN segment

AWS rule ARNs use the \`:listener-rule/\` segment, not \`:listener/\`:

\`\`\`
arn:aws:elasticloadbalancing:us-east-1:123:listener-rule/app/<lb>/<lb-id>/<listener-id>/<rule-id>
\`\`\`

The provider parses the rule ARN to derive its parent listener ARN by replacing exactly that segment, so the previous form (\`:listener/.../<rule-id>\`) feeds the parser a malformed parent ARN and downstream calls go to the wrong endpoint.

Added \`ruleArnFromListenerArn\` that does the AWS rewrite, used from \`CreateRule\` and the synthesized default rule.

### 2. Condition typed config children

Each rule condition response carries both the legacy \`<Values>\` element AND a typed config child:

- \`PathPatternConfig\`
- \`HostHeaderConfig\`
- \`HttpHeaderConfig\`
- \`HttpRequestMethodConfig\`
- \`QueryStringConfig\`
- \`SourceIpConfig\`

The AWS provider dereferences the config matching the condition's \`Field\` **without nil-checking**, so omitting it produces a SIGSEGV in \`resourceListenerRuleRead\` (terraform-provider-aws v5.x):

\`\`\`
panic: runtime error: invalid memory address or nil pointer dereference
github.com/hashicorp/terraform-provider-aws/internal/service/elbv2.resourceListenerRuleRead
\`\`\`

The fix surfaces the matching typed config as a non-nil pointer (with empty Values where we don't model the per-pair structure yet), keyed off the condition's \`Field\`. Legacy \`<Values>\` still ships, so SDKs that ignore the typed config keep working.

## Why

With these two changes, \`aws_lb_listener_rule\` lifecycle (create → re-read → modify → destroy) completes against kumo without provider panics. Caught while running terraform-provider-aws (5.x) end-to-end against kumo.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`TestELBv2_ListenerRuleLifecycle\` integration test still passes
- [ ] Reviewer: verify the typed config field tags match what AWS publishes (they're capitalized awkwardly — \`HttpHeaderConfig\` not \`HTTPHeaderConfig\` — to match the wire form exactly)

> Note: \`TestELBv2_CreateAndDeleteListener\` fails on this branch but **also fails on plain \`upstream/main\`** for an unrelated reason (the golden file does not match what the current CreateListener handler produces). It is not caused by this PR.