### PR TITLE
fix(server): path-prefix boundary + AWS S3 virtual-hosted-style support

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -176,6 +177,26 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Rewrite AWS S3 virtual-hosted-style requests so the rest of the
+	// router only deals with path-style. terraform / aws-sdk-go-v2
+	// default to virtual-hosted-style: the bucket goes in the Host
+	// header (`<bucket>.localhost:4566` or `<bucket>.s3.amazonaws.com`)
+	// and the URL path is `/` (for bucket-level ops) or `/<key>` (for
+	// object ops). Without this rewrite the wildcard `/{bucket}` route
+	// can't see the bucket name and `HEAD /` returns 200, which the
+	// SDK reads as "bucket exists" → spurious BucketAlreadyExists.
+	if bucket := extractBucketFromHost(req.Host); bucket != "" {
+		req = req.Clone(req.Context())
+
+		// `/` (bucket-level op) → `/<bucket>`.
+		// `/key/path` (object-level op) → `/<bucket>/key/path`.
+		if req.URL.Path == "" || req.URL.Path == "/" {
+			req.URL.Path = "/" + bucket
+		} else {
+			req.URL.Path = "/" + bucket + req.URL.Path
+		}
+	}
+
 	// Clean the URL path to prevent Go's ServeMux from returning 301 redirects
 	// for paths with double slashes (e.g., /bucket//key). S3 keys can start with
 	// "/" which produces double slashes in path-style URLs. We clean the path
@@ -208,6 +229,60 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // Routes returns all registered routes.
 func (r *Router) Routes() []Route {
 	return r.routes
+}
+
+// extractBucketFromHost recognises AWS S3 virtual-hosted-style hosts
+// and returns the bucket name. Empty result means path-style (or a
+// non-S3 host) — caller leaves the URL untouched.
+//
+// Recognised shapes:
+//
+//	<bucket>.localhost(:port)          (kumo-style custom endpoint)
+//	<bucket>.s3.amazonaws.com
+//	<bucket>.s3-<region>.amazonaws.com
+//	<bucket>.s3.<region>.amazonaws.com (incl. dualstack subdomains)
+func extractBucketFromHost(host string) string {
+	if host == "" {
+		return ""
+	}
+
+	// Strip port — ":4566" etc. We only need the host name.
+	if idx := strings.LastIndex(host, ":"); idx >= 0 {
+		host = host[:idx]
+	}
+
+	// Localhost / loopback IPs are never virtual-hosted.
+	if host == "localhost" || host == "127.0.0.1" {
+		return ""
+	}
+
+	dot := strings.Index(host, ".")
+	if dot <= 0 {
+		return ""
+	}
+
+	bucket := host[:dot]
+	rest := host[dot+1:]
+
+	// Reject the "no bucket prefix" case: e.g. `s3.amazonaws.com`,
+	// `s3.us-east-1.amazonaws.com`. The leftmost label *is* the
+	// service marker, not a bucket.
+	if bucket == "s3" || strings.HasPrefix(bucket, "s3-") {
+		return ""
+	}
+
+	switch {
+	case rest == "localhost":
+		return bucket
+	case rest == "s3.amazonaws.com":
+		return bucket
+	case strings.HasPrefix(rest, "s3.") && strings.HasSuffix(rest, ".amazonaws.com"):
+		return bucket
+	case strings.HasPrefix(rest, "s3-") && strings.HasSuffix(rest, ".amazonaws.com"):
+		return bucket
+	}
+
+	return ""
 }
 
 // responseWriter wraps http.ResponseWriter to capture the status code.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -80,12 +80,29 @@ func extractRoutePrefix(pattern string) string {
 	prefixes := []string{"/kumo", "/lambda", "/2015-03-31", "/eks", "/iam", "/buckets", "/namespaces", "/tables", "/get-table", "/apigateway", "/ses", "/2020-05-31", "/2013-04-01", "/service", "/appsync", "/v1", "/tags", "/applications", "/v20190125", "/scheduler", "/dlm", "/mq", "/v20180820", "/kx", "/kafka", "/create-app", "/describe-app", "/update-app", "/delete-app", "/list-apps", "/create-resiliency-policy", "/describe-resiliency-policy", "/update-resiliency-policy", "/delete-resiliency-policy", "/list-resiliency-policies", "/start-app-assessment", "/describe-app-assessment", "/delete-app-assessment", "/list-app-assessments", "/tag-resource", "/untag-resource", "/list-tags-for-resource", "/schemas", "/matchingworkflows", "/idmappingworkflows", "/providerservices", "/-", "/snapshots", "/apps", "/backup-vaults", "/backup", "/associations", "/codereviews", "/feedback", "/profilingGroups", "/maps", "/places", "/routes", "/geofencing", "/tracking", "/metadata", "/macie", "/allow-lists", "/jobs", "/custom-data-identifiers", "/findingsfilters", "/findings", "/managed-data-identifiers"}
 
 	for _, prefix := range prefixes {
-		if len(pattern) >= len(prefix) && pattern[:len(prefix)] == prefix {
+		if hasPathPrefix(pattern, prefix) {
 			return prefix
 		}
 	}
 
 	return ""
+}
+
+// hasPathPrefix reports whether path starts with prefix on a path
+// boundary — i.e. either the prefix consumes the entire path or the
+// next character is `/`. This stops `/kumo-audit-bad-bucket` from
+// being mis-classified as a `/kumo`-prefixed path, which would shadow
+// the S3 wildcard route `/{bucket}`.
+func hasPathPrefix(path, prefix string) bool {
+	if len(path) < len(prefix) {
+		return false
+	}
+
+	if path[:len(prefix)] != prefix {
+		return false
+	}
+
+	return len(path) == len(prefix) || path[len(prefix)] == '/'
 }
 
 // HandleFunc is an alias for Handle for compatibility with service.Router interface.
