### PR TITLE
feat(s3): PutBucketLogging / GetBucketLogging

### DIFF
--- a/internal/service/s3/bucket_logging_test.go
+++ b/internal/service/s3/bucket_logging_test.go
@@ -1,0 +1,158 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const httpLoggingBucket = "http-logging-test"
+
+// TestBucketLogging_PutGet exercises the storage round-trip. AWS lets
+// you POST a BucketLoggingStatus payload with LoggingEnabled to opt
+// in, or POST an empty status to opt out. terraform aws_s3_bucket_-
+// logging uses the LoggingEnabled form; audit consumers care whether
+// TargetBucket is non-empty.
+func TestBucketLogging_PutGet(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+
+	if err := store.CreateBucket(ctx, "logging-test"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	cfg := BucketLoggingConfig{TargetBucket: "log-target", TargetPrefix: "logs/"}
+
+	if err := store.PutBucketLogging(ctx, "logging-test", cfg); err != nil {
+		t.Fatalf("PutBucketLogging: %v", err)
+	}
+
+	got, err := store.GetBucketLogging(ctx, "logging-test")
+	if err != nil {
+		t.Fatalf("GetBucketLogging: %v", err)
+	}
+
+	if got == nil || got.TargetBucket != "log-target" || got.TargetPrefix != "logs/" {
+		t.Fatalf("logging round-trip mismatch: got %+v, want %+v", got, cfg)
+	}
+}
+
+// TestBucketLogging_OptOut empties the LoggingEnabled element to turn
+// logging off. Get then returns nil.
+func TestBucketLogging_OptOut(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+
+	_ = store.CreateBucket(ctx, "logging-off")
+	_ = store.PutBucketLogging(ctx, "logging-off", BucketLoggingConfig{TargetBucket: "x"})
+
+	if err := store.PutBucketLogging(ctx, "logging-off", BucketLoggingConfig{}); err != nil {
+		t.Fatalf("PutBucketLogging (off): %v", err)
+	}
+
+	got, err := store.GetBucketLogging(ctx, "logging-off")
+	if err != nil {
+		t.Fatalf("GetBucketLogging: %v", err)
+	}
+
+	if got != nil {
+		t.Fatalf("expected nil after opt-out, got %+v", got)
+	}
+}
+
+// TestBucketLogging_HTTP exercises the HTTP layer end-to-end. PUT
+// accepts the AWS XML payload; GET returns the same structure (or an
+// empty BucketLoggingStatus when not configured).
+func TestBucketLogging_HTTP(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	if err := store.CreateBucket(ctx, httpLoggingBucket); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	const putBody = `<?xml version="1.0" encoding="UTF-8"?>
+<BucketLoggingStatus xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <LoggingEnabled>
+    <TargetBucket>log-target</TargetBucket>
+    <TargetPrefix>logs/</TargetPrefix>
+  </LoggingEnabled>
+</BucketLoggingStatus>`
+
+	t.Run("PUT", func(t *testing.T) {
+		w := callLoggingHandler(svc.PutBucketLogging, http.MethodPut, strings.NewReader(putBody))
+		if w.Code != http.StatusOK {
+			t.Fatalf("PUT got %d, want 200; body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("GET", func(t *testing.T) {
+		w := callLoggingHandler(svc.GetBucketLogging, http.MethodGet, http.NoBody)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET got %d, want 200; body=%s", w.Code, w.Body.String())
+		}
+
+		var resp BucketLoggingStatus
+		if err := xml.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("xml unmarshal: %v\nbody=%s", err, w.Body.String())
+		}
+
+		if resp.LoggingEnabled == nil || resp.LoggingEnabled.TargetBucket != "log-target" {
+			t.Fatalf("expected LoggingEnabled with TargetBucket=log-target, got %+v", resp)
+		}
+	})
+
+	t.Run("GET on bucket without logging returns empty status", func(t *testing.T) {
+		assertEmptyLoggingStatus(ctx, t, svc, store)
+	})
+}
+
+// assertEmptyLoggingStatus exercises the "logging disabled" GET path
+// against a fresh bucket. Lifted out of TestBucketLogging_HTTP to keep
+// that function under the funlen lint cap.
+func assertEmptyLoggingStatus(ctx context.Context, t *testing.T, svc *Service, store *MemoryStorage) {
+	t.Helper()
+
+	_ = store.CreateBucket(ctx, "no-logging")
+
+	req := httptest.NewRequest(http.MethodGet, "/no-logging?logging", http.NoBody)
+	req.SetPathValue("bucket", "no-logging")
+
+	w := httptest.NewRecorder()
+	svc.GetBucketLogging(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp BucketLoggingStatus
+	if err := xml.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("xml unmarshal: %v\nbody=%s", err, w.Body.String())
+	}
+
+	if resp.LoggingEnabled != nil {
+		t.Fatalf("expected no LoggingEnabled element, got %+v", resp.LoggingEnabled)
+	}
+}
+
+// callLoggingHandler dispatches one of the logging handlers with the
+// path value already wired up.
+func callLoggingHandler(h http.HandlerFunc, method string, body interface{ Read(p []byte) (int, error) }) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, "/"+httpLoggingBucket+"?logging", body)
+	req.SetPathValue("bucket", httpLoggingBucket)
+
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	return w
+}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -130,6 +130,12 @@ func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, ok := r.URL.Query()["logging"]; ok {
+		s.GetBucketLogging(w, r)
+
+		return
+	}
+
 	if _, ok := r.URL.Query()["versions"]; ok {
 		s.ListObjectVersions(w, r)
 
@@ -165,11 +171,6 @@ func (s *Service) serveBucketSubresourceStub(w http.ResponseWriter, r *http.Requ
 			Xmlns   string   `xml:"xmlns,attr,omitempty"`
 			Value   string   `xml:",chardata"`
 		}{Xmlns: s3Namespace, Value: "us-east-1"})
