### PR TITLE
feat(s3): UploadPartCopy — copy bytes from existing object into a part

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"sort"
@@ -276,6 +277,12 @@ func (s *Service) handleObjectPut(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.URL.Query().Get("uploadId") != "" && r.URL.Query().Get("partNumber") != "" {
+		if r.Header.Get("X-Amz-Copy-Source") != "" {
+			s.UploadPartCopy(w, r)
+
+			return
+		}
+
 		s.UploadPart(w, r)
 
 		return
@@ -1492,6 +1499,92 @@ func (s *Service) UploadPart(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// UploadPartCopy handles
+//
+//	PUT /{bucket}/{key}?partNumber=N&uploadId=...
+//	X-Amz-Copy-Source: /<srcBucket>/<srcKey>
+//	X-Amz-Copy-Source-Range: bytes=START-END   (optional)
+//
+// — copies bytes from an existing object into a part of an in-progress
+// multipart upload, without the client having to re-upload the data.
+//
+// Cross-bucket copy is supported. Source object must already exist.
+// If `X-Amz-Copy-Source-Range` is absent, the whole source is copied.
+func (s *Service) UploadPartCopy(w http.ResponseWriter, r *http.Request) {
+	dstBucket := r.PathValue("bucket")
+	dstKey := r.PathValue("key")
+
+	uploadID := r.URL.Query().Get("uploadId")
+	if uploadID == "" {
+		writeS3Error(w, r, "InvalidArgument", "uploadId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	partNumber, err := strconv.Atoi(r.URL.Query().Get("partNumber"))
+	if err != nil || partNumber < 1 || partNumber > 10000 {
+		writeS3Error(w, r, "InvalidArgument", "Invalid partNumber", http.StatusBadRequest)
+
+		return
+	}
+
+	srcBucket, srcKey := parseCopySource(r.Header.Get("X-Amz-Copy-Source"))
+	if srcBucket == "" || srcKey == "" {
+		writeS3Error(w, r, "InvalidArgument", "Invalid copy source", http.StatusBadRequest)
+
+		return
+	}
+
+	copyRange, err := parseCopySourceRange(r.Header.Get("X-Amz-Copy-Source-Range"))
+	if err != nil {
+		writeS3Error(w, r, "InvalidArgument", err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	part, err := s.storage.UploadPartCopy(r.Context(), dstBucket, dstKey, uploadID, partNumber, srcBucket, srcKey, copyRange)
+	if err != nil {
+		handleMultipartError(w, r, err)
+
+		return
+	}
+
+	result := CopyPartResult{
+		Xmlns:        s3Namespace,
+		LastModified: part.LastModified.UTC().Format(timeFormatISO),
+		ETag:         part.ETag,
+	}
+	writeXMLResponse(w, result)
+}
+
+// parseCopySourceRange parses an `X-Amz-Copy-Source-Range: bytes=START-END`
+// header. Returns (nil, nil) when absent. Suffix / open-ended forms are
+// not allowed by S3 for UploadPartCopy — only closed ranges.
+func parseCopySourceRange(header string) (*CopyRange, error) {
+	if header == "" {
+		return nil, nil //nolint:nilnil // absent header is the "copy whole source" sentinel
+	}
+
+	spec, ok := strings.CutPrefix(header, "bytes=")
+	if !ok {
+		return nil, fmt.Errorf("X-Amz-Copy-Source-Range must use bytes unit")
+	}
+
+	dash := strings.IndexByte(spec, '-')
+	if dash <= 0 || dash == len(spec)-1 {
+		return nil, fmt.Errorf("X-Amz-Copy-Source-Range requires both START and END (closed range)")
+	}
+
+	start, err1 := strconv.ParseInt(strings.TrimSpace(spec[:dash]), 10, 64)
+	end, err2 := strconv.ParseInt(strings.TrimSpace(spec[dash+1:]), 10, 64)
+
+	if err1 != nil || err2 != nil || start < 0 || end < start {
+		return nil, fmt.Errorf("X-Amz-Copy-Source-Range has invalid byte range")
+	}
+
+	return &CopyRange{Start: start, End: end}, nil
+}
+
 // CompleteMultipartUpload handles POST /{bucket}/{key}?uploadId={uploadId} - complete a multipart upload.
 func (s *Service) CompleteMultipartUpload(w http.ResponseWriter, r *http.Request) {
 	bucket := r.PathValue("bucket")
@@ -1733,10 +1826,17 @@ func handleMultipartError(w http.ResponseWriter, r *http.Request, err error) {
 		return
 	}
 
+	var objectErr *ObjectError
+	if errors.As(err, &objectErr) {
+		writeS3Error(w, r, objectErr.Code, objectErr.Message, http.StatusNotFound)
+
+		return
+	}
+
 	var multipartErr *MultipartError
 	if errors.As(err, &multipartErr) {
 		status := http.StatusNotFound
-		if multipartErr.Code == "InvalidPart" {
+		if multipartErr.Code == "InvalidPart" || multipartErr.Code == "InvalidArgument" {
 			status = http.StatusBadRequest
 		}
 

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -51,6 +51,7 @@ type Storage interface {
 	AbortMultipartUpload(ctx context.Context, bucket, key, uploadID string) error
 	ListMultipartUploads(ctx context.Context, bucket, prefix string, maxUploads int) ([]*MultipartUpload, error)
 	ListParts(ctx context.Context, bucket, key, uploadID string, maxParts int) ([]*Part, error)
+	UploadPartCopy(ctx context.Context, dstBucket, dstKey, uploadID string, partNumber int, srcBucket, srcKey string, copyRange *CopyRange) (*Part, error)
 
 	// Object tagging
 	PutObjectTagging(ctx context.Context, bucket, key string, tags map[string]string) error
@@ -875,6 +876,59 @@ func (s *MemoryStorage) UploadPart(_ context.Context, bucket, key, uploadID stri
 		Size:         int64(len(data)),
 		LastModified: time.Now(),
 		Body:         data,
+	}
+
+	upload.Parts[partNumber] = part
+
+	return part, nil
+}
+
+// UploadPartCopy copies bytes from an existing object into a part of an
+// in-progress multipart upload. RFC-equivalent: AWS S3 UploadPartCopy.
+// `copyRange` may be nil to copy the entire source object.
+func (s *MemoryStorage) UploadPartCopy(_ context.Context, dstBucket, dstKey, uploadID string, partNumber int, srcBucket, srcKey string, copyRange *CopyRange) (*Part, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	srcB, exists := s.Buckets[srcBucket]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: srcBucket}
+	}
+
+	srcObj, exists := srcB.Objects[srcKey]
+	if !exists {
+		return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: srcKey}
+	}
+
+	dstB, exists := s.Buckets[dstBucket]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: dstBucket}
+	}
+
+	upload, exists := dstB.MultipartUploads[uploadID]
+	if !exists || upload.Key != dstKey {
+		return nil, &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
+	}
+
+	data := srcObj.Body
+	if copyRange != nil {
+		size := int64(len(data))
+		if copyRange.Start < 0 || copyRange.End >= size || copyRange.Start > copyRange.End {
+			return nil, &MultipartError{Code: "InvalidArgument", Message: "Range out of source object bounds", UploadID: uploadID}
+		}
+
+		data = data[copyRange.Start : copyRange.End+1]
+	}
+
+	hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
+	etag := hex.EncodeToString(hash[:])
+
+	part := &Part{
+		PartNumber:   partNumber,
+		ETag:         fmt.Sprintf("%q", etag),
+		Size:         int64(len(data)),
+		LastModified: time.Now(),
+		Body:         append([]byte(nil), data...),
 	}
 
 	upload.Parts[partNumber] = part

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -307,6 +307,13 @@ type CopyPartResult struct {
 	ETag         string   `xml:"ETag"`
 }
 
+// CopyRange is the resolved x-amz-copy-source-range — START..END inclusive.
+// nil means "copy the whole source object".
+type CopyRange struct {
+	Start int64
+	End   int64
+}
+
 // NotificationConfiguration represents S3 bucket notification configuration.
 type NotificationConfiguration struct {
 	XMLName           xml.Name           `xml:"NotificationConfiguration"`

--- a/internal/service/s3/uploadpartcopy_test.go
+++ b/internal/service/s3/uploadpartcopy_test.go
@@ -1,0 +1,222 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseCopySourceRange(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		header string
+		start  int64
+		end    int64
+		want   bool // valid
+		isNil  bool // result is nil (absent header)
+	}{
+		{"", 0, 0, true, true},
+		{"bytes=0-99", 0, 99, true, false},
+		{"bytes=100-199", 100, 199, true, false},
+		{"bytes= 0 - 99 ", 0, 99, true, false}, // tolerate spaces
+		{"bytes=-99", 0, 0, false, false},      // suffix not allowed
+		{"bytes=100-", 0, 0, false, false},     // open not allowed
+		{"bytes=200-100", 0, 0, false, false},  // inverted
+		{"items=0-99", 0, 0, false, false},     // wrong unit
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			got, err := parseCopySourceRange(tc.header)
+			if tc.want && err != nil {
+				t.Fatalf("want valid, got err=%v", err)
+			}
+
+			if !tc.want && err == nil {
+				t.Fatalf("want error, got nil")
+			}
+
+			if tc.isNil && got != nil {
+				t.Fatalf("want nil result, got %+v", got)
+			}
+
+			if !tc.isNil && got != nil && (got.Start != tc.start || got.End != tc.end) {
+				t.Fatalf("got (%d, %d), want (%d, %d)", got.Start, got.End, tc.start, tc.end)
+			}
+		})
+	}
+}
+
+// uploadPartCopyCase pins one HTTP-layer scenario for the table test.
+type uploadPartCopyCase struct {
+	name        string
+	srcPayload  string
+	copySource  string // X-Amz-Copy-Source
+	copyRange   string // X-Amz-Copy-Source-Range
+	wantStatus  int
+	wantPartLen int // expected stored part body length on success
+}
+
+var uploadPartCopyCases = []uploadPartCopyCase{
+	{"full source", "0123456789", "/src/file.txt", "", http.StatusOK, 10},
+	{"ranged copy", "0123456789", "/src/file.txt", "bytes=2-5", http.StatusOK, 4},
+	{"invalid range", "0123456789", "/src/file.txt", "bytes=20-30", http.StatusBadRequest, 0},
+	{"malformed source", "0123456789", "/single-segment", "", http.StatusBadRequest, 0},
+	{"source not found", "0123456789", "/src/missing.txt", "", http.StatusNotFound, 0},
+}
+
+// TestUploadPartCopy_HTTPRoundTrip exercises the dispatcher + handler
+// + storage end-to-end through the HTTP layer.
+func TestUploadPartCopy_HTTPRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range uploadPartCopyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runUploadPartCopyCase(t, &tc)
+		})
+	}
+}
+
+// runUploadPartCopyCase sets up a fresh storage with a single source
+// object + open multipart upload, then issues UploadPartCopy via the
+// dispatcher.
+func runUploadPartCopyCase(t *testing.T, tc *uploadPartCopyCase) {
+	t.Helper()
+
+	store, svc, uploadID := setupUploadPartCopyFixture(t, tc.srcPayload)
+	w := issueUploadPartCopy(svc, uploadID, tc.copySource, tc.copyRange)
+
+	if w.Code != tc.wantStatus {
+		t.Fatalf("status: got %d, want %d (body=%s)", w.Code, tc.wantStatus, w.Body.String())
+	}
+
+	if tc.wantStatus != http.StatusOK {
+		return
+	}
+
+	verifyStoredPart(t, store, uploadID, w, tc.wantPartLen)
+}
+
+// setupUploadPartCopyFixture wires up src+dst buckets, the source
+// payload, and an open multipart upload. Returns the store, service,
+// and the new uploadID.
+func setupUploadPartCopyFixture(t *testing.T, srcPayload string) (*MemoryStorage, *Service, string) {
+	t.Helper()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	if err := store.CreateBucket(ctx, "src"); err != nil {
+		t.Fatalf("CreateBucket src: %v", err)
+	}
+
+	if err := store.CreateBucket(ctx, "dst"); err != nil {
+		t.Fatalf("CreateBucket dst: %v", err)
+	}
+
+	if _, err := store.PutObject(ctx, "src", "file.txt", strings.NewReader(srcPayload), nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	upload, err := store.CreateMultipartUpload(ctx, "dst", "out.txt")
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	return store, svc, upload.UploadID
+}
+
+// issueUploadPartCopy builds + dispatches the PUT request through the
+// real handleObjectPut router so the dispatch logic is exercised too.
+func issueUploadPartCopy(svc *Service, uploadID, copySource, copyRange string) *httptest.ResponseRecorder {
+	url := "/dst/out.txt?partNumber=1&uploadId=" + uploadID
+	req := httptest.NewRequest(http.MethodPut, url, http.NoBody)
+	req.SetPathValue("bucket", "dst")
+	req.SetPathValue("key", "out.txt")
+
+	if copySource != "" {
+		req.Header.Set("X-Amz-Copy-Source", copySource)
+	}
+
+	if copyRange != "" {
+		req.Header.Set("X-Amz-Copy-Source-Range", copyRange)
+	}
+
+	w := httptest.NewRecorder()
+	svc.handleObjectPut(w, req)
+
+	return w
+}
+
+// verifyStoredPart confirms the response is a valid CopyPartResult
+// AND that the storage actually has one part of the expected size.
+func verifyStoredPart(t *testing.T, store *MemoryStorage, uploadID string, w *httptest.ResponseRecorder, wantLen int) {
+	t.Helper()
+
+	var got CopyPartResult
+	if err := xml.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal CopyPartResult: %v body=%s", err, w.Body.String())
+	}
+
+	if got.ETag == "" {
+		t.Fatalf("CopyPartResult.ETag is empty")
+	}
+
+	parts, err := store.ListParts(context.Background(), "dst", "out.txt", uploadID, 100)
+	if err != nil {
+		t.Fatalf("ListParts: %v", err)
+	}
+
+	if len(parts) != 1 {
+		t.Fatalf("parts: got %d, want 1", len(parts))
+	}
+
+	if int(parts[0].Size) != wantLen {
+		t.Fatalf("part size: got %d, want %d", parts[0].Size, wantLen)
+	}
+}
+
+// TestUploadPartCopy_RoundTripsThroughComplete confirms the copied
+// part can actually be assembled by CompleteMultipartUpload.
+func TestUploadPartCopy_RoundTripsThroughComplete(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, "src")
+	_ = store.CreateBucket(ctx, "dst")
+	_, _ = store.PutObject(ctx, "src", "blob", strings.NewReader("ABCDEFGHIJ"), nil)
+
+	upload, err := store.CreateMultipartUpload(ctx, "dst", "joined")
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	p1, err := store.UploadPartCopy(ctx, "dst", "joined", upload.UploadID, 1, "src", "blob", &CopyRange{Start: 0, End: 4})
+	if err != nil {
+		t.Fatalf("UploadPartCopy 1: %v", err)
+	}
+
+	p2, err := store.UploadPartCopy(ctx, "dst", "joined", upload.UploadID, 2, "src", "blob", &CopyRange{Start: 5, End: 9})
+	if err != nil {
+		t.Fatalf("UploadPartCopy 2: %v", err)
+	}
+
+	obj, err := store.CompleteMultipartUpload(ctx, "dst", "joined", upload.UploadID, []PartRequest{
+		{PartNumber: 1, ETag: p1.ETag},
+		{PartNumber: 2, ETag: p2.ETag},
+	})
+	if err != nil {
+		t.Fatalf("CompleteMultipartUpload: %v", err)
+	}
+
+	if string(obj.Body) != "ABCDEFGHIJ" {
+		t.Fatalf("assembled body: got %q, want ABCDEFGHIJ", obj.Body)
+	}
+}


