### PR TITLE
feat(ec2): real RevokeSecurityGroupIngress / RevokeSecurityGroupEgress

### DIFF
--- a/internal/service/ec2/handlers.go
+++ b/internal/service/ec2/handlers.go
@@ -267,6 +267,18 @@ func (s *Service) AuthorizeSecurityGroupIngress(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// The form-to-JSON converter doesn't expand
+	// IpPermissions.N.{IpProtocol,FromPort,ToPort,IpRanges.M.CidrIp}
+	// into a slice — the dotted keys land at the top level and never
+	// unmarshal into req.IPPermissions. Re-parse the form directly so
+	// the ingress rules actually reach storage. (Same bug class as the
+	// RegisterTargets / CreateListener / CreateRule fixes.)
+	if err := r.ParseForm(); err == nil {
+		if perms := parseIPPermissionsFromForm(r.Form); len(perms) > 0 {
+			req.IPPermissions = perms
+		}
+	}
+
 	err := s.storage.AuthorizeSecurityGroupIngress(r.Context(), req.GroupID, req.GroupName, req.IPPermissions)
 	if err != nil {
 		handleError(w, err)
@@ -294,6 +306,14 @@ func (s *Service) AuthorizeSecurityGroupEgress(w http.ResponseWriter, r *http.Re
 		writeError(w, errInvalidParameter, "GroupId is required", http.StatusBadRequest)
 
 		return
+	}
+
+	// Same form-converter limitation as AuthorizeSecurityGroupIngress
+	// above; re-parse so egress rules survive into storage.
+	if err := r.ParseForm(); err == nil {
+		if perms := parseIPPermissionsFromForm(r.Form); len(perms) > 0 {
+			req.IPPermissions = perms
+		}
 	}
 
 	err := s.storage.AuthorizeSecurityGroupEgress(r.Context(), req.GroupID, req.IPPermissions)
@@ -1408,6 +1428,9 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 		"DeleteSecurityGroup":           s.DeleteSecurityGroup,
 		"AuthorizeSecurityGroupIngress": s.AuthorizeSecurityGroupIngress,
 		"AuthorizeSecurityGroupEgress":  s.AuthorizeSecurityGroupEgress,
+		"DescribeSecurityGroups":        s.DescribeSecurityGroups,
+		"RevokeSecurityGroupIngress":    s.RevokeSecurityGroupIngress,
+		"RevokeSecurityGroupEgress":     s.RevokeSecurityGroupEgress,
 		// Key pair operations
 		"CreateKeyPair":    s.CreateKeyPair,
 		"DeleteKeyPair":    s.DeleteKeyPair,
@@ -1631,6 +1654,192 @@ func convertToXMLRouteTable(rt *RouteTable) XMLRouteTable {
 		RouteSet:       XMLRouteSet{Items: routes},
 		AssociationSet: XMLRouteTableAssociationSet{Items: associations},
 		TagSet:         XMLTagSet{Items: tags},
+	}
+}
+
+// RevokeSecurityGroupIngress / RevokeSecurityGroupEgress are accepted
+// as no-ops. terraform-aws issues these on every Create to clear the
+// default 0.0.0.0/0 egress rule before applying user rules; without a
+// 200 response the resource fails to create and downstream Authorize
+// calls never happen. We don't track egress today, so the no-op is
+// behaviourally equivalent to the cleanup terraform expects.
+func (s *Service) RevokeSecurityGroupIngress(w http.ResponseWriter, _ *http.Request) {
+	writeEC2XMLResponse(w, struct {
+		XMLName   xml.Name `xml:"RevokeSecurityGroupIngressResponse"`
+		Xmlns     string   `xml:"xmlns,attr"`
+		RequestID string   `xml:"requestId"`
+		Return    bool     `xml:"return"`
+	}{Xmlns: ec2XMLNS, RequestID: uuid.New().String(), Return: true})
+}
+
+// RevokeSecurityGroupEgress mirrors the ingress no-op above.
+func (s *Service) RevokeSecurityGroupEgress(w http.ResponseWriter, _ *http.Request) {
+	writeEC2XMLResponse(w, struct {
+		XMLName   xml.Name `xml:"RevokeSecurityGroupEgressResponse"`
+		Xmlns     string   `xml:"xmlns,attr"`
+		RequestID string   `xml:"requestId"`
+		Return    bool     `xml:"return"`
+	}{Xmlns: ec2XMLNS, RequestID: uuid.New().String(), Return: true})
+}
+
+// DescribeSecurityGroups handles the DescribeSecurityGroups action.
+// Filters honoured: GroupId.N, GroupName.N. Without either, every SG
+// in storage is returned.
+func (s *Service) DescribeSecurityGroups(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return
+	}
+
+	groupIDs := parseIndexedListFromForm(r.Form, "GroupId")
+	groupNames := parseIndexedListFromForm(r.Form, "GroupName")
+
+	sgs, err := s.storage.DescribeSecurityGroups(r.Context(), groupIDs, groupNames)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	items := make([]XMLSecurityGroup, 0, len(sgs))
+	for _, sg := range sgs {
+		items = append(items, convertToXMLSecurityGroup(sg))
+	}
+
+	writeEC2XMLResponse(w, XMLDescribeSecurityGroupsResponse{
+		Xmlns:             ec2XMLNS,
+		RequestID:         uuid.New().String(),
+		SecurityGroupInfo: XMLSecurityGroupInfo{Items: items},
+	})
+}
+
+// convertToXMLSecurityGroup is the SecurityGroup → wire-shape adapter.
+// The IngressRules / EgressRules are copied through ipPermission()
+// which handles the IpRanges nested list.
+func convertToXMLSecurityGroup(sg *SecurityGroup) XMLSecurityGroup {
+	tags := make([]XMLTag, 0, len(sg.Tags))
+	for _, t := range sg.Tags {
+		tags = append(tags, XMLTag(t))
+	}
+
+	return XMLSecurityGroup{
+		OwnerID:             defaultAccountID,
+		GroupID:             sg.GroupID,
+		GroupName:           sg.GroupName,
+		GroupDescription:    sg.Description,
+		VpcID:               sg.VpcID,
+		IPPermissions:       XMLIPPermissionSet{Items: ipPermissionsToXML(sg.IngressRules)},
+		IPPermissionsEgress: XMLIPPermissionSet{Items: ipPermissionsToXML(sg.EgressRules)},
+		TagSet:              XMLTagSet{Items: tags},
+	}
+}
+
+// ipPermissionsToXML translates each IPPermission into its wire form.
+func ipPermissionsToXML(perms []IPPermission) []XMLIPPermission {
+	out := make([]XMLIPPermission, 0, len(perms))
+
+	for _, p := range perms {
+		ranges := make([]XMLIPRange, 0, len(p.IPRanges))
+		for _, r := range p.IPRanges {
+			ranges = append(ranges, XMLIPRange(r))
+		}
+
+		out = append(out, XMLIPPermission{
+			IPProtocol: p.IPProtocol,
+			FromPort:   p.FromPort,
+			ToPort:     p.ToPort,
+			IPRanges:   XMLIPRanges{Items: ranges},
+		})
+	}
+
+	return out
+}
+
+// parseIPPermissionsFromForm reads the AWS Query wire shape for an
+// IpPermissions list — IpPermissions.N.{IpProtocol,FromPort,ToPort}
+// plus IpPermissions.N.IpRanges.M.CidrIp — into the slice the storage
+// layer expects. The shared form-to-JSON converter only handles flat
+// indexed scalar lists, not the nested member.N.<field> shape, so the
+// (Authorize|Revoke)SecurityGroup{Ingress,Egress} handlers need this
+// helper to recover the rules from r.Form directly.
+func parseIPPermissionsFromForm(form map[string][]string) []IPPermission {
+	byIdx := make(map[int]*IPPermission)
+
+	for key, values := range form {
+		applyIPPermissionFormEntry(byIdx, key, values)
+	}
+
+	indexes := make([]int, 0, len(byIdx))
+	for n := range byIdx {
+		indexes = append(indexes, n)
+	}
+
+	sort.Ints(indexes)
+
+	out := make([]IPPermission, 0, len(indexes))
+	for _, n := range indexes {
+		out = append(out, *byIdx[n])
+	}
+
+	return out
+}
+
+// applyIPPermissionFormEntry is a single-key apply for the
+// IpPermissions.N.X form shape. Only keys under that prefix are
+// considered; everything else is ignored so unrelated form fields
+// (e.g. GroupId) don't pollute the result.
+func applyIPPermissionFormEntry(byIdx map[int]*IPPermission, key string, values []string) {
+	suffix, ok := strings.CutPrefix(key, "IpPermissions.")
+	if !ok || len(values) == 0 {
+		return
+	}
+
+	dot := strings.Index(suffix, ".")
+	if dot < 0 {
+		return
+	}
+
+	n, err := strconv.Atoi(suffix[:dot])
+	if err != nil || n < 1 {
+		return
+	}
+
+	entry, exists := byIdx[n]
+	if !exists {
+		entry = &IPPermission{}
+		byIdx[n] = entry
+	}
+
+	setIPPermissionField(entry, suffix[dot+1:], values[0])
+}
+
+// setIPPermissionField applies one .X field on a single permission.
+// IpRanges is special-cased: each IpRanges.M.CidrIp encountered grows
+// the slice, so out-of-order M values still produce one entry each.
+func setIPPermissionField(entry *IPPermission, field, value string) {
+	switch {
+	case field == "IpProtocol":
+		entry.IPProtocol = value
+	case field == "FromPort":
+		if v, err := strconv.Atoi(value); err == nil {
+			entry.FromPort = v
+		}
+	case field == "ToPort":
+		if v, err := strconv.Atoi(value); err == nil {
+			entry.ToPort = v
+		}
+	case strings.HasPrefix(field, "IpRanges."):
+		rest := strings.TrimPrefix(field, "IpRanges.")
+
+		rdot := strings.Index(rest, ".")
+		if rdot < 0 {
+			return
+		}
+
+		if rest[rdot+1:] == "CidrIp" {
+			entry.IPRanges = append(entry.IPRanges, IPRange{CidrIP: value})
+		}
 	}
 }
 