@@ -174,7 +191,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	bestPrefix := ""
 
 	for prefix := range r.prefixRouters {
-		if len(req.URL.Path) >= len(prefix) && req.URL.Path[:len(prefix)] == prefix && len(prefix) > len(bestPrefix) {
+		if hasPathPrefix(req.URL.Path, prefix) && len(prefix) > len(bestPrefix) {
 			bestPrefix = prefix
 		}
 	}

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -26,6 +26,7 @@ func TestRouter_PrefixMatchRespectsBoundary(t *testing.T) {
 	// `/kumo` is a registered prefix (used by /_kumo/health etc.).
 	r.Handle("GET", "/kumo/health", func(w http.ResponseWriter, _ *http.Request) {
 		called = "kumo-health"
+
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -34,6 +35,7 @@ func TestRouter_PrefixMatchRespectsBoundary(t *testing.T) {
 	// prefix router (no matching pattern) → 404.
 	r.Handle("PUT", "/{bucket}", func(w http.ResponseWriter, _ *http.Request) {
 		called = "bucket-put"
+
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -56,7 +58,7 @@ func TestRouter_PrefixMatchRespectsBoundary(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			called = ""
 
-			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req := httptest.NewRequest(tc.method, tc.path, http.NoBody)
 			rec := httptest.NewRecorder()
 			r.ServeHTTP(rec, req)
 

--- a/internal/server/router_test.go
+++ b/internal/server/router_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRouter_PrefixMatchRespectsBoundary regression-tests a bug where
+// `extractRoutePrefix` and `Router.ServeHTTP` matched prefixes by raw
+// string-prefix, so a path like `/kumo-audit-bad-bucket` was routed to
+// the `/kumo` prefix router (which only handles `/_kumo/*` and
+// similar), shadowing the S3 wildcard route `PUT /{bucket}` and
+// returning 404. The fix requires the prefix to be followed by `/` or
+// end-of-string.
+func TestRouter_PrefixMatchRespectsBoundary(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewRouter(logger)
+
+	called := ""
+
+	// `/kumo` is a registered prefix (used by /_kumo/health etc.).
+	r.Handle("GET", "/kumo/health", func(w http.ResponseWriter, _ *http.Request) {
+		called = "kumo-health"
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// `/{bucket}` is the S3-style wildcard route. With the bug, a
+	// PUT to `/kumo-audit-bad-bucket` would be sent to the /kumo
+	// prefix router (no matching pattern) → 404.
+	r.Handle("PUT", "/{bucket}", func(w http.ResponseWriter, _ *http.Request) {
+		called = "bucket-put"
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// A bucket whose name *equals* an admin prefix (e.g. PUT /kumo) is
+	// an unavoidable shadow until kumo grows a Host- or scheme-based
+	// admin-route discriminator. The cases below cover only the
+	// previously-broken substring case that the fix resolves.
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		want   string
+	}{
+		{"prefix exact", "GET", "/kumo/health", "kumo-health"},
+		{"bucket name shares prefix substring", "PUT", "/kumo-audit-bad-bucket", "bucket-put"},
+		{"bucket name with longer admin prefix substring", "PUT", "/lambda-deploy-bucket", "bucket-put"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called = ""
+
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if called != tc.want {
+				t.Fatalf("path=%s: got handler %q, want %q (status=%d)",
+					tc.path, called, tc.want, rec.Code)
+			}
+		})
+	}
+}
+
+// TestExtractRoutePrefix_BoundaryGuard makes sure pattern registration
+// itself doesn't classify a wildcard like `/{bucket}` as a `/kumo`
+// prefixed route.
+func TestExtractRoutePrefix_BoundaryGuard(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		pattern string
+		want    string
+	}{
+		{"/kumo/health", "/kumo"},
+		{"/lambda/2015-03-31/functions", "/lambda"},
+		{"/{bucket}", ""},
+		{"/{bucket}/{key...}", ""},
+		{"/kumosomething", ""}, // no slash boundary → not a prefix
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.pattern, func(t *testing.T) {
+			got := extractRoutePrefix(tc.pattern)
+			if got != tc.want {
+				t.Errorf("extractRoutePrefix(%q) = %q, want %q", tc.pattern, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/virtualhost_test.go
+++ b/internal/server/virtualhost_test.go
@@ -1,0 +1,176 @@
+package server
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRouter_VirtualHostedStyleS3 covers AWS S3 virtual-hosted-style
+// addressing: the bucket sits in the Host header rather than the
+// URL path. Without rewrite the request `HEAD http://b.localhost/`
+// hits the wildcard `/{bucket}` route with bucket="" and returns 200,
+// which the AWS SDK reads as "bucket exists" → BucketAlreadyExists
+// when terraform tries to create.
+//
+// Recognised host shapes:
+//   - <bucket>.localhost(:port)       (kumo-style custom endpoint)
+//   - <bucket>.s3.amazonaws.com
+//   - <bucket>.s3-<region>.amazonaws.com
+//   - <bucket>.s3.<region>.amazonaws.com
+func TestRouter_VirtualHostedStyleS3(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	makeRouter := func() (*Router, *string) {
+		r := NewRouter(logger)
+		matched := new(string)
+
+		r.Handle("PUT", "/{bucket}", func(w http.ResponseWriter, req *http.Request) {
+			*matched = "create-bucket:" + req.PathValue("bucket")
+			w.WriteHeader(http.StatusOK)
+		})
+		r.Handle("HEAD", "/{bucket}", func(w http.ResponseWriter, req *http.Request) {
+			*matched = "head-bucket:" + req.PathValue("bucket")
+			w.WriteHeader(http.StatusOK)
+		})
+		r.Handle("PUT", "/{bucket}/{key...}", func(w http.ResponseWriter, req *http.Request) {
+			*matched = "put-object:" + req.PathValue("bucket") + "/" + req.PathValue("key")
+			w.WriteHeader(http.StatusOK)
+		})
+		r.Handle("GET", "/", func(w http.ResponseWriter, _ *http.Request) {
+			*matched = "list-buckets"
+			w.WriteHeader(http.StatusOK)
+		})
+
+		return r, matched
+	}
+
+	cases := []struct {
+		name   string
+		method string
+		host   string
+		path   string
+		want   string
+	}{
+		{
+			name:   "path-style PUT bucket",
+			method: "PUT",
+			host:   "127.0.0.1:4566",
+			path:   "/my-bucket",
+			want:   "create-bucket:my-bucket",
+		},
+		{
+			name:   "virtual-hosted PUT bucket via .localhost",
+			method: "PUT",
+			host:   "my-bucket.localhost:4566",
+			path:   "/",
+			want:   "create-bucket:my-bucket",
+		},
+		{
+			name:   "virtual-hosted HEAD bucket",
+			method: "HEAD",
+			host:   "my-bucket.localhost:4566",
+			path:   "/",
+			want:   "head-bucket:my-bucket",
+		},
+		{
+			name:   "virtual-hosted PUT object",
+			method: "PUT",
+			host:   "my-bucket.localhost:4566",
+			path:   "/some/key.txt",
+			want:   "put-object:my-bucket/some/key.txt",
+		},
+		{
+			name:   "virtual-hosted via real AWS S3 host",
+			method: "PUT",
+			host:   "my-bucket.s3.us-east-1.amazonaws.com",
+			path:   "/",
+			want:   "create-bucket:my-bucket",
+		},
+		{
+			name:   "virtual-hosted via legacy region-prefixed host",
+			method: "PUT",
+			host:   "my-bucket.s3-us-west-2.amazonaws.com",
+			path:   "/",
+			want:   "create-bucket:my-bucket",
+		},
+		{
+			name:   "virtual-hosted via global host",
+			method: "PUT",
+			host:   "my-bucket.s3.amazonaws.com",
+			path:   "/",
+			want:   "create-bucket:my-bucket",
+		},
+		{
+			name:   "list-buckets (no virtual host) stays at /",
+			method: "GET",
+			host:   "127.0.0.1:4566",
+			path:   "/",
+			want:   "list-buckets",
+		},
+		{
+			name:   "list-buckets via plain s3.amazonaws.com (no bucket prefix)",
+			method: "GET",
+			host:   "s3.amazonaws.com",
+			path:   "/",
+			want:   "list-buckets",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, matched := makeRouter()
+
+			req := httptest.NewRequest(tc.method, "http://"+tc.host+tc.path, nil)
+			req.Host = tc.host
+
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if *matched != tc.want {
+				t.Fatalf("host=%s path=%s: got handler %q, want %q (status=%d)",
+					tc.host, tc.path, *matched, tc.want, rec.Code)
+			}
+		})
+	}
+}
+
+// TestExtractBucketFromHost is a low-level test of the host-to-bucket
+// helper. It documents which host shapes are treated as virtual-hosted.
+func TestExtractBucketFromHost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"my-bucket.localhost:4566", "my-bucket"},
+		{"my-bucket.localhost", "my-bucket"},
+		{"my-bucket.s3.amazonaws.com", "my-bucket"},
+		{"my-bucket.s3.us-east-1.amazonaws.com", "my-bucket"},
+		{"my-bucket.s3-us-west-2.amazonaws.com", "my-bucket"},
+		{"my-bucket.s3.dualstack.us-east-1.amazonaws.com", "my-bucket"},
+
+		// Negative cases — must NOT extract a bucket.
+		{"127.0.0.1:4566", ""},
+		{"localhost", ""},
+		{"localhost:4566", ""},
+		{"s3.amazonaws.com", ""},
+		{"s3.us-east-1.amazonaws.com", ""},
+		{"s3-us-west-2.amazonaws.com", ""},
+		{"", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			got := extractBucketFromHost(tc.host)
+			if got != tc.want {
+				t.Errorf("extractBucketFromHost(%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/virtualhost_test.go
+++ b/internal/server/virtualhost_test.go
@@ -8,124 +8,111 @@ import (
 	"testing"
 )
 
+// virtualHostCase is one row in the virtual-hosted dispatch table.
+type virtualHostCase struct {
+	name   string
+	method string
+	host   string
+	path   string
+	want   string
+}
+
+// virtualHostCases enumerates host / path combinations the router has
+// to dispatch correctly. Defined once and reused so the test function
+// itself stays inside funlen budget.
+var virtualHostCases = []virtualHostCase{
+	{
+		name: "path-style PUT bucket", method: "PUT",
+		host: "127.0.0.1:4566", path: "/my-bucket",
+		want: "create-bucket:my-bucket",
+	},
+	{
+		name: "virtual-hosted PUT bucket via .localhost", method: "PUT",
+		host: "my-bucket.localhost:4566", path: "/",
+		want: "create-bucket:my-bucket",
+	},
+	{
+		name: "virtual-hosted HEAD bucket", method: "HEAD",
+		host: "my-bucket.localhost:4566", path: "/",
+		want: "head-bucket:my-bucket",
+	},
+	{
+		name: "virtual-hosted PUT object", method: "PUT",
+		host: "my-bucket.localhost:4566", path: "/some/key.txt",
+		want: "put-object:my-bucket/some/key.txt",
+	},
+	{
+		name: "virtual-hosted via real AWS S3 host", method: "PUT",
+		host: "my-bucket.s3.us-east-1.amazonaws.com", path: "/",
+		want: "create-bucket:my-bucket",
+	},
+	{
+		name: "virtual-hosted via legacy region-prefixed host", method: "PUT",
+		host: "my-bucket.s3-us-west-2.amazonaws.com", path: "/",
+		want: "create-bucket:my-bucket",
+	},
+	{
+		name: "virtual-hosted via global host", method: "PUT",
+		host: "my-bucket.s3.amazonaws.com", path: "/",
+		want: "create-bucket:my-bucket",
+	},
+	{
+		name: "list-buckets (no virtual host) stays at /", method: "GET",
+		host: "127.0.0.1:4566", path: "/",
+		want: "list-buckets",
+	},
+	{
+		name: "list-buckets via plain s3.amazonaws.com (no bucket prefix)", method: "GET",
+		host: "s3.amazonaws.com", path: "/",
+		want: "list-buckets",
+	},
+}
+
+// newS3StyleRouter wires up the four S3-style routes the dispatch
+// tests exercise. The returned *string captures which handler matched.
+func newS3StyleRouter() (*Router, *string) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	r := NewRouter(logger)
+	matched := new(string)
+
+	r.Handle("PUT", "/{bucket}", func(w http.ResponseWriter, req *http.Request) {
+		*matched = "create-bucket:" + req.PathValue("bucket")
+
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Handle("HEAD", "/{bucket}", func(w http.ResponseWriter, req *http.Request) {
+		*matched = "head-bucket:" + req.PathValue("bucket")
+
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Handle("PUT", "/{bucket}/{key...}", func(w http.ResponseWriter, req *http.Request) {
+		*matched = "put-object:" + req.PathValue("bucket") + "/" + req.PathValue("key")
+
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Handle("GET", "/", func(w http.ResponseWriter, _ *http.Request) {
+		*matched = "list-buckets"
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	return r, matched
+}
+
 // TestRouter_VirtualHostedStyleS3 covers AWS S3 virtual-hosted-style
 // addressing: the bucket sits in the Host header rather than the
 // URL path. Without rewrite the request `HEAD http://b.localhost/`
 // hits the wildcard `/{bucket}` route with bucket="" and returns 200,
 // which the AWS SDK reads as "bucket exists" → BucketAlreadyExists
 // when terraform tries to create.
-//
-// Recognised host shapes:
-//   - <bucket>.localhost(:port)       (kumo-style custom endpoint)
-//   - <bucket>.s3.amazonaws.com
-//   - <bucket>.s3-<region>.amazonaws.com
-//   - <bucket>.s3.<region>.amazonaws.com
 func TestRouter_VirtualHostedStyleS3(t *testing.T) {
 	t.Parallel()
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-
-	makeRouter := func() (*Router, *string) {
-		r := NewRouter(logger)
-		matched := new(string)
-
-		r.Handle("PUT", "/{bucket}", func(w http.ResponseWriter, req *http.Request) {
-			*matched = "create-bucket:" + req.PathValue("bucket")
-			w.WriteHeader(http.StatusOK)
-		})
-		r.Handle("HEAD", "/{bucket}", func(w http.ResponseWriter, req *http.Request) {
-			*matched = "head-bucket:" + req.PathValue("bucket")
-			w.WriteHeader(http.StatusOK)
-		})
-		r.Handle("PUT", "/{bucket}/{key...}", func(w http.ResponseWriter, req *http.Request) {
-			*matched = "put-object:" + req.PathValue("bucket") + "/" + req.PathValue("key")
-			w.WriteHeader(http.StatusOK)
-		})
-		r.Handle("GET", "/", func(w http.ResponseWriter, _ *http.Request) {
-			*matched = "list-buckets"
-			w.WriteHeader(http.StatusOK)
-		})
-
-		return r, matched
-	}
-
-	cases := []struct {
-		name   string
-		method string
-		host   string
-		path   string
-		want   string
-	}{
-		{
-			name:   "path-style PUT bucket",
-			method: "PUT",
-			host:   "127.0.0.1:4566",
-			path:   "/my-bucket",
-			want:   "create-bucket:my-bucket",
-		},
-		{
-			name:   "virtual-hosted PUT bucket via .localhost",
-			method: "PUT",
-			host:   "my-bucket.localhost:4566",
-			path:   "/",
-			want:   "create-bucket:my-bucket",
-		},
-		{
-			name:   "virtual-hosted HEAD bucket",
-			method: "HEAD",
-			host:   "my-bucket.localhost:4566",
-			path:   "/",
-			want:   "head-bucket:my-bucket",
-		},
-		{
-			name:   "virtual-hosted PUT object",
-			method: "PUT",
-			host:   "my-bucket.localhost:4566",
-			path:   "/some/key.txt",
-			want:   "put-object:my-bucket/some/key.txt",
-		},
-		{
-			name:   "virtual-hosted via real AWS S3 host",
-			method: "PUT",
-			host:   "my-bucket.s3.us-east-1.amazonaws.com",
-			path:   "/",
-			want:   "create-bucket:my-bucket",
-		},
-		{
-			name:   "virtual-hosted via legacy region-prefixed host",
-			method: "PUT",
-			host:   "my-bucket.s3-us-west-2.amazonaws.com",
-			path:   "/",
-			want:   "create-bucket:my-bucket",
-		},
-		{
-			name:   "virtual-hosted via global host",
-			method: "PUT",
-			host:   "my-bucket.s3.amazonaws.com",
-			path:   "/",
-			want:   "create-bucket:my-bucket",
-		},
-		{
-			name:   "list-buckets (no virtual host) stays at /",
-			method: "GET",
-			host:   "127.0.0.1:4566",
-			path:   "/",
-			want:   "list-buckets",
-		},
-		{
-			name:   "list-buckets via plain s3.amazonaws.com (no bucket prefix)",
-			method: "GET",
-			host:   "s3.amazonaws.com",
-			path:   "/",
-			want:   "list-buckets",
-		},
-	}
-
-	for _, tc := range cases {
+	for _, tc := range virtualHostCases {
 		t.Run(tc.name, func(t *testing.T) {
-			r, matched := makeRouter()
+			r, matched := newS3StyleRouter()
 
-			req := httptest.NewRequest(tc.method, "http://"+tc.host+tc.path, nil)
+			req := httptest.NewRequest(tc.method, "http://"+tc.host+tc.path, http.NoBody)
 			req.Host = tc.host
 
 			rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

Two related router fixes that together let the AWS terraform provider talk to kumo for S3 (and any future bucket-named admin-prefix collisions). Bundled because they touch the same `Router.ServeHTTP` and share an end-to-end repro: `tofu apply` of `aws_s3_bucket` against kumo. (Replaces #573, which is closed in favour of this PR.)

### Fix 1 — path-prefix boundary

`extractRoutePrefix` and `Router.ServeHTTP` matched service prefixes (`/kumo`, `/lambda`, …) by raw string-prefix, so a request to `/kumo-audit-bad-bucket` was dispatched to the `/kumo` admin router instead of the S3 wildcard route `PUT /{bucket}`, returning 404. Same shadow potentially affects buckets whose names start with `/iam`, `/lambda`, `/snapshots`, `/jobs`, `/findings`, `/-`, etc.

`hasPathPrefix` requires the next character after the prefix to be `/` (or end-of-string) and is used at both call sites. A bucket whose name **equals** an admin prefix exactly (e.g. `PUT /kumo`) remains shadowed — that's an unavoidable conflict until kumo grows a Host- or scheme-based admin discriminator. Documented in the test as a known limitation.

### Fix 2 — S3 virtual-hosted-style host headers

The aws-sdk-go-v2 (and therefore the terraform AWS provider) defaults to **virtual-hosted-style** for S3: the bucket lives in the `Host` header (`<bucket>.localhost:4566` for kumo / `<bucket>.s3.amazonaws.com` for real AWS) and the URL path is just `/`. kumo only knew path-style (`/{bucket}`), so:

- `HEAD /` matched the wildcard with `bucket=""` and returned 200 → the SDK reads that as "bucket exists" → terraform reports a spurious `BucketAlreadyExists` when it tries to create the bucket.
- `PUT /` (CreateBucket) was 405.
- Object ops on `<bucket>.localhost/key.txt` couldn't reach `/{bucket}/{key...}` either.

A host-rewrite step at the start of `Router.ServeHTTP` rewrites the request to path-style (`/<bucket>` / `/<bucket>/<key>`) when the Host has the shape:

```
<bucket>.localhost(:port)
<bucket>.s3.amazonaws.com
<bucket>.s3.<region>.amazonaws.com    (incl. dualstack subdomains)
<bucket>.s3-<region>.amazonaws.com    (legacy dash form)
```

Hosts without a bucket prefix (`s3.amazonaws.com`, `localhost:4566`, raw IP) are left untouched.

## End-to-end repro

Before this PR:

```
$ terraform apply (resource = aws_s3_bucket: kumo-audit-bad-bucket)
Error: creating S3 Bucket (kumo-audit-bad-bucket): operation error S3:
       CreateBucket, https response error StatusCode: 404, ...
       NotFound: Not Found
```

After:

```
$ tofu apply -target=aws_s3_bucket.insecure
aws_s3_bucket.insecure: Creation complete after 0s [id=kumo-audit-bad-bucket]
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

## Test plan

- [x] `go test ./internal/server/` — passes including new tests:
  - `TestRouter_PrefixMatchRespectsBoundary`
  - `TestExtractRoutePrefix_BoundaryGuard`
  - `TestRouter_VirtualHostedStyleS3` (9 sub-cases)
  - `TestExtractBucketFromHost` (13 sub-cases)
- [x] `go test ./...` — full suite green
- [x] Manual: `tofu apply` of an `aws_s3_bucket` against a kumo built from this branch creates the bucket, and `aws s3api list-buckets` returns it

🤖 Generated with [Claude Code](https://claude.com/claude-code)