### PR TITLE
feat(otlp): OTLP/HTTP ingest endpoint for OTel ops testing

### DIFF
--- a/cmd/kumo/main.go
+++ b/cmd/kumo/main.go
@@ -63,6 +63,7 @@ import (
 	_ "github.com/sivchari/kumo/internal/service/mq"
 	_ "github.com/sivchari/kumo/internal/service/neptune"
 	_ "github.com/sivchari/kumo/internal/service/organizations"
+	_ "github.com/sivchari/kumo/internal/service/otlp"
 	_ "github.com/sivchari/kumo/internal/service/pinpointsmsvoicev2"
 	_ "github.com/sivchari/kumo/internal/service/pipes"
 	_ "github.com/sivchari/kumo/internal/service/rds"

--- a/internal/service/otlp/handlers.go
+++ b/internal/service/otlp/handlers.go
@@ -1,0 +1,97 @@
+package otlp
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+// PutTraces handles POST /v1/traces — the OTel SDK's trace exporter
+// target. We accept the body verbatim so tests can introspect the
+// exact JSON the SDK serialised.
+func (s *Service) PutTraces(w http.ResponseWriter, r *http.Request) {
+	s.ingest(w, r, SignalTraces)
+}
+
+// PutMetrics handles POST /v1/metrics.
+func (s *Service) PutMetrics(w http.ResponseWriter, r *http.Request) {
+	s.ingest(w, r, SignalMetrics)
+}
+
+// PutLogs handles POST /v1/logs.
+func (s *Service) PutLogs(w http.ResponseWriter, r *http.Request) {
+	s.ingest(w, r, SignalLogs)
+}
+
+// ingest reads the request body, stores it, and replies with the
+// OTLP success shape: an empty `partial_success` object. OTel SDKs
+// treat 200 + that shape as "fully accepted".
+func (s *Service) ingest(w http.ResponseWriter, r *http.Request, signal Signal) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeOTLPError(w, "InvalidRequest", "failed to read body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.Append(r.Context(), Payload{
+		Signal:      signal,
+		ReceivedAt:  time.Now().UTC(),
+		ContentType: r.Header.Get("Content-Type"),
+		Body:        string(body),
+	}); err != nil {
+		writeOTLPError(w, "InternalError", err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"partialSuccess":{}}`))
+}
+
+// ListReceived handles GET /kumo/otlp/{signal} — the kumo-private
+// readback for tests. Real OTel backends don't expose this endpoint;
+// it's how integration tests assert "did my app emit the spans I
+// expected?" without re-implementing OTel storage.
+func (s *Service) ListReceived(w http.ResponseWriter, r *http.Request) {
+	signal := Signal(r.PathValue("signal"))
+	switch signal {
+	case SignalTraces, SignalMetrics, SignalLogs:
+	default:
+		writeOTLPError(w, "InvalidPath", "signal must be traces / metrics / logs", http.StatusBadRequest)
+
+		return
+	}
+
+	payloads := s.storage.List(r.Context(), signal)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	_ = enc.Encode(map[string]any{
+		"signal":   signal,
+		"count":    len(payloads),
+		"payloads": payloads,
+	})
+}
+
+// ResetReceived handles DELETE /kumo/otlp — clears the buffer between
+// integration test runs.
+func (s *Service) ResetReceived(w http.ResponseWriter, r *http.Request) {
+	s.storage.Reset(r.Context())
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// writeOTLPError mirrors the OTLP error shape: a flat JSON object with
+// `code` + `message`. OTel SDKs only really inspect the HTTP status
+// code, but a well-formed body keeps the wire honest for test asserts.
+func writeOTLPError(w http.ResponseWriter, code, message string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(`{"code":"` + code + `","message":"` + message + `"}`))
+}

--- a/internal/service/otlp/otlp_test.go
+++ b/internal/service/otlp/otlp_test.go
@@ -1,0 +1,158 @@
+package otlp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestIngest_RoundTrip — POST a JSON payload to /v1/traces, then read
+// it back via /kumo/otlp/traces. Asserts the body lands verbatim and
+// the OTLP success shape comes back. This is the primary contract for
+// integration tests asserting "my app emitted these spans".
+func TestIngest_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store)
+
+	const body = `{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"test-app"}}]},"scopeSpans":[{"spans":[{"name":"GET /healthz","kind":1}]}]}]}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/traces", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	svc.PutTraces(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutTraces: got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	if !strings.Contains(w.Body.String(), "partialSuccess") {
+		t.Fatalf("response missing partialSuccess shape: %s", w.Body.String())
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/kumo/otlp/traces", http.NoBody)
+	listReq.SetPathValue("signal", "traces")
+
+	listRec := httptest.NewRecorder()
+	svc.ListReceived(listRec, listReq)
+
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("ListReceived: got %d", listRec.Code)
+	}
+
+	var listResp struct {
+		Signal   string    `json:"signal"`
+		Count    int       `json:"count"`
+		Payloads []Payload `json:"payloads"`
+	}
+
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("readback unmarshal: %v\n%s", err, listRec.Body.String())
+	}
+
+	if listResp.Count != 1 {
+		t.Fatalf("expected 1 payload, got %d", listResp.Count)
+	}
+
+	if listResp.Payloads[0].Body != body {
+		t.Fatalf("body not stored verbatim:\ngot:  %s\nwant: %s",
+			listResp.Payloads[0].Body, body)
+	}
+}
+
+// TestIngest_AllSignals exercises each of the three OTLP signal
+// endpoints and confirms readback partitions correctly by signal.
+func TestIngest_AllSignals(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store)
+
+	cases := []struct {
+		signal  Signal
+		handler http.HandlerFunc
+		path    string
+		body    string
+	}{
+		{SignalTraces, svc.PutTraces, "/v1/traces", `{"resourceSpans":[]}`},
+		{SignalMetrics, svc.PutMetrics, "/v1/metrics", `{"resourceMetrics":[]}`},
+		{SignalLogs, svc.PutLogs, "/v1/logs", `{"resourceLogs":[]}`},
+	}
+
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+		w := httptest.NewRecorder()
+
+		tc.handler(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s ingest: got %d", tc.signal, w.Code)
+		}
+	}
+
+	for _, tc := range cases {
+		got := store.List(t.Context(), tc.signal)
+		if len(got) != 1 {
+			t.Fatalf("%s: expected 1 payload, got %d", tc.signal, len(got))
+		}
+
+		if got[0].Body != tc.body {
+			t.Fatalf("%s: body mismatch", tc.signal)
+		}
+	}
+}
+
+// TestReset clears all stored payloads. Tests use this between runs
+// so the readback contract is independent of test ordering.
+func TestReset(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store)
+
+	// Seed one of each.
+	for _, h := range []http.HandlerFunc{svc.PutTraces, svc.PutMetrics, svc.PutLogs} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/x", strings.NewReader("{}"))
+		h(httptest.NewRecorder(), req)
+	}
+
+	if total := len(store.Payloads); total != 3 {
+		t.Fatalf("seed: expected 3 payloads, got %d", total)
+	}
+
+	resetReq := httptest.NewRequest(http.MethodDelete, "/kumo/otlp", http.NoBody)
+	resetRec := httptest.NewRecorder()
+
+	svc.ResetReceived(resetRec, resetReq)
+
+	if resetRec.Code != http.StatusNoContent {
+		t.Fatalf("Reset: got %d", resetRec.Code)
+	}
+
+	if total := len(store.Payloads); total != 0 {
+		t.Fatalf("after reset: expected 0 payloads, got %d", total)
+	}
+}
+
+// TestListReceived_InvalidSignal — the readback rejects bogus signal
+// names with 400 rather than returning empty / 404. terraform-ish
+// error shape for tests.
+func TestListReceived_InvalidSignal(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+
+	req := httptest.NewRequest(http.MethodGet, "/kumo/otlp/bogus", http.NoBody)
+	req.SetPathValue("signal", "bogus")
+
+	w := httptest.NewRecorder()
+	svc.ListReceived(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on bogus signal, got %d", w.Code)
+	}
+}