-	case q.Has("logging"):
-		writeXMLResponse(w, struct {
-			XMLName xml.Name `xml:"BucketLoggingStatus"`
-			Xmlns   string   `xml:"xmlns,attr,omitempty"`
-		}{Xmlns: s3Namespace})
 	case q.Has("accelerate"):
 		writeXMLResponse(w, struct {
 			XMLName xml.Name `xml:"AccelerateConfiguration"`
@@ -1197,6 +1198,12 @@ func (s *Service) handleBucketPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, ok := r.URL.Query()["logging"]; ok {
+		s.PutBucketLogging(w, r)
+
+		return
+	}
+
 	s.CreateBucket(w, r)
 }
 
@@ -1356,6 +1363,69 @@ func (s *Service) GetBucketEncryption(w http.ResponseWriter, r *http.Request) {
 		Xmlns: s3Namespace,
 		Rules: xmlRules,
 	})
+}
+
+// PutBucketLogging handles PUT /{bucket}?logging. Body is the AWS
+// BucketLoggingStatus XML; an empty / missing LoggingEnabled element
+// disables logging on the bucket. terraform aws_s3_bucket_logging is
+// the primary caller.
+func (s *Service) PutBucketLogging(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeS3Error(w, r, "InvalidRequest", "Failed to read request body", http.StatusBadRequest)
+
+		return
+	}
+
+	var status BucketLoggingStatus
+	if len(body) > 0 {
+		if err := xml.Unmarshal(body, &status); err != nil {
+			writeS3Error(w, r, "MalformedXML", "Failed to parse BucketLoggingStatus", http.StatusBadRequest)
+
+			return
+		}
+	}
+
+	cfg := BucketLoggingConfig{}
+	if status.LoggingEnabled != nil {
+		cfg.TargetBucket = status.LoggingEnabled.TargetBucket
+		cfg.TargetPrefix = status.LoggingEnabled.TargetPrefix
+	}
+
+	if err := s.storage.PutBucketLogging(r.Context(), bucket, cfg); err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetBucketLogging handles GET /{bucket}?logging. Returns the wire
+// shape with LoggingEnabled present when configured, or an empty
+// status element when not — matching real AWS behaviour. terraform
+// reads this back to detect drift.
+func (s *Service) GetBucketLogging(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	cfg, err := s.storage.GetBucketLogging(r.Context(), bucket)
+	if err != nil {
+		writeBucketErrorOrInternal(w, r, err)
+
+		return
+	}
+
+	resp := BucketLoggingStatus{Xmlns: s3Namespace}
+	if cfg != nil {
+		resp.LoggingEnabled = &LoggingEnabledStatus{
+			TargetBucket: cfg.TargetBucket,
+			TargetPrefix: cfg.TargetPrefix,
+		}
+	}
+
+	writeXMLResponse(w, resp)
 }
 
 // DeleteBucketEncryption handles DELETE /{bucket}?encryption.

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -73,6 +73,9 @@ type Storage interface {
 	GetBucketPolicy(ctx context.Context, bucket string) (string, error)
 	DeleteBucketPolicy(ctx context.Context, bucket string) error
 	DeleteBucketEncryption(ctx context.Context, bucket string) error
+
+	PutBucketLogging(ctx context.Context, bucket string, cfg BucketLoggingConfig) error
+	GetBucketLogging(ctx context.Context, bucket string) (*BucketLoggingConfig, error)
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -112,6 +115,17 @@ type MemoryBucket struct {
 	PublicAccessBlock  *PublicAccessBlockConfig    `json:"publicAccessBlock,omitempty"` // public access block configuration
 	Encryption         *ServerSideEncryptionConfig `json:"encryption,omitempty"`        // server-side encryption configuration
 	Policy             string                      `json:"policy,omitempty"`            // bucket policy JSON document (empty == not configured)
+	Logging            *BucketLoggingConfig        `json:"logging,omitempty"`           // server access logging target (nil == disabled)
+}
+
+// BucketLoggingConfig stores the destination for server access logs.
+// AWS lets logging be opted out by sending an empty BucketLoggingStatus
+// (no LoggingEnabled element); we represent that as a nil pointer on
+// the bucket. TargetBucket == "" never lands in storage — the handler
+// only persists configs with a target.
+type BucketLoggingConfig struct {
+	TargetBucket string `json:"targetBucket"`
+	TargetPrefix string `json:"targetPrefix,omitempty"`
 }
 
 // PublicAccessBlockConfig stores the four PAB flags.
@@ -1343,4 +1357,51 @@ func (s *MemoryStorage) DeleteBucketPolicy(_ context.Context, bucket string) err
 	b.Policy = ""
 
 	return nil
+}
+
+// PutBucketLogging stores the server-access-log destination for a
+// bucket. An empty TargetBucket means the caller is opting out, so we
+// clear the config (matches AWS semantics where an empty
+// BucketLoggingStatus body disables logging).
+func (s *MemoryStorage) PutBucketLogging(_ context.Context, bucket string, cfg BucketLoggingConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if cfg.TargetBucket == "" {
+		b.Logging = nil
+
+		return nil
+	}
+
+	c := cfg
+	b.Logging = &c
+
+	return nil
+}
+
+// GetBucketLogging returns the configured destination, or nil when
+// logging is disabled. Real AWS GET on an unconfigured bucket returns
+// an empty <BucketLoggingStatus/> rather than NoSuch*; the handler
+// renders that case from a nil result.
+func (s *MemoryStorage) GetBucketLogging(_ context.Context, bucket string) (*BucketLoggingConfig, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if b.Logging == nil {
+		return nil, nil //nolint:nilnil // documented contract: nil cfg + nil err == disabled
+	}
+
+	c := *b.Logging
+
+	return &c, nil
 }

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -12,6 +12,23 @@ type Bucket struct {
 	CreationDate time.Time
 }
 
