### PR TITLE
feat(s3): PutBucketPolicy / GetBucketPolicy / DeleteBucketPolicy

### DIFF
--- a/internal/service/s3/bucket_policy_test.go
+++ b/internal/service/s3/bucket_policy_test.go
@@ -1,0 +1,170 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	codeNoSuchBucket       = "NoSuchBucket"
+	codeNoSuchBucketPolicy = "NoSuchBucketPolicy"
+)
+
+// TestBucketPolicy_PutGetDelete exercises the storage round-trip.
+// AWS treats a bucket policy as an opaque JSON document for the
+// purposes of Put / Get; structural validation belongs in IAM-layer
+// rules (which kumo doesn't model). So the storage just persists the
+// bytes and Get returns them verbatim.
+func TestBucketPolicy_PutGetDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+
+	if err := store.CreateBucket(ctx, "policy-test"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	const doc = `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":"*","Action":"s3:*","Resource":"*","Condition":{"Bool":{"aws:SecureTransport":"false"}}}]}`
+
+	if err := store.PutBucketPolicy(ctx, "policy-test", doc); err != nil {
+		t.Fatalf("PutBucketPolicy: %v", err)
+	}
+
+	got, err := store.GetBucketPolicy(ctx, "policy-test")
+	if err != nil {
+		t.Fatalf("GetBucketPolicy: %v", err)
+	}
+
+	if got != doc {
+		t.Fatalf("policy round-trip mismatch:\ngot:  %s\nwant: %s", got, doc)
+	}
+
+	if err := store.DeleteBucketPolicy(ctx, "policy-test"); err != nil {
+		t.Fatalf("DeleteBucketPolicy: %v", err)
+	}
+
+	if _, err := store.GetBucketPolicy(ctx, "policy-test"); err == nil {
+		t.Fatal("expected NoSuchBucketPolicy after delete, got nil")
+	}
+}
+
+// TestBucketPolicy_Errors covers the AWS error codes terraform and
+// the SDK look at — NoSuchBucket on a missing bucket and
+// NoSuchBucketPolicy on an unconfigured bucket.
+func TestBucketPolicy_Errors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := NewMemoryStorage()
+
+	if _, err := store.GetBucketPolicy(ctx, "no-such"); err == nil {
+		t.Fatal("expected error on missing bucket, got nil")
+	} else {
+		assertBucketErrorCode(t, err, codeNoSuchBucket)
+	}
+
+	if err := store.PutBucketPolicy(ctx, "no-such", "{}"); err == nil {
+		t.Fatal("expected NoSuchBucket on Put, got nil")
+	}
+
+	_ = store.CreateBucket(ctx, "policy-empty")
+
+	if _, err := store.GetBucketPolicy(ctx, "policy-empty"); err == nil {
+		t.Fatal("expected NoSuchBucketPolicy on unconfigured bucket, got nil")
+	} else {
+		assertBucketErrorCode(t, err, codeNoSuchBucketPolicy)
+	}
+}
+
+// TestBucketPolicy_HTTP exercises the HTTP layer end-to-end:
+// PUT /{bucket}?policy persists; GET /{bucket}?policy returns the
+// document; DELETE /{bucket}?policy removes it. terraform aws_s3_-
+// bucket_policy uses exactly this surface.
+func TestBucketPolicy_HTTP(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	if err := store.CreateBucket(ctx, "http-policy-test"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	doc := `{"Version":"2012-10-17","Statement":[]}`
+
+	t.Run("PUT", func(t *testing.T) {
+		w := callPolicyHandler(svc.PutBucketPolicy, http.MethodPut, strings.NewReader(doc))
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("PUT got %d, want 204; body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("GET", func(t *testing.T) {
+		w := callPolicyHandler(svc.GetBucketPolicy, http.MethodGet, http.NoBody)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET got %d, want 200; body=%s", w.Code, w.Body.String())
+		}
+
+		if w.Body.String() != doc {
+			t.Fatalf("GET body mismatch:\ngot:  %s\nwant: %s", w.Body.String(), doc)
+		}
+	})
+
+	t.Run("DELETE", func(t *testing.T) {
+		w := callPolicyHandler(svc.DeleteBucketPolicy, http.MethodDelete, http.NoBody)
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("DELETE got %d, want 204; body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("GET after DELETE returns NoSuchBucketPolicy", func(t *testing.T) {
+		w := callPolicyHandler(svc.GetBucketPolicy, http.MethodGet, http.NoBody)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d; body=%s", w.Code, w.Body.String())
+		}
+
+		var errResp struct {
+			XMLName xml.Name `xml:"Error"`
+			Code    string   `xml:"Code"`
+		}
+
+		if err := xml.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+			t.Fatalf("xml unmarshal: %v\nbody=%s", err, w.Body.String())
+		}
+
+		if errResp.Code != codeNoSuchBucketPolicy {
+			t.Fatalf("expected Code=NoSuchBucketPolicy, got %q", errResp.Code)
+		}
+	})
+}
+
+// callPolicyHandler dispatches one of the policy handlers with the
+// path value already wired up. Cuts test boilerplate.
+const httpPolicyBucket = "http-policy-test"
+
+func callPolicyHandler(h http.HandlerFunc, method string, body interface{ Read(p []byte) (int, error) }) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, "/"+httpPolicyBucket+"?policy", body)
+	req.SetPathValue("bucket", httpPolicyBucket)
+
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	return w
+}
+
+// assertBucketErrorCode unwraps to BucketError and checks Code.
+func assertBucketErrorCode(t *testing.T, err error, want string) {
+	t.Helper()
+
+	var be *BucketError
+	if !errors.As(err, &be) || be.Code != want {
+		t.Fatalf("expected %s, got %v", want, err)
+	}
+}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -118,6 +118,12 @@ func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, ok := r.URL.Query()["policy"]; ok {
+		s.GetBucketPolicy(w, r)
+
+		return
+	}
+
 	if _, ok := r.URL.Query()["versions"]; ok {
 		s.ListObjectVersions(w, r)
 
@@ -186,7 +192,6 @@ func (s *Service) serveBucketSubresourceStub(w http.ResponseWriter, r *http.Requ
 // code returned when the sub-resource is unconfigured.
 func bucketSubresourceErrorCode(q map[string][]string) (string, bool) {
 	mapping := map[string]string{
-		"policy":            "NoSuchBucketPolicy",
 		"cors":              "NoSuchCORSConfiguration",
 		"lifecycle":         "NoSuchLifecycleConfiguration",
 		"replication":       "ReplicationConfigurationNotFoundError",
@@ -1114,6 +1119,12 @@ func (s *Service) handleBucketPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, ok := r.URL.Query()["policy"]; ok {
+		s.PutBucketPolicy(w, r)
+
+		return
+	}
+
 	s.CreateBucket(w, r)
 }
 
@@ -1127,6 +1138,12 @@ func (s *Service) handleBucketDelete(w http.ResponseWriter, r *http.Request) {
 
 	if _, ok := r.URL.Query()["encryption"]; ok {
 		s.DeleteBucketEncryption(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["policy"]; ok {
+		s.DeleteBucketPolicy(w, r)
 
 		return
 	}
@@ -1282,6 +1299,61 @@ func (s *Service) DeleteBucketEncryption(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// PutBucketPolicy handles PUT /{bucket}?policy. The body is the
+// raw JSON policy document — AWS treats it as opaque for storage,
+// so we don't validate structure here. terraform aws_s3_bucket_policy
+// is the primary caller.
+func (s *Service) PutBucketPolicy(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeS3Error(w, r, "InvalidArgument", "Failed to read request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.PutBucketPolicy(r.Context(), bucket, string(body)); err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetBucketPolicy handles GET /{bucket}?policy. Returns the raw
+// document as application/json (mirroring real S3) or NoSuchBucketPolicy
+// when the bucket exists without a policy.
+func (s *Service) GetBucketPolicy(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	doc, err := s.storage.GetBucketPolicy(r.Context(), bucket)
+	if err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(doc))
+}
+
+// DeleteBucketPolicy handles DELETE /{bucket}?policy. AWS returns 204
+// even when no policy was set, so a missing policy is not an error.
+func (s *Service) DeleteBucketPolicy(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	if err := s.storage.DeleteBucketPolicy(r.Context(), bucket); err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // writeBucketErrorOrInternal maps a BucketError to its HTTP status code,
 // falling back to 500 for non-bucket errors. Used by sub-resource handlers.
 func writeBucketErrorOrInternal(w http.ResponseWriter, r *http.Request, err error) {
@@ -1290,7 +1362,7 @@ func writeBucketErrorOrInternal(w http.ResponseWriter, r *http.Request, err erro
 		status := http.StatusBadRequest
 
 		switch bucketErr.Code {
-		case "NoSuchBucket", "NoSuchPublicAccessBlockConfiguration", "ServerSideEncryptionConfigurationNotFoundError":
+		case "NoSuchBucket", "NoSuchPublicAccessBlockConfiguration", "ServerSideEncryptionConfigurationNotFoundError", "NoSuchBucketPolicy":
 			status = http.StatusNotFound
 		}
 

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -68,6 +68,9 @@ type Storage interface {
 
 	PutBucketEncryption(ctx context.Context, bucket string, cfg ServerSideEncryptionConfig) error
 	GetBucketEncryption(ctx context.Context, bucket string) (*ServerSideEncryptionConfig, error)
+	PutBucketPolicy(ctx context.Context, bucket, document string) error
+	GetBucketPolicy(ctx context.Context, bucket string) (string, error)
+	DeleteBucketPolicy(ctx context.Context, bucket string) error
 	DeleteBucketEncryption(ctx context.Context, bucket string) error
 }
 
@@ -107,6 +110,7 @@ type MemoryBucket struct {
 	CORSRules          []CORSRule                  `json:"corsRules,omitempty"`         // CORS configuration
 	PublicAccessBlock  *PublicAccessBlockConfig    `json:"publicAccessBlock,omitempty"` // public access block configuration
 	Encryption         *ServerSideEncryptionConfig `json:"encryption,omitempty"`        // server-side encryption configuration
+	Policy             string                      `json:"policy,omitempty"`            // bucket policy JSON document (empty == not configured)
 }
 
 // PublicAccessBlockConfig stores the four PAB flags.
@@ -1227,6 +1231,62 @@ func (s *MemoryStorage) DeleteBucketEncryption(_ context.Context, bucket string)
 	}
 
 	b.Encryption = nil
+
+	return nil
+}
+
+// PutBucketPolicy stores a bucket's policy document. AWS treats the
+// document as opaque JSON for the purposes of Put/Get, so we just
+// persist the bytes — IAM-layer evaluation is out of scope.
+func (s *MemoryStorage) PutBucketPolicy(_ context.Context, bucket, document string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	b.Policy = document
+
+	return nil
+}
+
+// GetBucketPolicy returns the configured policy document. Returns
+// NoSuchBucketPolicy when the bucket exists but has no policy set.
+func (s *MemoryStorage) GetBucketPolicy(_ context.Context, bucket string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return "", &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if b.Policy == "" {
+		return "", &BucketError{
+			Code:       "NoSuchBucketPolicy",
+			Message:    "The bucket policy does not exist",
+			BucketName: bucket,
+		}
+	}
+
+	return b.Policy, nil
+}
+
+// DeleteBucketPolicy clears the bucket's policy. AWS allows this on a
+// bucket without a policy (returns 204), so a missing policy is not
+// an error here either.
+func (s *MemoryStorage) DeleteBucketPolicy(_ context.Context, bucket string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	b.Policy = ""
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Real Put/Get/Delete for S3 bucket policies. Previously \`GET /{bucket}?policy\` always returned \`NoSuchBucketPolicy\` from the sub-resource stub and PUT had no route at all (404), which:

- broke \`terraform aws_s3_bucket_policy\` end-to-end against kumo
- left audit-style consumers of bucket policy unable to evaluate anything (CIS 2.1.1 \"deny non-TLS\", wildcard-Principal detection, …)

## Implementation

- \`MemoryBucket\` gains a \`Policy string\` field. AWS treats the document as opaque JSON for Put/Get — IAM-layer evaluation isn't kumo's concern — so storage just round-trips the bytes.
- Three handlers wire into the existing \`handleBucketPut\` / \`handleBucketGet\` / \`handleBucketDelete\` dispatchers via the \`?policy\` query.
- \`policy\` is removed from \`bucketSubresourceErrorCode\` mapping; the new GET handler owns the NoSuchBucketPolicy response.
- \`writeBucketErrorOrInternal\` adds NoSuchBucketPolicy → 404.

## Status codes

| op | response |
|---|---|
| PUT \`/{bucket}?policy\` (body = JSON) | 204 No Content |
| GET \`/{bucket}?policy\` | 200 + Content-Type: application/json + body verbatim |
| DELETE \`/{bucket}?policy\` | 204 No Content |
| GET on a bucket without a policy | 404 NoSuchBucketPolicy |
| any op on a missing bucket | 404 NoSuchBucket |

## Test plan

- [x] \`go test ./internal/service/s3/ -run TestBucketPolicy\` — 3 tests / 7 sub-tests pass:
  - \`PutGetDelete\` storage round-trip
  - \`Errors\` (NoSuchBucket / NoSuchBucketPolicy)
  - \`HTTP\` (PUT 204, GET 200 verbatim, DELETE 204, post-delete GET 404)
- [x] \`go test ./...\` — full suite green
- [x] \`make lint\` — clean
- [x] Manual: curl PUT/GET/DELETE on \`/{bucket}?policy\` against a kumo built from this branch returns the codes documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)