### PR TITLE
fix(server): require path boundary when matching admin route prefixes

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -79,12 +79,29 @@ func extractRoutePrefix(pattern string) string {
 	prefixes := []string{"/kumo", "/lambda", "/2015-03-31", "/eks", "/iam", "/buckets", "/namespaces", "/tables", "/get-table", "/apigateway", "/ses", "/2020-05-31", "/2013-04-01", "/service", "/appsync", "/v1", "/tags", "/applications", "/v20190125", "/scheduler", "/dlm", "/mq", "/v20180820", "/kx", "/kafka", "/create-app", "/describe-app", "/update-app", "/delete-app", "/list-apps", "/create-resiliency-policy", "/describe-resiliency-policy", "/update-resiliency-policy", "/delete-resiliency-policy", "/list-resiliency-policies", "/start-app-assessment", "/describe-app-assessment", "/delete-app-assessment", "/list-app-assessments", "/tag-resource", "/untag-resource", "/list-tags-for-resource", "/schemas", "/matchingworkflows", "/idmappingworkflows", "/providerservices", "/-", "/snapshots", "/apps", "/backup-vaults", "/backup", "/associations", "/codereviews", "/feedback", "/profilingGroups", "/maps", "/places", "/routes", "/geofencing", "/tracking", "/metadata", "/macie", "/allow-lists", "/jobs", "/custom-data-identifiers", "/findingsfilters", "/findings", "/managed-data-identifiers"}
 
 	for _, prefix := range prefixes {
-		if len(pattern) >= len(prefix) && pattern[:len(prefix)] == prefix {
+		if hasPathPrefix(pattern, prefix) {
 			return prefix
 		}
 	}
 
 	return ""
+}
+
+// hasPathPrefix reports whether path starts with prefix on a path
+// boundary — i.e. either the prefix consumes the entire path or the
+// next character is `/`. This stops `/kumo-audit-bad-bucket` from
+// being mis-classified as a `/kumo`-prefixed path, which would shadow
+// the S3 wildcard route `/{bucket}`.
+func hasPathPrefix(path, prefix string) bool {
+	if len(path) < len(prefix) {
+		return false
+	}
+
+	if path[:len(prefix)] != prefix {
+		return false
+	}
+
+	return len(path) == len(prefix) || path[len(prefix)] == '/'
 }
 
 // HandleFunc is an alias for Handle for compatibility with service.Router interface.
@@ -164,7 +181,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	bestPrefix := ""
 
 	for prefix := range r.prefixRouters {
-		if len(req.URL.Path) >= len(prefix) && req.URL.Path[:len(prefix)] == prefix && len(prefix) > len(bestPrefix) {
+		if hasPathPrefix(req.URL.Path, prefix) && len(prefix) > len(bestPrefix) {
 			bestPrefix = prefix
 		}
 	}

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRouter_PrefixMatchRespectsBoundary regression-tests a bug where
+// `extractRoutePrefix` and `Router.ServeHTTP` matched prefixes by raw
+// string-prefix, so a path like `/kumo-audit-bad-bucket` was routed to
+// the `/kumo` prefix router (which only handles `/_kumo/*` and
+// similar), shadowing the S3 wildcard route `PUT /{bucket}` and
+// returning 404. The fix requires the prefix to be followed by `/` or
+// end-of-string.
+func TestRouter_PrefixMatchRespectsBoundary(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewRouter(logger)
+
+	called := ""
+
+	// `/kumo` is a registered prefix (used by /_kumo/health etc.).
+	r.Handle("GET", "/kumo/health", func(w http.ResponseWriter, _ *http.Request) {
+		called = "kumo-health"
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// `/{bucket}` is the S3-style wildcard route. With the bug, a
+	// PUT to `/kumo-audit-bad-bucket` would be sent to the /kumo
+	// prefix router (no matching pattern) → 404.
+	r.Handle("PUT", "/{bucket}", func(w http.ResponseWriter, _ *http.Request) {
+		called = "bucket-put"
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// A bucket whose name *equals* an admin prefix (e.g. PUT /kumo) is
+	// an unavoidable shadow until kumo grows a Host- or scheme-based
+	// admin-route discriminator. The cases below cover only the
+	// previously-broken substring case that the fix resolves.
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		want   string
+	}{
+		{"prefix exact", "GET", "/kumo/health", "kumo-health"},
+		{"bucket name shares prefix substring", "PUT", "/kumo-audit-bad-bucket", "bucket-put"},
+		{"bucket name with longer admin prefix substring", "PUT", "/lambda-deploy-bucket", "bucket-put"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called = ""
+
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if called != tc.want {
+				t.Fatalf("path=%s: got handler %q, want %q (status=%d)",
+					tc.path, called, tc.want, rec.Code)
+			}
+		})
+	}
+}
+
+// TestExtractRoutePrefix_BoundaryGuard makes sure pattern registration
+// itself doesn't classify a wildcard like `/{bucket}` as a `/kumo`
+// prefixed route.
+func TestExtractRoutePrefix_BoundaryGuard(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		pattern string
+		want    string
+	}{
+		{"/kumo/health", "/kumo"},
+		{"/lambda/2015-03-31/functions", "/lambda"},
+		{"/{bucket}", ""},
+		{"/{bucket}/{key...}", ""},
+		{"/kumosomething", ""}, // no slash boundary → not a prefix
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.pattern, func(t *testing.T) {
+			got := extractRoutePrefix(tc.pattern)
+			if got != tc.want {
+				t.Errorf("extractRoutePrefix(%q) = %q, want %q", tc.pattern, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`extractRoutePrefix` and `Router.ServeHTTP` matched service prefixes (`/kumo`, `/lambda`, …) by raw string-prefix, so a request to `/kumo-audit-bad-bucket` was dispatched to the `/kumo` admin router instead of the S3 wildcard route `PUT /{bucket}`, returning 404. Same shadow potentially affects buckets whose names start with `/iam`, `/lambda`, `/snapshots`, `/jobs`, `/findings`, `/-`, etc.

The fix adds `hasPathPrefix` that requires the next character after the prefix to be `/` (or end-of-string) and uses it from both call sites.

A bucket whose name **equals** an admin prefix exactly (e.g. `PUT /kumo`) remains shadowed — that's an unavoidable conflict until kumo grows a Host- or scheme-based admin discriminator. Documented in the test as a known limitation.

## Repro (before fix)

```
$ kumo &
$ curl -X PUT http://localhost:4566/kumo-audit-bad-bucket
404 page not found
```

## After fix

```
$ curl -X PUT http://localhost:4566/kumo-audit-bad-bucket
HTTP/1.1 200 OK
Location: /kumo-audit-bad-bucket
$ aws --endpoint-url=http://localhost:4566 s3api list-buckets
{ "Buckets": [{ "Name": "kumo-audit-bad-bucket", ... }] }
```

## Test plan

- [x] `go test ./internal/server/` — passes including new `TestRouter_PrefixMatchRespectsBoundary` and `TestExtractRoutePrefix_BoundaryGuard`
- [x] `go test ./...` — full suite green
- [x] Manual: `curl -X PUT http://localhost:4566/<bucket-name-starting-with-admin-prefix>` returns 200 and `s3api list-buckets` shows it

🤖 Generated with [Claude Code](https://claude.com/claude-code)