### PR TITLE
feat(iam): UpdateRole / UpdateAssumeRolePolicy / TagRole + unified Query dispatcher

### DIFF
--- a/internal/service/iam/dispatcher_test.go
+++ b/internal/service/iam/dispatcher_test.go
@@ -1,0 +1,113 @@
+package iam
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestDispatchAction_JSONBody covers the path where the AWS Query dispatcher
+// has converted the form-encoded request to JSON before calling DispatchAction.
+//
+// terraform-provider-aws and other clients that target the unified `/`
+// endpoint hit this code path; the IAM-direct `/iam/` route keeps the form
+// payload as-is. The handlers must accept both shapes.
+func TestDispatchAction_JSONBody(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+
+	body := strings.NewReader(`{"RoleName":"json-role","AssumeRolePolicyDocument":"{\"Version\":\"2012-10-17\"}","Description":"from json"}`)
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "iam.CreateRole")
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("DispatchAction CreateRole (JSON): got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp CreateRoleResponse
+	if err := xml.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("xml unmarshal: %v", err)
+	}
+
+	if got, want := resp.CreateRoleResult.Role.RoleName, "json-role"; got != want {
+		t.Fatalf("RoleName: got %q, want %q", got, want)
+	}
+
+	if got, want := resp.CreateRoleResult.Role.Description, "from json"; got != want {
+		t.Fatalf("Description: got %q, want %q (body restoration broken — multiple getJSONValue calls couldn't re-read the request body)", got, want)
+	}
+}
+
+// TestQueryProtocolService confirms the IAM service surfaces the marker
+// methods the unified Query dispatcher uses to register a service.
+func TestQueryProtocolService(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+
+	if got := svc.ServiceIdentifier(); got != "iam" {
+		t.Fatalf("ServiceIdentifier: got %q, want %q", got, "iam")
+	}
+
+	if got := svc.TargetPrefix(); got == "" {
+		t.Fatal("TargetPrefix: must be non-empty so the dispatcher can register a key")
+	}
+
+	actions := svc.Actions()
+	if len(actions) == 0 {
+		t.Fatal("Actions: expected at least one action")
+	}
+
+	has := func(name string) bool {
+		for _, a := range actions {
+			if a == name {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for _, want := range []string{"CreateRole", "GetRole", "DeleteRole", "UpdateRole"} {
+		if !has(want) {
+			t.Errorf("Actions missing %q", want)
+		}
+	}
+
+	// QueryProtocol is a marker — calling it must not panic.
+	svc.QueryProtocol()
+}
+
+// TestGetJSONValue_BodyRestoration locks in the contract that getJSONValue
+// can be called repeatedly on the same request without consuming the body.
+//
+// IAM handlers call getFormValue once per parameter (RoleName,
+// AssumeRolePolicyDocument, Path, Description, MaxSessionDuration, Tags ...),
+// so the body must be readable across all of those calls.
+func TestGetJSONValue_BodyRestoration(t *testing.T) {
+	t.Parallel()
+
+	body := io.NopCloser(strings.NewReader(`{"a":"first","b":"second"}`))
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+
+	if got := getFormValue(req, "a"); got != "first" {
+		t.Fatalf("first read: got %q, want %q", got, "first")
+	}
+
+	if got := getFormValue(req, "b"); got != "second" {
+		t.Fatalf("second read (body must be restored): got %q, want %q", got, "second")
+	}
+
+	if got := getFormValue(req, "missing"); got != "" {
+		t.Fatalf("missing key: got %q, want empty", got)
+	}
+}

--- a/internal/service/iam/handlers.go
+++ b/internal/service/iam/handlers.go
@@ -146,6 +146,104 @@ func (s *Service) CreateRole(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// UpdateRole handles the UpdateRole action. terraform aws_iam_role
+// and alchemy's Role both call this on every apply after GetRole;
+// without it those resources fail on second-and-later runs.
+//
+// AWS treats Description and MaxSessionDuration as optional — present
+// fields update, missing fields preserve current state. We honour
+// that with nil-pointer semantics on the storage layer.
+func (s *Service) UpdateRole(w http.ResponseWriter, r *http.Request) {
+	roleName := getFormValue(r, "RoleName")
+	if roleName == "" {
+		writeIAMError(w, errInvalidParameter, "RoleName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	var description *string
+
+	if r.PostFormValue("Description") != "" || r.URL.Query().Get("Description") != "" {
+		v := getFormValue(r, "Description")
+		description = &v
+	}
+
+	var maxSession *int
+
+	if raw := getFormValue(r, "MaxSessionDuration"); raw != "" {
+		v := parseIntValue(r, "MaxSessionDuration")
+		maxSession = &v
+	}
+
+	if err := s.storage.UpdateRole(r.Context(), roleName, description, maxSession); err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, UpdateRoleResponse{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// TagRole handles the TagRole action. terraform / pulumi /
+// alchemy all use this to add `Name` / `alchemy_stage` /
+// resource tracking tags after role creation.
+func (s *Service) TagRole(w http.ResponseWriter, r *http.Request) {
+	roleName := getFormValue(r, "RoleName")
+	if roleName == "" {
+		writeIAMError(w, errInvalidParameter, "RoleName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	tags := parseTags(r)
+	if len(tags) == 0 {
+		writeIAMError(w, errInvalidParameter, "Tags is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.TagRole(r.Context(), roleName, tags); err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, TagRoleResponse{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// UpdateAssumeRolePolicy handles the UpdateAssumeRolePolicy action.
+// PolicyDocument is required and replaces the role's trust policy
+// verbatim — same semantics PutRolePolicy has for inline policies.
+func (s *Service) UpdateAssumeRolePolicy(w http.ResponseWriter, r *http.Request) {
+	roleName := getFormValue(r, "RoleName")
+	if roleName == "" {
+		writeIAMError(w, errInvalidParameter, "RoleName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	policyDocument := getFormValue(r, "PolicyDocument")
+	if policyDocument == "" {
+		writeIAMError(w, errInvalidParameter, "PolicyDocument is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.UpdateAssumeRolePolicy(r.Context(), roleName, policyDocument); err != nil {
+		handleIAMError(w, err)
+
+		return
+	}
+
+	writeIAMXMLResponse(w, UpdateAssumeRolePolicyResponse{
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
 // DeleteRole handles the DeleteRole action.
 func (s *Service) DeleteRole(w http.ResponseWriter, r *http.Request) {
 	roleName := getFormValue(r, "RoleName")

--- a/internal/service/iam/handlers.go
+++ b/internal/service/iam/handlers.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"bytes"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -1030,11 +1031,18 @@ func getFormValue(r *http.Request, key string) string {
 }
 
 // getJSONValue extracts a value from JSON request body.
+//
+// IAM handlers call getFormValue many times per request to read individual
+// fields (RoleName, AssumeRolePolicyDocument, Path, Description, ...). When
+// the body is JSON the underlying io.Reader is single-shot, so we restore
+// r.Body after each read so subsequent calls can re-parse the same payload.
 func getJSONValue(r *http.Request, key string) string {
 	body, err := io.ReadAll(r.Body)
 	if err != nil || len(body) == 0 {
 		return ""
 	}
+
+	r.Body = io.NopCloser(bytes.NewReader(body))
 
 	var data map[string]any
 	if err := json.Unmarshal(body, &data); err != nil {

--- a/internal/service/iam/role_update_test.go
+++ b/internal/service/iam/role_update_test.go
@@ -1,0 +1,258 @@
+package iam
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	updateRoleName    = "update-test-role"
+	originalAssume    = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+	replacementAssume = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+)
+
+// TestUpdateRole_Description exercises the storage layer: changing
+// Description and MaxSessionDuration via UpdateRole. Both arguments
+// are optional in AWS — only fields that are sent on the wire are
+// updated.
+func TestUpdateRole_Description(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+
+	if _, err := store.CreateRole(ctx, &CreateRoleRequest{
+		RoleName:                 updateRoleName,
+		AssumeRolePolicyDocument: originalAssume,
+		Description:              "before",
+		MaxSessionDuration:       3600,
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	desc := "after"
+
+	maxSession := int(7200)
+
+	if err := store.UpdateRole(ctx, updateRoleName, &desc, &maxSession); err != nil {
+		t.Fatalf("UpdateRole: %v", err)
+	}
+
+	got, err := store.GetRole(ctx, updateRoleName)
+	if err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+
+	if got.Description != "after" {
+		t.Fatalf("Description: got %q, want %q", got.Description, "after")
+	}
+
+	if got.MaxSessionDuration != 7200 {
+		t.Fatalf("MaxSessionDuration: got %d, want 7200", got.MaxSessionDuration)
+	}
+}
+
+// TestUpdateRole_PartialUpdate verifies that nil arguments are treated
+// as "leave unchanged" rather than "set to zero".
+func TestUpdateRole_PartialUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+
+	_, _ = store.CreateRole(ctx, &CreateRoleRequest{
+		RoleName:                 "partial-role",
+		AssumeRolePolicyDocument: originalAssume,
+		Description:              "keep this",
+		MaxSessionDuration:       1800,
+	})
+
+	maxSession := int(7200)
+	if err := store.UpdateRole(ctx, "partial-role", nil, &maxSession); err != nil {
+		t.Fatalf("UpdateRole: %v", err)
+	}
+
+	got, _ := store.GetRole(ctx, "partial-role")
+
+	if got.Description != "keep this" {
+		t.Fatalf("Description should be unchanged, got %q", got.Description)
+	}
+
+	if got.MaxSessionDuration != 7200 {
+		t.Fatalf("MaxSessionDuration: got %d, want 7200", got.MaxSessionDuration)
+	}
+}
+
+// TestUpdateAssumeRolePolicy replaces the trust policy on an existing
+// role. Audit consumers care about the policy text being current — a
+// stub that accepts the call but doesn't persist would mask drift.
+func TestUpdateAssumeRolePolicy(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+
+	_, _ = store.CreateRole(ctx, &CreateRoleRequest{
+		RoleName:                 "trust-role",
+		AssumeRolePolicyDocument: originalAssume,
+	})
+
+	if err := store.UpdateAssumeRolePolicy(ctx, "trust-role", replacementAssume); err != nil {
+		t.Fatalf("UpdateAssumeRolePolicy: %v", err)
+	}
+
+	got, _ := store.GetRole(ctx, "trust-role")
+	if got.AssumeRolePolicyDocument != replacementAssume {
+		t.Fatalf("AssumeRolePolicyDocument:\ngot:  %s\nwant: %s",
+			got.AssumeRolePolicyDocument, replacementAssume)
+	}
+}
+
+// TestTagRole_UpsertByKey verifies merge-by-key tagging semantics:
+// existing keys overwrite, new keys append. terraform/pulumi/alchemy
+// all expect this — they tag a role with provider-specific keys
+// (alchemy_stage, alchemy_resource, Name) on every apply.
+func TestTagRole_UpsertByKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+
+	_, _ = store.CreateRole(ctx, &CreateRoleRequest{
+		RoleName:                 "tag-role",
+		AssumeRolePolicyDocument: originalAssume,
+		Tags: []Tag{
+			{Key: "Name", Value: "first"},
+			{Key: "Owner", Value: "team-a"},
+		},
+	})
+
+	if err := store.TagRole(ctx, "tag-role", []Tag{
+		{Key: "Name", Value: "second"},
+		{Key: "alchemy_stage", Value: "dev"},
+	}); err != nil {
+		t.Fatalf("TagRole: %v", err)
+	}
+
+	got, _ := store.GetRole(ctx, "tag-role")
+
+	want := map[string]string{
+		"Name":          "second", // overwritten
+		"Owner":         "team-a", // preserved
+		"alchemy_stage": "dev",    // appended
+	}
+	if len(got.Tags) != len(want) {
+		t.Fatalf("len(Tags): got %d, want %d (%+v)", len(got.Tags), len(want), got.Tags)
+	}
+
+	for _, tag := range got.Tags {
+		if w, ok := want[tag.Key]; !ok || w != tag.Value {
+			t.Fatalf("tag mismatch: got %s=%s, want %s=%s", tag.Key, tag.Value, tag.Key, w)
+		}
+	}
+}
+
+// TestUpdateRole_NotFound returns AWS-style NoSuchEntity for both
+// updates when the role doesn't exist.
+func TestUpdateRole_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := NewMemoryStorage()
+
+	desc := "x"
+	if err := store.UpdateRole(ctx, "no-such-role", &desc, nil); err == nil {
+		t.Fatal("expected error from UpdateRole on missing role")
+	} else {
+		assertIAMErrorCode(t, err, errNoSuchEntity)
+	}
+
+	if err := store.UpdateAssumeRolePolicy(ctx, "no-such-role", "{}"); err == nil {
+		t.Fatal("expected error from UpdateAssumeRolePolicy on missing role")
+	} else {
+		assertIAMErrorCode(t, err, errNoSuchEntity)
+	}
+}
+
+// TestUpdateRole_HTTP exercises the AWS Query protocol surface. Real
+// callers (terraform, alchemy, AWS SDK) hit /iam with
+// Action=UpdateRole&RoleName=...&Description=...
+func TestUpdateRole_HTTP(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewMemoryStorage()
+	svc := New(store)
+
+	_, _ = store.CreateRole(ctx, &CreateRoleRequest{
+		RoleName:                 "http-update-role",
+		AssumeRolePolicyDocument: originalAssume,
+		Description:              "old",
+		MaxSessionDuration:       3600,
+	})
+
+	t.Run("UpdateRole sets Description", func(t *testing.T) {
+		body := strings.NewReader(
+			"Action=UpdateRole&RoleName=http-update-role&Description=new&Version=2010-05-08")
+		req := httptest.NewRequest(http.MethodPost, "/iam", body)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		w := httptest.NewRecorder()
+		svc.UpdateRole(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("UpdateRole HTTP: got %d, body=%s", w.Code, w.Body.String())
+		}
+
+		var resp UpdateRoleResponse
+		if err := xml.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("xml unmarshal: %v", err)
+		}
+
+		got, _ := store.GetRole(ctx, "http-update-role")
+		if got.Description != "new" {
+			t.Fatalf("Description not persisted: got %q", got.Description)
+		}
+	})
+
+	t.Run("UpdateAssumeRolePolicy replaces trust policy", func(t *testing.T) {
+		body := strings.NewReader(
+			"Action=UpdateAssumeRolePolicy&RoleName=http-update-role&PolicyDocument=" +
+				url(replacementAssume) + "&Version=2010-05-08")
+		req := httptest.NewRequest(http.MethodPost, "/iam", body)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		w := httptest.NewRecorder()
+		svc.UpdateAssumeRolePolicy(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("UpdateAssumeRolePolicy HTTP: got %d, body=%s", w.Code, w.Body.String())
+		}
+
+		got, _ := store.GetRole(ctx, "http-update-role")
+		if got.AssumeRolePolicyDocument != replacementAssume {
+			t.Fatalf("AssumeRolePolicyDocument not persisted")
+		}
+	})
+}
+
+// url is a tiny URL-encoder for the test bodies — the JSON document
+// has braces and quotes that the form parser would otherwise trip on.
+func url(s string) string {
+	return strings.NewReplacer("{", "%7B", "}", "%7D", `"`, "%22", " ", "+").Replace(s)
+}
+
+// assertIAMErrorCode unwraps to *Error and checks Code.
+func assertIAMErrorCode(t *testing.T, err error, want string) {
+	t.Helper()
+
+	var iamErr *Error
+	if !errors.As(err, &iamErr) || iamErr.Code != want {
+		t.Fatalf("expected %s, got %v", want, err)
+	}
+}

--- a/internal/service/iam/service.go
+++ b/internal/service/iam/service.go
@@ -47,10 +47,13 @@ func (s *Service) initActionHandlers() {
 		"GetUser":    s.GetUser,
 		"ListUsers":  s.ListUsers,
 		// Role management
-		"CreateRole": s.CreateRole,
-		"DeleteRole": s.DeleteRole,
-		"GetRole":    s.GetRole,
-		"ListRoles":  s.ListRoles,
+		"CreateRole":             s.CreateRole,
+		"DeleteRole":             s.DeleteRole,
+		"GetRole":                s.GetRole,
+		"ListRoles":              s.ListRoles,
+		"UpdateRole":             s.UpdateRole,
+		"UpdateAssumeRolePolicy": s.UpdateAssumeRolePolicy,
+		"TagRole":                s.TagRole,
 		// Policy management
 		"CreatePolicy": s.CreatePolicy,
 		"DeletePolicy": s.DeletePolicy,

--- a/internal/service/iam/service.go
+++ b/internal/service/iam/service.go
@@ -13,6 +13,10 @@ import (
 // Compile-time check that Service implements io.Closer.
 var _ io.Closer = (*Service)(nil)
 
+// serviceName is the IAM service identifier — also used as the X-Amz-Target
+// prefix and the SDK User-Agent api/ token.
+const serviceName = "iam"
+
 func init() {
 	var opts []Option
 	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
@@ -93,7 +97,7 @@ func (s *Service) initActionHandlers() {
 
 // Name returns the service name.
 func (s *Service) Name() string {
-	return "iam"
+	return serviceName
 }
 
 // RegisterRoutes registers the IAM routes.
@@ -105,6 +109,36 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.HandleFunc("POST", "/iam", s.DispatchAction)
 	r.HandleFunc("GET", "/iam", s.DispatchAction)
 }
+
+// TargetPrefix returns the IAM target prefix.
+//
+// IAM does not use X-Amz-Target, but the Query dispatcher requires a non-empty
+// key to register the fallback handler under. Returning the service name keeps
+// it unique and avoids collisions with other Query-protocol services.
+func (s *Service) TargetPrefix() string {
+	return serviceName
+}
+
+// ServiceIdentifier returns the SDK service identifier sent in the User-Agent
+// header by aws-sdk-go-v2 (api/iam#x.y.z). The Query dispatcher uses this to
+// route IAM actions to this service when the unified `/` endpoint is hit
+// (which is what terraform-provider-aws and other single-endpoint clients do).
+func (s *Service) ServiceIdentifier() string {
+	return serviceName
+}
+
+// Actions returns the list of action names this service handles.
+func (s *Service) Actions() []string {
+	actions := make([]string, 0, len(s.actionHandlers))
+	for action := range s.actionHandlers {
+		actions = append(actions, action)
+	}
+
+	return actions
+}
+
+// QueryProtocol is a marker method that indicates IAM uses AWS Query protocol.
+func (s *Service) QueryProtocol() {}
 
 // Close saves the storage state if persistence is enabled.
 func (s *Service) Close() error {

--- a/internal/service/iam/storage.go
+++ b/internal/service/iam/storage.go
@@ -41,6 +41,9 @@ type Storage interface {
 	DeleteRole(ctx context.Context, roleName string) error
 	GetRole(ctx context.Context, roleName string) (*Role, error)
 	ListRoles(ctx context.Context, pathPrefix string, maxItems int) ([]Role, error)
+	UpdateRole(ctx context.Context, roleName string, description *string, maxSessionDuration *int) error
+	UpdateAssumeRolePolicy(ctx context.Context, roleName, policyDocument string) error
+	TagRole(ctx context.Context, roleName string, tags []Tag) error
 
 	CreatePolicy(ctx context.Context, req *CreatePolicyRequest) (*Policy, error)
 	DeletePolicy(ctx context.Context, policyArn string) error
@@ -384,6 +387,87 @@ func (s *MemoryStorage) GetRole(_ context.Context, roleName string) (*Role, erro
 	}
 
 	return role, nil
+}
+
+// UpdateRole updates the Description / MaxSessionDuration of an
+// existing role. Both arguments are optional pointers — nil means
+// "leave unchanged" (matches the AWS UpdateRole behaviour where
+// omitted parameters preserve current state).
+func (s *MemoryStorage) UpdateRole(_ context.Context, roleName string, description *string, maxSessionDuration *int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	role, exists := s.Roles[roleName]
+	if !exists {
+		return &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("The role with name %s cannot be found.", roleName),
+		}
+	}
+
+	if description != nil {
+		role.Description = *description
+	}
+
+	if maxSessionDuration != nil {
+		role.MaxSessionDuration = *maxSessionDuration
+	}
+
+	return nil
+}
+
+// TagRole upserts the given tags on a role. AWS-style "merge by key"
+// semantics: existing tags whose Key matches are overwritten, others
+// are appended unchanged.
+func (s *MemoryStorage) TagRole(_ context.Context, roleName string, tags []Tag) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	role, exists := s.Roles[roleName]
+	if !exists {
+		return &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("The role with name %s cannot be found.", roleName),
+		}
+	}
+
+	byKey := make(map[string]int, len(role.Tags))
+	for i, t := range role.Tags {
+		byKey[t.Key] = i
+	}
+
+	for _, t := range tags {
+		if i, ok := byKey[t.Key]; ok {
+			role.Tags[i].Value = t.Value
+
+			continue
+		}
+
+		role.Tags = append(role.Tags, t)
+		byKey[t.Key] = len(role.Tags) - 1
+	}
+
+	return nil
+}
+
+// UpdateAssumeRolePolicy replaces the trust policy on an existing
+// role. AWS treats the policy document as opaque JSON for storage
+// purposes; we just persist the bytes.
+func (s *MemoryStorage) UpdateAssumeRolePolicy(_ context.Context, roleName, policyDocument string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	role, exists := s.Roles[roleName]
+	if !exists {
+		return &Error{
+			Code:    errNoSuchEntity,
+			Message: fmt.Sprintf("The role with name %s cannot be found.", roleName),
+		}
+	}
+
+	role.AssumeRolePolicyDocument = policyDocument
+
+	return nil
 }
 
 // ListRoles lists IAM roles.

--- a/internal/service/iam/types.go
+++ b/internal/service/iam/types.go
@@ -1,6 +1,9 @@
 package iam
 
-import "time"
+import (
+	"encoding/xml"
+	"time"
+)
 
 // User represents an IAM user.
 type User struct {
@@ -338,6 +341,26 @@ type CreateRoleResult struct {
 
 // DeleteRoleResponse represents a DeleteRole response.
 type DeleteRoleResponse struct {
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// UpdateRoleResponse represents an UpdateRole response. AWS only
+// returns ResponseMetadata — the updated role isn't echoed back.
+type UpdateRoleResponse struct {
+	XMLName          xml.Name         `xml:"UpdateRoleResponse"`
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// UpdateAssumeRolePolicyResponse mirrors UpdateRoleResponse — empty
+// result body, only the request metadata.
+type UpdateAssumeRolePolicyResponse struct {
+	XMLName          xml.Name         `xml:"UpdateAssumeRolePolicyResponse"`
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// TagRoleResponse is also empty — only ResponseMetadata.
+type TagRoleResponse struct {
+	XMLName          xml.Name         `xml:"TagRoleResponse"`
 	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
 }
 


### PR DESCRIPTION
## Summary

Two related IAM gaps surfaced by running real provider stacks against kumo:

1. **CRUD parity** — terraform `aws_iam_role`, pulumi-aws `Role`, and alchemy's `Role` all do `CreateRole` on first apply, then on every subsequent apply they `GetRole` and unconditionally call `UpdateRole` + `UpdateAssumeRolePolicy` + `TagRole` to reconcile `description` / `session-duration` / trust-policy / tag drift. Without these three actions, second-and-later applies fail with `InvalidAction`.
2. **Single-endpoint routing** — terraform-provider-aws sends every API call to the unified `/` endpoint regardless of service. IAM was only registered under `/iam/` and did not implement `QueryProtocolService`, so the Query dispatcher returned `UnknownService` for IAM actions hit via `/`. Discovered while doing the experiment in #416 / #589 — `CreateRole` from the AWS provider failed before any of the actions in (1) could even be tried.

## Implementation

### CRUD (UpdateRole / UpdateAssumeRolePolicy / TagRole)

- **UpdateRole** — patches `Description` and `MaxSessionDuration`. Both are `*string` / `*int` on the storage layer; `nil` means \"leave unchanged\", so terraform-style \"only send what changed\" works.
- **UpdateAssumeRolePolicy** — replaces the trust policy verbatim. Same opaque-JSON treatment `PutRolePolicy` already gives inline policies.
- **TagRole** — merge-by-key upsert: existing keys overwrite, new keys append (matches AWS).

All three return `NoSuchEntity` for a missing role and are wired into the action dispatch map. New types (`UpdateRoleResponse`, `UpdateAssumeRolePolicyResponse`, `TagRoleResponse`) match the empty-result-body shape AWS returns.

### Unified dispatcher (terraform compat)

- Implements `TargetPrefix() / ServiceIdentifier() / Actions() / QueryProtocol()` on the IAM service so `internal/server/server.go` picks it up at registration time and routes IAM actions arriving at `/` to the IAM handlers.
- Fixes `getJSONValue` to restore `r.Body` after each read. The Query dispatcher rewrites the body to a single-shot JSON reader (formToJSON) and IAM handlers call `getFormValue` once per parameter; without restoration the second call would return \"\" and `CreateRole` would surface `AssumeRolePolicyDocument is required` even when the field was sent. (This was the next failure mode after the routing fix.)
- New `dispatcher_test.go`:
  - `TestDispatchAction_JSONBody` — `CreateRole` via JSON body (the post-formToJSON shape), confirms RoleName + AssumeRolePolicyDocument + Description all read through.
  - `TestQueryProtocolService` — verifies the marker methods and that `Actions()` covers the core role lifecycle.
  - `TestGetJSONValue_BodyRestoration` — locks in the contract that multiple reads on a JSON-body request return the right values.

## Test plan

- [x] `go test ./internal/service/iam/...` — green (existing UpdateRole/TagRole/UpdateAssumeRolePolicy tests + the new dispatcher tests, 9 funcs / 11 sub-tests).
- [x] `go test ./...` — full suite green.
- [x] `make lint` — IAM package clean.
- [x] End-to-end: tofu (1.11.6) `apply` and `destroy` of `aws_iam_role` against `kumo serve` on `localhost:4566` — both succeed; before this PR `apply` failed with `UnknownAction` from the dispatcher and after only adding the dispatcher methods (without the body-restoration fix) failed with the spurious \"AssumeRolePolicyDocument is required\".

## Validated against

- alchemy `@sst/alchemy` v0.93.7 — `Role` resource now succeeds against kumo (was failing on the immediate post-Create UpdateAssumeRolePolicy / UpdateRole / TagRole calls).
- terraform / opentofu — `aws_iam_role` now succeeds against kumo via the unified `/` endpoint (was failing at `CreateRole` before, regardless of the CRUD additions).

Cross-ref: #416, #589.