--- a/internal/service/ec2/handlers.go
+++ b/internal/service/ec2/handlers.go
@@ -1657,13 +1657,40 @@ func convertToXMLRouteTable(rt *RouteTable) XMLRouteTable {
 	}
 }
 
-// RevokeSecurityGroupIngress / RevokeSecurityGroupEgress are accepted
-// as no-ops. terraform-aws issues these on every Create to clear the
-// default 0.0.0.0/0 egress rule before applying user rules; without a
-// 200 response the resource fails to create and downstream Authorize
-// calls never happen. We don't track egress today, so the no-op is
-// behaviourally equivalent to the cleanup terraform expects.
-func (s *Service) RevokeSecurityGroupIngress(w http.ResponseWriter, _ *http.Request) {
+// RevokeSecurityGroupIngress removes the requested rules / CIDRs
+// from the SG's ingress list. terraform aws_security_group calls this
+// on every Update where cidr_blocks shrinks, so the side effect must
+// reach storage — earlier this was a no-op stub which left stale
+// rules behind for the audit-style consumers to trip over.
+//
+// The form-converter dotted-key issue applies here too: re-parse the
+// form so IpPermissions.N.* lands in the request.
+func (s *Service) RevokeSecurityGroupIngress(w http.ResponseWriter, r *http.Request) {
+	var req AuthorizeSecurityGroupIngressRequest
+	if err := readEC2JSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.GroupID == "" && req.GroupName == "" {
+		writeError(w, errInvalidParameter, "GroupId or GroupName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := r.ParseForm(); err == nil {
+		if perms := parseIPPermissionsFromForm(r.Form); len(perms) > 0 {
+			req.IPPermissions = perms
+		}
+	}
+
+	if err := s.storage.RevokeSecurityGroupIngress(r.Context(), req.GroupID, req.GroupName, req.IPPermissions); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
 	writeEC2XMLResponse(w, struct {
 		XMLName   xml.Name `xml:"RevokeSecurityGroupIngressResponse"`
 		Xmlns     string   `xml:"xmlns,attr"`
@@ -1672,8 +1699,35 @@ func (s *Service) RevokeSecurityGroupIngress(w http.ResponseWriter, _ *http.Requ
 	}{Xmlns: ec2XMLNS, RequestID: uuid.New().String(), Return: true})
 }
 
-// RevokeSecurityGroupEgress mirrors the ingress no-op above.
-func (s *Service) RevokeSecurityGroupEgress(w http.ResponseWriter, _ *http.Request) {
+// RevokeSecurityGroupEgress is the egress mirror. Egress lookup is by
+// GroupID only — AWS doesn't accept GroupName for egress, mirroring
+// the existing Authorize handler.
+func (s *Service) RevokeSecurityGroupEgress(w http.ResponseWriter, r *http.Request) {
+	var req AuthorizeSecurityGroupEgressRequest
+	if err := readEC2JSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.GroupID == "" {
+		writeError(w, errInvalidParameter, "GroupId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := r.ParseForm(); err == nil {
+		if perms := parseIPPermissionsFromForm(r.Form); len(perms) > 0 {
+			req.IPPermissions = perms
+		}
+	}
+
+	if err := s.storage.RevokeSecurityGroupEgress(r.Context(), req.GroupID, req.IPPermissions); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
 	writeEC2XMLResponse(w, struct {
 		XMLName   xml.Name `xml:"RevokeSecurityGroupEgressResponse"`
 		Xmlns     string   `xml:"xmlns,attr"`

--- a/internal/service/ec2/service.go
+++ b/internal/service/ec2/service.go
@@ -65,6 +65,9 @@ func (s *Service) Actions() []string {
 		"DeleteSecurityGroup",
 		"AuthorizeSecurityGroupIngress",
 		"AuthorizeSecurityGroupEgress",
+		"DescribeSecurityGroups",
+		"RevokeSecurityGroupIngress",
+		"RevokeSecurityGroupEgress",
 		// Key Pair operations
 		"CreateKeyPair",
 		"DeleteKeyPair",

--- a/internal/service/ec2/sg_form_test.go
+++ b/internal/service/ec2/sg_form_test.go
@@ -1,0 +1,92 @@
+package ec2
+
+import "testing"
+
+// TestParseIPPermissionsFromForm covers the AWS Query wire shape for
+// AuthorizeSecurityGroupIngress / AuthorizeSecurityGroupEgress. The
+// terraform-aws provider sends these keys; without correct parsing the
+// handler stored an empty IngressRules slice and `DescribeSecurityGroups`
+// later surfaced `<ipPermissions></ipPermissions>` even though the
+// caller said "open 22 to 0.0.0.0/0".
+func TestParseIPPermissionsFromForm(t *testing.T) {
+	form := map[string][]string{
+		"IpPermissions.1.IpProtocol":        {"tcp"},
+		"IpPermissions.1.FromPort":          {"22"},
+		"IpPermissions.1.ToPort":            {"22"},
+		"IpPermissions.1.IpRanges.1.CidrIp": {"0.0.0.0/0"},
+		"IpPermissions.2.IpProtocol":        {"-1"},
+		"IpPermissions.2.FromPort":          {"0"},
+		"IpPermissions.2.ToPort":            {"0"},
+		"IpPermissions.2.IpRanges.1.CidrIp": {"10.0.0.0/8"},
+		// Unrelated keys don't pollute the parser.
+		"GroupId": {"sg-test"},
+	}
+
+	perms := parseIPPermissionsFromForm(form)
+	if got := len(perms); got != 2 {
+		t.Fatalf("len(perms) = %d, want 2", got)
+	}
+
+	if got := perms[0]; got.IPProtocol != "tcp" || got.FromPort != 22 || got.ToPort != 22 {
+		t.Errorf("perms[0] = %+v, want tcp 22→22", got)
+	}
+
+	if len(perms[0].IPRanges) != 1 || perms[0].IPRanges[0].CidrIP != "0.0.0.0/0" {
+		t.Errorf("perms[0].IPRanges = %+v, want one 0.0.0.0/0", perms[0].IPRanges)
+	}
+
+	if got := perms[1]; got.IPProtocol != "-1" {
+		t.Errorf("perms[1].IPProtocol = %q, want -1", got.IPProtocol)
+	}
+}
+
+// TestParseIPPermissionsFromForm_OutOfOrder confirms we sort by N so
+// member.2 supplied before member.1 still lands at the right slice
+// position.
+func TestParseIPPermissionsFromForm_OutOfOrder(t *testing.T) {
+	form := map[string][]string{
+		"IpPermissions.2.IpProtocol":        {"udp"},
+		"IpPermissions.2.IpRanges.1.CidrIp": {"10.0.0.0/8"},
+		"IpPermissions.1.IpProtocol":        {"tcp"},
+		"IpPermissions.1.IpRanges.1.CidrIp": {"0.0.0.0/0"},
+	}
+
+	perms := parseIPPermissionsFromForm(form)
+	if len(perms) != 2 {
+		t.Fatalf("len(perms) = %d, want 2", len(perms))
+	}
+
+	if perms[0].IPProtocol != "tcp" || perms[1].IPProtocol != "udp" {
+		t.Errorf("expected tcp, udp; got %s, %s", perms[0].IPProtocol, perms[1].IPProtocol)
+	}
+}
+
+// TestParseIPPermissionsFromForm_MultipleIpRanges checks the M-index
+// IpRanges.M.CidrIp loop appends every range, not just the first.
+func TestParseIPPermissionsFromForm_MultipleIpRanges(t *testing.T) {
+	form := map[string][]string{
+		"IpPermissions.1.IpProtocol":        {"tcp"},
+		"IpPermissions.1.FromPort":          {"443"},
+		"IpPermissions.1.ToPort":            {"443"},
+		"IpPermissions.1.IpRanges.1.CidrIp": {"10.0.0.0/8"},
+		"IpPermissions.1.IpRanges.2.CidrIp": {"172.16.0.0/12"},
+		"IpPermissions.1.IpRanges.3.CidrIp": {"192.168.0.0/16"},
+	}
+
+	perms := parseIPPermissionsFromForm(form)
+	if len(perms) != 1 {
+		t.Fatalf("len(perms) = %d, want 1", len(perms))
+	}
+
+	if got := len(perms[0].IPRanges); got != 3 {
+		t.Errorf("IPRanges count = %d, want 3", got)
+	}
+}
+
+// TestParseIPPermissionsFromForm_EmptyForm returns nil safely.
+func TestParseIPPermissionsFromForm_EmptyForm(t *testing.T) {
+	perms := parseIPPermissionsFromForm(map[string][]string{})
+	if len(perms) != 0 {
+		t.Errorf("empty form should yield no permissions; got %d", len(perms))
+	}
+}

--- a/internal/service/ec2/sg_revoke_test.go
+++ b/internal/service/ec2/sg_revoke_test.go
@@ -1,0 +1,157 @@
+package ec2
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestRevokeSecurityGroupIngress_RemovesMatchingCIDR exercises the
+// per-CIDR revoke semantics AWS implements: revoking
+// `{tcp, 22, 22, [0.0.0.0/0]}` from a rule that authorized
+// `{tcp, 22, 22, [0.0.0.0/0, 10.0.0.0/8]}` leaves only the
+// `10.0.0.0/8` range. terraform aws_security_group relies on this when
+// it re-applies a changed cidr_blocks list.
+func TestRevokeSecurityGroupIngress_RemovesMatchingCIDR(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+
+	vpc, err := store.CreateVpc(ctx, &CreateVpcRequest{CidrBlock: "10.0.0.0/16"})
+	if err != nil {
+		t.Fatalf("CreateVpc: %v", err)
+	}
+
+	sg, err := store.CreateSecurityGroup(ctx, &CreateSecurityGroupRequest{
+		GroupName:        "revoke-test",
+		GroupDescription: "revoke-test",
+		VpcID:            vpc.VpcID,
+	})
+	if err != nil {
+		t.Fatalf("CreateSecurityGroup: %v", err)
+	}
+
+	if err := store.AuthorizeSecurityGroupIngress(ctx, sg.GroupID, "", []IPPermission{{
+		IPProtocol: "tcp",
+		FromPort:   22,
+		ToPort:     22,
+		IPRanges: []IPRange{
+			{CidrIP: "0.0.0.0/0"},
+			{CidrIP: "10.0.0.0/8"},
+		},
+	}}); err != nil {
+		t.Fatalf("AuthorizeSecurityGroupIngress: %v", err)
+	}
+
+	if err := store.RevokeSecurityGroupIngress(ctx, sg.GroupID, "", []IPPermission{{
+		IPProtocol: "tcp",
+		FromPort:   22,
+		ToPort:     22,
+		IPRanges:   []IPRange{{CidrIP: "0.0.0.0/0"}},
+	}}); err != nil {
+		t.Fatalf("RevokeSecurityGroupIngress: %v", err)
+	}
+
+	got, err := store.DescribeSecurityGroups(ctx, []string{sg.GroupID}, nil)
+	if err != nil || len(got) != 1 {
+		t.Fatalf("DescribeSecurityGroups: err=%v len=%d", err, len(got))
+	}
+
+	if len(got[0].IngressRules) != 1 {
+		t.Fatalf("expected 1 surviving rule, got %d: %+v", len(got[0].IngressRules), got[0].IngressRules)
+	}
+
+	if len(got[0].IngressRules[0].IPRanges) != 1 || got[0].IngressRules[0].IPRanges[0].CidrIP != "10.0.0.0/8" {
+		t.Fatalf("expected only 10.0.0.0/8 to survive, got %+v", got[0].IngressRules[0].IPRanges)
+	}
+}
+
+// TestRevokeSecurityGroupIngress_DropsRuleWhenAllCIDRsRemoved verifies
+// that revoking the only CIDR on a rule deletes the whole rule entry,
+// not just empties its IPRanges. AWS shows the SG with no entries for
+// that proto/port combo afterwards.
+func TestRevokeSecurityGroupIngress_DropsRuleWhenAllCIDRsRemoved(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := NewMemoryStorage()
+
+	vpc, _ := store.CreateVpc(ctx, &CreateVpcRequest{CidrBlock: "10.0.0.0/16"})
+	sg, _ := store.CreateSecurityGroup(ctx, &CreateSecurityGroupRequest{
+		GroupName:        "drop-test",
+		GroupDescription: "drop-test",
+		VpcID:            vpc.VpcID,
+	})
+
+	_ = store.AuthorizeSecurityGroupIngress(ctx, sg.GroupID, "", []IPPermission{{
+		IPProtocol: "tcp", FromPort: 22, ToPort: 22,
+		IPRanges: []IPRange{{CidrIP: "0.0.0.0/0"}},
+	}})
+
+	if err := store.RevokeSecurityGroupIngress(ctx, sg.GroupID, "", []IPPermission{{
+		IPProtocol: "tcp", FromPort: 22, ToPort: 22,
+		IPRanges: []IPRange{{CidrIP: "0.0.0.0/0"}},
+	}}); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	got, _ := store.DescribeSecurityGroups(ctx, []string{sg.GroupID}, nil)
+	if len(got[0].IngressRules) != 0 {
+		t.Fatalf("expected 0 rules after revoking only CIDR, got %d: %+v",
+			len(got[0].IngressRules), got[0].IngressRules)
+	}
+}
+
+// TestRevokeSecurityGroupEgress mirrors the ingress drop case.
+func TestRevokeSecurityGroupEgress(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := NewMemoryStorage()
+
+	vpc, _ := store.CreateVpc(ctx, &CreateVpcRequest{CidrBlock: "10.0.0.0/16"})
+	sg, _ := store.CreateSecurityGroup(ctx, &CreateSecurityGroupRequest{
+		GroupName:        "egress-test",
+		GroupDescription: "egress-test",
+		VpcID:            vpc.VpcID,
+	})
+
+	_ = store.AuthorizeSecurityGroupEgress(ctx, sg.GroupID, []IPPermission{{
+		IPProtocol: "-1", FromPort: 0, ToPort: 0,
+		IPRanges: []IPRange{{CidrIP: "0.0.0.0/0"}},
+	}})
+
+	if err := store.RevokeSecurityGroupEgress(ctx, sg.GroupID, []IPPermission{{
+		IPProtocol: "-1", FromPort: 0, ToPort: 0,
+		IPRanges: []IPRange{{CidrIP: "0.0.0.0/0"}},
+	}}); err != nil {
+		t.Fatalf("revoke egress: %v", err)
+	}
+
+	got, _ := store.DescribeSecurityGroups(ctx, []string{sg.GroupID}, nil)
+	if len(got[0].EgressRules) != 0 {
+		t.Fatalf("expected 0 egress rules after revoke, got %d", len(got[0].EgressRules))
+	}
+}
+
+// TestRevokeSecurityGroup_NotFound returns the AWS-style error code
+// when the SG doesn't exist. terraform doesn't currently rely on the
+// distinction (it surfaces any 4xx), but staying close to AWS keeps
+// the door open for stricter consumers.
+func TestRevokeSecurityGroup_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := NewMemoryStorage()
+
+	err := store.RevokeSecurityGroupIngress(ctx, "sg-doesnotexist", "", nil)
+	if err == nil {
+		t.Fatal("expected error revoking from missing SG")
+	}
+
+	var ec2Err *Error
+	if !errors.As(err, &ec2Err) || ec2Err.Code != "InvalidGroup.NotFound" {
+		t.Fatalf("expected InvalidGroup.NotFound, got %v", err)
+	}
+}

--- a/internal/service/ec2/storage.go
+++ b/internal/service/ec2/storage.go
@@ -73,6 +73,7 @@ type Storage interface {
 	DeleteSecurityGroup(ctx context.Context, groupID, groupName string) error
 	AuthorizeSecurityGroupIngress(ctx context.Context, groupID, groupName string, permissions []IPPermission) error
 	AuthorizeSecurityGroupEgress(ctx context.Context, groupID string, permissions []IPPermission) error
+	DescribeSecurityGroups(ctx context.Context, groupIDs, groupNames []string) ([]*SecurityGroup, error)
 
 	// Key Pair operations
 	CreateKeyPair(ctx context.Context, keyName, keyType string) (*KeyPair, error)
@@ -514,6 +515,40 @@ func (m *MemoryStorage) AuthorizeSecurityGroupEgress(_ context.Context, groupID 
 	sg.EgressRules = append(sg.EgressRules, permissions...)
 
 	return nil
+}
+
+// DescribeSecurityGroups returns SGs filtered by GroupId / GroupName,
+// or every SG when both filters are empty.
+func (m *MemoryStorage) DescribeSecurityGroups(_ context.Context, groupIDs, groupNames []string) ([]*SecurityGroup, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(groupIDs) == 0 && len(groupNames) == 0 {
+		out := make([]*SecurityGroup, 0, len(m.SecurityGroups))
+		for _, sg := range m.SecurityGroups {
+			out = append(out, sg)
+		}
+
+		return out, nil
+	}
+
+	out := make([]*SecurityGroup, 0)
+
+	for _, id := range groupIDs {
+		if sg, ok := m.SecurityGroups[id]; ok {
+			out = append(out, sg)
+		}
+	}
+
+	for _, name := range groupNames {
+		for _, sg := range m.SecurityGroups {
+			if sg.GroupName == name {
+				out = append(out, sg)
+			}
+		}
+	}
+
+	return out, nil
 }
 
 // CreateKeyPair creates a new key pair.

--- a/internal/service/ec2/storage.go
+++ b/internal/service/ec2/storage.go
@@ -73,6 +73,8 @@ type Storage interface {
 	DeleteSecurityGroup(ctx context.Context, groupID, groupName string) error
 	AuthorizeSecurityGroupIngress(ctx context.Context, groupID, groupName string, permissions []IPPermission) error
 	AuthorizeSecurityGroupEgress(ctx context.Context, groupID string, permissions []IPPermission) error
+	RevokeSecurityGroupIngress(ctx context.Context, groupID, groupName string, permissions []IPPermission) error
+	RevokeSecurityGroupEgress(ctx context.Context, groupID string, permissions []IPPermission) error
 	DescribeSecurityGroups(ctx context.Context, groupIDs, groupNames []string) ([]*SecurityGroup, error)
 
 	// Key Pair operations
@@ -515,6 +517,110 @@ func (m *MemoryStorage) AuthorizeSecurityGroupEgress(_ context.Context, groupID 
 	sg.EgressRules = append(sg.EgressRules, permissions...)
 
 	return nil
+}
+
+// RevokeSecurityGroupIngress removes the IP ranges from any matching
+// ingress rule. Match key is (IPProtocol, FromPort, ToPort) — within a
+// matching rule, only the specified CidrIPs are removed (per AWS
+// semantics). A rule whose IPRanges become empty is dropped entirely.
+//
+// Note: real AWS returns InvalidPermission.NotFound when the requested
+// rule/CIDR doesn't exist; for terraform compatibility we silently
+// no-op on misses, which matches what the existing handler stub did
+// before this PR turned it real.
+func (m *MemoryStorage) RevokeSecurityGroupIngress(_ context.Context, groupID, groupName string, permissions []IPPermission) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sg := m.findSecurityGroup(groupID, groupName)
+	if sg == nil {
+		return &Error{
+			Code:    "InvalidGroup.NotFound",
+			Message: "The security group does not exist",
+		}
+	}
+
+	sg.IngressRules = revokeMatching(sg.IngressRules, permissions)
+
+	return nil
+}
+
+// RevokeSecurityGroupEgress is the egress mirror of the ingress
+// revoke. Egress lookup is by GroupID only, matching Authorize.
+func (m *MemoryStorage) RevokeSecurityGroupEgress(_ context.Context, groupID string, permissions []IPPermission) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sg, exists := m.SecurityGroups[groupID]
+	if !exists {
+		return &Error{
+			Code:    "InvalidGroup.NotFound",
+			Message: fmt.Sprintf("The security group '%s' does not exist", groupID),
+		}
+	}
+
+	sg.EgressRules = revokeMatching(sg.EgressRules, permissions)
+
+	return nil
+}
+
+// revokeMatching removes the CIDRs in `revoke` from any rule in
+// `rules` whose proto/port triple matches. Rules left with no IPRanges
+// are dropped from the returned slice. Pure function so the storage
+// methods can stay short.
+func revokeMatching(rules, revoke []IPPermission) []IPPermission {
+	for _, r := range revoke {
+		for i := range rules {
+			if !sameRuleKey(rules[i], r) {
+				continue
+			}
+
+			rules[i].IPRanges = removeCIDRs(rules[i].IPRanges, r.IPRanges)
+		}
+	}
+
+	out := rules[:0]
+
+	for _, rule := range rules {
+		if len(rule.IPRanges) > 0 {
+			out = append(out, rule)
+		}
+	}
+
+	return out
+}
+
+// sameRuleKey compares the proto/port triple AWS uses to identify a
+// rule. CIDR comparison is not part of the key — matching CIDRs are
+// removed from within the rule.
+func sameRuleKey(a, b IPPermission) bool {
+	return a.IPProtocol == b.IPProtocol && a.FromPort == b.FromPort && a.ToPort == b.ToPort
+}
+
+// removeCIDRs returns the elements of `from` whose CidrIP isn't in
+// `drop`. Matching is exact-string on CidrIP (matching AWS's CIDR
+// equality semantics — `0.0.0.0/0` and `0.0.0.0/00` are not the same).
+func removeCIDRs(from, drop []IPRange) []IPRange {
+	if len(drop) == 0 {
+		return from
+	}
+
+	dropSet := make(map[string]struct{}, len(drop))
+	for _, d := range drop {
+		dropSet[d.CidrIP] = struct{}{}
+	}
+
+	out := from[:0]
+
+	for _, r := range from {
+		if _, hit := dropSet[r.CidrIP]; hit {
+			continue
+		}
+
+		out = append(out, r)
+	}
+
+	return out
 }
 
 // DescribeSecurityGroups returns SGs filtered by GroupId / GroupName,

--- a/internal/service/ec2/types.go
+++ b/internal/service/ec2/types.go
@@ -283,6 +283,64 @@ type XMLAuthorizeSecurityGroupEgressResponse struct {
 	Return    bool     `xml:"return"`
 }
 
+// DescribeSecurityGroupsRequest carries the optional GroupId / GroupName
+// filters; an empty pair returns every SG.
+type DescribeSecurityGroupsRequest struct {
+	GroupIDs   []string `json:"GroupIds,omitempty"`
+	GroupNames []string `json:"GroupNames,omitempty"`
+}
+
+// XMLDescribeSecurityGroupsResponse is the AWS Query wire shape: a
+// securityGroupInfo container of <item> elements.
+type XMLDescribeSecurityGroupsResponse struct {
+	XMLName           xml.Name             `xml:"DescribeSecurityGroupsResponse"`
+	Xmlns             string               `xml:"xmlns,attr"`
+	RequestID         string               `xml:"requestId"`
+	SecurityGroupInfo XMLSecurityGroupInfo `xml:"securityGroupInfo"`
+}
+
+// XMLSecurityGroupInfo wraps the per-SG <item> list.
+type XMLSecurityGroupInfo struct {
+	Items []XMLSecurityGroup `xml:"item"`
+}
+
+// XMLSecurityGroup is one SG on the wire. Field names use the
+// lowercase-camel form AWS publishes for the legacy EC2 XML protocol.
+type XMLSecurityGroup struct {
+	OwnerID             string             `xml:"ownerId"`
+	GroupID             string             `xml:"groupId"`
+	GroupName           string             `xml:"groupName"`
+	GroupDescription    string             `xml:"groupDescription"`
+	VpcID               string             `xml:"vpcId,omitempty"`
+	IPPermissions       XMLIPPermissionSet `xml:"ipPermissions"`
+	IPPermissionsEgress XMLIPPermissionSet `xml:"ipPermissionsEgress"`
+	TagSet              XMLTagSet          `xml:"tagSet"`
+}
+
+// XMLIPPermissionSet is a list of IP permissions.
+type XMLIPPermissionSet struct {
+	Items []XMLIPPermission `xml:"item"`
+}
+
+// XMLIPPermission is one ingress / egress rule on the wire.
+type XMLIPPermission struct {
+	IPProtocol string      `xml:"ipProtocol"`
+	FromPort   int         `xml:"fromPort"`
+	ToPort     int         `xml:"toPort"`
+	IPRanges   XMLIPRanges `xml:"ipRanges"`
+}
+
+// XMLIPRanges wraps the per-CIDR <item> list.
+type XMLIPRanges struct {
+	Items []XMLIPRange `xml:"item"`
+}
+
+// XMLIPRange is one CIDR entry.
+type XMLIPRange struct {
+	CidrIP      string `xml:"cidrIp"`
+	Description string `xml:"description,omitempty"`
+}
+
 // XMLCreateKeyPairResponse is the XML response for CreateKeyPair.
 type XMLCreateKeyPairResponse struct {
 	XMLName        xml.Name `xml:"CreateKeyPairResponse"`


### PR DESCRIPTION
## Summary

Replace the no-op `RevokeSecurityGroup{Ingress,Egress}` stub from #572 with a real per-CIDR implementation that mutates storage. terraform sends \`Revoke\` whenever \`cidr_blocks\` shrinks on an existing SG; the stub left stale rules in kumo state, so anything that audits the SG afterwards (kumo-audit, IaC drift detection, …) saw rules that no longer existed in the source-of-truth config.

## AWS revoke semantics

- Rule identity key is **(IPProtocol, FromPort, ToPort)** — CIDR is *not* part of the key
- Within a matching rule, only the listed CidrIPs are removed (so `Revoke {tcp,22,22,[0.0.0.0/0]}` against an authorized `{tcp,22,22,[0.0.0.0/0, 10.0.0.0/8]}` leaves only `10.0.0.0/8`)
- A rule whose IPRanges become empty is dropped entirely
- A missing SG returns `InvalidGroup.NotFound`
- A missing rule/CIDR is a silent no-op (real AWS returns `InvalidPermission.NotFound`; matches the prior stub's behaviour and terraform doesn't distinguish)

## Implementation

- Storage interface gains `RevokeSecurityGroupIngress` / `RevokeSecurityGroupEgress`.
- Pure helpers (\`revokeMatching\`, \`sameRuleKey\`, \`removeCIDRs\`) keep the storage methods short and unit-testable.
- Handlers re-use the same form-parse recovery path \`Authorize*\` uses to work around kumo's form-to-JSON dotted-key limitation.

## Dependency on #572

Branched off \`fix/ec2-sg-ippermissions-form-parse\`. Whichever merges first, the other can rebase to drop the duplicate. The combination is what makes \`tofu apply -target=aws_security_group\` work end-to-end against kumo (and what lets kumo-audit's SG rule pack actually evaluate).

## Test plan

- [x] \`go test ./internal/service/ec2/ -run TestRevokeSecurityGroup\` — 4 sub-tests pass:
  - \`RemovesMatchingCIDR\` (per-CIDR semantics)
  - \`DropsRuleWhenAllCIDRsRemoved\` (empty-IPRanges → rule deletion)
  - \`Egress\` (egress mirror)
  - \`NotFound\` (InvalidGroup.NotFound on missing SG)
- [x] \`go test ./...\` — full suite green
- [x] \`make lint\` — clean
- [x] Manual: \`tofu apply -target=aws_security_group.wide_open\` against this branch creates the SG and \`kumo-audit\` reports \`sg-open-ssh\` / \`sg-open-rdp\` / \`sg-open-all-protocols\` findings against it

🤖 Generated with [Claude Code](https://claude.com/claude-code)