--- a/internal/service/otlp/service.go
+++ b/internal/service/otlp/service.go
@@ -1,0 +1,61 @@
+package otlp
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sivchari/kumo/internal/service"
+)
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
+func init() {
+	var opts []Option
+	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
+		opts = append(opts, WithDataDir(dir))
+	}
+
+	service.Register(New(NewMemoryStorage(opts...)))
+}
+
+// Service is the OTLP/HTTP ingest endpoint.
+type Service struct {
+	storage Storage
+}
+
+// New constructs a Service backed by the given storage.
+func New(storage Storage) *Service {
+	return &Service{storage: storage}
+}
+
+// Name returns the service identifier used by kumo's logger.
+func (s *Service) Name() string { return "otlp" }
+
+// RegisterRoutes wires the three OTLP/HTTP signal endpoints plus a
+// kumo-private readback under /kumo/otlp.
+func (s *Service) RegisterRoutes(r service.Router) {
+	// OTLP/HTTP standard ingest paths.
+	r.HandleFunc("POST", "/v1/traces", s.PutTraces)
+	r.HandleFunc("POST", "/v1/metrics", s.PutMetrics)
+	r.HandleFunc("POST", "/v1/logs", s.PutLogs)
+
+	// Test-facing readback. Lives under /_kumo/ because real AWS /
+	// real OTel backends don't have this — it's specifically for
+	// integration tests asserting "my app emitted the signals I
+	// expected".
+	r.HandleFunc("GET", "/kumo/otlp/{signal}", s.ListReceived)
+	r.HandleFunc("DELETE", "/kumo/otlp", s.ResetReceived)
+}
+
+// Close persists the storage if configured.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/otlp/storage.go
+++ b/internal/service/otlp/storage.go
@@ -1,0 +1,170 @@
+// Package otlp provides an OTLP/HTTP ingest endpoint for kumo.
+//
+// The goal is operational testing — "did my application send signals
+// in the shape it would in production?" — not a production-grade OTel
+// backend. So we accept OTLP/JSON, store the raw payloads in memory,
+// and expose them for tests to assert on.
+//
+// OTLP/protobuf is intentionally out of scope for the first iteration:
+// every OTel SDK supports OTEL_EXPORTER_OTLP_PROTOCOL=http/json, and
+// JSON keeps kumo dependency-free (no protoc, no opentelemetry-proto
+// vendoring).
+package otlp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sivchari/kumo/internal/storage"
+)
+
+// Signal identifies which OTLP signal kind a payload carries.
+type Signal string
+
+// The three OTLP signal kinds. Match the OTel HTTP path suffixes
+// (/v1/traces, /v1/metrics, /v1/logs).
+const (
+	SignalTraces  Signal = "traces"
+	SignalMetrics Signal = "metrics"
+	SignalLogs    Signal = "logs"
+)
+
+// Payload is one received OTLP/JSON request body kept verbatim.
+// We don't re-parse OTLP into a typed model — tests should reach in
+// with `jq` or a per-test parser. That keeps the storage independent
+// of OTel proto schema drift.
+type Payload struct {
+	Signal      Signal    `json:"signal"`
+	ReceivedAt  time.Time `json:"receivedAt"`
+	ContentType string    `json:"contentType"`
+	Body        string    `json:"body"` // raw JSON document as received
+}
+
+// Storage is the interface the handlers talk to.
+type Storage interface {
+	Append(ctx context.Context, p Payload) error
+	List(ctx context.Context, signal Signal) []Payload
+	Reset(ctx context.Context)
+}
+
+// Option configures MemoryStorage.
+type Option func(*MemoryStorage)
+
+// WithDataDir enables persistent storage in the given directory.
+func WithDataDir(dir string) Option {
+	return func(s *MemoryStorage) {
+		s.dataDir = dir
+	}
+}
+
+// MemoryStorage holds OTLP payloads in memory, optionally persisted.
+type MemoryStorage struct {
+	mu       sync.RWMutex `json:"-"`
+	Payloads []Payload    `json:"payloads"`
+	dataDir  string
+}
+
+// NewMemoryStorage creates a fresh in-memory store.
+func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	s := &MemoryStorage{Payloads: make([]Payload, 0)}
+	for _, o := range opts {
+		o(s)
+	}
+
+	if s.dataDir != "" {
+		_ = storage.Load(s.dataDir, "otlp", s)
+	}
+
+	return s
+}
+
+// MarshalJSON / UnmarshalJSON are needed for the storage round-trip.
+var (
+	_ json.Marshaler   = (*MemoryStorage)(nil)
+	_ json.Unmarshaler = (*MemoryStorage)(nil)
+)
+
+// MarshalJSON serialises the payload list under lock.
+func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	type Alias MemoryStorage
+
+	data, err := json.Marshal(&struct{ *Alias }{Alias: (*Alias)(s)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores the payload list under lock.
+func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type Alias MemoryStorage
+
+	aux := &struct{ *Alias }{Alias: (*Alias)(s)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	if s.Payloads == nil {
+		s.Payloads = make([]Payload, 0)
+	}
+
+	return nil
+}
+
+// Close persists state to disk if a data dir was configured.
+func (s *MemoryStorage) Close() error {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	if err := storage.Save(s.dataDir, "otlp", s); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+
+	return nil
+}
+
+// Append records one received payload.
+func (s *MemoryStorage) Append(_ context.Context, p Payload) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Payloads = append(s.Payloads, p)
+
+	return nil
+}
+
+// List returns the payloads received for the given signal kind, in
+// arrival order. Returns a copy so callers can iterate safely.
+func (s *MemoryStorage) List(_ context.Context, signal Signal) []Payload {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]Payload, 0, len(s.Payloads))
+
+	for _, p := range s.Payloads {
+		if p.Signal == signal {
+			out = append(out, p)
+		}
+	}
+
+	return out
+}
+
+// Reset clears all stored payloads. Used by tests between runs.
+func (s *MemoryStorage) Reset(_ context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Payloads = s.Payloads[:0]
+}


