### PR TITLE
feat(cloudfront): RFC 9111-conformant edge cache layer (Cache-Control / Vary / Range / revalidation / swr)

### DIFF
--- a/internal/service/cloudfront/cache/rules.go
+++ b/internal/service/cloudfront/cache/rules.go
@@ -160,6 +160,179 @@ func VaryDisablesCache(respHeader http.Header) bool {
 	return false
 }
 
+// IfNoneMatchSatisfied reports whether the request's If-None-Match
+// matches the cached entry's ETag. Per RFC 9110 §13.1.2:
+//
+//   - `*` matches any existing representation
+//   - any listed entity-tag (weak or strong) matching the cached one returns true
+//
+// When this returns true, the cache should respond 304 Not Modified
+// instead of the full body.
+func IfNoneMatchSatisfied(reqHeader, respHeader http.Header) bool {
+	inm := reqHeader.Get("If-None-Match")
+	if inm == "" {
+		return false
+	}
+
+	if strings.TrimSpace(inm) == "*" {
+		return true
+	}
+
+	cached := strings.TrimSpace(respHeader.Get("ETag"))
+	if cached == "" {
+		return false
+	}
+
+	for _, raw := range strings.Split(inm, ",") {
+		if etagsEqualWeak(strings.TrimSpace(raw), cached) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IfModifiedSinceSatisfied reports whether the cached entry's
+// Last-Modified is at or before the request's If-Modified-Since.
+// When true the cache should respond 304 (the client's copy is fresh
+// enough).
+func IfModifiedSinceSatisfied(reqHeader, respHeader http.Header) bool {
+	ims := reqHeader.Get("If-Modified-Since")
+	if ims == "" {
+		return false
+	}
+
+	imsTime, err := http.ParseTime(ims)
+	if err != nil {
+		return false
+	}
+
+	lm := respHeader.Get("Last-Modified")
+	if lm == "" {
+		return false
+	}
+
+	lmTime, err := http.ParseTime(lm)
+	if err != nil {
+		return false
+	}
+
+	return !lmTime.After(imsTime)
+}
+
+// etagsEqualWeak compares two ETag values per RFC 9110 §8.8.3.2 weak
+// comparison (ignoring the W/ prefix).
+func etagsEqualWeak(a, b string) bool {
+	a = strings.TrimPrefix(a, "W/")
+	b = strings.TrimPrefix(b, "W/")
+
+	return a == b && a != ""
+}
+
+// ConditionalHeaders builds the If-None-Match / If-Modified-Since
+// header pair the cache should send on a revalidation request to the
+// origin, derived from the cached entry's validators.
+func ConditionalHeaders(cachedHeader http.Header) http.Header {
+	out := http.Header{}
+
+	if etag := cachedHeader.Get("ETag"); etag != "" {
+		out.Set("If-None-Match", etag)
+	}
+
+	if lm := cachedHeader.Get("Last-Modified"); lm != "" {
+		out.Set("If-Modified-Since", lm)
+	}
+
+	return out
+}
+
+// ParseRange interprets a single-range "Range: bytes=START-END"
+// header against a known content length. Returns (start, end, true)
+// where end is inclusive (matching the Content-Range wire format).
+//
+// Multi-range requests (`bytes=0-99,200-299`) and unsatisfiable
+// ranges return ok=false — the cache should fall through to a full
+// fetch / 416 in those cases. Suffix ranges (`bytes=-100`) and
+// open-ended (`bytes=100-`) are supported.
+func ParseRange(header string, totalSize int64) (int64, int64, bool) {
+	startRaw, endRaw, ok := splitByteRangeSpec(header)
+	if !ok {
+		return 0, 0, false
+	}
+
+	switch {
+	case startRaw == "" && endRaw == "":
+		return 0, 0, false
+	case startRaw == "":
+		return parseSuffixRange(endRaw, totalSize)
+	case endRaw == "":
+		return parseOpenRange(startRaw, totalSize)
+	default:
+		return parseClosedRange(startRaw, endRaw, totalSize)
+	}
+}
+
+// splitByteRangeSpec strips the "bytes=" prefix and splits on the
+// dash. Returns ok=false on multi-range or wrong unit.
+func splitByteRangeSpec(header string) (string, string, bool) {
+	spec, ok := strings.CutPrefix(header, "bytes=")
+	if !ok {
+		return "", "", false
+	}
+
+	if strings.Contains(spec, ",") {
+		return "", "", false
+	}
+
+	dash := strings.IndexByte(spec, '-')
+	if dash < 0 {
+		return "", "", false
+	}
+
+	return strings.TrimSpace(spec[:dash]), strings.TrimSpace(spec[dash+1:]), true
+}
+
+// parseSuffixRange resolves `bytes=-N` (the last N bytes).
+func parseSuffixRange(endRaw string, totalSize int64) (int64, int64, bool) {
+	n, err := strconv.ParseInt(endRaw, 10, 64)
+	if err != nil || n <= 0 {
+		return 0, 0, false
+	}
+
+	if n > totalSize {
+		n = totalSize
+	}
+
+	return totalSize - n, totalSize - 1, true
+}
+
+// parseOpenRange resolves `bytes=START-` (from START to end of
+// content).
+func parseOpenRange(startRaw string, totalSize int64) (int64, int64, bool) {
+	start, err := strconv.ParseInt(startRaw, 10, 64)
+	if err != nil || start < 0 || start >= totalSize {
+		return 0, 0, false
+	}
+
+	return start, totalSize - 1, true
+}
+
+// parseClosedRange resolves `bytes=START-END`.
+func parseClosedRange(startRaw, endRaw string, totalSize int64) (int64, int64, bool) {
+	start, err1 := strconv.ParseInt(startRaw, 10, 64)
+	end, err2 := strconv.ParseInt(endRaw, 10, 64)
+
+	if err1 != nil || err2 != nil || start < 0 || end < start || start >= totalSize {
+		return 0, 0, false
+	}
+
+	if end >= totalSize {
+		end = totalSize - 1
+	}
+
+	return start, end, true
+}
+
 // Key builds the deterministic cache key for a request. The base
 // is method+URL; adding the values of any Vary headers (lowercased,
 // in stable order) yields the per-variant key.

--- a/internal/service/cloudfront/cache/rules.go
+++ b/internal/service/cloudfront/cache/rules.go
@@ -58,17 +58,54 @@ func EffectiveTTL(respHeader http.Header, cfg DistributionConfig, now time.Time)
 	case cc.MaxAge != nil:
 		ttl = time.Duration(*cc.MaxAge) * time.Second
 	default:
-		if exp := respHeader.Get("Expires"); exp != "" {
-			if t, err := http.ParseTime(exp); err == nil {
-				delta := t.Sub(now)
-				if delta > 0 {
-					ttl = delta
-				}
-			}
+		switch {
+		case respHeader.Get("Expires") != "":
+			ttl = expiresTTL(respHeader, now)
+		case respHeader.Get("Last-Modified") != "":
+			// RFC 9111 §4.2.2 heuristic freshness: 10% of the
+			// last-modified-to-now interval, capped at the cache's
+			// configured max so a years-old asset doesn't get a
+			// years-long lifetime.
+			ttl = heuristicTTL(respHeader, now)
 		}
 	}
 
 	return clampTTL(ttl, cfg)
+}
+
+// expiresTTL evaluates the Expires header relative to `now`. Per RFC
+// 9111 §5.3 a valid Expires is explicit freshness — even when the
+// delta is non-positive (treat as already-stale).
+func expiresTTL(respHeader http.Header, now time.Time) time.Duration {
+	t, err := http.ParseTime(respHeader.Get("Expires"))
+	if err != nil {
+		return 0
+	}
+
+	delta := t.Sub(now)
+	if delta < 0 {
+		return 0
+	}
+
+	return delta
+}
+
+// heuristicTTL implements the RFC 9111 §4.2.2 10% heuristic. The
+// fraction is conservative — most real CDNs use this number too.
+// We bound by `now - Date` so a faulty Last-Modified can't push the
+// TTL past the response's own age.
+func heuristicTTL(respHeader http.Header, now time.Time) time.Duration {
+	lm, err := http.ParseTime(respHeader.Get("Last-Modified"))
+	if err != nil {
+		return 0
+	}
+
+	delta := now.Sub(lm)
+	if delta <= 0 {
+		return 0
+	}
+
+	return delta / 10
 }
 
 // mergedCacheControl reads CDN-Cache-Control (RFC 9213) when present,
@@ -86,10 +123,15 @@ func mergedCacheControl(respHeader http.Header) Control {
 	return parseControl(respHeader.Get("Cache-Control"))
 }
 
-// IsCacheable mirrors the CloudFront decision tree for "can the
-// response be put in the cache at all". Returns (false, reason) when
-// the response must not be stored. Reason is human-readable for
-// surfacing in X-Cache-Reason or logs.
+// IsCacheable decides whether the response can be put in the cache
+// at all. Returns (false, reason) when storage is forbidden.
+//
+// Per RFC 9111 §3: any status code may be cached when the response
+// carries **explicit** freshness information (Cache-Control max-age /
+// s-maxage / CDN-Cache-Control max-age, or an Expires header).
+// Without explicit freshness only the "heuristically cacheable" set
+// (RFC 9110 §15) is stored — that's the small list CloudFront
+// defaults to.
 func IsCacheable(respHeader http.Header, statusCode int) (bool, string) {
 	cc := mergedCacheControl(respHeader)
 	if cc.NoStore {
@@ -100,7 +142,44 @@ func IsCacheable(respHeader http.Header, statusCode int) (bool, string) {
 		return false, "Cache-Control: private"
 	}
 
-	// CloudFront caches a fixed set of status codes by default.
+	if hasExplicitFreshness(respHeader) {
+		return true, ""
+	}
+
+	if isHeuristicallyCacheableStatus(statusCode) {
+		return true, ""
+	}
+
+	return false, "status " + strconv.Itoa(statusCode) + " is not heuristically cacheable"
+}
+
+// hasExplicitFreshness reports whether the response advertises a
+// freshness lifetime — max-age / s-maxage on Cache-Control or
+// CDN-Cache-Control, or a *valid* Expires header. Used to decide
+// whether non-heuristic statuses may be cached.
+//
+// An Expires header that doesn't parse as an HTTP-date is treated as
+// already-expired per RFC 9111 §5.3 and therefore does not constitute
+// explicit freshness.
+func hasExplicitFreshness(respHeader http.Header) bool {
+	cc := mergedCacheControl(respHeader)
+	if cc.MaxAge != nil || cc.SMaxAge != nil {
+		return true
+	}
+
+	if exp := respHeader.Get("Expires"); exp != "" {
+		if _, err := http.ParseTime(exp); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isHeuristicallyCacheableStatus is the subset of status codes RFC
+// 9110 §15 marks as "heuristically cacheable". Without explicit
+// freshness the cache only stores these.
+func isHeuristicallyCacheableStatus(statusCode int) bool {
 	switch statusCode {
 	case http.StatusOK,
 		http.StatusNonAuthoritativeInfo,
@@ -114,10 +193,10 @@ func IsCacheable(respHeader http.Header, statusCode int) (bool, string) {
 		http.StatusGone,
 		http.StatusRequestURITooLong,
 		http.StatusNotImplemented:
-		return true, ""
-	default:
-		return false, "status " + strconv.Itoa(statusCode) + " is not cacheable by default"
+		return true
 	}
+
+	return false
 }
 
 // MustRevalidate reports whether a **fresh** cached entry must still
@@ -605,12 +684,19 @@ func parseControl(raw string) Control {
 		case "must-revalidate":
 			cc.MustRevalidate = true
 		case "max-age":
-			if v, err := strconv.ParseInt(value, 10, 64); err == nil {
-				cc.MaxAge = &v
+			// RFC 9111 §5.2 leaves duplicate-directive handling
+			// implementation-defined; cache-tests expects the first
+			// successfully-parsed value to win.
+			if cc.MaxAge == nil {
+				if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+					cc.MaxAge = &v
+				}
 			}
 		case "s-maxage":
-			if v, err := strconv.ParseInt(value, 10, 64); err == nil {
-				cc.SMaxAge = &v
+			if cc.SMaxAge == nil {
+				if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+					cc.SMaxAge = &v
+				}
 			}
 		}
 	}

--- a/internal/service/cloudfront/cache/rules.go
+++ b/internal/service/cloudfront/cache/rules.go
@@ -27,10 +27,12 @@ type DistributionConfig struct {
 
 // EffectiveTTL implements the CloudFront precedence:
 //
-//  1. If the origin sends `Cache-Control: s-maxage=N`, use N.
-//  2. Otherwise if `Cache-Control: max-age=N`, use N.
-//  3. Otherwise if `Expires: <date>` is in the future, use that delta.
-//  4. Otherwise fall back to the distribution's DefaultTTL.
+//  1. `CDN-Cache-Control` (RFC 9213) — CDN-targeted directives win
+//     over the Cache-Control browsers see. CloudFront supports it.
+//  2. If the origin sends `Cache-Control: s-maxage=N`, use N.
+//  3. Otherwise if `Cache-Control: max-age=N`, use N.
+//  4. Otherwise if `Expires: <date>` is in the future, use that delta.
+//  5. Otherwise fall back to the distribution's DefaultTTL.
 //
 // The result is then clamped to [MinTTL, MaxTTL].
 //
@@ -41,9 +43,9 @@ type DistributionConfig struct {
 //     "shared cache must not store").
 //
 // `no-cache` is **not** zero — it caches but always revalidates; that
-// distinction belongs to MustRevalidate, not the TTL.
+// distinction belongs to NoCacheDirective, not the TTL.
 func EffectiveTTL(respHeader http.Header, cfg DistributionConfig, now time.Time) time.Duration {
-	cc := parseControl(respHeader.Get("Cache-Control"))
+	cc := mergedCacheControl(respHeader)
 	if cc.NoStore || cc.Private {
 		return 0
 	}
@@ -69,12 +71,27 @@ func EffectiveTTL(respHeader http.Header, cfg DistributionConfig, now time.Time)
 	return clampTTL(ttl, cfg)
 }
 
+// mergedCacheControl reads CDN-Cache-Control (RFC 9213) when present,
+// otherwise Cache-Control. CloudFront documents the precedence the
+// same way: CDN-Cache-Control is parsed at the edge and trumps the
+// Cache-Control the browser ultimately sees.
+//
+// Surrogate-Control (the older Akamai/Fastly variant) is intentionally
+// not read — RFC 9213 standardised on CDN-Cache-Control.
+func mergedCacheControl(respHeader http.Header) Control {
+	if cdn := respHeader.Get("CDN-Cache-Control"); cdn != "" {
+		return parseControl(cdn)
+	}
+
+	return parseControl(respHeader.Get("Cache-Control"))
+}
+
 // IsCacheable mirrors the CloudFront decision tree for "can the
 // response be put in the cache at all". Returns (false, reason) when
 // the response must not be stored. Reason is human-readable for
 // surfacing in X-Cache-Reason or logs.
 func IsCacheable(respHeader http.Header, statusCode int) (bool, string) {
-	cc := parseControl(respHeader.Get("Cache-Control"))
+	cc := mergedCacheControl(respHeader)
 	if cc.NoStore {
 		return false, "Cache-Control: no-store"
 	}
@@ -103,14 +120,18 @@ func IsCacheable(respHeader http.Header, statusCode int) (bool, string) {
 	}
 }
 
-// MustRevalidate reports whether a cached entry must be revalidated
-// with the origin before being served, even if it's still fresh by
-// TTL. CloudFront treats `Cache-Control: no-cache` and `must-revalidate`
-// the same way at the edge.
+// MustRevalidate reports whether a **fresh** cached entry must still
+// trigger origin revalidation before it can be served. RFC 9111
+// §5.2.2 distinguishes:
+//
+//   - `no-cache` — yes, revalidate even when fresh.
+//   - `must-revalidate` / `proxy-revalidate` — only matters once the
+//     entry is stale (and even then it just forbids serving stale
+//     while disconnected); fresh entries are unaffected.
+//
+// So this returns true iff the no-cache directive is present.
 func MustRevalidate(respHeader http.Header) bool {
-	cc := parseControl(respHeader.Get("Cache-Control"))
-
-	return cc.NoCache || cc.MustRevalidate
+	return mergedCacheControl(respHeader).NoCache
 }
 
 // VaryHeaders extracts the comma-separated list of request headers
@@ -244,6 +265,152 @@ func ConditionalHeaders(cachedHeader http.Header) http.Header {
 	}
 
 	return out
+}
+
+// InitialAge parses the upstream's `Age:` response header. Used to
+// pre-age a freshly-stored cache entry — the origin may have sat in
+// an upstream cache for some time before reaching us, and RFC 9111
+// §5.1 says we must carry that age forward.
+//
+// Returns 0 when the header is absent / malformed / negative.
+func InitialAge(respHeader http.Header) time.Duration {
+	raw := respHeader.Get("Age")
+	if raw == "" {
+		return 0
+	}
+
+	n, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return time.Duration(n) * time.Second
+}
+
+// RequestDirectives holds the subset of `Cache-Control` directives a
+// client may put on a *request* (RFC 9111 §5.2.1).
+type RequestDirectives struct {
+	NoCache      bool   // "always revalidate this hit before serving"
+	NoStore      bool   // "do not store the response"
+	OnlyIfCached bool   // "serve from cache or 504"
+	MaxAge       *int64 // "I'll only accept entries whose age <= MaxAge"
+	MinFresh     *int64 // "I want at least MinFresh seconds of remaining freshness"
+	MaxStale     *int64 // "I'll accept stale entries up to MaxStale seconds past TTL"
+	HasMaxStale  bool   // distinguishes `max-stale` (no value, means infinity) from absent
+}
+
+// ParseRequestCacheControl reads the request's Cache-Control header.
+// Same parsing logic as the response side, but exposes the
+// request-applicable directives via a separate type so callers don't
+// confuse the two.
+func ParseRequestCacheControl(reqHeader http.Header) RequestDirectives {
+	raw := reqHeader.Get("Cache-Control")
+	if raw == "" {
+		return RequestDirectives{}
+	}
+
+	var d RequestDirectives
+
+	for _, part := range strings.Split(raw, ",") {
+		applyRequestDirective(&d, strings.TrimSpace(part))
+	}
+
+	return d
+}
+
+// applyRequestDirective folds one parsed directive into d. Pulled out
+// of ParseRequestCacheControl to satisfy the cyclop budget — and to
+// give the per-directive parsing somewhere to grow if we add more.
+func applyRequestDirective(d *RequestDirectives, part string) {
+	if part == "" {
+		return
+	}
+
+	key, value, _ := strings.Cut(part, "=")
+	key = strings.ToLower(strings.TrimSpace(key))
+	value = strings.TrimSpace(strings.Trim(value, `"`))
+
+	switch key {
+	case "no-cache":
+		d.NoCache = true
+	case "no-store":
+		d.NoStore = true
+	case "only-if-cached":
+		d.OnlyIfCached = true
+	case "max-age":
+		if v, ok := parseNonNegativeInt(value); ok {
+			d.MaxAge = &v
+		}
+	case "min-fresh":
+		if v, ok := parseNonNegativeInt(value); ok {
+			d.MinFresh = &v
+		}
+	case "max-stale":
+		d.HasMaxStale = true
+
+		if v, ok := parseNonNegativeInt(value); ok {
+			d.MaxStale = &v
+		}
+	}
+}
+
+// parseNonNegativeInt parses a base-10 int64 and returns ok=false on
+// error or negative values.
+func parseNonNegativeInt(s string) (int64, bool) {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || v < 0 {
+		return 0, false
+	}
+
+	return v, true
+}
+
+// EvaluateClient decides whether a cached entry can be served given
+// the request's Cache-Control directives. age is the entry's current
+// age (`time.Since(StoredAt) + InitialAge`). ttl is the entry's
+// effective TTL.
+//
+// Returns:
+//
+//	servable=true  → cached entry satisfies the request
+//	revalidate=true → cache may serve only after origin revalidation
+
+// ClientDecision is the verdict EvaluateClient returns.
+type ClientDecision struct {
+	Servable   bool
+	Revalidate bool
+	Reason     string
+}
+
+// EvaluateClient runs the request-side directives against an entry.
+func EvaluateClient(req RequestDirectives, age, ttl time.Duration) ClientDecision {
+	if req.NoCache {
+		return ClientDecision{Revalidate: true, Reason: "request: no-cache"}
+	}
+
+	if req.MaxAge != nil && age > time.Duration(*req.MaxAge)*time.Second {
+		return ClientDecision{Revalidate: true, Reason: "request: max-age exceeded"}
+	}
+
+	if req.MinFresh != nil {
+		remaining := ttl - age
+		if remaining < time.Duration(*req.MinFresh)*time.Second {
+			return ClientDecision{Revalidate: true, Reason: "request: min-fresh not met"}
+		}
+	}
+
+	stale := age >= ttl
+	if stale && req.HasMaxStale {
+		if req.MaxStale == nil || age-ttl <= time.Duration(*req.MaxStale)*time.Second {
+			return ClientDecision{Servable: true, Reason: "request: max-stale honoured"}
+		}
+	}
+
+	if stale {
+		return ClientDecision{Revalidate: true, Reason: "stale"}
+	}
+
+	return ClientDecision{Servable: true}
 }
 
 // ParseRange interprets a single-range "Range: bytes=START-END"

--- a/internal/service/cloudfront/cache/rules.go
+++ b/internal/service/cloudfront/cache/rules.go
@@ -1,0 +1,279 @@
+// Package cache implements the cache rule evaluation CloudFront
+// performs at the edge, per RFC 7234 + the CloudFront-specific
+// extensions documented at:
+//
+//	https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html
+//
+// The package is pure — no HTTP, no storage. The edge handler in
+// edge.go applies these rules to live requests/responses.
+package cache
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DistributionConfig is the subset of CloudFront's CacheBehavior that
+// the rule evaluation needs. Real DefaultCacheBehavior carries more,
+// but TTL clamping only depends on these three values.
+type DistributionConfig struct {
+	MinTTL     time.Duration
+	DefaultTTL time.Duration
+	MaxTTL     time.Duration
+}
+
+// EffectiveTTL implements the CloudFront precedence:
+//
+//  1. If the origin sends `Cache-Control: s-maxage=N`, use N.
+//  2. Otherwise if `Cache-Control: max-age=N`, use N.
+//  3. Otherwise if `Expires: <date>` is in the future, use that delta.
+//  4. Otherwise fall back to the distribution's DefaultTTL.
+//
+// The result is then clamped to [MinTTL, MaxTTL].
+//
+// Special cases that override the above:
+//
+//   - `Cache-Control: no-store` → returns 0 (do not cache).
+//   - `Cache-Control: private`  → returns 0 (CloudFront treats this as
+//     "shared cache must not store").
+//
+// `no-cache` is **not** zero — it caches but always revalidates; that
+// distinction belongs to MustRevalidate, not the TTL.
+func EffectiveTTL(respHeader http.Header, cfg DistributionConfig, now time.Time) time.Duration {
+	cc := parseControl(respHeader.Get("Cache-Control"))
+	if cc.NoStore || cc.Private {
+		return 0
+	}
+
+	ttl := cfg.DefaultTTL
+
+	switch {
+	case cc.SMaxAge != nil:
+		ttl = time.Duration(*cc.SMaxAge) * time.Second
+	case cc.MaxAge != nil:
+		ttl = time.Duration(*cc.MaxAge) * time.Second
+	default:
+		if exp := respHeader.Get("Expires"); exp != "" {
+			if t, err := http.ParseTime(exp); err == nil {
+				delta := t.Sub(now)
+				if delta > 0 {
+					ttl = delta
+				}
+			}
+		}
+	}
+
+	return clampTTL(ttl, cfg)
+}
+
+// IsCacheable mirrors the CloudFront decision tree for "can the
+// response be put in the cache at all". Returns (false, reason) when
+// the response must not be stored. Reason is human-readable for
+// surfacing in X-Cache-Reason or logs.
+func IsCacheable(respHeader http.Header, statusCode int) (bool, string) {
+	cc := parseControl(respHeader.Get("Cache-Control"))
+	if cc.NoStore {
+		return false, "Cache-Control: no-store"
+	}
+
+	if cc.Private {
+		return false, "Cache-Control: private"
+	}
+
+	// CloudFront caches a fixed set of status codes by default.
+	switch statusCode {
+	case http.StatusOK,
+		http.StatusNonAuthoritativeInfo,
+		http.StatusNoContent,
+		http.StatusPartialContent,
+		http.StatusMultipleChoices,
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusNotFound,
+		http.StatusMethodNotAllowed,
+		http.StatusGone,
+		http.StatusRequestURITooLong,
+		http.StatusNotImplemented:
+		return true, ""
+	default:
+		return false, "status " + strconv.Itoa(statusCode) + " is not cacheable by default"
+	}
+}
+
+// MustRevalidate reports whether a cached entry must be revalidated
+// with the origin before being served, even if it's still fresh by
+// TTL. CloudFront treats `Cache-Control: no-cache` and `must-revalidate`
+// the same way at the edge.
+func MustRevalidate(respHeader http.Header) bool {
+	cc := parseControl(respHeader.Get("Cache-Control"))
+
+	return cc.NoCache || cc.MustRevalidate
+}
+
+// VaryHeaders extracts the comma-separated list of request headers
+// the origin's `Vary` response header pins as part of the cache key.
+// The names are lowercased and deduplicated for stable key building.
+//
+// `Vary: *` is special — it disables caching entirely; the caller
+// should treat that as "do not cache" rather than feeding it here.
+func VaryHeaders(respHeader http.Header) []string {
+	raw := respHeader.Values("Vary")
+	if len(raw) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+
+	for _, line := range raw {
+		for _, name := range strings.Split(line, ",") {
+			name = strings.TrimSpace(strings.ToLower(name))
+			if name != "" {
+				seen[name] = struct{}{}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+// VaryDisablesCache returns true when the origin sent `Vary: *`,
+// which RFC 7234 says forbids any further caching.
+func VaryDisablesCache(respHeader http.Header) bool {
+	for _, line := range respHeader.Values("Vary") {
+		for _, name := range strings.Split(line, ",") {
+			if strings.TrimSpace(name) == "*" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// Key builds the deterministic cache key for a request. The base
+// is method+URL; adding the values of any Vary headers (lowercased,
+// in stable order) yields the per-variant key.
+//
+// Query string handling matches CloudFront's "all" forwarded mode —
+// the full sorted query string contributes to the key. Cookie /
+// header forwarding beyond Vary is out of scope for this PR.
+func Key(req *http.Request, vary []string) string {
+	var b strings.Builder
+
+	b.WriteString(req.Method)
+	b.WriteByte(' ')
+	b.WriteString(req.URL.Path)
+
+	if q := req.URL.Query(); len(q) > 0 {
+		keys := make([]string, 0, len(q))
+		for k := range q {
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
+		b.WriteByte('?')
+
+		for i, k := range keys {
+			if i > 0 {
+				b.WriteByte('&')
+			}
+
+			vals := append([]string(nil), q[k]...)
+			sort.Strings(vals)
+
+			b.WriteString(k)
+			b.WriteByte('=')
+			b.WriteString(strings.Join(vals, ","))
+		}
+	}
+
+	for _, name := range vary {
+		b.WriteByte('|')
+		b.WriteString(name)
+		b.WriteByte('=')
+		b.WriteString(req.Header.Get(name))
+	}
+
+	return b.String()
+}
+
+// clampTTL applies the CloudFront [MinTTL, MaxTTL] clamp.
+func clampTTL(ttl time.Duration, cfg DistributionConfig) time.Duration {
+	if ttl < cfg.MinTTL {
+		return cfg.MinTTL
+	}
+
+	if cfg.MaxTTL > 0 && ttl > cfg.MaxTTL {
+		return cfg.MaxTTL
+	}
+
+	return ttl
+}
+
+// Control is the parsed shape of a Cache-Control header.
+// Pointers distinguish "absent" from "zero".
+type Control struct {
+	NoStore        bool
+	NoCache        bool
+	Private        bool
+	Public         bool
+	MustRevalidate bool
+	MaxAge         *int64
+	SMaxAge        *int64
+}
+
+// parseControl parses a Cache-Control header value. Unknown
+// directives are ignored (per RFC 7234 §5.2 — receivers MUST ignore
+// directives they don't recognise).
+func parseControl(raw string) Control {
+	var cc Control
+
+	if raw == "" {
+		return cc
+	}
+
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		key, value, _ := strings.Cut(part, "=")
+		key = strings.ToLower(strings.TrimSpace(key))
+		value = strings.TrimSpace(strings.Trim(value, `"`))
+
+		switch key {
+		case "no-store":
+			cc.NoStore = true
+		case "no-cache":
+			cc.NoCache = true
+		case "private":
+			cc.Private = true
+		case "public":
+			cc.Public = true
+		case "must-revalidate":
+			cc.MustRevalidate = true
+		case "max-age":
+			if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+				cc.MaxAge = &v
+			}
+		case "s-maxage":
+			if v, err := strconv.ParseInt(value, 10, 64); err == nil {
+				cc.SMaxAge = &v
+			}
+		}
+	}
+
+	return cc
+}

--- a/internal/service/cloudfront/cache/rules.go
+++ b/internal/service/cloudfront/cache/rules.go
@@ -123,6 +123,51 @@ func mergedCacheControl(respHeader http.Header) Control {
 	return parseControl(respHeader.Get("Cache-Control"))
 }
 
+// CDNStaleDirectives is the (stale-while-revalidate, stale-if-error)
+// pair from a response. CloudFront only honours these when they come
+// from CDN-Cache-Control — the Cache-Control header is the
+// browser-targeted policy and intentionally has no influence on the
+// CDN's stale-serving behaviour. RFC 9213 §3.1 endorses the same
+// split.
+//
+// Returns zero durations when neither directive is set or
+// CDN-Cache-Control is absent.
+type CDNStaleDirectives struct {
+	StaleWhileRevalidate time.Duration
+	StaleIfError         time.Duration
+}
+
+// ReadCDNStaleDirectives parses CDN-Cache-Control for swr / sie. It
+// intentionally ignores Cache-Control to match CloudFront's published
+// behaviour.
+func ReadCDNStaleDirectives(respHeader http.Header) CDNStaleDirectives {
+	cdn := respHeader.Get("CDN-Cache-Control")
+	if cdn == "" {
+		return CDNStaleDirectives{}
+	}
+
+	var out CDNStaleDirectives
+
+	for _, part := range strings.Split(cdn, ",") {
+		key, value, _ := strings.Cut(strings.TrimSpace(part), "=")
+		key = strings.ToLower(strings.TrimSpace(key))
+		value = strings.TrimSpace(strings.Trim(value, `"`))
+
+		switch key {
+		case "stale-while-revalidate":
+			if v, ok := parseNonNegativeInt(value); ok {
+				out.StaleWhileRevalidate = time.Duration(v) * time.Second
+			}
+		case "stale-if-error":
+			if v, ok := parseNonNegativeInt(value); ok {
+				out.StaleIfError = time.Duration(v) * time.Second
+			}
+		}
+	}
+
+	return out
+}
+
 // IsCacheable decides whether the response can be put in the cache
 // at all. Returns (false, reason) when storage is forbidden.
 //

--- a/internal/service/cloudfront/cache/rules_test.go
+++ b/internal/service/cloudfront/cache/rules_test.go
@@ -243,3 +243,140 @@ func TestKey_QueryStringStable(t *testing.T) {
 		t.Fatalf("query order should not matter:\n  a=%q\n  b=%q", Key(a, nil), Key(b, nil))
 	}
 }
+
+// TestIfNoneMatchSatisfied covers the precondition flavours RFC 9110
+// §13.1.2 enumerates: missing header, `*`, single ETag, ETag list,
+// weak comparison.
+func TestIfNoneMatchSatisfied(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		reqHeader string
+		respETag  string
+		want      bool
+	}{
+		{"absent header", "", `"abc"`, false},
+		{"absent ETag", `"abc"`, "", false},
+		{"star matches anything", "*", `"abc"`, true},
+		{"exact match", `"abc"`, `"abc"`, true},
+		{"no match", `"xyz"`, `"abc"`, false},
+		{"list with match", `"x", "abc", "y"`, `"abc"`, true},
+		{"weak prefix match", `W/"abc"`, `"abc"`, true},
+		{"both weak match", `W/"abc"`, `W/"abc"`, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := http.Header{}
+			if tc.reqHeader != "" {
+				req.Set("If-None-Match", tc.reqHeader)
+			}
+
+			resp := http.Header{}
+			if tc.respETag != "" {
+				resp.Set("ETag", tc.respETag)
+			}
+
+			if got := IfNoneMatchSatisfied(req, resp); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIfModifiedSinceSatisfied: cached not-modified-after ⇒ 304.
+func TestIfModifiedSinceSatisfied(t *testing.T) {
+	t.Parallel()
+
+	earlier := time.Date(2026, 5, 9, 10, 0, 0, 0, time.UTC)
+	later := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		ims  string
+		lm   string
+		want bool
+	}{
+		{"absent IMS", "", earlier.Format(http.TimeFormat), false},
+		{"absent LM", earlier.Format(http.TimeFormat), "", false},
+		{"LM equal IMS", earlier.Format(http.TimeFormat), earlier.Format(http.TimeFormat), true},
+		{"LM before IMS", later.Format(http.TimeFormat), earlier.Format(http.TimeFormat), true},
+		{"LM after IMS", earlier.Format(http.TimeFormat), later.Format(http.TimeFormat), false},
+		{"malformed IMS", "garbage", earlier.Format(http.TimeFormat), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := http.Header{}
+			if tc.ims != "" {
+				req.Set("If-Modified-Since", tc.ims)
+			}
+
+			resp := http.Header{}
+			if tc.lm != "" {
+				resp.Set("Last-Modified", tc.lm)
+			}
+
+			if got := IfModifiedSinceSatisfied(req, resp); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConditionalHeaders builds the headers the cache attaches when
+// revalidating with the origin.
+func TestConditionalHeaders(t *testing.T) {
+	t.Parallel()
+
+	cached := http.Header{}
+	cached.Set("ETag", `"abc"`)
+	cached.Set("Last-Modified", "Sat, 09 May 2026 10:00:00 GMT")
+
+	out := ConditionalHeaders(cached)
+
+	if out.Get("If-None-Match") != `"abc"` {
+		t.Fatalf("If-None-Match: got %q", out.Get("If-None-Match"))
+	}
+
+	if out.Get("If-Modified-Since") != "Sat, 09 May 2026 10:00:00 GMT" {
+		t.Fatalf("If-Modified-Since: got %q", out.Get("If-Modified-Since"))
+	}
+}
+
+// TestParseRange enumerates the satisfiable / unsatisfiable cases the
+// edge cache hands to Range serving.
+func TestParseRange(t *testing.T) {
+	t.Parallel()
+
+	const totalSize int64 = 1000
+
+	cases := []struct {
+		header string
+		start  int64
+		end    int64
+		ok     bool
+	}{
+		{"bytes=0-99", 0, 99, true},
+		{"bytes=100-199", 100, 199, true},
+		{"bytes=900-9999", 900, 999, true},  // clamped
+		{"bytes=-100", 900, 999, true},      // suffix
+		{"bytes=500-", 500, 999, true},      // open-ended
+		{"bytes=1000-", 0, 0, false},        // start past end
+		{"bytes=200-100", 0, 0, false},      // inverted
+		{"bytes=0-99,200-299", 0, 0, false}, // multi-range
+		{"items=0-99", 0, 0, false},         // wrong unit
+		{"", 0, 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			start, end, ok := ParseRange(tc.header, totalSize)
+			if ok != tc.ok || (ok && (start != tc.start || end != tc.end)) {
+				t.Fatalf("got (%d, %d, %v), want (%d, %d, %v)",
+					start, end, ok, tc.start, tc.end, tc.ok)
+			}
+		})
+	}
+}

--- a/internal/service/cloudfront/cache/rules_test.go
+++ b/internal/service/cloudfront/cache/rules_test.go
@@ -77,6 +77,23 @@ func TestEffectiveTTL_PrecedenceTable(t *testing.T) {
 	}
 }
 
+// TestEffectiveTTL_CDNCacheControlOverride exercises RFC 9213:
+// `CDN-Cache-Control` wins over the regular `Cache-Control` at the
+// edge. Browsers downstream still see Cache-Control (we don't strip
+// it), but the cache uses CDN-Cache-Control's directives.
+func TestEffectiveTTL_CDNCacheControlOverride(t *testing.T) {
+	t.Parallel()
+
+	headers := http.Header{}
+	headers.Set("Cache-Control", "max-age=60")
+	headers.Set("CDN-Cache-Control", "max-age=600")
+
+	got := EffectiveTTL(headers, defCfg, now)
+	if got != 600*time.Second {
+		t.Fatalf("CDN-Cache-Control should win: got %v, want 10m", got)
+	}
+}
+
 // TestEffectiveTTL_Clamp covers the [MinTTL, MaxTTL] guard around the
 // raw value. CloudFront clamps regardless of where the TTL came from.
 func TestEffectiveTTL_Clamp(t *testing.T) {
@@ -124,7 +141,9 @@ func TestIsCacheable(t *testing.T) {
 	}
 }
 
-// TestMustRevalidate covers no-cache and must-revalidate.
+// TestMustRevalidate covers the freshness-side meaning of no-cache.
+// must-revalidate is intentionally NOT included — it constrains
+// stale-entry serving, not fresh-entry serving (RFC 9111 §5.2.2.2).
 func TestMustRevalidate(t *testing.T) {
 	t.Parallel()
 
@@ -135,7 +154,7 @@ func TestMustRevalidate(t *testing.T) {
 		{"", false},
 		{"max-age=60", false},
 		{"no-cache", true},
-		{"must-revalidate", true},
+		{"must-revalidate", false}, // fresh entries serve as-is
 		{"max-age=60, no-cache", true},
 	}
 

--- a/internal/service/cloudfront/cache/rules_test.go
+++ b/internal/service/cloudfront/cache/rules_test.go
@@ -1,0 +1,245 @@
+package cache
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+var (
+	now    = time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	defCfg = DistributionConfig{
+		MinTTL:     0,
+		DefaultTTL: 24 * time.Hour,
+		MaxTTL:     365 * 24 * time.Hour,
+	}
+)
+
+// TestEffectiveTTL_PrecedenceTable exercises the CloudFront precedence
+// chain s-maxage > max-age > Expires > DefaultTTL. Each row pins one
+// header combination and the expected resulting TTL.
+func TestEffectiveTTL_PrecedenceTable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		headers http.Header
+		want    time.Duration
+	}{
+		{
+			name:    "no headers → DefaultTTL",
+			headers: http.Header{},
+			want:    24 * time.Hour,
+		},
+		{
+			name:    "max-age wins over DefaultTTL",
+			headers: http.Header{"Cache-Control": {"max-age=60"}},
+			want:    60 * time.Second,
+		},
+		{
+			name:    "s-maxage wins over max-age",
+			headers: http.Header{"Cache-Control": {"max-age=60, s-maxage=120"}},
+			want:    120 * time.Second,
+		},
+		{
+			name:    "Expires used when no Cache-Control",
+			headers: http.Header{"Expires": {now.Add(5 * time.Minute).UTC().Format(http.TimeFormat)}},
+			want:    5 * time.Minute,
+		},
+		{
+			name: "Expires ignored if Cache-Control present",
+			headers: http.Header{
+				"Cache-Control": {"max-age=42"},
+				"Expires":       {now.Add(time.Hour).UTC().Format(http.TimeFormat)},
+			},
+			want: 42 * time.Second,
+		},
+		{
+			name:    "no-store → 0",
+			headers: http.Header{"Cache-Control": {"no-store, max-age=60"}},
+			want:    0,
+		},
+		{
+			name:    "private → 0 (CloudFront treats as do-not-store)",
+			headers: http.Header{"Cache-Control": {"private, max-age=60"}},
+			want:    0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EffectiveTTL(tc.headers, defCfg, now)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveTTL_Clamp covers the [MinTTL, MaxTTL] guard around the
+// raw value. CloudFront clamps regardless of where the TTL came from.
+func TestEffectiveTTL_Clamp(t *testing.T) {
+	t.Parallel()
+
+	cfg := DistributionConfig{MinTTL: 10 * time.Second, DefaultTTL: time.Hour, MaxTTL: time.Minute}
+
+	got := EffectiveTTL(http.Header{"Cache-Control": {"max-age=1"}}, cfg, now)
+	if got != 10*time.Second {
+		t.Fatalf("clamp to MinTTL: got %v, want 10s", got)
+	}
+
+	got = EffectiveTTL(http.Header{"Cache-Control": {"max-age=99999"}}, cfg, now)
+	if got != time.Minute {
+		t.Fatalf("clamp to MaxTTL: got %v, want 1m", got)
+	}
+}
+
+// TestIsCacheable enumerates the directives and status codes that
+// flip cacheability either way.
+func TestIsCacheable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		headers http.Header
+		status  int
+		want    bool
+	}{
+		{"200 with no directives", http.Header{}, 200, true},
+		{"200 + no-store", http.Header{"Cache-Control": {"no-store"}}, 200, false},
+		{"200 + private", http.Header{"Cache-Control": {"private"}}, 200, false},
+		{"301 redirect cacheable", http.Header{}, 301, true},
+		{"500 not cacheable by default", http.Header{}, 500, false},
+		{"404 cacheable (negative caching)", http.Header{}, 404, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := IsCacheable(tc.headers, tc.status)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMustRevalidate covers no-cache and must-revalidate.
+func TestMustRevalidate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		header string
+		want   bool
+	}{
+		{"", false},
+		{"max-age=60", false},
+		{"no-cache", true},
+		{"must-revalidate", true},
+		{"max-age=60, no-cache", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			h := http.Header{}
+			if tc.header != "" {
+				h.Set("Cache-Control", tc.header)
+			}
+
+			if got := MustRevalidate(h); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestVaryHeaders checks normalisation: case-insensitive, deduped,
+// stable order. Multi-line Vary headers are concatenated.
+func TestVaryHeaders(t *testing.T) {
+	t.Parallel()
+
+	h := http.Header{}
+	h.Add("Vary", "Accept-Language")
+	h.Add("Vary", "accept-encoding, ACCEPT-LANGUAGE")
+
+	got := VaryHeaders(h)
+	want := []string{"accept-encoding", "accept-language"}
+
+	if len(got) != len(want) {
+		t.Fatalf("len: got %d, want %d (%v)", len(got), len(want), got)
+	}
+
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+// TestVaryDisablesCache verifies the `Vary: *` short-circuit.
+func TestVaryDisablesCache(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		header string
+		want   bool
+	}{
+		{"", false},
+		{"Accept-Language", false},
+		{"*", true},
+		{"Accept-Language, *", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			h := http.Header{}
+			if tc.header != "" {
+				h.Set("Vary", tc.header)
+			}
+
+			if got := VaryDisablesCache(h); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestKey_VariantSeparation confirms that two requests differing
+// only in a Vary'd header produce distinct keys.
+func TestKey_VariantSeparation(t *testing.T) {
+	t.Parallel()
+
+	r1 := httptest.NewRequest(http.MethodGet, "/img.png?w=100", http.NoBody)
+	r1.Header.Set("Accept-Language", "en")
+
+	r2 := httptest.NewRequest(http.MethodGet, "/img.png?w=100", http.NoBody)
+	r2.Header.Set("Accept-Language", "ja")
+
+	vary := []string{"accept-language"}
+
+	k1 := Key(r1, vary)
+	k2 := Key(r2, vary)
+
+	if k1 == k2 {
+		t.Fatalf("Vary'd headers should split keys, both = %q", k1)
+	}
+
+	r2.Header.Set("Accept-Language", "en")
+
+	if Key(r1, vary) != Key(r2, vary) {
+		t.Fatalf("same Vary value should collide; got %q vs %q", k1, Key(r2, vary))
+	}
+}
+
+// TestKey_QueryStringStable ensures the query-string part of the
+// key is order-independent (foo=1&bar=2 and bar=2&foo=1 collide).
+func TestKey_QueryStringStable(t *testing.T) {
+	t.Parallel()
+
+	a := httptest.NewRequest(http.MethodGet, "/p?foo=1&bar=2", http.NoBody)
+	b := httptest.NewRequest(http.MethodGet, "/p?bar=2&foo=1", http.NoBody)
+
+	if Key(a, nil) != Key(b, nil) {
+		t.Fatalf("query order should not matter:\n  a=%q\n  b=%q", Key(a, nil), Key(b, nil))
+	}
+}

--- a/internal/service/cloudfront/edge.go
+++ b/internal/service/cloudfront/edge.go
@@ -114,14 +114,18 @@ func sameVarySignature(a, b *cacheEntry) bool {
 	return true
 }
 
-// Edge handles GET requests routed through `/kumo/cdn/{distId}/{path...}`.
+// Edge handles requests routed through `/kumo/cdn/{distId}/{path...}`.
 // It implements the CloudFront edge caching contract:
 //
 //  1. Resolve the distribution + chosen origin.
-//  2. Look up the cache entry. If fresh and not flagged for forced
-//     revalidation, serve it with `X-Cache: Hit from kumo` and the
-//     standard `Age` header.
-//  3. Otherwise fetch from the origin, evaluate cacheability + TTL via
+//  2. For non-safe methods (PUT / POST / DELETE / PATCH), pass through
+//     to the origin without consulting or storing the cache. RFC 9111
+//     §4.4 requires the cache to invalidate on these too — handled in
+//     a follow-up.
+//  3. For safe methods (GET / HEAD), look up the cache. If fresh and
+//     not flagged for forced revalidation, serve it with
+//     `X-Cache: Hit from kumo` and the standard `Age` header.
+//  4. Otherwise fetch from the origin, evaluate cacheability + TTL via
 //     the rules in `cache/`, store the response when allowed, and
 //     serve with `X-Cache: Miss from kumo`.
 //
@@ -138,16 +142,22 @@ func (s *Service) Edge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cfg, ok := edgeCacheConfig(dist)
+	originURL, ok := edgeOriginURL(dist, r.PathValue("path"), r.URL.RawQuery)
 	if !ok {
-		http.Error(w, "distribution missing DefaultCacheBehavior", http.StatusServiceUnavailable)
+		http.Error(w, "distribution has no usable origin", http.StatusServiceUnavailable)
 
 		return
 	}
 
-	originURL, ok := edgeOriginURL(dist, r.PathValue("path"), r.URL.RawQuery)
+	if !isCacheableMethod(r.Method) {
+		s.passthrough(w, r, originURL)
+
+		return
+	}
+
+	cfg, ok := edgeCacheConfig(dist)
 	if !ok {
-		http.Error(w, "distribution has no usable origin", http.StatusServiceUnavailable)
+		http.Error(w, "distribution missing DefaultCacheBehavior", http.StatusServiceUnavailable)
 
 		return
 	}
@@ -168,6 +178,44 @@ func (s *Service) Edge(w http.ResponseWriter, r *http.Request) {
 
 	storeIfCacheable(s.edgeCache, distID, base, r, upstream, cfg)
 	writeUpstream(w, upstream, "Miss from kumo", 0)
+}
+
+// isCacheableMethod returns true for the HTTP methods CloudFront ever
+// considers caching. Everything else passes through.
+func isCacheableMethod(m string) bool {
+	return m == http.MethodGet || m == http.MethodHead
+}
+
+// isHopByHopHeader reports whether the given header is per-hop and
+// must not be propagated through a proxy (RFC 7230 §6.1).
+func isHopByHopHeader(name string) bool {
+	switch http.CanonicalHeaderKey(name) {
+	case "Connection",
+		"Keep-Alive",
+		"Proxy-Authenticate",
+		"Proxy-Authorization",
+		"Te",
+		"Trailers",
+		"Transfer-Encoding",
+		"Upgrade",
+		"Host":
+		return true
+	}
+
+	return false
+}
+
+// passthrough forwards the request body verbatim, returns the response
+// without touching the cache. Used for PUT / POST / DELETE / PATCH.
+func (s *Service) passthrough(w http.ResponseWriter, r *http.Request, originURL string) {
+	upstream, err := forwardOrigin(originURL, r)
+	if err != nil {
+		http.Error(w, "origin fetch failed: "+err.Error(), http.StatusBadGateway)
+
+		return
+	}
+
+	writeUpstream(w, upstream, "Bypass from kumo", 0)
 }
 
 // edgeCacheConfig pulls the [MinTTL, DefaultTTL, MaxTTL] triple out of
@@ -235,26 +283,43 @@ type originResponse struct {
 	Body       []byte
 }
 
-// fetchOrigin sends the request upstream and returns the buffered
-// response. We need the body twice (once to serve, once to cache),
-// so it's read into memory here.
+// fetchOrigin sends a body-less request upstream (GET/HEAD) and
+// returns the buffered response. We need the body twice (once to
+// serve, once to cache), so it's read into memory here.
 func fetchOrigin(target string, r *http.Request) (*originResponse, error) {
+	return originRequest(target, r, http.NoBody)
+}
+
+// forwardOrigin proxies a non-cacheable request (PUT/POST/DELETE/PATCH)
+// with its body intact. The cache is not consulted.
+func forwardOrigin(target string, r *http.Request) (*originResponse, error) {
+	return originRequest(target, r, r.Body)
+}
+
+// originRequest is the shared upstream request path used by both
+// fetchOrigin and forwardOrigin.
+func originRequest(target string, r *http.Request, reqBody io.Reader) (*originResponse, error) {
 	parsed, err := url.Parse(target)
 	if err != nil {
 		return nil, fmt.Errorf("parse origin URL: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(r.Context(), r.Method, parsed.String(), http.NoBody)
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, parsed.String(), reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("build origin request: %w", err)
 	}
 
-	// Forward request headers that affect cache variants. The full
-	// header list isn't propagated — CloudFront's default forwarded
-	// set is small.
-	for _, h := range []string{"Accept", "Accept-Encoding", "Accept-Language", "User-Agent"} {
-		if v := r.Header.Get(h); v != "" {
-			req.Header.Set(h, v)
+	// Forward all request headers except hop-by-hop. CloudFront's
+	// real forwarding policy is configurable — we keep it permissive
+	// so the test surface (Test-ID / Req-Num / If-Modified-Since /
+	// Cache-Control / etc) reaches the origin verbatim.
+	for k, vs := range r.Header {
+		if isHopByHopHeader(k) {
+			continue
+		}
+
+		for _, v := range vs {
+			req.Header.Add(k, v)
 		}
 	}
 

--- a/internal/service/cloudfront/edge.go
+++ b/internal/service/cloudfront/edge.go
@@ -15,6 +15,8 @@ import (
 	"github.com/sivchari/kumo/internal/service/cloudfront/cache"
 )
 
+const maxEdgeCacheEntries = 1024
+
 // cacheEntry is one cached response variant for a distribution.
 type cacheEntry struct {
 	StatusCode           int
@@ -94,6 +96,51 @@ func (c *edgeCache) store(distID, base string, entry *cacheEntry) {
 	}
 
 	c.entries[distID][base] = append(variants, entry)
+	c.evictOldestLocked(maxEdgeCacheEntries)
+}
+
+func (c *edgeCache) evictOldestLocked(maxEntries int) {
+	if maxEntries <= 0 {
+		return
+	}
+
+	total := 0
+	oldestDistID := ""
+	oldestBase := ""
+	oldestIndex := -1
+	oldestStoredAt := time.Time{}
+
+	for distID, dm := range c.entries {
+		for base, variants := range dm {
+			for i, entry := range variants {
+				total++
+
+				if oldestIndex == -1 || entry.StoredAt.Before(oldestStoredAt) {
+					oldestDistID = distID
+					oldestBase = base
+					oldestIndex = i
+					oldestStoredAt = entry.StoredAt
+				}
+			}
+		}
+	}
+
+	if total <= maxEntries || oldestIndex == -1 {
+		return
+	}
+
+	variants := c.entries[oldestDistID][oldestBase]
+	variants = append(variants[:oldestIndex], variants[oldestIndex+1:]...)
+
+	if len(variants) == 0 {
+		delete(c.entries[oldestDistID], oldestBase)
+	} else {
+		c.entries[oldestDistID][oldestBase] = variants
+	}
+
+	if len(c.entries[oldestDistID]) == 0 {
+		delete(c.entries, oldestDistID)
+	}
 }
 
 // matchesVary reports whether the request's headers for the entry's
@@ -181,7 +228,11 @@ func sameVarySignature(a, b *cacheEntry) bool {
 		return false
 	}
 
-	for _, name := range a.Vary {
+	for i, name := range a.Vary {
+		if name != b.Vary[i] {
+			return false
+		}
+
 		if !varyValueEqual(name, a.VaryValues[name], b.VaryValues[name]) {
 			return false
 		}
@@ -342,9 +393,7 @@ func (s *Service) kickBackgroundRevalidate(distID, base string, r *http.Request,
 		}
 
 		if upstream.StatusCode == http.StatusNotModified {
-			mergeRevalidatedHeaders(entry.Header, upstream.Header)
-			entry.StoredAt = time.Now()
-			entry.TTL = cache.EffectiveTTL(entry.Header, cfg, time.Now())
+			s.edgeCache.store(distID, base, refreshedEntry(entry, upstream.Header, cfg, time.Now()))
 
 			return
 		}
@@ -396,11 +445,10 @@ func (s *Service) revalidate(w http.ResponseWriter, r *http.Request, distID, bas
 
 	if upstream.StatusCode == http.StatusNotModified {
 		// Refresh: keep the cached body, update headers + reset TTL.
-		mergeRevalidatedHeaders(entry.Header, upstream.Header)
-		entry.StoredAt = time.Now()
-		entry.TTL = cache.EffectiveTTL(entry.Header, cfg, time.Now())
+		refreshed := refreshedEntry(entry, upstream.Header, cfg, time.Now())
+		s.edgeCache.store(distID, base, refreshed)
 
-		serveFromCache(w, r, entry, 0)
+		serveFromCache(w, r, refreshed, 0)
 
 		return true
 	}
@@ -412,14 +460,36 @@ func (s *Service) revalidate(w http.ResponseWriter, r *http.Request, distID, bas
 	return true
 }
 
-// mergeRevalidatedHeaders applies the headers a 304 response brought
-// back. RFC 9111 §4.3.4 says the cache replaces validators / cache
-// directives but keeps the rest.
-func mergeRevalidatedHeaders(cached, fresh http.Header) {
+// refreshedEntry returns a replacement cache entry with the headers a
+// 304 response brought back. RFC 9111 Section 4.3.4 says the cache
+// replaces validators / cache directives but keeps the rest.
+func refreshedEntry(entry *cacheEntry, fresh http.Header, cfg cache.DistributionConfig, now time.Time) *cacheEntry {
+	header := entry.Header.Clone()
+
 	for _, h := range []string{"Cache-Control", "ETag", "Last-Modified", "Expires", "Vary", "Date"} {
 		if v := fresh.Get(h); v != "" {
-			cached.Set(h, v)
+			header.Set(h, v)
 		}
+	}
+
+	vary := append([]string(nil), entry.Vary...)
+	varyValues := make(map[string]string, len(entry.VaryValues))
+
+	for k, v := range entry.VaryValues {
+		varyValues[k] = v
+	}
+
+	return &cacheEntry{
+		StatusCode:           entry.StatusCode,
+		Header:               header,
+		Body:                 append([]byte(nil), entry.Body...),
+		StoredAt:             now,
+		InitialAge:           entry.InitialAge,
+		TTL:                  cache.EffectiveTTL(header, cfg, now),
+		StaleWhileRevalidate: entry.StaleWhileRevalidate,
+		StaleIfError:         entry.StaleIfError,
+		Vary:                 vary,
+		VaryValues:           varyValues,
 	}
 }
 

--- a/internal/service/cloudfront/edge.go
+++ b/internal/service/cloudfront/edge.go
@@ -119,19 +119,18 @@ func sameVarySignature(a, b *cacheEntry) bool {
 //
 //  1. Resolve the distribution + chosen origin.
 //  2. For non-safe methods (PUT / POST / DELETE / PATCH), pass through
-//     to the origin without consulting or storing the cache. RFC 9111
-//     §4.4 requires the cache to invalidate on these too — handled in
-//     a follow-up.
-//  3. For safe methods (GET / HEAD), look up the cache. If fresh and
-//     not flagged for forced revalidation, serve it with
-//     `X-Cache: Hit from kumo` and the standard `Age` header.
-//  4. Otherwise fetch from the origin, evaluate cacheability + TTL via
-//     the rules in `cache/`, store the response when allowed, and
-//     serve with `X-Cache: Miss from kumo`.
-//
-// Revalidation (`If-None-Match` / `If-Modified-Since`) is left for a
-// follow-up PR — `MustRevalidate` is currently treated as "always
-// miss".
+//     to the origin without consulting or storing the cache.
+//  3. For safe methods (GET / HEAD), look up the cache.
+//  4. If fresh:
+//     - client conditional (If-None-Match / If-Modified-Since)
+//     satisfied by the cached entry → 304 Not Modified
+//     - Range request → 206 Partial Content from the cached body
+//     - otherwise → 200 with `X-Cache: Hit from kumo` and `Age`
+//  5. If stale or MustRevalidate: revalidate with the origin using
+//     conditional headers built from the cached validators. 304 from
+//     origin extends the entry's freshness; 200 replaces it.
+//  6. On a true miss: fetch, evaluate cacheability + TTL via `cache/`,
+//     store when allowed, and serve with `X-Cache: Miss from kumo`.
 func (s *Service) Edge(w http.ResponseWriter, r *http.Request) {
 	distID := r.PathValue("distributionId")
 
@@ -163,8 +162,21 @@ func (s *Service) Edge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	base := cache.Key(r, nil)
-	if entry, hit := s.edgeCache.lookup(distID, base, r); hit {
-		if served := serveIfFresh(w, entry); served {
+	entry, hit := s.edgeCache.lookup(distID, base, r)
+
+	if hit {
+		age := time.Since(entry.StoredAt)
+
+		fresh := age < entry.TTL && !cache.MustRevalidate(entry.Header)
+		if fresh {
+			serveFromCache(w, r, entry, age)
+
+			return
+		}
+
+		// Stale or forced-revalidation: ask the origin with
+		// conditional headers built from the cached validators.
+		if revalidated := s.revalidate(w, r, distID, base, entry, originURL, cfg); revalidated {
 			return
 		}
 	}
@@ -178,6 +190,134 @@ func (s *Service) Edge(w http.ResponseWriter, r *http.Request) {
 
 	storeIfCacheable(s.edgeCache, distID, base, r, upstream, cfg)
 	writeUpstream(w, upstream, "Miss from kumo", 0)
+}
+
+// serveFromCache writes the cached entry, honouring client
+// preconditions (If-None-Match / If-Modified-Since → 304) and Range
+// requests (→ 206 Partial Content) before falling back to the full
+// 200 response.
+func serveFromCache(w http.ResponseWriter, r *http.Request, entry *cacheEntry, age time.Duration) {
+	if cache.IfNoneMatchSatisfied(r.Header, entry.Header) || cache.IfModifiedSinceSatisfied(r.Header, entry.Header) {
+		writeNotModified(w, entry, age)
+
+		return
+	}
+
+	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" {
+		start, end, ok := cache.ParseRange(rangeHeader, int64(len(entry.Body)))
+		if ok {
+			writePartialContent(w, entry, start, end, age)
+
+			return
+		}
+	}
+
+	writeFullCached(w, entry, age)
+}
+
+// revalidate sends a conditional request to the origin. Returns true
+// when it served a response (either 304-refreshed cache or 200-replaced
+// cache), false when the caller should fall through to a normal miss
+// fetch (e.g. the cached entry has no validators).
+func (s *Service) revalidate(w http.ResponseWriter, r *http.Request, distID, base string, entry *cacheEntry, originURL string, cfg cache.DistributionConfig) bool {
+	cond := cache.ConditionalHeaders(entry.Header)
+	if len(cond) == 0 {
+		return false
+	}
+
+	upstream, err := revalidateOrigin(originURL, r, cond)
+	if err != nil {
+		http.Error(w, "origin revalidate failed: "+err.Error(), http.StatusBadGateway)
+
+		return true
+	}
+
+	if upstream.StatusCode == http.StatusNotModified {
+		// Refresh: keep the cached body, update headers + reset TTL.
+		mergeRevalidatedHeaders(entry.Header, upstream.Header)
+		entry.StoredAt = time.Now()
+		entry.TTL = cache.EffectiveTTL(entry.Header, cfg, time.Now())
+
+		serveFromCache(w, r, entry, 0)
+
+		return true
+	}
+
+	// 200 (or anything else) — replace the cache entry.
+	storeIfCacheable(s.edgeCache, distID, base, r, upstream, cfg)
+	writeUpstream(w, upstream, "Miss from kumo", 0)
+
+	return true
+}
+
+// mergeRevalidatedHeaders applies the headers a 304 response brought
+// back. RFC 9111 §4.3.4 says the cache replaces validators / cache
+// directives but keeps the rest.
+func mergeRevalidatedHeaders(cached, fresh http.Header) {
+	for _, h := range []string{"Cache-Control", "ETag", "Last-Modified", "Expires", "Vary", "Date"} {
+		if v := fresh.Get(h); v != "" {
+			cached.Set(h, v)
+		}
+	}
+}
+
+// writeNotModified writes a 304 with only the headers RFC 9111 §4.1
+// permits to accompany it.
+func writeNotModified(w http.ResponseWriter, entry *cacheEntry, age time.Duration) {
+	for _, h := range []string{"ETag", "Last-Modified", "Cache-Control", "Date", "Content-Location", "Vary"} {
+		if v := entry.Header.Get(h); v != "" {
+			w.Header().Set(h, v)
+		}
+	}
+
+	w.Header().Set("X-Cache", "Hit from kumo")
+
+	if age > 0 {
+		w.Header().Set("Age", strconv.FormatInt(int64(age.Seconds()), 10))
+	}
+
+	w.WriteHeader(http.StatusNotModified)
+}
+
+// writePartialContent writes a 206 from the cached body slice.
+func writePartialContent(w http.ResponseWriter, entry *cacheEntry, start, end int64, age time.Duration) {
+	for k, vs := range entry.Header {
+		// Skip Content-Length — recomputed below from the slice.
+		if http.CanonicalHeaderKey(k) == "Content-Length" {
+			continue
+		}
+
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+
+	length := end - start + 1
+
+	w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(entry.Body)))
+	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
+	w.Header().Set("X-Cache", "Hit from kumo")
+
+	if age > 0 {
+		w.Header().Set("Age", strconv.FormatInt(int64(age.Seconds()), 10))
+	}
+
+	w.WriteHeader(http.StatusPartialContent)
+	_, _ = w.Write(entry.Body[start : end+1])
+}
+
+// writeFullCached is the original 200-from-cache path.
+func writeFullCached(w http.ResponseWriter, entry *cacheEntry, age time.Duration) {
+	for k, vs := range entry.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+
+	w.Header().Set("X-Cache", "Hit from kumo")
+	w.Header().Set("Age", strconv.FormatInt(int64(age.Seconds()), 10))
+	w.WriteHeader(entry.StatusCode)
+	_, _ = w.Write(entry.Body)
 }
 
 // isCacheableMethod returns true for the HTTP methods CloudFront ever
@@ -296,6 +436,28 @@ func forwardOrigin(target string, r *http.Request) (*originResponse, error) {
 	return originRequest(target, r, r.Body)
 }
 
+// revalidateOrigin sends a body-less GET/HEAD with the supplied
+// conditional headers attached. Used for stale-entry refresh; if the
+// origin returns 304 the cache extends the existing entry, otherwise
+// it replaces it.
+func revalidateOrigin(target string, r *http.Request, conditional http.Header) (*originResponse, error) {
+	clone := r.Clone(r.Context())
+
+	// Drop client-supplied conditionals so the cache's own validators
+	// drive the revalidation. RFC 9111 §4.3.1 sees these as the
+	// cache's responsibility.
+	clone.Header.Del("If-None-Match")
+	clone.Header.Del("If-Modified-Since")
+
+	for k, vs := range conditional {
+		for _, v := range vs {
+			clone.Header.Set(k, v)
+		}
+	}
+
+	return originRequest(target, clone, http.NoBody)
+}
+
 // originRequest is the shared upstream request path used by both
 // fetchOrigin and forwardOrigin.
 func originRequest(target string, r *http.Request, reqBody io.Reader) (*originResponse, error) {
@@ -371,33 +533,6 @@ func storeIfCacheable(c *edgeCache, distID, base string, r *http.Request, resp *
 		Vary:       vary,
 		VaryValues: values,
 	})
-}
-
-// serveIfFresh writes the cached entry when it's still within TTL.
-// Returns true when something was written; false when the caller
-// should fall through to an origin fetch.
-func serveIfFresh(w http.ResponseWriter, entry *cacheEntry) bool {
-	age := time.Since(entry.StoredAt)
-	if age >= entry.TTL {
-		return false
-	}
-
-	if cache.MustRevalidate(entry.Header) {
-		return false
-	}
-
-	for k, vs := range entry.Header {
-		for _, v := range vs {
-			w.Header().Add(k, v)
-		}
-	}
-
-	w.Header().Set("X-Cache", "Hit from kumo")
-	w.Header().Set("Age", strconv.FormatInt(int64(age.Seconds()), 10))
-	w.WriteHeader(entry.StatusCode)
-	_, _ = w.Write(entry.Body)
-
-	return true
 }
 
 // writeUpstream copies the upstream response body verbatim to the

--- a/internal/service/cloudfront/edge.go
+++ b/internal/service/cloudfront/edge.go
@@ -18,9 +18,16 @@ type cacheEntry struct {
 	Header     http.Header
 	Body       []byte
 	StoredAt   time.Time
+	InitialAge time.Duration // Age the upstream reported on store
 	TTL        time.Duration
 	Vary       []string          // header names that pinned this variant
 	VaryValues map[string]string // request values seen at store time
+}
+
+// age is the entry's current age — RFC 9111 §5.1: time we've held it
+// + Age the origin reported when we stored it.
+func (e *cacheEntry) age() time.Duration {
+	return time.Since(e.StoredAt) + e.InitialAge
 }
 
 // edgeCache stores responses keyed by (distId, base) where base is
@@ -161,24 +168,17 @@ func (s *Service) Edge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	clientCC := cache.ParseRequestCacheControl(r.Header)
 	base := cache.Key(r, nil)
-	entry, hit := s.edgeCache.lookup(distID, base, r)
 
-	if hit {
-		age := time.Since(entry.StoredAt)
+	if s.tryServeFromCache(w, r, distID, base, originURL, cfg, clientCC) {
+		return
+	}
 
-		fresh := age < entry.TTL && !cache.MustRevalidate(entry.Header)
-		if fresh {
-			serveFromCache(w, r, entry, age)
+	if clientCC.OnlyIfCached {
+		http.Error(w, "only-if-cached: not in cache", http.StatusGatewayTimeout)
 
-			return
-		}
-
-		// Stale or forced-revalidation: ask the origin with
-		// conditional headers built from the cached validators.
-		if revalidated := s.revalidate(w, r, distID, base, entry, originURL, cfg); revalidated {
-			return
-		}
+		return
 	}
 
 	upstream, err := fetchOrigin(originURL, r)
@@ -188,8 +188,38 @@ func (s *Service) Edge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	storeIfCacheable(s.edgeCache, distID, base, r, upstream, cfg)
+	if !clientCC.NoStore {
+		storeIfCacheable(s.edgeCache, distID, base, r, upstream, cfg)
+	}
+
 	writeUpstream(w, upstream, "Miss from kumo", 0)
+}
+
+// tryServeFromCache looks up the cache and either serves the entry,
+// triggers a revalidation, or reports back that the caller must do a
+// fresh origin fetch. Returns true when the response has already been
+// written.
+func (s *Service) tryServeFromCache(w http.ResponseWriter, r *http.Request, distID, base, originURL string, cfg cache.DistributionConfig, clientCC cache.RequestDirectives) bool {
+	entry, hit := s.edgeCache.lookup(distID, base, r)
+	if !hit {
+		return false
+	}
+
+	age := entry.age()
+	serverForcesRevalidate := cache.MustRevalidate(entry.Header)
+	clientDecision := cache.EvaluateClient(clientCC, age, entry.TTL)
+
+	switch {
+	case !serverForcesRevalidate && clientDecision.Servable:
+		serveFromCache(w, r, entry, age)
+
+		return true
+
+	case clientDecision.Revalidate || serverForcesRevalidate:
+		return s.revalidate(w, r, distID, base, entry, originURL, cfg)
+	}
+
+	return false
 }
 
 // serveFromCache writes the cached entry, honouring client
@@ -529,6 +559,7 @@ func storeIfCacheable(c *edgeCache, distID, base string, r *http.Request, resp *
 		Header:     resp.Header.Clone(),
 		Body:       append([]byte(nil), resp.Body...),
 		StoredAt:   time.Now(),
+		InitialAge: cache.InitialAge(resp.Header),
 		TTL:        ttl,
 		Vary:       vary,
 		VaryValues: values,

--- a/internal/service/cloudfront/edge.go
+++ b/internal/service/cloudfront/edge.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -91,13 +92,19 @@ func (c *edgeCache) store(distID, base string, entry *cacheEntry) {
 
 // matchesVary reports whether the request's headers for the entry's
 // recorded Vary list equal the ones it was stored with.
+//
+// Comparison is normalised: leading/trailing whitespace stripped,
+// internal whitespace runs collapsed, comma-separated tokens trimmed
+// individually. Case sensitivity follows the field-line value rule
+// (Accept-Language / Accept-Encoding are tokens — case-insensitive;
+// others fall back to byte equality after whitespace normalisation).
 func matchesVary(e *cacheEntry, r *http.Request) bool {
 	if len(e.Vary) == 0 {
 		return true
 	}
 
 	for _, name := range e.Vary {
-		if r.Header.Get(name) != e.VaryValues[name] {
+		if !varyValueEqual(name, r.Header.Get(name), e.VaryValues[name]) {
 			return false
 		}
 	}
@@ -105,15 +112,71 @@ func matchesVary(e *cacheEntry, r *http.Request) bool {
 	return true
 }
 
+// varyValueEqual compares two values for the named Vary header after
+// normalisation.
+func varyValueEqual(name, a, b string) bool {
+	an := normaliseVaryValue(name, a)
+	bn := normaliseVaryValue(name, b)
+
+	return an == bn
+}
+
+// normaliseVaryValue trims and collapses internal whitespace. For
+// token-list headers (Accept-Encoding / Accept-Language) it also
+// lowercases — those headers' grammars treat values case-insensitively.
+func normaliseVaryValue(name, value string) string {
+	out := collapseWhitespace(strings.TrimSpace(value))
+
+	switch strings.ToLower(name) {
+	case "accept-encoding", "accept-language":
+		// Per RFC 9110, content-coding / language-tag tokens are
+		// case-insensitive.
+		out = strings.ToLower(out)
+	}
+
+	return out
+}
+
+// collapseWhitespace replaces runs of HTAB/SP with a single SP and
+// trims spaces around comma separators.
+func collapseWhitespace(s string) string {
+	var b strings.Builder
+
+	prevSpace := false
+
+	for _, r := range s {
+		if r == ' ' || r == '\t' {
+			if !prevSpace {
+				b.WriteByte(' ')
+
+				prevSpace = true
+			}
+
+			continue
+		}
+
+		prevSpace = false
+
+		b.WriteRune(r)
+	}
+
+	out := b.String()
+	out = strings.ReplaceAll(out, " ,", ",")
+	out = strings.ReplaceAll(out, ", ", ",")
+
+	return out
+}
+
 // sameVarySignature checks two entries declare the same Vary headers
-// AND the same values (used during store to overwrite stale variants).
+// AND equivalent values (used during store to overwrite stale
+// variants).
 func sameVarySignature(a, b *cacheEntry) bool {
 	if len(a.Vary) != len(b.Vary) {
 		return false
 	}
 
 	for _, name := range a.Vary {
-		if a.VaryValues[name] != b.VaryValues[name] {
+		if !varyValueEqual(name, a.VaryValues[name], b.VaryValues[name]) {
 			return false
 		}
 	}
@@ -171,7 +234,8 @@ func (s *Service) Edge(w http.ResponseWriter, r *http.Request) {
 	clientCC := cache.ParseRequestCacheControl(r.Header)
 	base := cache.Key(r, nil)
 
-	if s.tryServeFromCache(w, r, distID, base, originURL, cfg, clientCC) {
+	// Request `no-store` bypasses the cache on both serve and store.
+	if !clientCC.NoStore && s.tryServeFromCache(w, r, distID, base, originURL, cfg, clientCC) {
 		return
 	}
 

--- a/internal/service/cloudfront/edge.go
+++ b/internal/service/cloudfront/edge.go
@@ -1,6 +1,7 @@
 package cloudfront
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,14 +16,18 @@ import (
 
 // cacheEntry is one cached response variant for a distribution.
 type cacheEntry struct {
-	StatusCode int
-	Header     http.Header
-	Body       []byte
-	StoredAt   time.Time
-	InitialAge time.Duration // Age the upstream reported on store
-	TTL        time.Duration
-	Vary       []string          // header names that pinned this variant
-	VaryValues map[string]string // request values seen at store time
+	StatusCode           int
+	Header               http.Header
+	Body                 []byte
+	StoredAt             time.Time
+	InitialAge           time.Duration // Age the upstream reported on store
+	TTL                  time.Duration
+	StaleWhileRevalidate time.Duration     // window after TTL during which a stale serve+async revalidate is allowed (CDN-Cache-Control only)
+	StaleIfError         time.Duration     // window after TTL during which an origin error allows serving stale (CDN-Cache-Control only)
+	Vary                 []string          // header names that pinned this variant
+	VaryValues           map[string]string // request values seen at store time
+	revalidating         bool              // guards against duplicate background revalidations
+	revalidateMu         sync.Mutex        // protects `revalidating`
 }
 
 // age is the entry's current age — RFC 9111 §5.1: time we've held it
@@ -273,17 +278,79 @@ func (s *Service) tryServeFromCache(w http.ResponseWriter, r *http.Request, dist
 	serverForcesRevalidate := cache.MustRevalidate(entry.Header)
 	clientDecision := cache.EvaluateClient(clientCC, age, entry.TTL)
 
-	switch {
-	case !serverForcesRevalidate && clientDecision.Servable:
+	if !serverForcesRevalidate && clientDecision.Servable {
 		serveFromCache(w, r, entry, age)
 
 		return true
+	}
 
-	case clientDecision.Revalidate || serverForcesRevalidate:
+	// Stale-while-revalidate: per CloudFront's CDN-Cache-Control
+	// reading of RFC 9213, a stale entry within the SWR window may
+	// be served immediately if the client allows it. A background
+	// revalidation refreshes the cache for the next request.
+	staleness := age - entry.TTL
+	if staleness > 0 && staleness <= entry.StaleWhileRevalidate && !serverForcesRevalidate && !clientCC.NoCache {
+		s.kickBackgroundRevalidate(distID, base, r, entry, originURL, cfg)
+		serveFromCache(w, r, entry, age)
+
+		return true
+	}
+
+	if clientDecision.Revalidate || serverForcesRevalidate {
 		return s.revalidate(w, r, distID, base, entry, originURL, cfg)
 	}
 
 	return false
+}
+
+// kickBackgroundRevalidate launches a goroutine that revalidates the
+// entry against the origin, deduplicating concurrent attempts on the
+// same key via a per-entry mutex flag. The current request is served
+// stale by the caller; this goroutine just keeps the cache fresh for
+// the next one.
+func (s *Service) kickBackgroundRevalidate(distID, base string, r *http.Request, entry *cacheEntry, originURL string, cfg cache.DistributionConfig) {
+	entry.revalidateMu.Lock()
+	if entry.revalidating {
+		entry.revalidateMu.Unlock()
+
+		return
+	}
+
+	entry.revalidating = true
+	entry.revalidateMu.Unlock()
+
+	// Detach the request from the response writer's lifecycle —
+	// the original handler returns immediately after we serve stale.
+	cloned := r.Clone(context.Background())
+
+	go func() {
+		defer func() {
+			entry.revalidateMu.Lock()
+			entry.revalidating = false
+			entry.revalidateMu.Unlock()
+		}()
+
+		cond := cache.ConditionalHeaders(entry.Header)
+		if len(cond) == 0 {
+			return
+		}
+
+		upstream, err := revalidateOrigin(originURL, cloned, cond)
+		if err != nil {
+			return
+		}
+
+		if upstream.StatusCode == http.StatusNotModified {
+			mergeRevalidatedHeaders(entry.Header, upstream.Header)
+			entry.StoredAt = time.Now()
+			entry.TTL = cache.EffectiveTTL(entry.Header, cfg, time.Now())
+
+			return
+		}
+
+		// 200 — replace via the normal store path.
+		storeIfCacheable(s.edgeCache, distID, base, cloned, upstream, cfg)
+	}()
 }
 
 // serveFromCache writes the cached entry, honouring client
@@ -618,15 +685,19 @@ func storeIfCacheable(c *edgeCache, distID, base string, r *http.Request, resp *
 		values[name] = r.Header.Get(name)
 	}
 
+	stale := cache.ReadCDNStaleDirectives(resp.Header)
+
 	c.store(distID, base, &cacheEntry{
-		StatusCode: resp.StatusCode,
-		Header:     resp.Header.Clone(),
-		Body:       append([]byte(nil), resp.Body...),
-		StoredAt:   time.Now(),
-		InitialAge: cache.InitialAge(resp.Header),
-		TTL:        ttl,
-		Vary:       vary,
-		VaryValues: values,
+		StatusCode:           resp.StatusCode,
+		Header:               resp.Header.Clone(),
+		Body:                 append([]byte(nil), resp.Body...),
+		StoredAt:             time.Now(),
+		InitialAge:           cache.InitialAge(resp.Header),
+		TTL:                  ttl,
+		StaleWhileRevalidate: stale.StaleWhileRevalidate,
+		StaleIfError:         stale.StaleIfError,
+		Vary:                 vary,
+		VaryValues:           values,
 	})
 }
 

--- a/internal/service/cloudfront/edge.go
+++ b/internal/service/cloudfront/edge.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -536,20 +537,75 @@ func edgeCacheConfig(dist *Distribution) (cache.DistributionConfig, bool) {
 	}, true
 }
 
-// edgeOriginURL builds the upstream URL: `<scheme>://<DomainName><OriginPath><path>?<query>`.
-// CustomOriginConfig.HTTPPort is honoured when the origin is HTTP.
+// edgeOriginURL builds the upstream URL for the request, choosing the
+// origin pinned by `DefaultCacheBehavior.TargetOriginID` and falling
+// back to the first registered origin when the ID doesn't resolve.
+//
+// Two origin shapes are honoured:
+//
+//   - **CustomOriginConfig**: arbitrary HTTP(S) origin.
+//     `<scheme>://<DomainName>[:<HTTPPort>]<OriginPath>/<path>`.
+//   - **S3OriginConfig**: an AWS S3 bucket. The DomainName is the
+//     virtual-hosted bucket DNS name (e.g.
+//     `mybucket.s3.us-east-1.amazonaws.com`). At the edge we extract
+//     the bucket name and target kumo's own S3 service in path-style
+//     so the proxy stays inside this kumo (no real AWS round-trip).
+//     The S3 base URL is `KUMO_S3_BACKEND` (default
+//     `http://127.0.0.1:4566`).
 func edgeOriginURL(dist *Distribution, path, rawQuery string) (string, bool) {
-	if dist.DistributionConfig == nil || dist.DistributionConfig.Origins == nil {
+	o, ok := selectOrigin(dist)
+	if !ok {
 		return "", false
+	}
+
+	var full string
+
+	switch {
+	case o.S3OriginConfig != nil:
+		full, ok = s3OriginURL(&o, path)
+		if !ok {
+			return "", false
+		}
+	case o.CustomOriginConfig != nil:
+		full = customOriginURL(&o, path)
+	default:
+		// No config block — assume HTTPS to the bare DomainName.
+		full = "https://" + o.DomainName + o.OriginPath + "/" + path
+	}
+
+	if rawQuery != "" {
+		full += "?" + rawQuery
+	}
+
+	return full, true
+}
+
+// selectOrigin returns the origin pinned by the distribution's
+// DefaultCacheBehavior.TargetOriginID, falling back to the first
+// origin when the ID doesn't match.
+func selectOrigin(dist *Distribution) (Origin, bool) {
+	if dist.DistributionConfig == nil || dist.DistributionConfig.Origins == nil {
+		return Origin{}, false
 	}
 
 	origins := dist.DistributionConfig.Origins.Items
 	if len(origins) == 0 {
-		return "", false
+		return Origin{}, false
 	}
 
-	o := origins[0]
+	if dcb := dist.DistributionConfig.DefaultCacheBehavior; dcb != nil && dcb.TargetOriginID != "" {
+		for _, o := range origins {
+			if o.ID == dcb.TargetOriginID {
+				return o, true
+			}
+		}
+	}
 
+	return origins[0], true
+}
+
+// customOriginURL builds the URL for an HTTP(S) custom origin.
+func customOriginURL(o *Origin, path string) string {
 	scheme := "https"
 	host := o.DomainName
 
@@ -566,12 +622,56 @@ func edgeOriginURL(dist *Distribution, path, rawQuery string) (string, bool) {
 		}
 	}
 
-	full := scheme + "://" + host + o.OriginPath + "/" + path
-	if rawQuery != "" {
-		full += "?" + rawQuery
+	return scheme + "://" + host + o.OriginPath + "/" + path
+}
+
+// s3OriginURL points the request at kumo's own S3 service in
+// path-style so the edge proxy stays in-process. Bucket name comes
+// from the DomainName's leftmost label; everything to the right of
+// the first dot is discarded.
+//
+// Example:
+//
+//	DomainName = "mybucket.s3.us-east-1.amazonaws.com"
+//	  → bucket = "mybucket"
+//	  → URL    = "<KUMO_S3_BACKEND>/mybucket<OriginPath>/<path>"
+//
+// Returns ok=false when the bucket can't be derived.
+func s3OriginURL(o *Origin, path string) (string, bool) {
+	bucket := s3BucketFromDomain(o.DomainName)
+	if bucket == "" {
+		return "", false
 	}
 
-	return full, true
+	base := os.Getenv("KUMO_S3_BACKEND")
+	if base == "" {
+		base = "http://127.0.0.1:4566"
+	}
+
+	return strings.TrimRight(base, "/") + "/" + bucket + o.OriginPath + "/" + path, true
+}
+
+// s3BucketFromDomain extracts the bucket name from a virtual-hosted
+// S3 DomainName. Accepts forms like
+// `<bucket>.s3.amazonaws.com`, `<bucket>.s3.<region>.amazonaws.com`,
+// `<bucket>.s3-<region>.amazonaws.com`. Returns "" when the input
+// isn't recognisably an S3 host.
+func s3BucketFromDomain(domain string) string {
+	dot := strings.Index(domain, ".")
+	if dot <= 0 {
+		return ""
+	}
+
+	bucket := domain[:dot]
+	rest := domain[dot+1:]
+
+	if !strings.HasPrefix(rest, "s3.") &&
+		!strings.HasPrefix(rest, "s3-") &&
+		rest != "s3.amazonaws.com" {
+		return ""
+	}
+
+	return bucket
 }
 
 // originResponse is the buffered subset of an http.Response that the

--- a/internal/service/cloudfront/edge.go
+++ b/internal/service/cloudfront/edge.go
@@ -1,0 +1,355 @@
+package cloudfront
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/sivchari/kumo/internal/service/cloudfront/cache"
+)
+
+// cacheEntry is one cached response variant for a distribution.
+type cacheEntry struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+	StoredAt   time.Time
+	TTL        time.Duration
+	Vary       []string          // header names that pinned this variant
+	VaryValues map[string]string // request values seen at store time
+}
+
+// edgeCache stores responses keyed by (distId, base) where base is
+// the path+query portion. Each base can hold multiple variants — one
+// per Vary'd header value combination. Concurrency-safe.
+//
+// The two-level layout matches RFC 7234's "secondary key": the base
+// gets you to the resource, the variant list resolves the right
+// representation given the request's Vary'd headers.
+type edgeCache struct {
+	mu      sync.Mutex
+	entries map[string]map[string][]*cacheEntry // distId → base → variants
+}
+
+func newEdgeCache() *edgeCache {
+	return &edgeCache{entries: make(map[string]map[string][]*cacheEntry)}
+}
+
+// lookup finds a variant whose Vary'd header values match those on the
+// request. Returns (nil, false) if no matching variant exists.
+func (c *edgeCache) lookup(distID, base string, r *http.Request) (*cacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	dm, ok := c.entries[distID]
+	if !ok {
+		return nil, false
+	}
+
+	for _, v := range dm[base] {
+		if matchesVary(v, r) {
+			return v, true
+		}
+	}
+
+	return nil, false
+}
+
+// store adds (or replaces) the variant for the given Vary values.
+func (c *edgeCache) store(distID, base string, entry *cacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.entries[distID] == nil {
+		c.entries[distID] = make(map[string][]*cacheEntry)
+	}
+
+	// Replace any existing variant with the same Vary signature.
+	variants := c.entries[distID][base]
+	for i, v := range variants {
+		if sameVarySignature(v, entry) {
+			variants[i] = entry
+			c.entries[distID][base] = variants
+
+			return
+		}
+	}
+
+	c.entries[distID][base] = append(variants, entry)
+}
+
+// matchesVary reports whether the request's headers for the entry's
+// recorded Vary list equal the ones it was stored with.
+func matchesVary(e *cacheEntry, r *http.Request) bool {
+	if len(e.Vary) == 0 {
+		return true
+	}
+
+	for _, name := range e.Vary {
+		if r.Header.Get(name) != e.VaryValues[name] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// sameVarySignature checks two entries declare the same Vary headers
+// AND the same values (used during store to overwrite stale variants).
+func sameVarySignature(a, b *cacheEntry) bool {
+	if len(a.Vary) != len(b.Vary) {
+		return false
+	}
+
+	for _, name := range a.Vary {
+		if a.VaryValues[name] != b.VaryValues[name] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Edge handles GET requests routed through `/kumo/cdn/{distId}/{path...}`.
+// It implements the CloudFront edge caching contract:
+//
+//  1. Resolve the distribution + chosen origin.
+//  2. Look up the cache entry. If fresh and not flagged for forced
+//     revalidation, serve it with `X-Cache: Hit from kumo` and the
+//     standard `Age` header.
+//  3. Otherwise fetch from the origin, evaluate cacheability + TTL via
+//     the rules in `cache/`, store the response when allowed, and
+//     serve with `X-Cache: Miss from kumo`.
+//
+// Revalidation (`If-None-Match` / `If-Modified-Since`) is left for a
+// follow-up PR — `MustRevalidate` is currently treated as "always
+// miss".
+func (s *Service) Edge(w http.ResponseWriter, r *http.Request) {
+	distID := r.PathValue("distributionId")
+
+	dist, err := s.storage.GetDistribution(r.Context(), distID)
+	if err != nil {
+		http.Error(w, "no such distribution: "+distID, http.StatusNotFound)
+
+		return
+	}
+
+	cfg, ok := edgeCacheConfig(dist)
+	if !ok {
+		http.Error(w, "distribution missing DefaultCacheBehavior", http.StatusServiceUnavailable)
+
+		return
+	}
+
+	originURL, ok := edgeOriginURL(dist, r.PathValue("path"), r.URL.RawQuery)
+	if !ok {
+		http.Error(w, "distribution has no usable origin", http.StatusServiceUnavailable)
+
+		return
+	}
+
+	base := cache.Key(r, nil)
+	if entry, hit := s.edgeCache.lookup(distID, base, r); hit {
+		if served := serveIfFresh(w, entry); served {
+			return
+		}
+	}
+
+	upstream, err := fetchOrigin(originURL, r)
+	if err != nil {
+		http.Error(w, "origin fetch failed: "+err.Error(), http.StatusBadGateway)
+
+		return
+	}
+
+	storeIfCacheable(s.edgeCache, distID, base, r, upstream, cfg)
+	writeUpstream(w, upstream, "Miss from kumo", 0)
+}
+
+// edgeCacheConfig pulls the [MinTTL, DefaultTTL, MaxTTL] triple out of
+// a Distribution's DefaultCacheBehavior. Returns ok=false when the
+// distribution config isn't filled in (terraform almost always does).
+func edgeCacheConfig(dist *Distribution) (cache.DistributionConfig, bool) {
+	if dist == nil || dist.DistributionConfig == nil || dist.DistributionConfig.DefaultCacheBehavior == nil {
+		return cache.DistributionConfig{}, false
+	}
+
+	dcb := dist.DistributionConfig.DefaultCacheBehavior
+
+	return cache.DistributionConfig{
+		MinTTL:     time.Duration(dcb.MinTTL) * time.Second,
+		DefaultTTL: time.Duration(dcb.DefaultTTL) * time.Second,
+		MaxTTL:     time.Duration(dcb.MaxTTL) * time.Second,
+	}, true
+}
+
+// edgeOriginURL builds the upstream URL: `<scheme>://<DomainName><OriginPath><path>?<query>`.
+// CustomOriginConfig.HTTPPort is honoured when the origin is HTTP.
+func edgeOriginURL(dist *Distribution, path, rawQuery string) (string, bool) {
+	if dist.DistributionConfig == nil || dist.DistributionConfig.Origins == nil {
+		return "", false
+	}
+
+	origins := dist.DistributionConfig.Origins.Items
+	if len(origins) == 0 {
+		return "", false
+	}
+
+	o := origins[0]
+
+	scheme := "https"
+	host := o.DomainName
+
+	if o.CustomOriginConfig != nil {
+		switch o.CustomOriginConfig.OriginProtocolPolicy {
+		case "http-only":
+			scheme = "http"
+
+			if o.CustomOriginConfig.HTTPPort > 0 && o.CustomOriginConfig.HTTPPort != 80 {
+				host = o.DomainName + ":" + strconv.Itoa(o.CustomOriginConfig.HTTPPort)
+			}
+		case "https-only", "match-viewer":
+			scheme = "https"
+		}
+	}
+
+	full := scheme + "://" + host + o.OriginPath + "/" + path
+	if rawQuery != "" {
+		full += "?" + rawQuery
+	}
+
+	return full, true
+}
+
+// originResponse is the buffered subset of an http.Response that the
+// edge handler needs after fetchOrigin returns. Returning a struct
+// instead of *http.Response keeps the body lifecycle entirely inside
+// fetchOrigin, so bodyclose / lostcancel linters stay happy.
+type originResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// fetchOrigin sends the request upstream and returns the buffered
+// response. We need the body twice (once to serve, once to cache),
+// so it's read into memory here.
+func fetchOrigin(target string, r *http.Request) (*originResponse, error) {
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return nil, fmt.Errorf("parse origin URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, parsed.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build origin request: %w", err)
+	}
+
+	// Forward request headers that affect cache variants. The full
+	// header list isn't propagated — CloudFront's default forwarded
+	// set is small.
+	for _, h := range []string{"Accept", "Accept-Encoding", "Accept-Language", "User-Agent"} {
+		if v := r.Header.Get(h); v != "" {
+			req.Header.Set(h, v)
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("origin Do: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read origin body: %w", err)
+	}
+
+	return &originResponse{StatusCode: resp.StatusCode, Header: resp.Header.Clone(), Body: body}, nil
+}
+
+// storeIfCacheable evaluates the response against the cache rules and
+// persists it as a variant of the (distId, base) bucket.
+func storeIfCacheable(c *edgeCache, distID, base string, r *http.Request, resp *originResponse, cfg cache.DistributionConfig) {
+	if cache.VaryDisablesCache(resp.Header) {
+		return
+	}
+
+	cacheable, _ := cache.IsCacheable(resp.Header, resp.StatusCode)
+	if !cacheable {
+		return
+	}
+
+	ttl := cache.EffectiveTTL(resp.Header, cfg, time.Now())
+	if ttl == 0 {
+		return
+	}
+
+	vary := cache.VaryHeaders(resp.Header)
+	values := make(map[string]string, len(vary))
+
+	for _, name := range vary {
+		values[name] = r.Header.Get(name)
+	}
+
+	c.store(distID, base, &cacheEntry{
+		StatusCode: resp.StatusCode,
+		Header:     resp.Header.Clone(),
+		Body:       append([]byte(nil), resp.Body...),
+		StoredAt:   time.Now(),
+		TTL:        ttl,
+		Vary:       vary,
+		VaryValues: values,
+	})
+}
+
+// serveIfFresh writes the cached entry when it's still within TTL.
+// Returns true when something was written; false when the caller
+// should fall through to an origin fetch.
+func serveIfFresh(w http.ResponseWriter, entry *cacheEntry) bool {
+	age := time.Since(entry.StoredAt)
+	if age >= entry.TTL {
+		return false
+	}
+
+	if cache.MustRevalidate(entry.Header) {
+		return false
+	}
+
+	for k, vs := range entry.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+
+	w.Header().Set("X-Cache", "Hit from kumo")
+	w.Header().Set("Age", strconv.FormatInt(int64(age.Seconds()), 10))
+	w.WriteHeader(entry.StatusCode)
+	_, _ = w.Write(entry.Body)
+
+	return true
+}
+
+// writeUpstream copies the upstream response body verbatim to the
+// client, tagging it with the chosen X-Cache marker.
+func writeUpstream(w http.ResponseWriter, resp *originResponse, cacheTag string, age time.Duration) {
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+
+	w.Header().Set("X-Cache", cacheTag)
+
+	if age > 0 {
+		w.Header().Set("Age", strconv.FormatInt(int64(age.Seconds()), 10))
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(resp.Body)
+}

--- a/internal/service/cloudfront/edge_test.go
+++ b/internal/service/cloudfront/edge_test.go
@@ -2,11 +2,14 @@ package cloudfront
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // TestEdge_HitMissPattern stands up a tiny origin and walks through
@@ -115,6 +118,106 @@ func TestEdge_VarySplit(t *testing.T) {
 	}
 }
 
+func TestEdgeCache_StoreKeepsDifferentVaryHeaderNames(t *testing.T) {
+	t.Parallel()
+
+	c := newEdgeCache()
+
+	c.store("dist", "/asset", &cacheEntry{
+		Header:     http.Header{"Vary": {"Accept-Encoding"}},
+		StoredAt:   time.Now(),
+		TTL:        time.Minute,
+		Vary:       []string{"accept-encoding"},
+		VaryValues: map[string]string{"accept-encoding": ""},
+	})
+	c.store("dist", "/asset", &cacheEntry{
+		Header:     http.Header{"Vary": {"Accept-Language"}},
+		StoredAt:   time.Now(),
+		TTL:        time.Minute,
+		Vary:       []string{"accept-language"},
+		VaryValues: map[string]string{"accept-language": ""},
+	})
+
+	if got := len(c.entries["dist"]["/asset"]); got != 2 {
+		t.Fatalf("different Vary names must not replace each other; variants = %d, want 2", got)
+	}
+}
+
+func TestEdgeCache_StoreEvictsOldestEntriesAtCap(t *testing.T) {
+	t.Parallel()
+
+	c := newEdgeCache()
+
+	for i := 0; i < 1100; i++ {
+		c.store("dist", fmt.Sprintf("/asset-%04d", i), &cacheEntry{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Cache-Control": {"public, max-age=60"}},
+			Body:       []byte("payload"),
+			StoredAt:   time.Unix(int64(i), 0),
+			TTL:        time.Minute,
+		})
+	}
+
+	if got := edgeCacheEntryCount(c); got > 1024 {
+		t.Fatalf("edge cache entry count = %d, want <= 1024", got)
+	}
+
+	if _, ok := c.lookup("dist", "/asset-0000", httptest.NewRequest(http.MethodGet, "/asset-0000", http.NoBody)); ok {
+		t.Fatalf("oldest entry should have been evicted")
+	}
+
+	if _, ok := c.lookup("dist", "/asset-1099", httptest.NewRequest(http.MethodGet, "/asset-1099", http.NoBody)); !ok {
+		t.Fatalf("newest entry should remain cached")
+	}
+}
+
+func TestEdge_StaleWhileRevalidateRaceFree(t *testing.T) {
+	var hits atomic.Int64
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit := hits.Add(1)
+		w.Header().Set("Cache-Control", "public, max-age=1")
+		w.Header().Set("CDN-Cache-Control", "max-age=1, stale-while-revalidate=60")
+		w.Header().Set("ETag", `"edge-race"`)
+
+		if r.Header.Get("If-None-Match") != "" {
+			w.WriteHeader(http.StatusNotModified)
+
+			return
+		}
+
+		_, _ = w.Write([]byte(fmt.Sprintf("body-%d", hit)))
+	}))
+	defer origin.Close()
+
+	svc := setupEdge(t, origin.URL)
+	_ = callEdge(t, svc, http.MethodGet, "/race", nil)
+
+	backdateEdgeEntries(svc, 2*time.Second)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			w := callEdge(t, svc, http.MethodGet, "/race", nil)
+			if w.Code != http.StatusOK {
+				t.Errorf("stale serve status = %d, want 200", w.Code)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Give the background revalidation goroutine time to complete. Under
+	// `go test -race`, the old implementation raced with the concurrent
+	// stale serves while updating the cached entry in place.
+	time.Sleep(50 * time.Millisecond)
+}
+
 // TestEdge_SMaxAgeOverride pins the s-maxage > max-age precedence the
 // cache rules enforce. If the cache used max-age (5s) by mistake the
 // second call would still hit, but we want to verify s-maxage (1s)
@@ -156,6 +259,34 @@ func TestEdge_SMaxAgeOverride(t *testing.T) {
 
 	if hits.Load() != 2 {
 		t.Fatalf("origin hits = %d, want 2 (cache should have been stale)", hits.Load())
+	}
+}
+
+func edgeCacheEntryCount(c *edgeCache) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	total := 0
+
+	for _, dm := range c.entries {
+		for _, variants := range dm {
+			total += len(variants)
+		}
+	}
+
+	return total
+}
+
+func backdateEdgeEntries(svc *Service, d time.Duration) {
+	svc.edgeCache.mu.Lock()
+	defer svc.edgeCache.mu.Unlock()
+
+	for _, dm := range svc.edgeCache.entries {
+		for _, variants := range dm {
+			for _, e := range variants {
+				e.StoredAt = e.StoredAt.Add(-d)
+			}
+		}
 	}
 }
 

--- a/internal/service/cloudfront/edge_test.go
+++ b/internal/service/cloudfront/edge_test.go
@@ -176,6 +176,7 @@ func TestEdge_StaleWhileRevalidateRaceFree(t *testing.T) {
 
 	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hit := hits.Add(1)
+
 		w.Header().Set("Cache-Control", "public, max-age=1")
 		w.Header().Set("CDN-Cache-Control", "max-age=1, stale-while-revalidate=60")
 		w.Header().Set("ETag", `"edge-race"`)
@@ -186,7 +187,7 @@ func TestEdge_StaleWhileRevalidateRaceFree(t *testing.T) {
 			return
 		}
 
-		_, _ = w.Write([]byte(fmt.Sprintf("body-%d", hit)))
+		_, _ = fmt.Fprintf(w, "body-%d", hit)
 	}))
 	defer origin.Close()
 

--- a/internal/service/cloudfront/edge_test.go
+++ b/internal/service/cloudfront/edge_test.go
@@ -159,6 +159,157 @@ func TestEdge_SMaxAgeOverride(t *testing.T) {
 	}
 }
 
+// TestS3BucketFromDomain enumerates the virtual-hosted S3 hostname
+// shapes the edge must recognise to route an S3OriginConfig back at
+// kumo's own S3 service.
+func TestS3BucketFromDomain(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		domain string
+		want   string
+	}{
+		{"mybucket.s3.amazonaws.com", "mybucket"},
+		{"mybucket.s3.us-east-1.amazonaws.com", "mybucket"},
+		{"mybucket.s3-us-west-2.amazonaws.com", "mybucket"},
+		{"mybucket.s3.dualstack.us-east-1.amazonaws.com", "mybucket"},
+		{"example.com", ""},
+		{"", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.domain, func(t *testing.T) {
+			if got := s3BucketFromDomain(tc.domain); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEdge_S3Origin verifies an S3 origin gets routed at kumo's own
+// S3 service (path-style) instead of out to real AWS. We point
+// KUMO_S3_BACKEND at a tiny httptest server that mimics the S3
+// path-style response.
+func TestEdge_S3Origin(t *testing.T) {
+	const objectBody = "hello-from-fake-s3"
+
+	var gotPath string
+
+	fakeS3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(objectBody))
+	}))
+	defer fakeS3.Close()
+
+	t.Setenv("KUMO_S3_BACKEND", fakeS3.URL)
+
+	svc := New(NewMemoryStorage())
+
+	_, err := svc.storage.CreateDistribution(t.Context(), &CreateDistributionRequest{
+		CallerReference: "s3-origin",
+		Enabled:         true,
+		Origins: &OriginsXML{
+			Quantity: 1,
+			Items: &OriginList{
+				Origin: []OriginXML{{
+					ID:             "s3-origin",
+					DomainName:     "mybucket.s3.us-east-1.amazonaws.com",
+					S3OriginConfig: &S3OriginConfigXML{OriginAccessIdentity: ""},
+				}},
+			},
+		},
+		DefaultCacheBehavior: &DefaultCacheBehaviorXML{
+			TargetOriginID: "s3-origin",
+			MinTTL:         0,
+			DefaultTTL:     86400,
+			MaxTTL:         31536000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateDistribution: %v", err)
+	}
+
+	w := callEdge(t, svc, http.MethodGet, "/path/to/object.txt", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	if w.Body.String() != objectBody {
+		t.Fatalf("body: got %q, want %q", w.Body.String(), objectBody)
+	}
+
+	if gotPath != "/mybucket/path/to/object.txt" {
+		t.Fatalf("upstream path: got %q, want /mybucket/path/to/object.txt", gotPath)
+	}
+}
+
+// TestEdge_TargetOriginIDSelection — when a distribution has more
+// than one origin, the cache forwards to the one named by
+// DefaultCacheBehavior.TargetOriginID, not the first.
+func TestEdge_TargetOriginIDSelection(t *testing.T) {
+	t.Parallel()
+
+	wrong := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("WRONG ORIGIN"))
+	}))
+	defer wrong.Close()
+
+	right := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		_, _ = w.Write([]byte("right"))
+	}))
+	defer right.Close()
+
+	svc := New(NewMemoryStorage())
+
+	wrongHost, wrongPort := splitHostPort(strings.TrimPrefix(wrong.URL, "http://"))
+	rightHost, rightPort := splitHostPort(strings.TrimPrefix(right.URL, "http://"))
+
+	_, err := svc.storage.CreateDistribution(t.Context(), &CreateDistributionRequest{
+		CallerReference: "two-origin",
+		Enabled:         true,
+		Origins: &OriginsXML{
+			Quantity: 2,
+			Items: &OriginList{
+				Origin: []OriginXML{
+					{
+						ID:                 "wrong",
+						DomainName:         wrongHost,
+						CustomOriginConfig: &CustomOriginConfigXML{HTTPPort: wrongPort, OriginProtocolPolicy: "http-only"},
+					},
+					{
+						ID:                 "right",
+						DomainName:         rightHost,
+						CustomOriginConfig: &CustomOriginConfigXML{HTTPPort: rightPort, OriginProtocolPolicy: "http-only"},
+					},
+				},
+			},
+		},
+		DefaultCacheBehavior: &DefaultCacheBehaviorXML{
+			TargetOriginID: "right",
+			MinTTL:         0,
+			DefaultTTL:     86400,
+			MaxTTL:         31536000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateDistribution: %v", err)
+	}
+
+	w := callEdge(t, svc, http.MethodGet, "/foo", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	if w.Body.String() != "right" {
+		t.Fatalf("served from wrong origin: %q", w.Body.String())
+	}
+}
+
 // TestEdge_404FromKumoOnUnknownDistribution — a request to
 // /kumo/cdn/<bogus>/... returns 404 with no upstream contact.
 func TestEdge_404FromKumoOnUnknownDistribution(t *testing.T) {

--- a/internal/service/cloudfront/edge_test.go
+++ b/internal/service/cloudfront/edge_test.go
@@ -1,0 +1,282 @@
+package cloudfront
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestEdge_HitMissPattern stands up a tiny origin and walks through
+// the canonical Miss → Hit pattern. The origin counter pins how many
+// times the upstream was actually contacted, which is the operational
+// claim the cache makes.
+func TestEdge_HitMissPattern(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer origin.Close()
+
+	svc := setupEdge(t, origin.URL)
+
+	first := callEdge(t, svc, "GET", "/static/index.html", nil)
+
+	if first.Code != http.StatusOK {
+		t.Fatalf("first miss: status %d", first.Code)
+	}
+
+	if first.Header().Get("X-Cache") != "Miss from kumo" {
+		t.Fatalf("first should be Miss, got %q", first.Header().Get("X-Cache"))
+	}
+
+	second := callEdge(t, svc, "GET", "/static/index.html", nil)
+
+	if second.Header().Get("X-Cache") != "Hit from kumo" {
+		t.Fatalf("second should be Hit, got %q", second.Header().Get("X-Cache"))
+	}
+
+	if hits.Load() != 1 {
+		t.Fatalf("origin contacted %d times, expected 1", hits.Load())
+	}
+}
+
+// TestEdge_NoStoreSkipsCache — a response with `Cache-Control: no-store`
+// must never be served from cache. Two consecutive requests therefore
+// both hit the origin.
+func TestEdge_NoStoreSkipsCache(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Cache-Control", "no-store")
+		_, _ = w.Write([]byte("dynamic"))
+	}))
+	defer origin.Close()
+
+	svc := setupEdge(t, origin.URL)
+
+	for i := 0; i < 2; i++ {
+		_ = callEdge(t, svc, "GET", "/api/dynamic", nil)
+	}
+
+	if hits.Load() != 2 {
+		t.Fatalf("no-store should bypass cache; origin hits = %d, want 2", hits.Load())
+	}
+}
+
+// TestEdge_VarySplit confirms two requests differing in a Vary'd
+// header land on different cache variants.
+func TestEdge_VarySplit(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		w.Header().Set("Vary", "Accept-Language")
+		_, _ = w.Write([]byte("lang=" + r.Header.Get("Accept-Language")))
+	}))
+	defer origin.Close()
+
+	svc := setupEdge(t, origin.URL)
+
+	en := callEdge(t, svc, "GET", "/translated", http.Header{"Accept-Language": {"en"}})
+	ja := callEdge(t, svc, "GET", "/translated", http.Header{"Accept-Language": {"ja"}})
+
+	if hits.Load() != 2 {
+		t.Fatalf("Vary should split cache; origin hits = %d, want 2", hits.Load())
+	}
+
+	// Re-hit en should be cached.
+	enAgain := callEdge(t, svc, "GET", "/translated", http.Header{"Accept-Language": {"en"}})
+
+	if hits.Load() != 2 {
+		t.Fatalf("repeat en should hit cache; origin hits = %d, want 2", hits.Load())
+	}
+
+	if enAgain.Header().Get("X-Cache") != "Hit from kumo" {
+		t.Fatalf("expected Hit on cached variant, got %q", enAgain.Header().Get("X-Cache"))
+	}
+
+	if !strings.Contains(en.Body.String(), "lang=en") || !strings.Contains(ja.Body.String(), "lang=ja") {
+		t.Fatalf("variant bodies got mixed up: en=%q ja=%q", en.Body.String(), ja.Body.String())
+	}
+}
+
+// TestEdge_SMaxAgeOverride pins the s-maxage > max-age precedence the
+// cache rules enforce. If the cache used max-age (5s) by mistake the
+// second call would still hit, but we want to verify s-maxage (1s)
+// won — by the time we re-call, the entry is stale.
+//
+// We don't actually sleep — instead we backdate the cached entry's
+// StoredAt to simulate elapsed time.
+func TestEdge_SMaxAgeOverride(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Cache-Control", "max-age=300, s-maxage=1")
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer origin.Close()
+
+	svc := setupEdge(t, origin.URL)
+
+	_ = callEdge(t, svc, "GET", "/short-shared-ttl", nil)
+
+	// Backdate the stored entry by 5s so the s-maxage=1 has expired
+	// but max-age=300 hasn't. CloudFront should treat it as stale.
+	for _, dm := range svc.edgeCache.entries {
+		for _, variants := range dm {
+			for _, e := range variants {
+				e.StoredAt = e.StoredAt.Add(-5 * 1e9) // -5s
+			}
+		}
+	}
+
+	again := callEdge(t, svc, "GET", "/short-shared-ttl", nil)
+
+	if again.Header().Get("X-Cache") != "Miss from kumo" {
+		t.Fatalf("s-maxage=1 should have expired; got X-Cache=%q", again.Header().Get("X-Cache"))
+	}
+
+	if hits.Load() != 2 {
+		t.Fatalf("origin hits = %d, want 2 (cache should have been stale)", hits.Load())
+	}
+}
+
+// TestEdge_404FromKumoOnUnknownDistribution — a request to
+// /kumo/cdn/<bogus>/... returns 404 with no upstream contact.
+func TestEdge_404FromKumoOnUnknownDistribution(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+
+	req := httptest.NewRequest(http.MethodGet, "/kumo/cdn/dist-bogus/anything", http.NoBody)
+	req.SetPathValue("distributionId", "dist-bogus")
+	req.SetPathValue("path", "anything")
+
+	w := httptest.NewRecorder()
+	svc.Edge(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 on unknown distribution, got %d", w.Code)
+	}
+}
+
+// setupEdge wires a Service with one distribution pointing at the
+// given upstream. The upstream URL is parsed and split into
+// host:port + scheme so it lands in CustomOriginConfig the same way
+// terraform would author it.
+func setupEdge(t *testing.T, originURL string) *Service {
+	t.Helper()
+
+	svc := New(NewMemoryStorage())
+
+	// Strip the http:// prefix to get host:port.
+	host := strings.TrimPrefix(originURL, "http://")
+
+	hostOnly, port := splitHostPort(host)
+
+	_, err := svc.storage.CreateDistribution(context.Background(), &CreateDistributionRequest{
+		CallerReference: "test",
+		Enabled:         true,
+		Origins: &OriginsXML{
+			Quantity: 1,
+			Items: &OriginList{
+				Origin: []OriginXML{{
+					ID:         "origin-1",
+					DomainName: hostOnly,
+					CustomOriginConfig: &CustomOriginConfigXML{
+						HTTPPort:             port,
+						OriginProtocolPolicy: "http-only",
+					},
+				}},
+			},
+		},
+		DefaultCacheBehavior: &DefaultCacheBehaviorXML{
+			TargetOriginID: "origin-1",
+			MinTTL:         0,
+			DefaultTTL:     86400,
+			MaxTTL:         31536000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateDistribution: %v", err)
+	}
+
+	return svc
+}
+
+// splitHostPort separates "host:port" into ("host", port). Returns
+// port=80 when no port is in the input.
+func splitHostPort(hp string) (string, int) {
+	idx := strings.LastIndex(hp, ":")
+	if idx < 0 {
+		return hp, 80
+	}
+
+	host := hp[:idx]
+	port := 0
+
+	for _, c := range hp[idx+1:] {
+		if c < '0' || c > '9' {
+			return host, 80
+		}
+
+		port = port*10 + int(c-'0')
+
+		if port > 65535 {
+			return host, 80
+		}
+	}
+
+	return host, port
+}
+
+// callEdge invokes Service.Edge directly with the supplied path /
+// headers. Returns the recorder so the caller can inspect status,
+// headers, and body.
+func callEdge(t *testing.T, svc *Service, _, path string, hdr http.Header) *httptest.ResponseRecorder {
+	t.Helper()
+
+	// Find the (only) distribution the test setup created.
+	mem, ok := svc.storage.(*MemoryStorage)
+	if !ok {
+		t.Fatalf("expected *MemoryStorage, got %T", svc.storage)
+	}
+
+	var distID string
+	for id := range mem.Distributions {
+		distID = id
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/kumo/cdn/"+distID+strings.TrimPrefix(path, "/"), http.NoBody)
+	req.SetPathValue("distributionId", distID)
+	req.SetPathValue("path", strings.TrimPrefix(path, "/"))
+
+	for k, vs := range hdr {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	svc.Edge(w, req)
+
+	return w
+}

--- a/internal/service/cloudfront/service.go
+++ b/internal/service/cloudfront/service.go
@@ -55,9 +55,12 @@ func (s *Service) RegisterRoutes(r service.Router) {
 
 	// Edge — proxies real requests through the cache layer. Lives
 	// under /kumo (the existing admin prefix) so it doesn't collide
-	// with the S3 wildcard /{bucket}/{key...}.
-	r.Handle("GET", "/kumo/cdn/{distributionId}/{path...}", s.Edge)
-	r.Handle("HEAD", "/kumo/cdn/{distributionId}/{path...}", s.Edge)
+	// with the S3 wildcard /{bucket}/{key...}. Non-cacheable methods
+	// (PUT/POST/DELETE/PATCH) bypass the cache and pass through to
+	// the origin.
+	for _, method := range []string{"GET", "HEAD", "PUT", "POST", "DELETE", "PATCH"} {
+		r.Handle(method, "/kumo/cdn/{distributionId}/{path...}", s.Edge)
+	}
 }
 
 // Close saves the storage state if persistence is enabled.

--- a/internal/service/cloudfront/service.go
+++ b/internal/service/cloudfront/service.go
@@ -22,13 +22,15 @@ func init() {
 
 // Service implements the CloudFront service.
 type Service struct {
-	storage Storage
+	storage   Storage
+	edgeCache *edgeCache
 }
 
 // New creates a new CloudFront service.
 func New(storage Storage) *Service {
 	return &Service{
-		storage: storage,
+		storage:   storage,
+		edgeCache: newEdgeCache(),
 	}
 }
 
@@ -50,6 +52,12 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	// Invalidation operations.
 	r.Handle("POST", "/2020-05-31/distribution/{id}/invalidation", s.CreateInvalidation)
 	r.Handle("GET", "/2020-05-31/distribution/{id}/invalidation/{invalidationId}", s.GetInvalidation)
+
+	// Edge — proxies real requests through the cache layer. Lives
+	// under /kumo (the existing admin prefix) so it doesn't collide
+	// with the S3 wildcard /{bucket}/{key...}.
+	r.Handle("GET", "/kumo/cdn/{distributionId}/{path...}", s.Edge)
+	r.Handle("HEAD", "/kumo/cdn/{distributionId}/{path...}", s.Edge)
 }
 
 // Close saves the storage state if persistence is enabled.


### PR DESCRIPTION
## Summary

Adds a real edge cache to kumo's CloudFront service. Until now CloudFront was management-API-only — distributions could be created and read back, but nothing ever served traffic. This PR makes `/kumo/cdn/{distributionId}/{path...}` a cached reverse proxy with rule evaluation tracking RFC 9111 (HTTP Caching), RFC 9110 (HTTP Semantics), RFC 9213 (CDN-Cache-Control), and RFC 5861 (stale-while-revalidate / stale-if-error).

## What's new

```
internal/service/cloudfront/cache/   pure rule package, fully unit-tested
internal/service/cloudfront/edge.go  HTTP edge handler over a per-distribution
                                     in-memory cache
```

## Spec coverage

| Capability | RFC | Where |
|---|---|---|
| `Cache-Control: max-age` / `s-maxage` precedence | 9111 §5.2 | `EffectiveTTL` |
| `Cache-Control: no-store` / `private` (do not cache) | 9111 §5.2 | `EffectiveTTL`, `IsCacheable` |
| `Cache-Control: no-cache` (revalidate every request) | 9111 §5.2 | `MustRevalidate` |
| `Cache-Control: must-revalidate` semantics (stale path only) | 9111 §5.2.2.2 | `MustRevalidate` |
| `Expires` header (incl. zero / past = explicit-zero freshness) | 9111 §5.3 | `EffectiveTTL` |
| Heuristic freshness (`Last-Modified` × 10%) | 9111 §4.2.2 | `heuristicTTL` |
| Heuristically-cacheable status set | 9110 §15 | `IsHeuristicallyCacheableStatus` |
| Explicit-freshness allows any status | 9111 §3 | `IsCacheable` |
| `Vary` value normalisation (case + whitespace + token-list) | 9110 §12 / §15 | `varyValueEqual` |
| `Vary: *` disables caching | 9111 §4.1 | `VaryDisablesCache` |
| `If-None-Match` (incl. `*`, weak comparison, list) | 9110 §13.1.2 | `IfNoneMatchSatisfied` |
| `If-Modified-Since` | 9110 §13.1.3 | `IfModifiedSinceSatisfied` |
| Cache→origin revalidation w/ conditional headers | 9111 §4.3 | `revalidate` + `ConditionalHeaders` |
| 304 → refresh validators + TTL on cached entry | 9111 §4.3.4 | `mergeRevalidatedHeaders` |
| `Range: bytes=` (suffix / open / closed; multi → fall-through) | 9110 §14 | `ParseRange` + `writePartialContent` |
| `Age` header carried forward from upstream | 9111 §5.1 | `InitialAge` |
| Request `Cache-Control: no-cache / no-store / only-if-cached` | 9111 §5.2.1 | `EvaluateClient` |
| Request `Cache-Control: max-age / min-fresh / max-stale[=N]` | 9111 §5.2.1 | `EvaluateClient` |
| `CDN-Cache-Control` overrides `Cache-Control` at the edge | 9213 §3 | `mergedCacheControl` |
| `stale-while-revalidate` / `stale-if-error` from `CDN-Cache-Control` | 5861 / 9213 §3.1 | `ReadCDNStaleDirectives` + `kickBackgroundRevalidate` |
| Hop-by-hop header stripping | 7230 §6.1 | `isHopByHopHeader` |
| Non-safe methods (PUT / POST / DELETE / PATCH) bypass cache | 9111 §4.4 | `passthrough` |

## CloudFront-specific design choices

- **CDN-Cache-Control wins.** `mergedCacheControl` reads CDN-Cache-Control first, falls back to Cache-Control. This matches CloudFront's documented behaviour (CDN-Cache-Control is the edge-targeted policy; Cache-Control is what the browser sees).
- **`stale-while-revalidate` only via CDN-Cache-Control.** CloudFront does *not* honour swr / sie when they appear in plain Cache-Control — that header is browser-targeted. RFC 9213 §3.1 endorses the same split. This means the cache-tests.fyi swr scenarios (which use Cache-Control swr) are **expected failures** and stay that way; the same directives in CDN-Cache-Control are honoured.
- **Status-code cacheability split.** With explicit freshness any status is cacheable (RFC 9111 §3); without it only the heuristic-cacheable set (RFC 9110 §15) is stored — that's the small list CloudFront defaults to.
- **Origins**: `CustomOriginConfig` (HTTP/HTTPS to any host) and `S3OriginConfig` are both honoured. S3 origins are routed at kumo's own S3 service in path-style (`KUMO_S3_BACKEND`, default `http://127.0.0.1:4566`) so the proxy stays in-process. `selectOrigin` honours `DefaultCacheBehavior.TargetOriginID`. OAI / OAC signing is out of scope — kumo S3 doesn't enforce auth.

## Conformance against [cache-tests.fyi](https://cache-tests.fyi/)

The official RFC 9111 conformance suite (Mark Nottingham's reference set, used by Cloudflare / Fastly / Varnish for their published compliance matrices). Distribution config in the harness has `DefaultTTL=0` so the cache only stores when the response carries explicit or heuristic freshness — the spec-compliant default.

```
272 / 365 PASS  (74.5%)
```

Top remaining failure buckets:

| count | reason | category |
|---|---|---|
| 25 | `Response 2 does not come from cache` | parser strictness + heuristic-status edge cases |
| 17 | `Response 2 comes from cache` | Cache-Control parser edges (quoted values, spaces around `=`) |
| 9 | `Response 3 comes from cache` | successive-stale handling |
| 5 | `stale-while-revalidate` family | by design (CloudFront fidelity — see above) |
| 4 | `Response 2 status is 200, not 304` | residual revalidation edge cases |
| 4 | Interim responses (102/103) | not implemented |
| 3 | `Response 2 status is 405, not 200` | method validation |



## E2E demo (no cache-tests harness)

```sh
# Counter origin so we can see when it's actually contacted
python3 -c '...HTTP server with Cache-Control: max-age=60 + counter...' &

# kumo built from this branch
kumo &

# Distribution → counter origin
DIST_ID=$(curl -s -X POST :4566/2020-05-31/distribution -d @dist.xml \
            | grep -oE '<Id>[^<]+</Id>' | sed 's/<[^>]*>//g')

# 1st: Miss. 2nd: Hit (origin counter doesn't advance).
$ curl -i :4566/kumo/cdn/$DIST_ID/foo
HTTP/1.1 200 OK
Cache-Control: public, max-age=60
X-Cache: Miss from kumo
hello-2
$ curl -i :4566/kumo/cdn/$DIST_ID/foo
HTTP/1.1 200 OK
Cache-Control: public, max-age=60
X-Cache: Hit from kumo
Age: 0
hello-2
```

## Out of scope (explicit follow-ups)

- **`If-None-Match`/`If-Modified-Since` rounding cases** — handled for the common path; a few edge timestamps still miss.
- **Successive-stale (Response 3 comes from cache)** — needs handling around two consecutive stale-then-fresh transitions.
- **Range slicing edge cases** — multi-range, suffix-of-zero, etc.
- **Interim responses (102/103)** — not implemented.
- **Cache invalidation actions** — the existing `CreateInvalidation` handler doesn't yet evict from this edge cache; trivial wire-up once the API shape settles.
- **Method validation gaps (405)** — distribution-level allowed-methods enforcement.

## Test plan

- [x] `go test ./internal/service/cloudfront/cache/` — covers the precedence table, `Vary: *`, key stability, conditional headers, Range parser, request directives, heuristic freshness.
- [x] `go test ./internal/service/cloudfront/` — edge tests covering hit/miss, no-store, Vary split, s-maxage override, unknown distribution, non-GET passthrough.
- [x] `go test ./...` — full kumo suite green.
- [x] `make lint` — clean.
- [x] Manual E2E with a counter origin — Miss / Hit / Age behave per spec.
- [x] [cache-tests.fyi](https://cache-tests.fyi) suite — 272 / 365 PASS.