### PR TITLE
feat(cloudwatch): register JSON 1.0 protocol alongside CBOR

### DIFF
--- a/internal/service/cloudwatch/json_protocol_test.go
+++ b/internal/service/cloudwatch/json_protocol_test.go
@@ -1,0 +1,85 @@
+package cloudwatch
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const targetPrefix = "GraniteServiceVersion20100801"
+
+// TestDispatchAction_PutMetricData confirms that the JSON 1.0
+// dispatcher routes the X-Amz-Target header to the existing
+// PutMetricData handler — the wire that aws-cli / boto3 / older AWS
+// SDKs use against CloudWatch. Until this PR lands, those callers
+// land on the JSON dispatcher's "Unknown service" path because
+// kumo's CloudWatch only registered the Smithy CBOR route.
+func TestDispatchAction_PutMetricData(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage("")
+	svc := New(store)
+
+	body := `{"Namespace":"TestApp","MetricData":[{"MetricName":"Latency","Value":42.0,"Unit":"Milliseconds"}]}`
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", targetPrefix+".PutMetricData")
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutMetricData: got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	listed, err := store.ListMetrics(req.Context(), &ListMetricsRequest{Namespace: "TestApp"})
+	if err != nil {
+		t.Fatalf("ListMetrics: %v", err)
+	}
+
+	if len(listed.Metrics) != 1 || listed.Metrics[0].MetricName != "Latency" {
+		t.Fatalf("metric not persisted: got %+v", listed.Metrics)
+	}
+}
+
+// TestDispatchAction_UnknownTarget keeps the dispatcher honest: a
+// well-formed but unimplemented action returns InvalidAction without
+// crashing.
+func TestDispatchAction_UnknownTarget(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage(""))
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	req.Header.Set("X-Amz-Target", targetPrefix+".SomeUnknownAction")
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown action, got %d", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not JSON: %v\n%s", err, w.Body.String())
+	}
+
+	if resp["__type"] != "InvalidAction" {
+		t.Fatalf("expected __type=InvalidAction, got %v", resp)
+	}
+}
+
+// TestTargetPrefix nails the AWS-SDK-facing constant. Boto3 / aws-cli
+// derive it from the service model; we just need the string match.
+func TestTargetPrefix(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage(""))
+	if got := svc.TargetPrefix(); got != targetPrefix {
+		t.Fatalf("TargetPrefix: got %q, want %q", got, targetPrefix)
+	}
+}

--- a/internal/service/cloudwatch/service.go
+++ b/internal/service/cloudwatch/service.go
@@ -54,6 +54,24 @@ func (s *Service) ServiceName() string {
 // CBORProtocol is a marker method that indicates CloudWatch uses RPC v2 CBOR protocol.
 func (s *Service) CBORProtocol() {}
 
+// TargetPrefix returns the X-Amz-Target prefix for CloudWatch JSON 1.0
+// requests. botocore-derived clients (aws-cli, boto3, older AWS SDKs)
+// continue to use the JSON 1.0 wire format even though newer SDKs are
+// migrating to RPC v2 CBOR; supporting both is the only way kumo can
+// be a target for the broad client population.
+func (s *Service) TargetPrefix() string {
+	return "GraniteServiceVersion20100801"
+}
+
+// JSONProtocol marks CloudWatch as also speaking AWS JSON 1.0,
+// alongside CBOR. The server's JSONProtocolDispatcher and
+// CBORProtocolDispatcher are independent — JSON dispatches off
+// X-Amz-Target, CBOR off URL path — so a single service can register
+// for both without conflict. The action dispatcher itself
+// (`DispatchAction`) lives in handlers.go alongside the JSON handlers
+// it routes to.
+func (s *Service) JSONProtocol() {}
+
 // DispatchCBORAction handles RPC v2 CBOR protocol requests.
 func (s *Service) DispatchCBORAction(w http.ResponseWriter, r *http.Request, operation string) {
 	switch operation {


### PR DESCRIPTION
## Summary

aws-cli, boto3, and older AWS SDKs use **AWS JSON 1.0** (\`X-Amz-Target: GraniteServiceVersion20100801.<Action>\`) for CloudWatch. kumo's CloudWatch only registered the Smithy RPC v2 **CBOR** path, so botocore-based clients hit the JSON dispatcher's \`Unknown service: GraniteServiceVersion20100801\` path and can't put / read metrics at all:

```
$ aws --endpoint-url=http://127.0.0.1:4566 cloudwatch put-metric-data \
    --namespace TestApp --metric-data MetricName=Latency,Value=42,Unit=Milliseconds
An error occurred (UnknownService) when calling the PutMetricData operation:
  Unknown service: GraniteServiceVersion20100801
```

## Implementation

The JSON-shape handlers (\`PutMetricData\`, \`GetMetricData\`, \`ListMetrics\`, \`GetMetricStatistics\`, \`PutMetricAlarm\`, \`DeleteAlarms\`, \`DescribeAlarms\`) and a \`DispatchAction\` X-Amz-Target switch already existed in \`handlers.go\` — they just weren't wired into any dispatcher. Two new methods on \`Service\` finish the wiring:

- \`TargetPrefix() string\` returns \`"GraniteServiceVersion20100801"\`
- \`JSONProtocol()\` marker

That triggers \`Server.RegisterService\` to register the CW \`DispatchAction\` against the \`JSONProtocolDispatcher\`.

CBOR keeps working unchanged. The JSON and CBOR dispatchers are independent: JSON dispatches off \`X-Amz-Target\`, CBOR off URL path \`/service/{name}/operation/{op}\`. A single service can register for both without conflict.

## After

```
$ aws --endpoint-url=http://127.0.0.1:4566 cloudwatch put-metric-data \
    --namespace TestApp --metric-data MetricName=Latency,Value=42,Unit=Milliseconds
$ aws --endpoint-url=http://127.0.0.1:4566 cloudwatch list-metrics --namespace TestApp
{
    "Metrics": [{"Namespace":"TestApp","MetricName":"Latency"}],
    "OwningAccounts": ["000000000000"]
}
```

## Why this matters

This is the wire-format gap that blocks every botocore-based caller — aws-cli, boto3, Python OTel exporters, the AWS X-Ray daemon's CW agent path, ADOT collector when it ships metrics back to CloudWatch, etc. Newer aws-sdk-go-v2 / aws-sdk-js v3 are migrating to CBOR, but the JSON 1.0 fleet is enormous and not going away.

## Test plan

- [x] \`go test ./internal/service/cloudwatch/ -run TestDispatchAction\` — 2 sub-tests pass:
  - happy path: \`PutMetricData\` via JSON 1.0 persists to storage
  - unknown action returns \`InvalidAction\` (not 500)
- [x] \`go test ./...\` — full suite green
- [x] \`make lint\` — clean
- [x] Manual aws-cli round-trip (put + list) succeeds