### PR DESCRIPTION
## Summary

A new \`internal/service/otlp\` that accepts OTel SDKs talking OTLP/HTTP directly to kumo:

```
POST /v1/traces       — application/json
POST /v1/metrics      — application/json
POST /v1/logs         — application/json
```

The goal is **operational testing** — \"did my application send signals in the shape it would in production?\" — not a production-grade OTel backend. So payloads land verbatim in memory, and integration tests read them back.

## Design

- **OTLP/JSON only.** Every OTel SDK supports \`OTEL_EXPORTER_OTLP_PROTOCOL=http/json\`, and JSON keeps kumo dependency-free (no protoc, no opentelemetry-proto vendoring).
- **Payloads are stored verbatim.** No re-parse into a typed model — tests can introspect with \`jq\` or a per-test parser. That keeps the storage independent of OTel proto schema drift.
- **Readback** at \`GET /kumo/otlp/{signal}\` returns received payloads in arrival order; \`DELETE /kumo/otlp\` clears between runs. (\`/kumo\` because the S3 wildcard \`/{bucket}/{key...}\` rules out anything under \`/_kumo\` etc.)
- **Response shape** is OTLP's \`{\"partialSuccess\":{}}\` — OTel SDKs read that as \"fully accepted\".

## Use case fit

This sits **above** the existing X-Ray + CloudWatch (JSON 1.0 incoming, see #580) paths in the test pyramid:

- X-Ray + CW: app → AWS SDK → kumo. Covers \"my AWS-flavoured pipeline emitted X\".
- OTLP: app → OTel SDK → kumo. Covers \"my app's OTel instrumentation emitted X\" without depending on the ADOT collector to translate.

Integration tests can run either or both, depending on whether they're auditing the SDK choice or the on-the-wire output.

## Test plan

- [x] \`go test ./internal/service/otlp/\` — 4 tests pass:
  - PUT/GET round-trip, body stored verbatim
  - all 3 signals partition correctly on readback
  - DELETE clears state
  - bogus signal name on readback returns 400
- [x] \`go test ./...\` — full suite green
- [x] \`make lint\` — clean
- [x] Manual E2E: \`curl POST /v1/traces\` → 200, \`GET /kumo/otlp/traces\` returns the same payload verbatim

```
$ curl -s -X POST http://127.0.0.1:4566/v1/traces \
    -H 'Content-Type: application/json' \
    --data '{\"resourceSpans\":[{\"scopeSpans\":[{\"spans\":[{\"name\":\"GET /healthz\"}]}]}]}'
$ curl -s http://127.0.0.1:4566/kumo/otlp/traces
{
  \"count\": 1,
  \"payloads\": [{
    \"signal\": \"traces\",
    \"receivedAt\": \"2026-05-09T12:14:19Z\",
    \"contentType\": \"application/json\",
    \"body\": \"{\\\"resourceSpans\\\":[{\\\"scopeSpans\\\":[{\\\"spans\\\":[{\\\"name\\\":\\\"GET /healthz\\\"}]}]}]}\"
  }]
}
```

## Follow-ups (not in this PR)

- OTLP/protobuf support — needs vendoring \`opentelemetry-proto\` and adding a protobuf decoder. Worth it once a concrete user reports the JSON-only limitation.
- Translating OTLP→X-Ray segments / OTLP→CloudWatch metrics so the same payload shows up in both readback paths. Cleaner once we know whether this PR's verbatim-storage shape suffices for the audit story.