### PR DESCRIPTION
## Summary

S3 multipart upload already supported uploading parts from request bodies (\`UploadPart\`), but lacked **\`UploadPartCopy\`** — the variant that sources part bytes from another (or the same) S3 object via the \`X-Amz-Copy-Source\` header.

\`UploadPartCopy\` is how AWS SDKs concatenate / re-package large objects without re-uploading from the client side: log-roll-up jobs, multipart re-uploads of objects > the 5 GiB \`CopyObject\` limit, and any \"merge N existing files into one\" workflow.

## Wire shape

```
PUT /<dst-bucket>/<dst-key>?partNumber=N&uploadId=...
X-Amz-Copy-Source: /<src-bucket>/<src-key>
X-Amz-Copy-Source-Range: bytes=START-END        (optional)

→ 200 OK
  <CopyPartResult>
    <LastModified>2026-05-09T...</LastModified>
    <ETag>\"...\"</ETag>
  </CopyPartResult>
```

## Spec notes

\`X-Amz-Copy-Source-Range\` follows the same \`bytes=START-END\` form as PR #584's S3 Range parser, but per AWS spec **only closed ranges** are accepted — suffix (\`bytes=-N\`) and open-ended (\`bytes=N-\`) forms are rejected with \`400 InvalidArgument\` (matches real S3).

Cross-bucket copy works. The \`parseCopySource\` helper that already backed \`CopyObject\` is reused for source parsing.

## Errors

| condition | status | code |
|---|---|---|
| missing / malformed \`X-Amz-Copy-Source\` | 400 | InvalidArgument |
| source object not found | 404 | NoSuchKey |
| source bucket not found | 404 | NoSuchBucket |
| \`copy-source-range\` out of bounds | 400 | InvalidArgument |
| upload not found / wrong key | 404 | NoSuchUpload |

\`handleMultipartError\` was extended to map \`ObjectError\` to 404 and \`MultipartError{Code: \"InvalidArgument\"}\` to 400 — both already-existing error types benefit (no other call site changes needed).

## Test plan

- [x] \`go test ./internal/service/s3/\` — 3 new tests / 13 sub-cases:
  - \`TestParseCopySourceRange\` — 8 forms (closed / suffix-rejected / open-rejected / inverted / wrong-unit / spaces / absent)
  - \`TestUploadPartCopy_HTTPRoundTrip\` — full / ranged / out-of-bounds / malformed-source / source-not-found
  - \`TestUploadPartCopy_RoundTripsThroughComplete\` — 2 ranged copies → \`CompleteMultipartUpload\` → final body equals expected concat
- [x] Full suite \`go test ./...\` — green
- [x] \`make lint\` — clean