+// BucketLoggingStatus is the wire shape of {Put,Get}BucketLogging.
+// LoggingEnabled is omitted (nil pointer) when logging is disabled —
+// AWS sends `<BucketLoggingStatus/>` in that case.
+type BucketLoggingStatus struct {
+	XMLName        xml.Name              `xml:"BucketLoggingStatus"`
+	Xmlns          string                `xml:"xmlns,attr,omitempty"`
+	LoggingEnabled *LoggingEnabledStatus `xml:"LoggingEnabled,omitempty"`
+}
+
+// LoggingEnabledStatus is the body of LoggingEnabled. TargetGrants
+// isn't modelled; terraform's aws_s3_bucket_logging only sets target
+// + prefix.
+type LoggingEnabledStatus struct {
+	TargetBucket string `xml:"TargetBucket"`
+	TargetPrefix string `xml:"TargetPrefix,omitempty"`
+}
+
 // Object represents an S3 object.
 type Object struct {
 	Key            string


### PR DESCRIPTION
## Summary

Real Put/Get for S3 bucket server-access-log configuration. Previously \`GET /{bucket}?logging\` always returned an empty \`<BucketLoggingStatus/>\` from the sub-resource stub and \`PUT /{bucket}?logging\` had no dispatch at all (silently fell through to \`CreateBucket\`), which:

- broke \`terraform aws_s3_bucket_logging\` end-to-end against kumo (refresh saw no logging configured even after apply)
- left audit consumers of access-log configuration (CIS 3.6 \"S3 access logging enabled\") unable to distinguish a logged bucket from an unlogged one — the stub-only path locked everything to \"unlogged\"

## Implementation

- \`MemoryBucket\` gains a \`Logging *BucketLoggingConfig\` (TargetBucket + TargetPrefix). \`TargetGrants\` isn't modelled — terraform doesn't set them and audit doesn't read them.
- PUT with an empty / missing \`LoggingEnabled\` clears the config, matching AWS \"opt out\" semantics.
- GET returns \`LoggingEnabled\` when configured, or \`<BucketLoggingStatus xmlns=\"...\"/>\` when not — same shape real AWS uses to say \"logging disabled\".
- The \`?logging\` branch in \`serveBucketSubresourceStub\` is removed; the new GET handler owns it.

## Status codes

| op | response |
|---|---|
| PUT \`/{bucket}?logging\` (LoggingEnabled body) | 200 OK |
| PUT \`/{bucket}?logging\` (empty body) | 200 OK, logging cleared |
| GET \`/{bucket}?logging\` (configured) | 200 OK + LoggingEnabled element |
| GET \`/{bucket}?logging\` (not configured) | 200 OK + empty status |
| any op on missing bucket | 404 NoSuchBucket |

## Test plan

- [x] \`go test ./internal/service/s3/ -run TestBucketLogging\` — 3 tests / 3 sub-tests pass:
  - \`PutGet\` storage round-trip
  - \`OptOut\` (empty config clears state, GET returns nil)
  - \`HTTP\` (PUT 200, GET verbatim, GET on unconfigured bucket returns empty status)
- [x] \`go test ./...\` — full suite green
- [x] \`make lint\` — clean
- [x] Manual: \`curl PUT /bucket?logging\` with the AWS XML payload persists, subsequent \`GET /bucket?logging\` returns the same payload verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)