### PR TITLE
feat(s3): GetObject Range support + UploadPartCopy

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"sort"
@@ -281,6 +282,12 @@ func (s *Service) handleObjectPut(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.URL.Query().Get("uploadId") != "" && r.URL.Query().Get("partNumber") != "" {
+		if r.Header.Get("X-Amz-Copy-Source") != "" {
+			s.UploadPartCopy(w, r)
+
+			return
+		}
+
 		s.UploadPart(w, r)
 
 		return
@@ -1557,6 +1564,92 @@ func (s *Service) UploadPart(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// UploadPartCopy handles
+//
+//	PUT /{bucket}/{key}?partNumber=N&uploadId=...
+//	X-Amz-Copy-Source: /<srcBucket>/<srcKey>
+//	X-Amz-Copy-Source-Range: bytes=START-END   (optional)
+//
+// — copies bytes from an existing object into a part of an in-progress
+// multipart upload, without the client having to re-upload the data.
+//
+// Cross-bucket copy is supported. Source object must already exist.
+// If `X-Amz-Copy-Source-Range` is absent, the whole source is copied.
+func (s *Service) UploadPartCopy(w http.ResponseWriter, r *http.Request) {
+	dstBucket := r.PathValue("bucket")
+	dstKey := r.PathValue("key")
+
+	uploadID := r.URL.Query().Get("uploadId")
+	if uploadID == "" {
+		writeS3Error(w, r, "InvalidArgument", "uploadId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	partNumber, err := strconv.Atoi(r.URL.Query().Get("partNumber"))
+	if err != nil || partNumber < 1 || partNumber > 10000 {
+		writeS3Error(w, r, "InvalidArgument", "Invalid partNumber", http.StatusBadRequest)
+
+		return
+	}
+
+	srcBucket, srcKey := parseCopySource(r.Header.Get("X-Amz-Copy-Source"))
+	if srcBucket == "" || srcKey == "" {
+		writeS3Error(w, r, "InvalidArgument", "Invalid copy source", http.StatusBadRequest)
+
+		return
+	}
+
+	copyRange, err := parseCopySourceRange(r.Header.Get("X-Amz-Copy-Source-Range"))
+	if err != nil {
+		writeS3Error(w, r, "InvalidArgument", err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	part, err := s.storage.UploadPartCopy(r.Context(), dstBucket, dstKey, uploadID, partNumber, srcBucket, srcKey, copyRange)
+	if err != nil {
+		handleMultipartError(w, r, err)
+
+		return
+	}
+
+	result := CopyPartResult{
+		Xmlns:        s3Namespace,
+		LastModified: part.LastModified.UTC().Format(timeFormatISO),
+		ETag:         part.ETag,
+	}
+	writeXMLResponse(w, result)
+}
+
+// parseCopySourceRange parses an `X-Amz-Copy-Source-Range: bytes=START-END`
+// header. Returns (nil, nil) when absent. Suffix / open-ended forms are
+// not allowed by S3 for UploadPartCopy — only closed ranges.
+func parseCopySourceRange(header string) (*CopyRange, error) {
+	if header == "" {
+		return nil, nil //nolint:nilnil // absent header is the "copy whole source" sentinel
+	}
+
+	spec, ok := strings.CutPrefix(header, "bytes=")
+	if !ok {
+		return nil, fmt.Errorf("X-Amz-Copy-Source-Range must use bytes unit")
+	}
+
+	dash := strings.IndexByte(spec, '-')
+	if dash <= 0 || dash == len(spec)-1 {
+		return nil, fmt.Errorf("X-Amz-Copy-Source-Range requires both START and END (closed range)")
+	}
+
+	start, err1 := strconv.ParseInt(strings.TrimSpace(spec[:dash]), 10, 64)
+	end, err2 := strconv.ParseInt(strings.TrimSpace(spec[dash+1:]), 10, 64)
+
+	if err1 != nil || err2 != nil || start < 0 || end < start {
+		return nil, fmt.Errorf("X-Amz-Copy-Source-Range has invalid byte range")
+	}
+
+	return &CopyRange{Start: start, End: end}, nil
+}
+
 // CompleteMultipartUpload handles POST /{bucket}/{key}?uploadId={uploadId} - complete a multipart upload.
 func (s *Service) CompleteMultipartUpload(w http.ResponseWriter, r *http.Request) {
 	bucket := r.PathValue("bucket")
@@ -1798,10 +1891,17 @@ func handleMultipartError(w http.ResponseWriter, r *http.Request, err error) {
 		return
 	}
 
+	var objectErr *ObjectError
+	if errors.As(err, &objectErr) {
+		writeS3Error(w, r, objectErr.Code, objectErr.Message, http.StatusNotFound)
+
+		return
+	}
+
 	var multipartErr *MultipartError
 	if errors.As(err, &multipartErr) {
 		status := http.StatusNotFound
-		if multipartErr.Code == "InvalidPart" {
+		if multipartErr.Code == "InvalidPart" || multipartErr.Code == "InvalidArgument" {
 			status = http.StatusBadRequest
 		}
 

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -20,6 +20,11 @@ const (
 	s3Namespace    = "http://s3.amazonaws.com/doc/2006-03-01/"
 	timeFormatISO  = "2006-01-02T15:04:05.000Z"
 	timeFormatHTTP = "Mon, 02 Jan 2006 15:04:05 GMT"
+
+	// contentTypeHeader is the canonical "Content-Type" string. Hoisted
+	// to a const because the metadata-pass loop excludes it in three
+	// different handlers — goconst was flagging the literal.
+	contentTypeHeader = "Content-Type"
 )
 
 // applyCORSHeaders sets CORS response headers if the bucket has CORS configured and the request Origin matches.
@@ -678,7 +683,65 @@ func (s *Service) GetObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if rng := r.Header.Get("Range"); rng != "" {
+		writeRangeOrFull(w, r, obj, rng)
+
+		return
+	}
+
 	writeObjectResponse(w, obj)
+}
+
+// writeRangeOrFull serves a 206 Partial Content slice when the Range
+// is satisfiable, a 416 Requested Range Not Satisfiable when the spec
+// is well-formed but unsatisfiable, and falls through to a full 200
+// when the unit isn't bytes (RFC 9110 §14.1.3 lets the server treat
+// an unknown range unit as if the header were absent).
+func writeRangeOrFull(w http.ResponseWriter, r *http.Request, obj *Object, rangeHeader string) {
+	if !strings.HasPrefix(rangeHeader, "bytes=") {
+		writeObjectResponse(w, obj)
+
+		return
+	}
+
+	start, end, ok := parseByteRange(rangeHeader, obj.Size)
+	if !ok {
+		w.Header().Set("Content-Range", "bytes */"+strconv.FormatInt(obj.Size, 10))
+		writeS3Error(w, r, "InvalidRange",
+			"The requested range is not satisfiable", http.StatusRequestedRangeNotSatisfiable)
+
+		return
+	}
+
+	writePartialObjectResponse(w, obj, start, end)
+}
+
+// writePartialObjectResponse writes a 206 with the byte slice plus
+// matching Content-Range / Content-Length / object metadata headers.
+func writePartialObjectResponse(w http.ResponseWriter, obj *Object, start, end int64) {
+	length := end - start + 1
+
+	w.Header().Set("Content-Type", obj.ContentType)
+	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
+	w.Header().Set("Content-Range",
+		"bytes "+strconv.FormatInt(start, 10)+"-"+strconv.FormatInt(end, 10)+
+			"/"+strconv.FormatInt(obj.Size, 10))
+	w.Header().Set("Accept-Ranges", "bytes")
+	w.Header().Set("ETag", obj.ETag)
+	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(timeFormatHTTP))
+
+	if obj.VersionID != "" {
+		w.Header().Set("x-amz-version-id", obj.VersionID)
+	}
+
+	for k, v := range obj.Metadata {
+		if k != contentTypeHeader {
+			w.Header().Set("x-amz-meta-"+k, v)
+		}
+	}
+
+	w.WriteHeader(http.StatusPartialContent)
+	_, _ = w.Write(obj.Body[start : end+1])
 }
 
 // handleGetObjectError handles errors from GetObject/GetObjectVersion.
@@ -706,13 +769,14 @@ func writeObjectResponse(w http.ResponseWriter, obj *Object) {
 	w.Header().Set("Content-Length", strconv.FormatInt(obj.Size, 10))
 	w.Header().Set("ETag", obj.ETag)
 	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(timeFormatHTTP))
+	w.Header().Set("Accept-Ranges", "bytes")
 
 	if obj.VersionID != "" {
 		w.Header().Set("x-amz-version-id", obj.VersionID)
 	}
 
 	for k, v := range obj.Metadata {
-		if k != "Content-Type" {
+		if k != contentTypeHeader {
 			w.Header().Set("x-amz-meta-"+k, v)
 		}
 	}
@@ -891,10 +955,11 @@ func (s *Service) HeadObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", strconv.FormatInt(obj.Size, 10))
 	w.Header().Set("ETag", obj.ETag)
 	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(timeFormatHTTP))
+	w.Header().Set("Accept-Ranges", "bytes")
 
 	// Set metadata headers
 	for k, v := range obj.Metadata {
-		if k != "Content-Type" {
+		if k != contentTypeHeader {
 			w.Header().Set("x-amz-meta-"+k, v)
 		}
 	}

--- a/internal/service/s3/range.go
+++ b/internal/service/s3/range.go
@@ -1,0 +1,104 @@
+package s3
+
+import (
+	"strconv"
+	"strings"
+)
+
+// parseByteRange interprets a single-range "Range: bytes=START-END"
+// header against a known content length. Returns (start, end, true)
+// where end is inclusive (the wire form of Content-Range).
+//
+// Spec covered (RFC 9110 §14):
+//
+//   - Suffix range: `bytes=-100`  → last 100 bytes
+//   - Open-ended:    `bytes=100-`  → byte 100 to end
+//   - Closed:        `bytes=0-99`  → bytes 0 through 99 inclusive
+//
+// Multi-range requests (`bytes=0-99,200-299`), syntactically invalid
+// specs, and unsatisfiable ranges (start past end-of-content,
+// inverted range, wrong unit) all return ok=false. The caller should
+// fall through to a full 200 in those cases — multi-part 206 is left
+// for a follow-up since the typical S3 consumer (multipart download)
+// only sends single-range requests.
+func parseByteRange(header string, totalSize int64) (start, end int64, ok bool) {
+	startRaw, endRaw, valid := splitByteRangeSpec(header)
+	if !valid {
+		return 0, 0, false
+	}
+
+	switch {
+	case startRaw == "" && endRaw == "":
+		return 0, 0, false
+	case startRaw == "":
+		return parseSuffixRange(endRaw, totalSize)
+	case endRaw == "":
+		return parseOpenRange(startRaw, totalSize)
+	default:
+		return parseClosedRange(startRaw, endRaw, totalSize)
+	}
+}
+
+// splitByteRangeSpec strips the "bytes=" prefix and splits on the
+// dash. Returns ok=false on multi-range or wrong unit.
+func splitByteRangeSpec(header string) (string, string, bool) {
+	spec, ok := strings.CutPrefix(header, "bytes=")
+	if !ok {
+		return "", "", false
+	}
+
+	if strings.Contains(spec, ",") {
+		return "", "", false
+	}
+
+	dash := strings.IndexByte(spec, '-')
+	if dash < 0 {
+		return "", "", false
+	}
+
+	return strings.TrimSpace(spec[:dash]), strings.TrimSpace(spec[dash+1:]), true
+}
+
+// parseSuffixRange resolves `bytes=-N` (the last N bytes). N is
+// clamped to totalSize so a request for "the last 9999 bytes" of a
+// 100-byte object returns the whole object.
+func parseSuffixRange(endRaw string, totalSize int64) (int64, int64, bool) {
+	n, err := strconv.ParseInt(endRaw, 10, 64)
+	if err != nil || n <= 0 {
+		return 0, 0, false
+	}
+
+	if n > totalSize {
+		n = totalSize
+	}
+
+	return totalSize - n, totalSize - 1, true
+}
+
+// parseOpenRange resolves `bytes=START-` (from START to end of
+// content).
+func parseOpenRange(startRaw string, totalSize int64) (int64, int64, bool) {
+	start, err := strconv.ParseInt(startRaw, 10, 64)
+	if err != nil || start < 0 || start >= totalSize {
+		return 0, 0, false
+	}
+
+	return start, totalSize - 1, true
+}
+
+// parseClosedRange resolves `bytes=START-END`. END is clamped to the
+// last byte of content; start past end → unsatisfiable.
+func parseClosedRange(startRaw, endRaw string, totalSize int64) (int64, int64, bool) {
+	start, err1 := strconv.ParseInt(startRaw, 10, 64)
+	end, err2 := strconv.ParseInt(endRaw, 10, 64)
+
+	if err1 != nil || err2 != nil || start < 0 || end < start || start >= totalSize {
+		return 0, 0, false
+	}
+
+	if end >= totalSize {
+		end = totalSize - 1
+	}
+
+	return start, end, true
+}

--- a/internal/service/s3/range_test.go
+++ b/internal/service/s3/range_test.go
@@ -1,0 +1,155 @@
+package s3
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestParseByteRange enumerates the satisfiable / unsatisfiable
+// shapes the GetObject Range path hands off to.
+func TestParseByteRange(t *testing.T) {
+	t.Parallel()
+
+	const totalSize int64 = 1000
+
+	cases := []struct {
+		header string
+		start  int64
+		end    int64
+		ok     bool
+	}{
+		{"bytes=0-99", 0, 99, true},
+		{"bytes=100-199", 100, 199, true},
+		{"bytes=900-9999", 900, 999, true},  // clamped at end-of-object
+		{"bytes=-100", 900, 999, true},      // suffix
+		{"bytes=500-", 500, 999, true},      // open-ended
+		{"bytes=1000-", 0, 0, false},        // start past end
+		{"bytes=200-100", 0, 0, false},      // inverted
+		{"bytes=0-99,200-299", 0, 0, false}, // multi-range
+		{"items=0-99", 0, 0, false},         // wrong unit
+		{"", 0, 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			start, end, ok := parseByteRange(tc.header, totalSize)
+			if ok != tc.ok || (ok && (start != tc.start || end != tc.end)) {
+				t.Fatalf("got (%d, %d, %v), want (%d, %d, %v)",
+					start, end, ok, tc.start, tc.end, tc.ok)
+			}
+		})
+	}
+}
+
+// rangeCase pins one Range scenario for the HTTP-layer table test.
+type rangeCase struct {
+	name        string
+	rangeHeader string
+	wantStatus  int
+	wantBody    string
+	wantCR      string // expected Content-Range value, empty for 200
+}
+
+var rangeCases = []rangeCase{
+	{"closed", "bytes=2-5", http.StatusPartialContent, "2345", "bytes 2-5/16"},
+	{"suffix", "bytes=-3", http.StatusPartialContent, "def", "bytes 13-15/16"},
+	{"open-ended", "bytes=10-", http.StatusPartialContent, "abcdef", "bytes 10-15/16"},
+	{"clamped end", "bytes=10-99", http.StatusPartialContent, "abcdef", "bytes 10-15/16"},
+	{"unsatisfiable", "bytes=99-", http.StatusRequestedRangeNotSatisfiable, "", ""},
+	{"wrong unit falls through to 200", "items=0-3", http.StatusOK, "0123456789abcdef", ""},
+	{"absent header returns full 200", "", http.StatusOK, "0123456789abcdef", ""},
+}
+
+// TestGetObject_RangeRoundTrip puts an object and then asks for a
+// range of it through the HTTP handler. Confirms 206 + Content-Range +
+// the right body slice.
+func TestGetObject_RangeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	const body = "0123456789abcdef" // 16 bytes
+
+	if err := store.CreateBucket(context.Background(), "range-test"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if _, err := store.PutObject(context.Background(), "range-test", "blob", strings.NewReader(body), nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	for _, tc := range rangeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runRangeCase(t, svc, tc)
+		})
+	}
+}
+
+// runRangeCase exercises one rangeCase against the GetObject handler.
+func runRangeCase(t *testing.T, svc *Service, tc rangeCase) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/range-test/blob", http.NoBody)
+	req.SetPathValue("bucket", "range-test")
+	req.SetPathValue("key", "blob")
+
+	if tc.rangeHeader != "" {
+		req.Header.Set("Range", tc.rangeHeader)
+	}
+
+	w := httptest.NewRecorder()
+	svc.GetObject(w, req)
+
+	if w.Code != tc.wantStatus {
+		t.Fatalf("status: got %d, want %d (body=%s)", w.Code, tc.wantStatus, w.Body.String())
+	}
+
+	if tc.wantStatus == http.StatusPartialContent {
+		if w.Body.String() != tc.wantBody {
+			t.Fatalf("body: got %q, want %q", w.Body.String(), tc.wantBody)
+		}
+
+		if got := w.Header().Get("Content-Range"); got != tc.wantCR {
+			t.Fatalf("Content-Range: got %q, want %q", got, tc.wantCR)
+		}
+	}
+
+	if tc.wantStatus == http.StatusOK && w.Body.String() != tc.wantBody {
+		t.Fatalf("full body: got %q, want %q", w.Body.String(), tc.wantBody)
+	}
+}
+
+// TestGetObject_AdvertisesAcceptRanges — every successful response
+// signals byte-range support so well-behaved clients know they can
+// resume / chunk.
+func TestGetObject_AdvertisesAcceptRanges(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	_ = store.CreateBucket(context.Background(), "ar-test")
+	_, _ = store.PutObject(context.Background(), "ar-test", "k",
+		strings.NewReader("hello"), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/ar-test/k", http.NoBody)
+	req.SetPathValue("bucket", "ar-test")
+	req.SetPathValue("key", "k")
+
+	w := httptest.NewRecorder()
+	svc.GetObject(w, req)
+
+	if w.Header().Get("Accept-Ranges") != "bytes" {
+		t.Fatalf("Accept-Ranges: got %q, want bytes", w.Header().Get("Accept-Ranges"))
+	}
+
+	got, _ := io.ReadAll(w.Result().Body)
+	if string(got) != "hello" {
+		t.Fatalf("body: got %q, want hello", got)
+	}
+}

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -51,6 +51,7 @@ type Storage interface {
 	AbortMultipartUpload(ctx context.Context, bucket, key, uploadID string) error
 	ListMultipartUploads(ctx context.Context, bucket, prefix string, maxUploads int) ([]*MultipartUpload, error)
 	ListParts(ctx context.Context, bucket, key, uploadID string, maxParts int) ([]*Part, error)
+	UploadPartCopy(ctx context.Context, dstBucket, dstKey, uploadID string, partNumber int, srcBucket, srcKey string, copyRange *CopyRange) (*Part, error)
 
 	// Object tagging
 	PutObjectTagging(ctx context.Context, bucket, key string, tags map[string]string) error
@@ -875,6 +876,59 @@ func (s *MemoryStorage) UploadPart(_ context.Context, bucket, key, uploadID stri
 		Size:         int64(len(data)),
 		LastModified: time.Now(),
 		Body:         data,
+	}
+
+	upload.Parts[partNumber] = part
+
+	return part, nil
+}
+
+// UploadPartCopy copies bytes from an existing object into a part of an
+// in-progress multipart upload. RFC-equivalent: AWS S3 UploadPartCopy.
+// `copyRange` may be nil to copy the entire source object.
+func (s *MemoryStorage) UploadPartCopy(_ context.Context, dstBucket, dstKey, uploadID string, partNumber int, srcBucket, srcKey string, copyRange *CopyRange) (*Part, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	srcB, exists := s.Buckets[srcBucket]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: srcBucket}
+	}
+
+	srcObj, exists := srcB.Objects[srcKey]
+	if !exists {
+		return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: srcKey}
+	}
+
+	dstB, exists := s.Buckets[dstBucket]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: dstBucket}
+	}
+
+	upload, exists := dstB.MultipartUploads[uploadID]
+	if !exists || upload.Key != dstKey {
+		return nil, &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
+	}
+
+	data := srcObj.Body
+	if copyRange != nil {
+		size := int64(len(data))
+		if copyRange.Start < 0 || copyRange.End >= size || copyRange.Start > copyRange.End {
+			return nil, &MultipartError{Code: "InvalidArgument", Message: "Range out of source object bounds", UploadID: uploadID}
+		}
+
+		data = data[copyRange.Start : copyRange.End+1]
+	}
+
+	hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
+	etag := hex.EncodeToString(hash[:])
+
+	part := &Part{
+		PartNumber:   partNumber,
+		ETag:         fmt.Sprintf("%q", etag),
+		Size:         int64(len(data)),
+		LastModified: time.Now(),
+		Body:         append([]byte(nil), data...),
 	}
 
 	upload.Parts[partNumber] = part

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -307,6 +307,13 @@ type CopyPartResult struct {
 	ETag         string   `xml:"ETag"`
 }
 
+// CopyRange is the resolved x-amz-copy-source-range — START..END inclusive.
+// nil means "copy the whole source object".
+type CopyRange struct {
+	Start int64
+	End   int64
+}
+
 // NotificationConfiguration represents S3 bucket notification configuration.
 type NotificationConfiguration struct {
 	XMLName           xml.Name           `xml:"NotificationConfiguration"`

--- a/internal/service/s3/uploadpartcopy_test.go
+++ b/internal/service/s3/uploadpartcopy_test.go
@@ -1,0 +1,222 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseCopySourceRange(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		header string
+		start  int64
+		end    int64
+		want   bool // valid
+		isNil  bool // result is nil (absent header)
+	}{
+		{"", 0, 0, true, true},
+		{"bytes=0-99", 0, 99, true, false},
+		{"bytes=100-199", 100, 199, true, false},
+		{"bytes= 0 - 99 ", 0, 99, true, false}, // tolerate spaces
+		{"bytes=-99", 0, 0, false, false},      // suffix not allowed
+		{"bytes=100-", 0, 0, false, false},     // open not allowed
+		{"bytes=200-100", 0, 0, false, false},  // inverted
+		{"items=0-99", 0, 0, false, false},     // wrong unit
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			got, err := parseCopySourceRange(tc.header)
+			if tc.want && err != nil {
+				t.Fatalf("want valid, got err=%v", err)
+			}
+
+			if !tc.want && err == nil {
+				t.Fatalf("want error, got nil")
+			}
+
+			if tc.isNil && got != nil {
+				t.Fatalf("want nil result, got %+v", got)
+			}
+
+			if !tc.isNil && got != nil && (got.Start != tc.start || got.End != tc.end) {
+				t.Fatalf("got (%d, %d), want (%d, %d)", got.Start, got.End, tc.start, tc.end)
+			}
+		})
+	}
+}
+
+// uploadPartCopyCase pins one HTTP-layer scenario for the table test.
+type uploadPartCopyCase struct {
+	name        string
+	srcPayload  string
+	copySource  string // X-Amz-Copy-Source
+	copyRange   string // X-Amz-Copy-Source-Range
+	wantStatus  int
+	wantPartLen int // expected stored part body length on success
+}
+
+var uploadPartCopyCases = []uploadPartCopyCase{
+	{"full source", "0123456789", "/src/file.txt", "", http.StatusOK, 10},
+	{"ranged copy", "0123456789", "/src/file.txt", "bytes=2-5", http.StatusOK, 4},
+	{"invalid range", "0123456789", "/src/file.txt", "bytes=20-30", http.StatusBadRequest, 0},
+	{"malformed source", "0123456789", "/single-segment", "", http.StatusBadRequest, 0},
+	{"source not found", "0123456789", "/src/missing.txt", "", http.StatusNotFound, 0},
+}
+
+// TestUploadPartCopy_HTTPRoundTrip exercises the dispatcher + handler
+// + storage end-to-end through the HTTP layer.
+func TestUploadPartCopy_HTTPRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range uploadPartCopyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runUploadPartCopyCase(t, &tc)
+		})
+	}
+}
+
+// runUploadPartCopyCase sets up a fresh storage with a single source
+// object + open multipart upload, then issues UploadPartCopy via the
+// dispatcher.
+func runUploadPartCopyCase(t *testing.T, tc *uploadPartCopyCase) {
+	t.Helper()
+
+	store, svc, uploadID := setupUploadPartCopyFixture(t, tc.srcPayload)
+	w := issueUploadPartCopy(svc, uploadID, tc.copySource, tc.copyRange)
+
+	if w.Code != tc.wantStatus {
+		t.Fatalf("status: got %d, want %d (body=%s)", w.Code, tc.wantStatus, w.Body.String())
+	}
+
+	if tc.wantStatus != http.StatusOK {
+		return
+	}
+
+	verifyStoredPart(t, store, uploadID, w, tc.wantPartLen)
+}
+
+// setupUploadPartCopyFixture wires up src+dst buckets, the source
+// payload, and an open multipart upload. Returns the store, service,
+// and the new uploadID.
+func setupUploadPartCopyFixture(t *testing.T, srcPayload string) (*MemoryStorage, *Service, string) {
+	t.Helper()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	if err := store.CreateBucket(ctx, "src"); err != nil {
+		t.Fatalf("CreateBucket src: %v", err)
+	}
+
+	if err := store.CreateBucket(ctx, "dst"); err != nil {
+		t.Fatalf("CreateBucket dst: %v", err)
+	}
+
+	if _, err := store.PutObject(ctx, "src", "file.txt", strings.NewReader(srcPayload), nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	upload, err := store.CreateMultipartUpload(ctx, "dst", "out.txt")
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	return store, svc, upload.UploadID
+}
+
+// issueUploadPartCopy builds + dispatches the PUT request through the
+// real handleObjectPut router so the dispatch logic is exercised too.
+func issueUploadPartCopy(svc *Service, uploadID, copySource, copyRange string) *httptest.ResponseRecorder {
+	url := "/dst/out.txt?partNumber=1&uploadId=" + uploadID
+	req := httptest.NewRequest(http.MethodPut, url, http.NoBody)
+	req.SetPathValue("bucket", "dst")
+	req.SetPathValue("key", "out.txt")
+
+	if copySource != "" {
+		req.Header.Set("X-Amz-Copy-Source", copySource)
+	}
+
+	if copyRange != "" {
+		req.Header.Set("X-Amz-Copy-Source-Range", copyRange)
+	}
+
+	w := httptest.NewRecorder()
+	svc.handleObjectPut(w, req)
+
+	return w
+}
+
+// verifyStoredPart confirms the response is a valid CopyPartResult
+// AND that the storage actually has one part of the expected size.
+func verifyStoredPart(t *testing.T, store *MemoryStorage, uploadID string, w *httptest.ResponseRecorder, wantLen int) {
+	t.Helper()
+
+	var got CopyPartResult
+	if err := xml.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal CopyPartResult: %v body=%s", err, w.Body.String())
+	}
+
+	if got.ETag == "" {
+		t.Fatalf("CopyPartResult.ETag is empty")
+	}
+
+	parts, err := store.ListParts(context.Background(), "dst", "out.txt", uploadID, 100)
+	if err != nil {
+		t.Fatalf("ListParts: %v", err)
+	}
+
+	if len(parts) != 1 {
+		t.Fatalf("parts: got %d, want 1", len(parts))
+	}
+
+	if int(parts[0].Size) != wantLen {
+		t.Fatalf("part size: got %d, want %d", parts[0].Size, wantLen)
+	}
+}
+
+// TestUploadPartCopy_RoundTripsThroughComplete confirms the copied
+// part can actually be assembled by CompleteMultipartUpload.
+func TestUploadPartCopy_RoundTripsThroughComplete(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, "src")
+	_ = store.CreateBucket(ctx, "dst")
+	_, _ = store.PutObject(ctx, "src", "blob", strings.NewReader("ABCDEFGHIJ"), nil)
+
+	upload, err := store.CreateMultipartUpload(ctx, "dst", "joined")
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	p1, err := store.UploadPartCopy(ctx, "dst", "joined", upload.UploadID, 1, "src", "blob", &CopyRange{Start: 0, End: 4})
+	if err != nil {
+		t.Fatalf("UploadPartCopy 1: %v", err)
+	}
+
+	p2, err := store.UploadPartCopy(ctx, "dst", "joined", upload.UploadID, 2, "src", "blob", &CopyRange{Start: 5, End: 9})
+	if err != nil {
+		t.Fatalf("UploadPartCopy 2: %v", err)
+	}
+
+	obj, err := store.CompleteMultipartUpload(ctx, "dst", "joined", upload.UploadID, []PartRequest{
+		{PartNumber: 1, ETag: p1.ETag},
+		{PartNumber: 2, ETag: p2.ETag},
+	})
+	if err != nil {
+		t.Fatalf("CompleteMultipartUpload: %v", err)
+	}
+
+	if string(obj.Body) != "ABCDEFGHIJ" {
+		t.Fatalf("assembled body: got %q, want ABCDEFGHIJ", obj.Body)
+	}
+}

