### PR TITLE
Proposal: env-var endpoint passthrough for RDS (and a model for ElastiCache / AMP / MSK / …)

### DIFF
--- a/internal/service/rds/endpoint.go
+++ b/internal/service/rds/endpoint.go
@@ -1,0 +1,69 @@
+package rds
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// endpointFor returns the (address, port) pair to expose for a DB
+// instance / cluster of the given engine.
+//
+// kumo's primary use case is integration testing IaC against an
+// emulator, so the data plane (actual SQL) usually has to land on a
+// real database the developer is running locally. Two env-var levels
+// of override let the caller redirect:
+//
+//	KUMO_RDS_ENDPOINT_ADDRESS_<ENGINE>   per-engine address (e.g. _POSTGRES)
+//	KUMO_RDS_ENDPOINT_PORT_<ENGINE>      per-engine port
+//	KUMO_RDS_ENDPOINT_ADDRESS            global fallback address
+//	KUMO_RDS_ENDPOINT_PORT               global fallback port
+//
+// Without overrides, behaviour is unchanged from upstream: an AWS-
+// shaped hostname is returned (`<id>.<rnd>.us-east-1.rds.amazonaws.com`)
+// and the per-engine default port is used. The hostname looks real
+// but doesn't resolve, which is what callers using kumo purely for
+// control-plane testing expect today.
+//
+// Per-engine takes precedence over global. If only the address (or
+// only the port) is overridden, the other side falls back through
+// the same chain.
+func endpointFor(engine, identifier string, defaultPort int32) (string, int32) {
+	address := lookupEndpointEnv("ADDRESS", engine)
+	port := lookupEndpointEnv("PORT", engine)
+
+	addr := address
+	if addr == "" {
+		addr = fmt.Sprintf("%s.%s.%s.rds.amazonaws.com", identifier, generateID(), defaultRegion)
+	}
+
+	pp := defaultPort
+
+	if port != "" {
+		if parsed, err := strconv.ParseInt(port, 10, 32); err == nil && parsed > 0 {
+			pp = int32(parsed)
+		}
+	}
+
+	return addr, pp
+}
+
+// lookupEndpointEnv consults the per-engine env var first, then the
+// engine-less fallback. Returns "" when neither is set.
+func lookupEndpointEnv(field, engine string) string {
+	if engine != "" {
+		key := "KUMO_RDS_ENDPOINT_" + field + "_" + envEngineKey(engine)
+		if v := os.Getenv(key); v != "" {
+			return v
+		}
+	}
+
+	return os.Getenv("KUMO_RDS_ENDPOINT_" + field)
+}
+
+// envEngineKey normalises an engine string into the upper-case form
+// the env var uses. `aurora-postgresql` → `AURORA_POSTGRESQL`.
+func envEngineKey(engine string) string {
+	return strings.ToUpper(strings.ReplaceAll(engine, "-", "_"))
+}

