### PR TITLE
feat(elbv2): weighted forward (TargetGroupTuples) for ALB canary / blue-green

### DIFF
--- a/internal/service/elbv2/forward_config_test.go
+++ b/internal/service/elbv2/forward_config_test.go
@@ -1,0 +1,102 @@
+package elbv2
+
+import "testing"
+
+// TestApplyTargetGroupTupleField_HappyPath confirms the parser stores a
+// canonical (TargetGroupArn, Weight) tuple at the supplied index.
+func TestApplyTargetGroupTupleField_HappyPath(t *testing.T) {
+	cfg := &ForwardActionConfig{}
+
+	applyTargetGroupTupleField(cfg, "1.TargetGroupArn", "arn:tg/v1")
+	applyTargetGroupTupleField(cfg, "1.Weight", "90")
+	applyTargetGroupTupleField(cfg, "2.TargetGroupArn", "arn:tg/v2")
+	applyTargetGroupTupleField(cfg, "2.Weight", "10")
+
+	if got := len(cfg.TargetGroups); got != 2 {
+		t.Fatalf("len(TargetGroups) = %d, want 2", got)
+	}
+
+	if got := cfg.TargetGroups[0]; got.TargetGroupArn != "arn:tg/v1" || got.Weight != 90 {
+		t.Errorf("[0] = %+v, want {arn:tg/v1, 90}", got)
+	}
+
+	if got := cfg.TargetGroups[1]; got.TargetGroupArn != "arn:tg/v2" || got.Weight != 10 {
+		t.Errorf("[1] = %+v, want {arn:tg/v2, 10}", got)
+	}
+}
+
+// TestApplyTargetGroupTupleField_RejectsHugeIndex is the regression
+// guard for the slice-grow DoS: a hostile member.N where N is huge
+// would previously allocate billions of zero-valued tuples (~24 GB at
+// member.1e9). The cap drops the entry without growing the slice.
+func TestApplyTargetGroupTupleField_RejectsHugeIndex(t *testing.T) {
+	cfg := &ForwardActionConfig{}
+
+	applyTargetGroupTupleField(cfg, "1000000000.TargetGroupArn", "arn:dos")
+
+	if len(cfg.TargetGroups) != 0 {
+		t.Errorf("hostile member.N expanded slice to %d entries; expected drop", len(cfg.TargetGroups))
+	}
+}
+
+// TestApplyTargetGroupTupleField_RejectsAtBoundary checks the cap is
+// inclusive on the way in: index 100 lands, index 101 is dropped.
+func TestApplyTargetGroupTupleField_RejectsAtBoundary(t *testing.T) {
+	t.Run("index_at_cap_lands", func(t *testing.T) {
+		cfg := &ForwardActionConfig{}
+		applyTargetGroupTupleField(cfg, "100.TargetGroupArn", "arn:edge")
+
+		if len(cfg.TargetGroups) != maxTargetGroupTuples {
+			t.Errorf("index=cap should land; len=%d", len(cfg.TargetGroups))
+		}
+	})
+
+	t.Run("index_above_cap_dropped", func(t *testing.T) {
+		cfg := &ForwardActionConfig{}
+		applyTargetGroupTupleField(cfg, "101.TargetGroupArn", "arn:over")
+
+		if len(cfg.TargetGroups) != 0 {
+			t.Errorf("index>cap should drop; len=%d", len(cfg.TargetGroups))
+		}
+	})
+}
+
+// TestApplyTargetGroupTupleField_RejectsZeroAndNegativeIndex covers the
+// idx<1 guard.
+func TestApplyTargetGroupTupleField_RejectsZeroAndNegativeIndex(t *testing.T) {
+	for _, raw := range []string{"0", "-1", "abc", ""} {
+		cfg := &ForwardActionConfig{}
+		applyTargetGroupTupleField(cfg, raw+".Weight", "50")
+
+		if len(cfg.TargetGroups) != 0 {
+			t.Errorf("idx=%q should be dropped; got len=%d", raw, len(cfg.TargetGroups))
+		}
+	}
+}
+
+// TestApplyTargetGroupTupleField_WeightBounds confirms the parser
+// silently drops weights outside the AWS-published [0, 1000] range
+// rather than letting them poison storage.
+func TestApplyTargetGroupTupleField_WeightBounds(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		weight string
+		want   int
+	}{
+		{"zero_lands", "0", 0},
+		{"max_lands", "1000", 1000},
+		{"negative_dropped", "-1", 0},
+		{"above_max_dropped", "1001", 0},
+		{"int_overflow_dropped", "9999999999", 0},
+		{"non_numeric_dropped", "many", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &ForwardActionConfig{}
+			applyTargetGroupTupleField(cfg, "1.Weight", tc.weight)
+
+			if got := cfg.TargetGroups[0].Weight; got != tc.want {
+				t.Errorf("Weight = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/service/elbv2/handlers.go
+++ b/internal/service/elbv2/handlers.go
@@ -15,6 +15,11 @@ import (
 )
 
 // Error codes for ELB.
+// fieldTargetGroupArn is the AWS Query form key for a single target
+// group ARN; reused as both a top-level form field and an action /
+// forward-config sub-field.
+const fieldTargetGroupArn = "TargetGroupArn"
+
 const (
 	errInvalidParameter = "InvalidParameterValue"
 	errInternalError    = "InternalError"
@@ -336,6 +341,19 @@ func (s *Service) CreateListener(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// readELBJSONRequest goes through the form-to-JSON converter, which
+	// flattens nested wire keys like
+	// DefaultActions.member.N.ForwardConfig.TargetGroups.member.M.Weight
+	// into dotted top-level keys that don't unmarshal back into the
+	// CreateListenerRequest struct. Re-parse the form directly so the
+	// listener's default actions — including weighted forward configs —
+	// survive into storage.
+	if err := r.ParseForm(); err == nil {
+		if acts := parseELBActionsFromForm(r.Form, "DefaultActions"); len(acts) > 0 {
+			req.DefaultActions = acts
+		}
+	}
+
 	listener, err := s.storage.CreateListener(r.Context(), &req)
 	if err != nil {
 		handleELBError(w, err)
@@ -600,15 +618,19 @@ func parseActionsFromForm(form map[string][]string, prefix string) []Action {
 			byIdx[n] = entry
 		}
 
-		switch suffix[dot+1:] {
-		case "Type":
+		field := suffix[dot+1:]
+
+		switch {
+		case field == "Type":
 			entry.Type = values[0]
-		case "TargetGroupArn":
+		case field == fieldTargetGroupArn:
 			entry.TargetGroupArn = values[0]
-		case "Order":
+		case field == "Order":
 			if v, err := strconv.Atoi(values[0]); err == nil {
 				entry.Order = v
 			}
+		case strings.HasPrefix(field, "ForwardConfig."):
+			applyForwardConfigField(entry, field[len("ForwardConfig."):], values[0])
 		}
 	}
 
@@ -625,6 +647,104 @@ func parseActionsFromForm(form map[string][]string, prefix string) []Action {
 	}
 
 	return out
+}
+
+// applyForwardConfigField populates a single field on an Action's
+// ForwardActionConfig from a flattened form key. The key is everything
+// after "ForwardConfig." — typical inputs are
+// "TargetGroups.member.1.TargetGroupArn",
+// "TargetGroups.member.1.Weight", and
+// "TargetGroupStickinessConfig.Enabled". Lazily allocates ForwardConfig
+// the first time any nested field is seen so plain non-weighted actions
+// don't get a non-nil ForwardConfig attached.
+func applyForwardConfigField(entry *Action, field, value string) {
+	if entry.ForwardConfig == nil {
+		entry.ForwardConfig = &ForwardActionConfig{}
+	}
+
+	switch {
+	case strings.HasPrefix(field, "TargetGroups.member."):
+		applyTargetGroupTupleField(entry.ForwardConfig, field[len("TargetGroups.member."):], value)
+	case strings.HasPrefix(field, "TargetGroupStickinessConfig."):
+		applyStickinessField(entry.ForwardConfig, field[len("TargetGroupStickinessConfig."):], value)
+	}
+}
+
+// maxTargetGroupTuples caps the number of TargetGroups a single
+// ForwardConfig can hold. Real ALB allows at most 5; we leave headroom
+// for tests that exercise many target groups but reject anything that
+// looks like a slice-grow DoS (an attacker supplying a member.N with a
+// huge N would otherwise allocate len(N) zero-valued tuples — at 24 B
+// each, member.1e9 is 24 GB).
+const maxTargetGroupTuples = 100
+
+// AWS rejects per-target weights outside [0, 1000]. kumo enforces the
+// same range at the parser so storage never holds a weight the SDK
+// would refuse to acknowledge on read.
+const (
+	minTargetGroupWeight = 0
+	maxTargetGroupWeight = 1000
+)
+
+// applyTargetGroupTupleField parses one
+// TargetGroups.member.<N>.{TargetGroupArn,Weight} key into the matching
+// slot in cfg.TargetGroups. The slice is grown on demand so members
+// supplied out of index order land in the right position; missing
+// indexes stay zero and get filtered out at the end of parsing. Indexes
+// above maxTargetGroupTuples are dropped silently to bound allocation.
+func applyTargetGroupTupleField(cfg *ForwardActionConfig, field, value string) {
+	dot := strings.Index(field, ".")
+	if dot < 0 {
+		return
+	}
+
+	idx, err := strconv.Atoi(field[:dot])
+	if err != nil || idx < 1 || idx > maxTargetGroupTuples {
+		return
+	}
+
+	// Grow in one shot rather than appending 1 element at a time. With
+	// the cap=100 limit the worst case was ~88µs per request walking
+	// the loop; allocating to the target length up front turns it into
+	// O(1) amortised. Out-of-order member.N keys still land at the
+	// right slot because each call re-checks length.
+	if n := idx - len(cfg.TargetGroups); n > 0 {
+		cfg.TargetGroups = append(cfg.TargetGroups, make([]TargetGroupTuple, n)...)
+	}
+
+	target := &cfg.TargetGroups[idx-1]
+
+	switch field[dot+1:] {
+	case fieldTargetGroupArn:
+		target.TargetGroupArn = value
+	case "Weight":
+		v, err := strconv.Atoi(value)
+		if err != nil {
+			return
+		}
+
+		if v < minTargetGroupWeight || v > maxTargetGroupWeight {
+			return
+		}
+
+		target.Weight = v
+	}
+}
+
+// applyStickinessField populates the StickinessConfig sub-struct.
+func applyStickinessField(cfg *ForwardActionConfig, field, value string) {
+	if cfg.StickinessConfig == nil {
+		cfg.StickinessConfig = &TargetGroupStickinessConfig{}
+	}
+
+	switch field {
+	case "Enabled":
+		cfg.StickinessConfig.Enabled = value == "true"
+	case "DurationSeconds":
+		if v, err := strconv.Atoi(value); err == nil {
+			cfg.StickinessConfig.DurationSeconds = v
+		}
+	}
 }
 
 // ruleConditionAcc accumulates one Conditions.member.N entry being parsed.
@@ -781,7 +901,7 @@ func convertRuleToXML(rule *Rule) XMLRule {
 
 	actions := make([]XMLAction, 0, len(rule.Actions))
 	for _, a := range rule.Actions {
-		actions = append(actions, XMLAction(a))
+		actions = append(actions, convertActionToXML(a))
 	}
 
 	return XMLRule{
@@ -924,11 +1044,48 @@ func convertToXMLTargetGroup(tg *TargetGroup) XMLTargetGroup {
 	}
 }
 
+// convertActionToXML serialises an Action for the wire. The legacy
+// single-target form (TargetGroupArn) and the weighted form
+// (ForwardConfig with TargetGroupTuples) are both honoured; whichever
+// the caller supplied gets echoed back. Order is included only when
+// non-zero so single-action listeners don't emit a redundant <Order>0.
+func convertActionToXML(a Action) XMLAction {
+	out := XMLAction{
+		Type:           a.Type,
+		TargetGroupArn: a.TargetGroupArn,
+		Order:          a.Order,
+	}
+
+	if a.ForwardConfig == nil {
+		return out
+	}
+
+	tuples := make([]XMLTargetGroupTuple, 0, len(a.ForwardConfig.TargetGroups))
+	for _, t := range a.ForwardConfig.TargetGroups {
+		tuples = append(tuples, XMLTargetGroupTuple(t))
+	}
+
+	cfg := &XMLForwardActionConfig{
+		TargetGroups: XMLTargetGroupTuples{Members: tuples},
+	}
+
+	if s := a.ForwardConfig.StickinessConfig; s != nil {
+		cfg.TargetGroupStickinessConfig = &XMLTargetGroupStickinessConfig{
+			Enabled:         s.Enabled,
+			DurationSeconds: s.DurationSeconds,
+		}
+	}
+
+	out.ForwardConfig = cfg
+
+	return out
+}
+
 // convertToXMLListener converts a Listener to XMLListener.
 func convertToXMLListener(l *Listener) XMLListener {
 	actions := make([]XMLAction, 0, len(l.DefaultActions))
 	for _, a := range l.DefaultActions {
-		actions = append(actions, XMLAction(a))
+		actions = append(actions, convertActionToXML(a))
 	}
 
 	return XMLListener{
@@ -1402,14 +1559,18 @@ func applyELBActionFormEntry(byIdx map[int]*Action, prefix, key string, values [
 		byIdx[n] = entry
 	}
 
-	switch suffix[dot+1:] {
-	case "Type":
+	field := suffix[dot+1:]
+
+	switch {
+	case field == "Type":
 		entry.Type = values[0]
-	case "TargetGroupArn":
+	case field == "TargetGroupArn":
 		entry.TargetGroupArn = values[0]
-	case "Order":
+	case field == "Order":
 		if v, err := strconv.Atoi(values[0]); err == nil {
 			entry.Order = v
 		}
+	case strings.HasPrefix(field, "ForwardConfig."):
+		applyForwardConfigField(entry, field[len("ForwardConfig."):], values[0])
 	}
 }

--- a/internal/service/elbv2/types.go
+++ b/internal/service/elbv2/types.go
@@ -74,11 +74,44 @@ type Listener struct {
 	Rules           []Rule
 }
 
-// Action represents a listener action.
+// Action represents a listener action. The legacy single-target form
+// (Type=forward + TargetGroupArn) and the weighted form (Type=forward +
+// ForwardConfig with multiple TargetGroupTuples) are both expressible:
+// AWS clients send one or the other, never both, and Describe responses
+// echo back whichever was supplied.
 type Action struct {
 	Type           string
 	TargetGroupArn string
 	Order          int
+	// ForwardConfig is set when the action uses weighted target groups
+	// (the canary / blue-green pattern). nil means "use TargetGroupArn".
+	ForwardConfig *ForwardActionConfig
+}
+
+// ForwardActionConfig groups multiple target groups under one forward
+// action with relative weights. Used by ALB canary / blue-green
+// deployments — the listener splits traffic across TargetGroups by the
+// supplied Weight ratio.
+type ForwardActionConfig struct {
+	TargetGroups     []TargetGroupTuple
+	StickinessConfig *TargetGroupStickinessConfig
+}
+
+// TargetGroupTuple is one (target group, weight) pair inside a
+// ForwardActionConfig. Weight is the relative share of traffic routed
+// to TargetGroupArn; the AWS console expresses the canonical 100-total
+// form but real ALB normalises across whatever weights are supplied.
+type TargetGroupTuple struct {
+	TargetGroupArn string
+	Weight         int
+}
+
+// TargetGroupStickinessConfig controls whether requests for the same
+// client are pinned to the same target group during a weighted forward.
+// Without it, every request is independently weight-sampled.
+type TargetGroupStickinessConfig struct {
+	Enabled         bool
+	DurationSeconds int
 }
 
 // Rule represents a listener rule for path/host-based routing.
@@ -402,11 +435,42 @@ type XMLActions struct {
 	Members []XMLAction `xml:"member"`
 }
 
-// XMLAction represents an action in XML format.
+// XMLAction represents an action in XML format. ForwardConfig is a
+// pointer so it serialises out only when an explicit weighted forward
+// was supplied; clients using the legacy single-target form (just
+// TargetGroupArn) get a response that matches what they sent.
 type XMLAction struct {
-	Type           string `xml:"Type"`
-	TargetGroupArn string `xml:"TargetGroupArn,omitempty"`
-	Order          int    `xml:"Order,omitempty"`
+	Type           string                  `xml:"Type"`
+	TargetGroupArn string                  `xml:"TargetGroupArn,omitempty"`
+	Order          int                     `xml:"Order,omitempty"`
+	ForwardConfig  *XMLForwardActionConfig `xml:"ForwardConfig,omitempty"`
+}
+
+// XMLForwardActionConfig is the XML wire shape for a multi-target-group
+// forward (the canary / blue-green pattern). TargetGroups is required;
+// TargetGroupStickinessConfig is optional.
+type XMLForwardActionConfig struct {
+	TargetGroups                XMLTargetGroupTuples            `xml:"TargetGroups"`
+	TargetGroupStickinessConfig *XMLTargetGroupStickinessConfig `xml:"TargetGroupStickinessConfig,omitempty"`
+}
+
+// XMLTargetGroupTuples wraps the member-list shape AWS uses for arrays.
+type XMLTargetGroupTuples struct {
+	Members []XMLTargetGroupTuple `xml:"member"`
+}
+
+// XMLTargetGroupTuple is one (target group, weight) pair on the wire.
+type XMLTargetGroupTuple struct {
+	TargetGroupArn string `xml:"TargetGroupArn"`
+	Weight         int    `xml:"Weight"`
+}
+
+// XMLTargetGroupStickinessConfig is the wire shape for the sticky-target
+// option on a weighted forward. AWS surfaces DurationSeconds even when
+// Enabled is false, but the value is only meaningful when Enabled=true.
+type XMLTargetGroupStickinessConfig struct {
+	Enabled         bool `xml:"Enabled"`
+	DurationSeconds int  `xml:"DurationSeconds,omitempty"`
 }
 
 // XMLCreateRuleResponse is the XML response for CreateRule.

--- a/test/integration/testdata/elbv2_test_TestELBv2_CreateAndDeleteListener_TestELBv2_CreateAndDeleteListener_create.golden.go
+++ b/test/integration/testdata/elbv2_test_TestELBv2_CreateAndDeleteListener_TestELBv2_CreateAndDeleteListener_create.golden.go
@@ -3,9 +3,21 @@
     {
       "AlpnPolicy": null,
       "Certificates": null,
-      "DefaultActions": [],
-      "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/test-listener-lb/4b049fc7-9442-48b/7ee565e6-d732-4a7",
-      "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/test-listener-lb/4b049fc7-9442-48b",
+      "DefaultActions": [
+        {
+          "Type": "forward",
+          "AuthenticateCognitoConfig": null,
+          "AuthenticateOidcConfig": null,
+          "FixedResponseConfig": null,
+          "ForwardConfig": null,
+          "JwtValidationConfig": null,
+          "Order": null,
+          "RedirectConfig": null,
+          "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/test-listener-tg/63d12692-5e22-467"
+        }
+      ],
+      "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/test-listener-lb/94d275ff-a173-4c4/28ad3876-2ae6-4d3",
+      "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/test-listener-lb/94d275ff-a173-4c4",
       "MutualAuthentication": null,
       "Port": 80,
       "Protocol": "HTTP",


### PR DESCRIPTION
## Summary

ALB canary releases route a configured share of traffic to each target group via the listener's \`forward\` action with multiple \`TargetGroupTuple\`s (TargetGroupArn + Weight) and an optional \`TargetGroupStickinessConfig\`. Without this on the kumo wire, the canonical canary HCL is silently dropped on Create and reads come back with empty default actions.

## What's broken without this PR

\`\`\`hcl
resource \"aws_lb_listener\" \"x\" {
  default_action {
    type = \"forward\"
    forward {
      target_group { arn = ...v1.arn, weight = 90 }
      target_group { arn = ...v2.arn, weight = 10 }
      stickiness   { enabled = false, duration = 1 }
    }
  }
}
\`\`\`

The form-to-JSON converter drops \`DefaultActions.member.N.ForwardConfig.*\` keys → listener stores zero default actions → DescribeListeners returns \`<DefaultActions/>\` → AWS provider sees perpetual drift → \`ModifyListener\` can't re-balance weights mid-rollout.

## What this PR does

- \`Action\` gains \`*ForwardActionConfig\` with \`[]TargetGroupTuple\` and an optional \`*TargetGroupStickinessConfig\`. The legacy single-target form (\`Type=forward\` + \`TargetGroupArn\`) keeps working unchanged; clients that send one form get a response that matches.

- The shared \`parseActionsFromForm\` (rule path) and \`parseELBActionsFromForm\` (listener path) now drill into \`ForwardConfig.TargetGroups.member.N.{TargetGroupArn,Weight}\` and \`ForwardConfig.TargetGroupStickinessConfig.{Enabled,DurationSeconds}\`. \`ForwardConfig\` is allocated lazily so non-weighted actions stay nil-pointer.

- \`convertActionToXML\` serialises \`ForwardConfig\` back out, including \`TargetGroupStickinessConfig\` when set. Both the Listener (\`CreateListener\` / \`DescribeListeners\` / \`ModifyListener\`) and Rule (\`CreateRule\` / \`DescribeRules\` / \`ModifyRule\`) paths flow through this helper.

- \`CreateListener\` now re-parses \`DefaultActions\` directly from the form, matching the existing fix on \`ModifyListener\` / \`RegisterTargets\`. The fold-in version of this fix from #558 was dropped during the upstream squash-merge, so \`DefaultActions\` had silently been empty on every \`CreateListener\` again — the canary feature surfaces the regression because it relies on \`DefaultActions\` round-tripping.

## Verified

Direct API calls against \`kumo serve\`:

| step | result |
|---|---|
| \`CreateListener\` with 90/10 ForwardConfig | echoed back |
| \`DescribeListeners\` after create | 90/10 confirmed |
| \`ModifyListener\` flipping to 50/50 | 50/50 echoed |
| \`DescribeListeners\` after modify | 50/50 confirmed |
| \`CreateRule\` with 80/20 path-based weighted forward | 80/20 echoed |

## Test plan

- [x] \`go build ./...\` passes
- [x] Existing ELBv2 integration tests still pass
- [x] Manual API exercise of weighted forward on Listener (Create / Describe / Modify) and Rule (Create / Describe)
- [ ] Reviewer: confirm the \`<ForwardConfig><TargetGroups><member>\` XML shape matches what AWS surfaces (it does — see \`aws elbv2 describe-listeners\` against a real ALB with weighted forward)