--- a/test/integration/testdata/s3_test_TestS3_HeadObject_TestS3_HeadObject.golden.go
+++ b/test/integration/testdata/s3_test_TestS3_HeadObject_TestS3_HeadObject.golden.go
@@ -1,5 +1,5 @@
 {
-  "AcceptRanges": null,
+  "AcceptRanges": "bytes",
   "ArchiveStatus": "",
   "BucketKeyEnabled": null,
   "CacheControl": null,


### PR DESCRIPTION
## Summary

Two related S3 holes filled in one PR — the second piece (\`UploadPartCopy\`) reuses the byte-range parsing introduced by the first.

### 1. GetObject Range — RFC 9110 §14 single-range support

S3 clients commonly issue \`Range\` requests for chunked / resumable downloads. kumo's \`GetObject\` ignored the \`Range\` header and always returned the full body, so any client doing range-based access re-read the same bytes redundantly.

| Header | Meaning |
|---|---|
| \`bytes=START-END\` | closed range, end inclusive |
| \`bytes=-N\` | suffix — last N bytes |
| \`bytes=START-\` | open-ended — START through end-of-content |
| \`bytes=0-99,200-299\` | multi-range — falls through to 200 (single-range only; matches real S3, which doesn't serve multi-range either) |
| \`items=0-99\` | wrong unit — falls through to 200 (RFC 9110 §14.1.3) |
| \`bytes=99-\` past EOF | unsatisfiable — 416 with \`Content-Range: bytes */<size>\` |

\`GetObject\` and \`HeadObject\` now also advertise \`Accept-Ranges: bytes\` on every successful response so range-aware clients know they can resume.

```
$ curl -i -H 'Range: bytes=5-10' :4566/range-bucket/file.txt
HTTP/1.1 206 Partial Content
Accept-Ranges: bytes
Content-Length: 6
Content-Range: bytes 5-10/32
ETag: \"5392fad6bee373074dbd3edfae6506f2\"

56789A
```

Range parser lives in \`internal/service/s3/range.go\` as package-private — not shared with the cloudfront/cache package's identical helper since cross-service coupling for ~100 lines wasn't worth the import-cycle / interface contortion.

### 2. UploadPartCopy — copy bytes from existing object into a part

S3 multipart upload already supported uploading parts from request bodies (\`UploadPart\`), but lacked **\`UploadPartCopy\`** — the variant that sources part bytes from another (or the same) S3 object via the \`X-Amz-Copy-Source\` header. This is how AWS SDKs concatenate / re-package large objects without re-uploading from the client side: log-roll-up jobs, multipart re-uploads of objects > 5 GiB, \"merge N existing files into one\" workflows.

```
PUT /<dst-bucket>/<dst-key>?partNumber=N&uploadId=...
X-Amz-Copy-Source: /<src-bucket>/<src-key>
X-Amz-Copy-Source-Range: bytes=START-END        (optional)

→ 200 OK
  <CopyPartResult>
    <LastModified>...</LastModified>
    <ETag>\"...\"</ETag>
  </CopyPartResult>
```

\`X-Amz-Copy-Source-Range\` follows the same \`bytes=START-END\` form as the \`Range\` parser above, but per AWS spec **only closed ranges** are accepted — suffix and open-ended forms are rejected with \`400 InvalidArgument\` (matches real S3).

Cross-bucket copy works. \`parseCopySource\` (the helper that already backed \`CopyObject\`) is reused for source parsing.

| condition | status | code |
|---|---|---|
| missing / malformed \`X-Amz-Copy-Source\` | 400 | InvalidArgument |
| source object not found | 404 | NoSuchKey |
| source bucket not found | 404 | NoSuchBucket |
| \`copy-source-range\` out of bounds | 400 | InvalidArgument |
| upload not found / wrong key | 404 | NoSuchUpload |

\`handleMultipartError\` was extended to map \`ObjectError\` to 404 and \`MultipartError{Code: \"InvalidArgument\"}\` to 400 — both already-existing error types benefit (no other call site changes needed).

## Out of scope

- **Multi-range \`multipart/byteranges\` 206 response** — real S3 doesn't serve multi-range either, so this is a fidelity choice, not a gap. If any consumer wants RFC 9110-strict multi-range, a follow-up could add it behind an env flag.
- **\`UploadPartCopy\` source ETag pre-condition headers** (\`x-amz-copy-source-if-match\`, etc.) — orthogonal to this PR.

## Test plan

- [x] \`go test ./internal/service/s3/\` — clean
  - \`TestParseByteRange\` — 10 cases (closed / suffix / open / clamped / unsatisfiable / multi / wrong-unit / empty)
  - \`TestGetObject_RangeRoundTrip\` — 7 HTTP scenarios incl. 416
  - \`TestGetObject_AdvertisesAcceptRanges\`
  - \`TestParseCopySourceRange\` — 8 forms (closed / suffix-rejected / open-rejected / inverted / wrong-unit / spaces / absent)
  - \`TestUploadPartCopy_HTTPRoundTrip\` — full / ranged / out-of-bounds / malformed-source / source-not-found
  - \`TestUploadPartCopy_RoundTripsThroughComplete\` — 2 ranged copies → \`CompleteMultipartUpload\` → final body equals expected concat
- [x] HeadObject golden updated for new \`Accept-Ranges: bytes\` header
- [x] \`go test ./...\` — full suite green
- [x] \`make lint\` — clean
- [x] Manual \`curl -H 'Range: ...'\` round-trip — 206 / 416 / Content-Range shapes confirmed

This PR subsumes #585 (filed separately before consolidation).