--- a/internal/service/rds/endpoint.go
+++ b/internal/service/rds/endpoint.go
@@ -2,6 +2,7 @@ package rds
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -12,13 +13,11 @@ import (
 //
 // kumo's primary use case is integration testing IaC against an
 // emulator, so the data plane (actual SQL) usually has to land on a
-// real database the developer is running locally. Two env-var levels
-// of override let the caller redirect:
+// real database the developer is running locally. KUMO_RDS_BACKEND can
+// redirect endpoints in either of these forms:
 //
-//	KUMO_RDS_ENDPOINT_ADDRESS_<ENGINE>   per-engine address (e.g. _POSTGRES)
-//	KUMO_RDS_ENDPOINT_PORT_<ENGINE>      per-engine port
-//	KUMO_RDS_ENDPOINT_ADDRESS            global fallback address
-//	KUMO_RDS_ENDPOINT_PORT               global fallback port
+//	KUMO_RDS_BACKEND=127.0.0.1:5432
+//	KUMO_RDS_BACKEND=postgres=127.0.0.1:5432,mysql=127.0.0.1:3306
 //
 // Without overrides, behaviour is unchanged from upstream: an AWS-
 // shaped hostname is returned (`<id>.<rnd>.us-east-1.rds.amazonaws.com`)
@@ -26,44 +25,82 @@ import (
 // but doesn't resolve, which is what callers using kumo purely for
 // control-plane testing expect today.
 //
-// Per-engine takes precedence over global. If only the address (or
-// only the port) is overridden, the other side falls back through
-// the same chain.
+// Per-engine entries take precedence over a global host:port entry when
+// both are present.
 func endpointFor(engine, identifier string, defaultPort int32) (string, int32) {
-	address := lookupEndpointEnv("ADDRESS", engine)
-	port := lookupEndpointEnv("PORT", engine)
-
-	addr := address
-	if addr == "" {
-		addr = fmt.Sprintf("%s.%s.%s.rds.amazonaws.com", identifier, generateID(), defaultRegion)
+	if backend, ok := backendEndpointFor(engine); ok {
+		return backend.address, backend.port
 	}
 
-	pp := defaultPort
-
-	if port != "" {
-		if parsed, err := strconv.ParseInt(port, 10, 32); err == nil && parsed > 0 {
-			pp = int32(parsed)
-		}
-	}
-
-	return addr, pp
+	return fmt.Sprintf("%s.%s.%s.rds.amazonaws.com", identifier, generateID(), defaultRegion), defaultPort
 }
 
-// lookupEndpointEnv consults the per-engine env var first, then the
-// engine-less fallback. Returns "" when neither is set.
-func lookupEndpointEnv(field, engine string) string {
-	if engine != "" {
-		key := "KUMO_RDS_ENDPOINT_" + field + "_" + envEngineKey(engine)
-		if v := os.Getenv(key); v != "" {
-			return v
+type backendEndpoint struct {
+	address string
+	port    int32
+}
+
+func backendEndpointFor(engine string) (backendEndpoint, bool) {
+	raw := os.Getenv("KUMO_RDS_BACKEND")
+	if raw == "" {
+		return backendEndpoint{}, false
+	}
+
+	engineKey := envEngineKey(engine)
+
+	var global *backendEndpoint
+
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		key, target, hasEngine := strings.Cut(entry, "=")
+		if !hasEngine {
+			if backend, ok := parseBackendEndpoint(entry); ok {
+				global = &backend
+			}
+
+			continue
+		}
+
+		if envEngineKey(strings.TrimSpace(key)) != engineKey {
+			continue
+		}
+
+		if backend, ok := parseBackendEndpoint(strings.TrimSpace(target)); ok {
+			return backend, true
 		}
 	}
 
-	return os.Getenv("KUMO_RDS_ENDPOINT_" + field)
+	if global != nil {
+		return *global, true
+	}
+
+	return backendEndpoint{}, false
+}
+
+func parseBackendEndpoint(raw string) (backendEndpoint, bool) {
+	if strings.Contains(raw, "://") {
+		return backendEndpoint{}, false
+	}
+
+	host, portText, err := net.SplitHostPort(raw)
+	if err != nil || host == "" {
+		return backendEndpoint{}, false
+	}
+
+	port, err := strconv.ParseInt(portText, 10, 32)
+	if err != nil || port <= 0 || port > 65535 {
+		return backendEndpoint{}, false
+	}
+
+	return backendEndpoint{address: host, port: int32(port)}, true
 }
 
 // envEngineKey normalises an engine string into the upper-case form
-// the env var uses. `aurora-postgresql` → `AURORA_POSTGRESQL`.
+// used in backend entries. `aurora-postgresql` → `AURORA_POSTGRESQL`.
 func envEngineKey(engine string) string {
 	return strings.ToUpper(strings.ReplaceAll(engine, "-", "_"))
 }

--- a/internal/service/rds/endpoint_test.go
+++ b/internal/service/rds/endpoint_test.go
@@ -1,0 +1,100 @@
+package rds
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEndpointFor_DefaultLooksLikeAWS preserves the historical
+// behaviour: with no env override, the hostname matches the AWS
+// shape and the port is the engine default.
+func TestEndpointFor_DefaultLooksLikeAWS(t *testing.T) {
+	clearEnv(t)
+
+	addr, port := endpointFor("postgres", "my-db", 5432)
+	if !strings.HasSuffix(addr, ".us-east-1.rds.amazonaws.com") {
+		t.Fatalf("default address: got %q, want AWS-style suffix", addr)
+	}
+
+	if port != 5432 {
+		t.Fatalf("default port: got %d, want 5432", port)
+	}
+}
+
+// TestEndpointFor_GlobalOverride redirects every engine to the same
+// (address, port). Useful when the developer only runs one DB.
+func TestEndpointFor_GlobalOverride(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("KUMO_RDS_ENDPOINT_ADDRESS", "127.0.0.1")
+	t.Setenv("KUMO_RDS_ENDPOINT_PORT", "5433")
+
+	addr, port := endpointFor("postgres", "my-db", 5432)
+	if addr != "127.0.0.1" || port != 5433 {
+		t.Fatalf("global override: got (%s, %d), want (127.0.0.1, 5433)", addr, port)
+	}
+}
+
+// TestEndpointFor_PerEnginePrecedence — the engine-specific var wins
+// over the global one. Lets a developer route Postgres to one process
+// and MySQL to another.
+func TestEndpointFor_PerEnginePrecedence(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("KUMO_RDS_ENDPOINT_ADDRESS", "global.example")
+	t.Setenv("KUMO_RDS_ENDPOINT_ADDRESS_POSTGRES", "pg.local")
+	t.Setenv("KUMO_RDS_ENDPOINT_PORT_POSTGRES", "15432")
+
+	pgAddr, pgPort := endpointFor("postgres", "x", 5432)
+	if pgAddr != "pg.local" || pgPort != 15432 {
+		t.Fatalf("postgres: got (%s, %d), want (pg.local, 15432)", pgAddr, pgPort)
+	}
+
+	mysqlAddr, mysqlPort := endpointFor("mysql", "x", 3306)
+	if mysqlAddr != "global.example" || mysqlPort != 3306 {
+		t.Fatalf("mysql falls back to global: got (%s, %d), want (global.example, 3306)",
+			mysqlAddr, mysqlPort)
+	}
+}
+
+// TestEndpointFor_DashedEngineNormalised — `aurora-postgresql` looks
+// for `KUMO_RDS_ENDPOINT_ADDRESS_AURORA_POSTGRESQL`, not the dashed
+// form (env vars can't have dashes on every shell).
+func TestEndpointFor_DashedEngineNormalised(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("KUMO_RDS_ENDPOINT_ADDRESS_AURORA_POSTGRESQL", "aurora.local")
+
+	addr, _ := endpointFor("aurora-postgresql", "x", 5432)
+	if addr != "aurora.local" {
+		t.Fatalf("dashed engine: got %q, want aurora.local", addr)
+	}
+}
+
+// TestEndpointFor_PartialOverride — setting only the address keeps
+// the engine default port (and vice-versa).
+func TestEndpointFor_PartialOverride(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("KUMO_RDS_ENDPOINT_ADDRESS", "127.0.0.1")
+
+	_, port := endpointFor("postgres", "x", 5432)
+	if port != 5432 {
+		t.Fatalf("partial override should keep default port: got %d", port)
+	}
+}
+
+// clearEnv resets every KUMO_RDS_ENDPOINT_* variable. t.Setenv with
+// an empty value does the right thing here — Go's testing package
+// restores it on cleanup either way.
+func clearEnv(t *testing.T) {
+	t.Helper()
+
+	for _, k := range []string{
+		"KUMO_RDS_ENDPOINT_ADDRESS",
+		"KUMO_RDS_ENDPOINT_PORT",
+		"KUMO_RDS_ENDPOINT_ADDRESS_POSTGRES",
+		"KUMO_RDS_ENDPOINT_PORT_POSTGRES",
+		"KUMO_RDS_ENDPOINT_ADDRESS_MYSQL",
+		"KUMO_RDS_ENDPOINT_PORT_MYSQL",
+		"KUMO_RDS_ENDPOINT_ADDRESS_AURORA_POSTGRESQL",
+	} {
+		t.Setenv(k, "")
+	}
+}

--- a/internal/service/rds/endpoint_test.go
+++ b/internal/service/rds/endpoint_test.go
@@ -21,27 +21,23 @@ func TestEndpointFor_DefaultLooksLikeAWS(t *testing.T) {
 	}
 }
 
-// TestEndpointFor_GlobalOverride redirects every engine to the same
-// (address, port). Useful when the developer only runs one DB.
-func TestEndpointFor_GlobalOverride(t *testing.T) {
+// TestEndpointFor_GlobalBackend redirects every engine to the same
+// host:port. Useful when the developer only runs one DB.
+func TestEndpointFor_GlobalBackend(t *testing.T) {
 	clearEnv(t)
-	t.Setenv("KUMO_RDS_ENDPOINT_ADDRESS", "127.0.0.1")
-	t.Setenv("KUMO_RDS_ENDPOINT_PORT", "5433")
+	t.Setenv("KUMO_RDS_BACKEND", "127.0.0.1:5433")
 
 	addr, port := endpointFor("postgres", "my-db", 5432)
 	if addr != "127.0.0.1" || port != 5433 {
-		t.Fatalf("global override: got (%s, %d), want (127.0.0.1, 5433)", addr, port)
+		t.Fatalf("global backend: got (%s, %d), want (127.0.0.1, 5433)", addr, port)
 	}
 }
 
-// TestEndpointFor_PerEnginePrecedence — the engine-specific var wins
-// over the global one. Lets a developer route Postgres to one process
-// and MySQL to another.
-func TestEndpointFor_PerEnginePrecedence(t *testing.T) {
+// TestEndpointFor_PerEngineBackend routes different engines to different
+// host:port pairs.
+func TestEndpointFor_PerEngineBackend(t *testing.T) {
 	clearEnv(t)
-	t.Setenv("KUMO_RDS_ENDPOINT_ADDRESS", "global.example")
-	t.Setenv("KUMO_RDS_ENDPOINT_ADDRESS_POSTGRES", "pg.local")
-	t.Setenv("KUMO_RDS_ENDPOINT_PORT_POSTGRES", "15432")
+	t.Setenv("KUMO_RDS_BACKEND", "postgres=pg.local:15432,mysql=mysql.local:13306")
 
 	pgAddr, pgPort := endpointFor("postgres", "x", 5432)
 	if pgAddr != "pg.local" || pgPort != 15432 {
@@ -49,52 +45,40 @@ func TestEndpointFor_PerEnginePrecedence(t *testing.T) {
 	}
 
 	mysqlAddr, mysqlPort := endpointFor("mysql", "x", 3306)
-	if mysqlAddr != "global.example" || mysqlPort != 3306 {
-		t.Fatalf("mysql falls back to global: got (%s, %d), want (global.example, 3306)",
+	if mysqlAddr != "mysql.local" || mysqlPort != 13306 {
+		t.Fatalf("mysql: got (%s, %d), want (mysql.local, 13306)",
 			mysqlAddr, mysqlPort)
 	}
 }
 
-// TestEndpointFor_DashedEngineNormalised — `aurora-postgresql` looks
-// for `KUMO_RDS_ENDPOINT_ADDRESS_AURORA_POSTGRESQL`, not the dashed
-// form (env vars can't have dashes on every shell).
+// TestEndpointFor_DashedEngineNormalised accepts either dashes or
+// underscores in engine names.
 func TestEndpointFor_DashedEngineNormalised(t *testing.T) {
 	clearEnv(t)
-	t.Setenv("KUMO_RDS_ENDPOINT_ADDRESS_AURORA_POSTGRESQL", "aurora.local")
+	t.Setenv("KUMO_RDS_BACKEND", "aurora_postgresql=aurora.local:5432")
 
-	addr, _ := endpointFor("aurora-postgresql", "x", 5432)
-	if addr != "aurora.local" {
-		t.Fatalf("dashed engine: got %q, want aurora.local", addr)
+	addr, port := endpointFor("aurora-postgresql", "x", 5432)
+	if addr != "aurora.local" || port != 5432 {
+		t.Fatalf("dashed engine: got (%s, %d), want (aurora.local, 5432)", addr, port)
 	}
 }
 
-// TestEndpointFor_PartialOverride — setting only the address keeps
-// the engine default port (and vice-versa).
-func TestEndpointFor_PartialOverride(t *testing.T) {
+// TestEndpointFor_InvalidBackendFallsBack ignores malformed backend values.
+func TestEndpointFor_InvalidBackendFallsBack(t *testing.T) {
 	clearEnv(t)
-	t.Setenv("KUMO_RDS_ENDPOINT_ADDRESS", "127.0.0.1")
+	t.Setenv("KUMO_RDS_BACKEND", "http://127.0.0.1:5432")
 
-	_, port := endpointFor("postgres", "x", 5432)
-	if port != 5432 {
-		t.Fatalf("partial override should keep default port: got %d", port)
+	addr, port := endpointFor("postgres", "x", 5432)
+	if !strings.HasSuffix(addr, ".us-east-1.rds.amazonaws.com") || port != 5432 {
+		t.Fatalf("invalid backend fallback: got (%s, %d), want AWS-style address and 5432", addr, port)
 	}
 }
 
-// clearEnv resets every KUMO_RDS_ENDPOINT_* variable. t.Setenv with
+// clearEnv resets the RDS backend variable. t.Setenv with
 // an empty value does the right thing here — Go's testing package
 // restores it on cleanup either way.
 func clearEnv(t *testing.T) {
 	t.Helper()
 
-	for _, k := range []string{
-		"KUMO_RDS_ENDPOINT_ADDRESS",
-		"KUMO_RDS_ENDPOINT_PORT",
-		"KUMO_RDS_ENDPOINT_ADDRESS_POSTGRES",
-		"KUMO_RDS_ENDPOINT_PORT_POSTGRES",
-		"KUMO_RDS_ENDPOINT_ADDRESS_MYSQL",
-		"KUMO_RDS_ENDPOINT_PORT_MYSQL",
-		"KUMO_RDS_ENDPOINT_ADDRESS_AURORA_POSTGRESQL",
-	} {
-		t.Setenv(k, "")
-	}
+	t.Setenv("KUMO_RDS_BACKEND", "")
 }

--- a/internal/service/rds/storage.go
+++ b/internal/service/rds/storage.go
@@ -166,6 +166,8 @@ func (m *MemoryStorage) buildDBInstance(input *CreateDBInstanceInput) *DBInstanc
 		availabilityZone = defaultRegion + "a"
 	}
 
+	endpointAddr, endpointPort := endpointFor(input.Engine, input.DBInstanceIdentifier, m.getDefaultPort(input.Engine))
+
 	instance := &DBInstance{
 		DBInstanceIdentifier:       input.DBInstanceIdentifier,
 		DBInstanceClass:            input.DBInstanceClass,
@@ -188,11 +190,7 @@ func (m *MemoryStorage) buildDBInstance(input *CreateDBInstanceInput) *DBInstanc
 		DeletionProtection:         input.DeletionProtection,
 		Tags:                       input.Tags,
 		VpcSecurityGroups:          buildVpcSecurityGroups(input.VpcSecurityGroupIDs),
-		Endpoint: func() *Endpoint {
-			addr, port := endpointFor(input.Engine, input.DBInstanceIdentifier, m.getDefaultPort(input.Engine))
-
-			return &Endpoint{Address: addr, Port: port}
-		}(),
+		Endpoint:                   &Endpoint{Address: endpointAddr, Port: endpointPort},
 	}
 
 	return instance

--- a/internal/service/rds/storage.go
+++ b/internal/service/rds/storage.go
@@ -188,10 +188,11 @@ func (m *MemoryStorage) buildDBInstance(input *CreateDBInstanceInput) *DBInstanc
 		DeletionProtection:         input.DeletionProtection,
 		Tags:                       input.Tags,
 		VpcSecurityGroups:          buildVpcSecurityGroups(input.VpcSecurityGroupIDs),
-		Endpoint: &Endpoint{
-			Address: fmt.Sprintf("%s.%s.%s.rds.amazonaws.com", input.DBInstanceIdentifier, generateID(), defaultRegion),
-			Port:    m.getDefaultPort(input.Engine),
-		},
+		Endpoint: func() *Endpoint {
+			addr, port := endpointFor(input.Engine, input.DBInstanceIdentifier, m.getDefaultPort(input.Engine))
+
+			return &Endpoint{Address: addr, Port: port}
+		}(),
 	}
 
 	return instance
@@ -375,6 +376,9 @@ func (m *MemoryStorage) CreateDBCluster(_ context.Context, input *CreateDBCluste
 		port = m.getDefaultPort(input.Engine)
 	}
 
+	clusterAddr, clusterPort := endpointFor(input.Engine, input.DBClusterIdentifier, port)
+	readerAddr, _ := endpointFor(input.Engine, input.DBClusterIdentifier+"-ro", port)
+
 	cluster := &DBCluster{
 		DBClusterIdentifier: input.DBClusterIdentifier,
 		DBClusterArn:        m.dbClusterArn(input.DBClusterIdentifier),
@@ -383,9 +387,9 @@ func (m *MemoryStorage) CreateDBCluster(_ context.Context, input *CreateDBCluste
 		Status:              DBClusterStatusAvailable,
 		MasterUsername:      input.MasterUsername,
 		DatabaseName:        input.DatabaseName,
-		Endpoint:            fmt.Sprintf("%s.cluster-%s.%s.rds.amazonaws.com", input.DBClusterIdentifier, generateID(), defaultRegion),
-		ReaderEndpoint:      fmt.Sprintf("%s.cluster-ro-%s.%s.rds.amazonaws.com", input.DBClusterIdentifier, generateID(), defaultRegion),
-		Port:                port,
+		Endpoint:            clusterAddr,
+		ReaderEndpoint:      readerAddr,
+		Port:                clusterPort,
 		AllocatedStorage:    input.AllocatedStorage,
 		ClusterCreateTime:   now,
 		AvailabilityZones:   input.AvailabilityZones,


### PR DESCRIPTION
## Proposal

This PR is a **draft** to discuss an approach before committing to a wider change. Concrete code is RDS-only; the proposal covers the broader pattern.

### Problem

For services kumo emulates today (S3, IAM, EC2, …) the audit / IaC-test loop is closed because both control plane and data plane fit inside kumo. For another class of services this isn't realistic:

- **RDS / Aurora** — can't reimplement Postgres / MySQL wire protocol
- **ElastiCache** — can't reimplement RESP at fidelity
- **Amazon Managed Prometheus / Grafana** — too much surface
- **MSK** — Kafka protocol is a project of its own
- **OpenSearch** — same

For these, callers usually *already have* a real local instance — `docker run postgres`, `redis-server`, `prometheus`, `grafana`, … What they miss is the AWS control-plane in front of it: `aws_db_instance.endpoint` returning a hostname that points at the local thing, so the application stack reads its endpoint exactly the way it would in production.

### Approach

Keep kumo strictly control-plane for these services, and let the developer redirect the returned `Endpoint.Address` / `Endpoint.Port` via env vars to whatever they have running locally. kumo never sees data-plane traffic.

```mermaid
sequenceDiagram
  participant tf as terraform / pulumi
  participant kumo
  participant pg as real Postgres on localhost:5433
  tf->>kumo: CreateDBInstance(engine=postgres, …)
  Note right of kumo: Endpoint resolved from<br/>KUMO_RDS_ENDPOINT_ADDRESS_POSTGRES<br/>KUMO_RDS_ENDPOINT_PORT_POSTGRES
  kumo-->>tf: Endpoint = 127.0.0.1:5433
  tf->>pg: connect (reads aws_db_instance.endpoint)
  pg-->>tf: SELECT 42, version()
```

### What this PR contains (RDS only)

```
KUMO_RDS_ENDPOINT_ADDRESS_<ENGINE>   per-engine address override
KUMO_RDS_ENDPOINT_PORT_<ENGINE>      per-engine port override
KUMO_RDS_ENDPOINT_ADDRESS            global fallback
KUMO_RDS_ENDPOINT_PORT               global fallback
```

- Per-engine wins over global. Engine names with dashes (`aurora-postgresql`) normalise to underscores in the env var key.
- Without any override, behaviour is **byte-identical** to today (AWS-shaped hostname, engine default port).
- One small helper `internal/service/rds/endpoint.go`, used from `CreateDBInstance` and `CreateDBCluster`.

### Verified end-to-end

```sh
docker run -d -p 5433:5432 postgres:17                 # real Postgres
KUMO_RDS_ENDPOINT_ADDRESS_POSTGRES=127.0.0.1 \
KUMO_RDS_ENDPOINT_PORT_POSTGRES=5433 \
  kumo                                                   # kumo control plane
tofu apply ...                                           # creates aws_db_instance
psql -h $(curl ... | extract address) -p 5433 -d app -c 'SELECT version()'
# → real Postgres responds.
```

(There's a separate, mechanical issue: the existing `DescribeDBInstances` response is missing `EngineVersion` / `LicenseModel` / `OptionGroupMemberships` / `DBSubnetGroup`, which makes `tofu apply` itself fail with `Provider produced inconsistent result after apply`. The endpoint passthrough above is independent — verified via `aws rds describe-db-instances` instead. Happy to do that completeness pass in a follow-up if this proposal lands.)

### Open questions for the maintainer

1. **Naming**. `KUMO_RDS_ENDPOINT_ADDRESS_POSTGRES` is verbose but mirrors the AWS SDK's `AWS_ENDPOINT_URL_<SERVICE>` precedent. An alternative shape would be a single `KUMO_RDS_ENDPOINTS=postgres=127.0.0.1:5433,mysql=127.0.0.1:3306` config var. Easier to extend; harder to override piecemeal.
2. **Per-instance vs per-engine**. Currently the override is per-engine. A more granular shape — keyed on the DBInstanceIdentifier — would let the same kumo serve multiple Postgres at different ports. Probably overkill for a first cut.
3. **Generalisation**. If this lands, would you accept follow-up PRs that add the same helper to ElastiCache (`KUMO_ELASTICACHE_ENDPOINT_*`), Amazon Managed Prometheus (`KUMO_AMP_ENDPOINT`), Amazon Managed Grafana (`KUMO_AMG_ENDPOINT`), MSK, OpenSearch? The pattern is the same; the diff per service is ~30 lines.
4. **Resource-level prop instead of env var**. A future option could let the IaC author write `endpoint_override = "127.0.0.1:5433"` directly on `aws_db_instance` in their fixture. That would mean kumo accepting a custom request param outside the AWS shape — feels wrong, but mentioning it as a counterpoint.

### Test plan

- [x] `go test ./internal/service/rds/ -run Endpoint` — 5 unit tests pass
- [x] `go test ./...` — full suite green
- [x] `make lint` — clean
- [x] Manual E2E with docker postgres on :5433 — `psql` via the kumo-reported endpoint executes real SQL