### PR TITLE
feat(cloudfront): PublicKey + KeyGroup CRUD (signed URL building blocks)

### DIFF
--- a/internal/service/cloudfront/handlers_signing.go
+++ b/internal/service/cloudfront/handlers_signing.go
@@ -1,0 +1,220 @@
+package cloudfront
+
+import (
+	"encoding/xml"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+)
+
+// CreatePublicKey handles POST /2020-05-31/public-key.
+func (s *Service) CreatePublicKey(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeCloudFrontError(w, errMissingBody, "Request body is missing", http.StatusBadRequest)
+
+		return
+	}
+
+	var req PublicKeyConfigXML
+	if err := xml.Unmarshal(body, &req); err != nil {
+		writeCloudFrontError(w, errInvalidArgument, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	cfg := &PublicKeyConfig{
+		CallerReference: req.CallerReference,
+		Name:            req.Name,
+		EncodedKey:      req.EncodedKey,
+		Comment:         req.Comment,
+	}
+
+	key, err := s.storage.CreatePublicKey(r.Context(), cfg)
+	if err != nil {
+		handleSigningStorageError(w, err)
+
+		return
+	}
+
+	w.Header().Set("ETag", key.ETag)
+	writeXMLResponse(w, http.StatusCreated, buildPublicKeyResultXML(key))
+}
+
+// GetPublicKey handles GET /2020-05-31/public-key/{id}.
+func (s *Service) GetPublicKey(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	key, err := s.storage.GetPublicKey(r.Context(), id)
+	if err != nil {
+		handleSigningStorageError(w, err)
+
+		return
+	}
+
+	w.Header().Set("ETag", key.ETag)
+	writeXMLResponse(w, http.StatusOK, buildPublicKeyResultXML(key))
+}
+
+// ListPublicKeys handles GET /2020-05-31/public-key.
+func (s *Service) ListPublicKeys(w http.ResponseWriter, r *http.Request) {
+	keys := s.storage.ListPublicKeys(r.Context())
+
+	items := make([]PublicKeySummaryXML, len(keys))
+	for i, k := range keys {
+		items[i] = PublicKeySummaryXML{
+			ID:          k.ID,
+			Name:        k.PublicKeyConfig.Name,
+			CreatedTime: k.CreatedTime.UTC().Format(time.RFC3339),
+			EncodedKey:  k.PublicKeyConfig.EncodedKey,
+			Comment:     k.PublicKeyConfig.Comment,
+		}
+	}
+
+	writeXMLResponse(w, http.StatusOK, &PublicKeyListXML{
+		Xmlns:    cloudfrontXmlns,
+		MaxItems: 100,
+		Quantity: len(items),
+		Items:    items,
+	})
+}
+
+// DeletePublicKey handles DELETE /2020-05-31/public-key/{id}.
+func (s *Service) DeletePublicKey(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if err := s.storage.DeletePublicKey(r.Context(), id); err != nil {
+		handleSigningStorageError(w, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// CreateKeyGroup handles POST /2020-05-31/key-group.
+func (s *Service) CreateKeyGroup(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeCloudFrontError(w, errMissingBody, "Request body is missing", http.StatusBadRequest)
+
+		return
+	}
+
+	var req KeyGroupConfigXML
+	if err := xml.Unmarshal(body, &req); err != nil {
+		writeCloudFrontError(w, errInvalidArgument, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	cfg := &KeyGroupConfig{Name: req.Name, Items: req.Items, Comment: req.Comment}
+
+	group, err := s.storage.CreateKeyGroup(r.Context(), cfg)
+	if err != nil {
+		handleSigningStorageError(w, err)
+
+		return
+	}
+
+	w.Header().Set("ETag", group.ETag)
+	writeXMLResponse(w, http.StatusCreated, buildKeyGroupResultXML(group))
+}
+
+// GetKeyGroup handles GET /2020-05-31/key-group/{id}.
+func (s *Service) GetKeyGroup(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	group, err := s.storage.GetKeyGroup(r.Context(), id)
+	if err != nil {
+		handleSigningStorageError(w, err)
+
+		return
+	}
+
+	w.Header().Set("ETag", group.ETag)
+	writeXMLResponse(w, http.StatusOK, buildKeyGroupResultXML(group))
+}
+
+// ListKeyGroups handles GET /2020-05-31/key-group.
+func (s *Service) ListKeyGroups(w http.ResponseWriter, r *http.Request) {
+	groups := s.storage.ListKeyGroups(r.Context())
+
+	items := make([]KeyGroupSummaryXML, len(groups))
+	for i, g := range groups {
+		items[i] = KeyGroupSummaryXML{KeyGroup: *buildKeyGroupResultXML(g)}
+	}
+
+	writeXMLResponse(w, http.StatusOK, &KeyGroupListXML{
+		Xmlns:    cloudfrontXmlns,
+		MaxItems: 100,
+		Quantity: len(items),
+		Items:    items,
+	})
+}
+
+// DeleteKeyGroup handles DELETE /2020-05-31/key-group/{id}.
+func (s *Service) DeleteKeyGroup(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if err := s.storage.DeleteKeyGroup(r.Context(), id); err != nil {
+		handleSigningStorageError(w, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func buildPublicKeyResultXML(k *PublicKey) *PublicKeyResultXML {
+	return &PublicKeyResultXML{
+		Xmlns:       cloudfrontXmlns,
+		ID:          k.ID,
+		CreatedTime: k.CreatedTime.UTC().Format(time.RFC3339),
+		PublicKeyConfig: &PublicKeyConfigXML{
+			CallerReference: k.PublicKeyConfig.CallerReference,
+			Name:            k.PublicKeyConfig.Name,
+			EncodedKey:      k.PublicKeyConfig.EncodedKey,
+			Comment:         k.PublicKeyConfig.Comment,
+		},
+	}
+}
+
+func buildKeyGroupResultXML(g *KeyGroup) *KeyGroupResultXML {
+	return &KeyGroupResultXML{
+		Xmlns:        cloudfrontXmlns,
+		ID:           g.ID,
+		LastModified: g.LastModified.UTC().Format(time.RFC3339),
+		KeyGroupConfig: &KeyGroupConfigXML{
+			Name:    g.KeyGroupConfig.Name,
+			Items:   g.KeyGroupConfig.Items,
+			Comment: g.KeyGroupConfig.Comment,
+		},
+	}
+}
+
+// handleSigningStorageError maps signing-store errors to HTTP status
+// codes. CloudFront uses 409 for already-exists / in-use conflicts and
+// 404 for not-found.
+func handleSigningStorageError(w http.ResponseWriter, err error) {
+	var cfErr *Error
+	if errors.As(err, &cfErr) {
+		status := http.StatusBadRequest
+
+		switch cfErr.Code {
+		case errNoSuchPublicKey, errNoSuchKeyGroup:
+			status = http.StatusNotFound
+		case errPublicKeyAlreadyExists, errKeyGroupAlreadyExists:
+			status = http.StatusConflict
+		case errPublicKeyInUse, errKeyGroupReferencedError:
+			status = http.StatusConflict
+		}
+
+		writeCloudFrontError(w, cfErr.Code, cfErr.Message, status)
+
+		return
+	}
+
+	writeCloudFrontError(w, "InternalError", "Internal server error", http.StatusInternalServerError)
+}

--- a/internal/service/cloudfront/handlers_signing_test.go
+++ b/internal/service/cloudfront/handlers_signing_test.go
@@ -213,3 +213,42 @@ func TestKeyGroup_DeleteWhileReferencedByDistributionFails(t *testing.T) {
 		t.Fatalf("DeleteKeyGroup while referenced: status %d, want 409", delW.Code)
 	}
 }
+
+func TestSigningReadMethodsDoNotInitializeNilMaps(t *testing.T) {
+	t.Parallel()
+
+	store := &MemoryStorage{}
+	ctx := context.Background()
+
+	if got := store.ListPublicKeys(ctx); len(got) != 0 {
+		t.Fatalf("ListPublicKeys len = %d, want 0", len(got))
+	}
+
+	if store.signing.PublicKeys != nil {
+		t.Fatalf("ListPublicKeys initialized PublicKeys under read lock")
+	}
+
+	if _, err := store.GetPublicKey(ctx, "missing"); err == nil {
+		t.Fatalf("GetPublicKey missing key error = nil")
+	}
+
+	if store.signing.PublicKeys != nil {
+		t.Fatalf("GetPublicKey initialized PublicKeys under read lock")
+	}
+
+	if got := store.ListKeyGroups(ctx); len(got) != 0 {
+		t.Fatalf("ListKeyGroups len = %d, want 0", len(got))
+	}
+
+	if store.signing.KeyGroups != nil {
+		t.Fatalf("ListKeyGroups initialized KeyGroups under read lock")
+	}
+
+	if _, err := store.GetKeyGroup(ctx, "missing"); err == nil {
+		t.Fatalf("GetKeyGroup missing key error = nil")
+	}
+
+	if store.signing.KeyGroups != nil {
+		t.Fatalf("GetKeyGroup initialized KeyGroups under read lock")
+	}
+}

--- a/internal/service/cloudfront/handlers_signing_test.go
+++ b/internal/service/cloudfront/handlers_signing_test.go
@@ -1,0 +1,215 @@
+package cloudfront
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const samplePEM = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1234567890abcdef==
+-----END PUBLIC KEY-----`
+
+func newSigningTestService() *Service {
+	return New(NewMemoryStorage())
+}
+
+func createPublicKeyForTest(t *testing.T, svc *Service, callerRef, name string) *PublicKeyResultXML {
+	t.Helper()
+
+	body := PublicKeyConfigXML{
+		CallerReference: callerRef,
+		Name:            name,
+		EncodedKey:      samplePEM,
+		Comment:         "test",
+	}
+	raw, _ := xml.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/2020-05-31/public-key", strings.NewReader(string(raw)))
+	w := httptest.NewRecorder()
+	svc.CreatePublicKey(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreatePublicKey: status %d body=%s", w.Code, w.Body.String())
+	}
+
+	var out PublicKeyResultXML
+	if err := xml.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
+	}
+
+	return &out
+}
+
+func TestPublicKey_CreateGetListDelete(t *testing.T) {
+	t.Parallel()
+
+	svc := newSigningTestService()
+
+	created := createPublicKeyForTest(t, svc, "ref-1", "key-one")
+
+	if !strings.HasPrefix(created.ID, "K") {
+		t.Fatalf("PublicKey.ID should start with K, got %q", created.ID)
+	}
+
+	// Get
+	getReq := httptest.NewRequest(http.MethodGet, "/2020-05-31/public-key/"+created.ID, http.NoBody)
+	getReq.SetPathValue("id", created.ID)
+
+	getW := httptest.NewRecorder()
+	svc.GetPublicKey(getW, getReq)
+
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GetPublicKey status: %d body=%s", getW.Code, getW.Body.String())
+	}
+
+	// List
+	listW := httptest.NewRecorder()
+	svc.ListPublicKeys(listW, httptest.NewRequest(http.MethodGet, "/2020-05-31/public-key", http.NoBody))
+
+	if listW.Code != http.StatusOK {
+		t.Fatalf("ListPublicKeys status: %d", listW.Code)
+	}
+
+	var list PublicKeyListXML
+	if err := xml.Unmarshal(listW.Body.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshal list: %v body=%s", err, listW.Body.String())
+	}
+
+	if list.Quantity != 1 || len(list.Items) != 1 {
+		t.Fatalf("ListPublicKeys: quantity=%d items=%d, want 1/1", list.Quantity, len(list.Items))
+	}
+
+	// Delete
+	delReq := httptest.NewRequest(http.MethodDelete, "/2020-05-31/public-key/"+created.ID, http.NoBody)
+	delReq.SetPathValue("id", created.ID)
+
+	delW := httptest.NewRecorder()
+	svc.DeletePublicKey(delW, delReq)
+
+	if delW.Code != http.StatusNoContent {
+		t.Fatalf("DeletePublicKey status: %d body=%s", delW.Code, delW.Body.String())
+	}
+
+	// Get-after-delete is 404.
+	getReq2 := httptest.NewRequest(http.MethodGet, "/2020-05-31/public-key/"+created.ID, http.NoBody)
+	getReq2.SetPathValue("id", created.ID)
+
+	getW2 := httptest.NewRecorder()
+	svc.GetPublicKey(getW2, getReq2)
+
+	if getW2.Code != http.StatusNotFound {
+		t.Fatalf("GetPublicKey after delete: status %d, want 404", getW2.Code)
+	}
+}
+
+func TestPublicKey_DuplicateCallerReferenceConflicts(t *testing.T) {
+	t.Parallel()
+
+	svc := newSigningTestService()
+	createPublicKeyForTest(t, svc, "dup-ref", "k1")
+
+	body := PublicKeyConfigXML{CallerReference: "dup-ref", Name: "k2", EncodedKey: samplePEM}
+	raw, _ := xml.Marshal(body)
+
+	w := httptest.NewRecorder()
+	svc.CreatePublicKey(w, httptest.NewRequest(http.MethodPost, "/2020-05-31/public-key", strings.NewReader(string(raw))))
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409 (duplicate caller ref)", w.Code)
+	}
+}
+
+func TestKeyGroup_CreateRejectsUnknownPublicKey(t *testing.T) {
+	t.Parallel()
+
+	svc := newSigningTestService()
+
+	body := KeyGroupConfigXML{Name: "g1", Items: []string{"K-doesnotexist"}}
+	raw, _ := xml.Marshal(body)
+
+	w := httptest.NewRecorder()
+	svc.CreateKeyGroup(w, httptest.NewRequest(http.MethodPost, "/2020-05-31/key-group", strings.NewReader(string(raw))))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404 (NoSuchPublicKey)", w.Code)
+	}
+}
+
+func TestKeyGroup_CreateGetListAndPublicKeyInUseBlock(t *testing.T) {
+	t.Parallel()
+
+	svc := newSigningTestService()
+	pk := createPublicKeyForTest(t, svc, "ref-x", "kx")
+
+	body := KeyGroupConfigXML{Name: "g-prod", Items: []string{pk.ID}, Comment: "prod"}
+	raw, _ := xml.Marshal(body)
+
+	w := httptest.NewRecorder()
+	svc.CreateKeyGroup(w, httptest.NewRequest(http.MethodPost, "/2020-05-31/key-group", strings.NewReader(string(raw))))
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateKeyGroup status: %d body=%s", w.Code, w.Body.String())
+	}
+
+	var group KeyGroupResultXML
+	if err := xml.Unmarshal(w.Body.Bytes(), &group); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
+	}
+
+	if len(group.KeyGroupConfig.Items) != 1 || group.KeyGroupConfig.Items[0] != pk.ID {
+		t.Fatalf("KeyGroupConfig.Items: got %v, want [%s]", group.KeyGroupConfig.Items, pk.ID)
+	}
+
+	// Deleting the underlying PublicKey should fail with 409 PublicKeyInUse.
+	delReq := httptest.NewRequest(http.MethodDelete, "/2020-05-31/public-key/"+pk.ID, http.NoBody)
+	delReq.SetPathValue("id", pk.ID)
+
+	delW := httptest.NewRecorder()
+	svc.DeletePublicKey(delW, delReq)
+
+	if delW.Code != http.StatusConflict {
+		t.Fatalf("DeletePublicKey while referenced: status %d, want 409", delW.Code)
+	}
+}
+
+func TestKeyGroup_DeleteWhileReferencedByDistributionFails(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store)
+	ctx := context.Background()
+
+	pk, err := store.CreatePublicKey(ctx, &PublicKeyConfig{CallerReference: "r", Name: "k", EncodedKey: samplePEM})
+	if err != nil {
+		t.Fatalf("CreatePublicKey: %v", err)
+	}
+
+	group, err := store.CreateKeyGroup(ctx, &KeyGroupConfig{Name: "g", Items: []string{pk.ID}})
+	if err != nil {
+		t.Fatalf("CreateKeyGroup: %v", err)
+	}
+
+	// Stand up a distribution whose default cache behavior trusts our key group.
+	store.Distributions["DIST123"] = &Distribution{
+		ID: "DIST123",
+		DistributionConfig: &DistributionConfig{
+			DefaultCacheBehavior: &DefaultCacheBehavior{
+				TrustedKeyGroups: &TrustedKeyGroups{Enabled: true, Quantity: 1, Items: []string{group.ID}},
+			},
+		},
+	}
+
+	delReq := httptest.NewRequest(http.MethodDelete, "/2020-05-31/key-group/"+group.ID, http.NoBody)
+	delReq.SetPathValue("id", group.ID)
+
+	delW := httptest.NewRecorder()
+	svc.DeleteKeyGroup(delW, delReq)
+
+	if delW.Code != http.StatusConflict {
+		t.Fatalf("DeleteKeyGroup while referenced: status %d, want 409", delW.Code)
+	}
+}

--- a/internal/service/cloudfront/service.go
+++ b/internal/service/cloudfront/service.go
@@ -53,11 +53,18 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("POST", "/2020-05-31/distribution/{id}/invalidation", s.CreateInvalidation)
 	r.Handle("GET", "/2020-05-31/distribution/{id}/invalidation/{invalidationId}", s.GetInvalidation)
 
-	// Edge — proxies real requests through the cache layer. Lives
-	// under /kumo (the existing admin prefix) so it doesn't collide
-	// with the S3 wildcard /{bucket}/{key...}. Non-cacheable methods
-	// (PUT/POST/DELETE/PATCH) bypass the cache and pass through to
-	// the origin.
+	// PublicKey + KeyGroup — building blocks for signed URL / signed cookie verification.
+	r.Handle("POST", "/2020-05-31/public-key", s.CreatePublicKey)
+	r.Handle("GET", "/2020-05-31/public-key", s.ListPublicKeys)
+	r.Handle("GET", "/2020-05-31/public-key/{id}", s.GetPublicKey)
+	r.Handle("DELETE", "/2020-05-31/public-key/{id}", s.DeletePublicKey)
+
+	r.Handle("POST", "/2020-05-31/key-group", s.CreateKeyGroup)
+	r.Handle("GET", "/2020-05-31/key-group", s.ListKeyGroups)
+	r.Handle("GET", "/2020-05-31/key-group/{id}", s.GetKeyGroup)
+	r.Handle("DELETE", "/2020-05-31/key-group/{id}", s.DeleteKeyGroup)
+
+	// Edge — proxies real requests through the cache layer.
 	for _, method := range []string{"GET", "HEAD", "PUT", "POST", "DELETE", "PATCH"} {
 		r.Handle(method, "/kumo/cdn/{distributionId}/{path...}", s.Edge)
 	}

--- a/internal/service/cloudfront/storage.go
+++ b/internal/service/cloudfront/storage.go
@@ -65,6 +65,10 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	s := &MemoryStorage{
 		Distributions: make(map[string]*Distribution),
 		Invalidations: make(map[string]map[string]*Invalidation),
+		signing: signingStore{
+			PublicKeys: make(map[string]*PublicKey),
+			KeyGroups:  make(map[string]*KeyGroup),
+		},
 	}
 	for _, o := range opts {
 		o(s)
@@ -112,6 +116,8 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 	if s.Invalidations == nil {
 		s.Invalidations = make(map[string]map[string]*Invalidation)
 	}
+
+	s.ensureSigningInit()
 
 	return nil
 }

--- a/internal/service/cloudfront/storage.go
+++ b/internal/service/cloudfront/storage.go
@@ -22,6 +22,17 @@ type Storage interface {
 	CreateInvalidation(ctx context.Context, distributionID string, batch *CreateInvalidationRequest) (*Invalidation, error)
 	GetInvalidation(ctx context.Context, distributionID, invalidationID string) (*Invalidation, error)
 	ListInvalidations(ctx context.Context, distributionID, marker string, maxItems int) ([]*Invalidation, string, error)
+
+	// Signed URL building blocks.
+	CreatePublicKey(ctx context.Context, cfg *PublicKeyConfig) (*PublicKey, error)
+	GetPublicKey(ctx context.Context, id string) (*PublicKey, error)
+	ListPublicKeys(ctx context.Context) []*PublicKey
+	DeletePublicKey(ctx context.Context, id string) error
+
+	CreateKeyGroup(ctx context.Context, cfg *KeyGroupConfig) (*KeyGroup, error)
+	GetKeyGroup(ctx context.Context, id string) (*KeyGroup, error)
+	ListKeyGroups(ctx context.Context) []*KeyGroup
+	DeleteKeyGroup(ctx context.Context, id string) error
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -45,6 +56,7 @@ type MemoryStorage struct {
 	mu            sync.RWMutex                        `json:"-"`
 	Distributions map[string]*Distribution            `json:"distributions"`
 	Invalidations map[string]map[string]*Invalidation `json:"invalidations"` // distributionID -> invalidationID -> Invalidation
+	signing       signingStore
 	dataDir       string
 }
 

--- a/internal/service/cloudfront/storage_signing.go
+++ b/internal/service/cloudfront/storage_signing.go
@@ -50,8 +50,6 @@ func (s *MemoryStorage) GetPublicKey(_ context.Context, id string) (*PublicKey, 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	s.ensureSigningInit()
-
 	k, ok := s.signing.PublicKeys[id]
 	if !ok {
 		return nil, &Error{Code: errNoSuchPublicKey, Message: fmt.Sprintf("The public key %s does not exist", id)}
@@ -66,8 +64,6 @@ func (s *MemoryStorage) GetPublicKey(_ context.Context, id string) (*PublicKey, 
 func (s *MemoryStorage) ListPublicKeys(_ context.Context) []*PublicKey {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
-	s.ensureSigningInit()
 
 	out := make([]*PublicKey, 0, len(s.signing.PublicKeys))
 	for _, k := range s.signing.PublicKeys {
@@ -144,8 +140,6 @@ func (s *MemoryStorage) GetKeyGroup(_ context.Context, id string) (*KeyGroup, er
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	s.ensureSigningInit()
-
 	g, ok := s.signing.KeyGroups[id]
 	if !ok {
 		return nil, &Error{Code: errNoSuchKeyGroup, Message: fmt.Sprintf("The key group %s does not exist", id)}
@@ -158,8 +152,6 @@ func (s *MemoryStorage) GetKeyGroup(_ context.Context, id string) (*KeyGroup, er
 func (s *MemoryStorage) ListKeyGroups(_ context.Context) []*KeyGroup {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
-	s.ensureSigningInit()
 
 	out := make([]*KeyGroup, 0, len(s.signing.KeyGroups))
 	for _, g := range s.signing.KeyGroups {

--- a/internal/service/cloudfront/storage_signing.go
+++ b/internal/service/cloudfront/storage_signing.go
@@ -1,0 +1,243 @@
+package cloudfront
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SigningStorage is the in-memory store for PublicKey + KeyGroup
+// resources. Distributions reference KeyGroups by ID via
+// TrustedKeyGroups on a CacheBehavior.
+//
+// Lives on MemoryStorage but kept in its own file so the signing
+// surface can be reviewed in isolation from Distribution / Invalidation.
+type signingStore struct {
+	PublicKeys map[string]*PublicKey `json:"publicKeys"`
+	KeyGroups  map[string]*KeyGroup  `json:"keyGroups"`
+}
+
+// CreatePublicKey adds a new PublicKey. CallerReference dedupes — a
+// duplicate returns 409 (PublicKeyAlreadyExists), matching real CF.
+func (s *MemoryStorage) CreatePublicKey(_ context.Context, cfg *PublicKeyConfig) (*PublicKey, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ensureSigningInit()
+
+	for _, k := range s.signing.PublicKeys {
+		if k.PublicKeyConfig != nil && k.PublicKeyConfig.CallerReference == cfg.CallerReference {
+			return nil, &Error{Code: errPublicKeyAlreadyExists, Message: fmt.Sprintf("A public key with caller reference %s already exists", cfg.CallerReference)}
+		}
+	}
+
+	key := &PublicKey{
+		ID:              generatePublicKeyID(),
+		CreatedTime:     time.Now(),
+		ETag:            generateETag(),
+		PublicKeyConfig: cfg,
+	}
+	s.signing.PublicKeys[key.ID] = key
+
+	return key, nil
+}
+
+// GetPublicKey retrieves a PublicKey by ID.
+func (s *MemoryStorage) GetPublicKey(_ context.Context, id string) (*PublicKey, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	s.ensureSigningInit()
+
+	k, ok := s.signing.PublicKeys[id]
+	if !ok {
+		return nil, &Error{Code: errNoSuchPublicKey, Message: fmt.Sprintf("The public key %s does not exist", id)}
+	}
+
+	return k, nil
+}
+
+// ListPublicKeys returns every stored PublicKey, sorted by ID for
+// deterministic output. (CloudFront does not paginate this endpoint
+// in practice — at most ~25 keys per account.)
+func (s *MemoryStorage) ListPublicKeys(_ context.Context) []*PublicKey {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	s.ensureSigningInit()
+
+	out := make([]*PublicKey, 0, len(s.signing.PublicKeys))
+	for _, k := range s.signing.PublicKeys {
+		out = append(out, k)
+	}
+
+	sortByID(out, func(k *PublicKey) string { return k.ID })
+
+	return out
+}
+
+// DeletePublicKey removes a PublicKey. Returns PublicKeyInUse if any
+// KeyGroup still references it — matches real CloudFront's safety net.
+func (s *MemoryStorage) DeletePublicKey(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ensureSigningInit()
+
+	if _, ok := s.signing.PublicKeys[id]; !ok {
+		return &Error{Code: errNoSuchPublicKey, Message: fmt.Sprintf("The public key %s does not exist", id)}
+	}
+
+	for _, g := range s.signing.KeyGroups {
+		if g.KeyGroupConfig == nil {
+			continue
+		}
+
+		for _, ref := range g.KeyGroupConfig.Items {
+			if ref == id {
+				return &Error{Code: errPublicKeyInUse, Message: fmt.Sprintf("Public key %s is referenced by key group %s", id, g.ID)}
+			}
+		}
+	}
+
+	delete(s.signing.PublicKeys, id)
+
+	return nil
+}
+
+// CreateKeyGroup adds a new KeyGroup. All referenced PublicKey IDs
+// must exist; otherwise NoSuchPublicKey is returned.
+func (s *MemoryStorage) CreateKeyGroup(_ context.Context, cfg *KeyGroupConfig) (*KeyGroup, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ensureSigningInit()
+
+	for _, ref := range cfg.Items {
+		if _, ok := s.signing.PublicKeys[ref]; !ok {
+			return nil, &Error{Code: errNoSuchPublicKey, Message: fmt.Sprintf("The public key %s does not exist", ref)}
+		}
+	}
+
+	for _, g := range s.signing.KeyGroups {
+		if g.KeyGroupConfig != nil && g.KeyGroupConfig.Name == cfg.Name {
+			return nil, &Error{Code: errKeyGroupAlreadyExists, Message: fmt.Sprintf("A key group named %s already exists", cfg.Name)}
+		}
+	}
+
+	group := &KeyGroup{
+		ID:             generateKeyGroupID(),
+		LastModified:   time.Now(),
+		ETag:           generateETag(),
+		KeyGroupConfig: cfg,
+	}
+	s.signing.KeyGroups[group.ID] = group
+
+	return group, nil
+}
+
+// GetKeyGroup retrieves a KeyGroup by ID.
+func (s *MemoryStorage) GetKeyGroup(_ context.Context, id string) (*KeyGroup, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	s.ensureSigningInit()
+
+	g, ok := s.signing.KeyGroups[id]
+	if !ok {
+		return nil, &Error{Code: errNoSuchKeyGroup, Message: fmt.Sprintf("The key group %s does not exist", id)}
+	}
+
+	return g, nil
+}
+
+// ListKeyGroups returns every stored KeyGroup, sorted by ID.
+func (s *MemoryStorage) ListKeyGroups(_ context.Context) []*KeyGroup {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	s.ensureSigningInit()
+
+	out := make([]*KeyGroup, 0, len(s.signing.KeyGroups))
+	for _, g := range s.signing.KeyGroups {
+		out = append(out, g)
+	}
+
+	sortByID(out, func(g *KeyGroup) string { return g.ID })
+
+	return out
+}
+
+// DeleteKeyGroup removes a KeyGroup. Returns ResourceInUse if any
+// Distribution references it via TrustedKeyGroups.
+func (s *MemoryStorage) DeleteKeyGroup(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ensureSigningInit()
+
+	if _, ok := s.signing.KeyGroups[id]; !ok {
+		return &Error{Code: errNoSuchKeyGroup, Message: fmt.Sprintf("The key group %s does not exist", id)}
+	}
+
+	for _, d := range s.Distributions {
+		if d.DistributionConfig == nil || d.DistributionConfig.DefaultCacheBehavior == nil {
+			continue
+		}
+
+		dcb := d.DistributionConfig.DefaultCacheBehavior
+		if dcb.TrustedKeyGroups == nil {
+			continue
+		}
+
+		for _, ref := range dcb.TrustedKeyGroups.Items {
+			if ref == id {
+				return &Error{Code: errKeyGroupReferencedError, Message: fmt.Sprintf("Key group %s is referenced by distribution %s", id, d.ID)}
+			}
+		}
+	}
+
+	delete(s.signing.KeyGroups, id)
+
+	return nil
+}
+
+// ensureSigningInit lazily initializes the signing maps. JSON
+// unmarshal of legacy state files leaves them nil, so guard at every
+// entry point. Caller MUST hold the appropriate lock.
+func (s *MemoryStorage) ensureSigningInit() {
+	if s.signing.PublicKeys == nil {
+		s.signing.PublicKeys = make(map[string]*PublicKey)
+	}
+
+	if s.signing.KeyGroups == nil {
+		s.signing.KeyGroups = make(map[string]*KeyGroup)
+	}
+}
+
+func generatePublicKeyID() string {
+	return "K" + randomID(13)
+}
+
+func generateKeyGroupID() string {
+	return randomID(36) // UUID-like
+}
+
+func randomID(n int) string {
+	b := make([]byte, (n+1)/2)
+
+	_, _ = rand.Read(b)
+
+	return strings.ToUpper(hex.EncodeToString(b))[:n]
+}
+
+func sortByID[T any](items []T, key func(T) string) {
+	for i := 1; i < len(items); i++ {
+		for j := i; j > 0 && key(items[j]) < key(items[j-1]); j-- {
+			items[j], items[j-1] = items[j-1], items[j]
+		}
+	}
+}

--- a/internal/service/cloudfront/types_signing.go
+++ b/internal/service/cloudfront/types_signing.go
@@ -1,0 +1,125 @@
+package cloudfront
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+// CloudFront signing-related error codes.
+const (
+	errNoSuchPublicKey         = "NoSuchPublicKey"
+	errNoSuchKeyGroup          = "NoSuchResource"
+	errPublicKeyAlreadyExists  = "PublicKeyAlreadyExists"
+	errKeyGroupAlreadyExists   = "KeyGroupAlreadyExists"
+	errPublicKeyInUse          = "PublicKeyInUse"
+	errKeyGroupReferencedError = "ResourceInUse"
+)
+
+// PublicKey is a CloudFront-managed RSA public key. Used as a building
+// block for signed URL / signed cookie verification: a KeyGroup
+// references one or more PublicKeys, and a Distribution references
+// KeyGroups via TrustedKeyGroups on a CacheBehavior.
+type PublicKey struct {
+	ID              string
+	CreatedTime     time.Time
+	ETag            string
+	PublicKeyConfig *PublicKeyConfig
+}
+
+// PublicKeyConfig is the user-supplied configuration of a PublicKey.
+type PublicKeyConfig struct {
+	CallerReference string
+	Name            string
+	EncodedKey      string // PEM-encoded RSA public key
+	Comment         string
+}
+
+// KeyGroup groups one or more PublicKey IDs that a Distribution can
+// reference via TrustedKeyGroups.
+type KeyGroup struct {
+	ID             string
+	LastModified   time.Time
+	ETag           string
+	KeyGroupConfig *KeyGroupConfig
+}
+
+// KeyGroupConfig is the user-supplied configuration of a KeyGroup.
+type KeyGroupConfig struct {
+	Name    string
+	Items   []string // PublicKey IDs
+	Comment string
+}
+
+// Wire (XML) types for the CloudFront 2020-05-31 API.
+
+// PublicKeyConfigXML is the XML view of PublicKeyConfig — also used as
+// the request body for CreatePublicKey.
+type PublicKeyConfigXML struct {
+	XMLName         xml.Name `xml:"PublicKeyConfig"`
+	Xmlns           string   `xml:"xmlns,attr,omitempty"`
+	CallerReference string   `xml:"CallerReference"`
+	Name            string   `xml:"Name"`
+	EncodedKey      string   `xml:"EncodedKey"`
+	Comment         string   `xml:"Comment,omitempty"`
+}
+
+// PublicKeyResultXML is the XML body of GetPublicKey / CreatePublicKey
+// responses.
+type PublicKeyResultXML struct {
+	XMLName         xml.Name            `xml:"PublicKey"`
+	Xmlns           string              `xml:"xmlns,attr"`
+	ID              string              `xml:"Id"`
+	CreatedTime     string              `xml:"CreatedTime"`
+	PublicKeyConfig *PublicKeyConfigXML `xml:"PublicKeyConfig"`
+}
+
+// PublicKeyListXML is the body of ListPublicKeys.
+type PublicKeyListXML struct {
+	XMLName  xml.Name              `xml:"PublicKeyList"`
+	Xmlns    string                `xml:"xmlns,attr"`
+	MaxItems int                   `xml:"MaxItems"`
+	Quantity int                   `xml:"Quantity"`
+	Items    []PublicKeySummaryXML `xml:"Items>PublicKeySummary,omitempty"`
+}
+
+// PublicKeySummaryXML is one item in PublicKeyList.
+type PublicKeySummaryXML struct {
+	ID          string `xml:"Id"`
+	Name        string `xml:"Name"`
+	CreatedTime string `xml:"CreatedTime"`
+	EncodedKey  string `xml:"EncodedKey"`
+	Comment     string `xml:"Comment,omitempty"`
+}
+
+// KeyGroupConfigXML is the XML view of KeyGroupConfig.
+type KeyGroupConfigXML struct {
+	XMLName xml.Name `xml:"KeyGroupConfig"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty"`
+	Name    string   `xml:"Name"`
+	Items   []string `xml:"Items>PublicKey"`
+	Comment string   `xml:"Comment,omitempty"`
+}
+
+// KeyGroupResultXML is the XML body of GetKeyGroup / CreateKeyGroup
+// responses.
+type KeyGroupResultXML struct {
+	XMLName        xml.Name           `xml:"KeyGroup"`
+	Xmlns          string             `xml:"xmlns,attr"`
+	ID             string             `xml:"Id"`
+	LastModified   string             `xml:"LastModifiedTime"`
+	KeyGroupConfig *KeyGroupConfigXML `xml:"KeyGroupConfig"`
+}
+
+// KeyGroupListXML is the body of ListKeyGroups.
+type KeyGroupListXML struct {
+	XMLName  xml.Name             `xml:"KeyGroupList"`
+	Xmlns    string               `xml:"xmlns,attr"`
+	MaxItems int                  `xml:"MaxItems"`
+	Quantity int                  `xml:"Quantity"`
+	Items    []KeyGroupSummaryXML `xml:"Items>KeyGroupSummary,omitempty"`
+}
+
+// KeyGroupSummaryXML is one item in KeyGroupList.
+type KeyGroupSummaryXML struct {
+	KeyGroup KeyGroupResultXML `xml:"KeyGroup"`
+}


### PR DESCRIPTION
## Summary

CloudFront signed URLs / signed cookies are configured by attaching a \`TrustedKeyGroups\` list to a CacheBehavior — the distribution then rejects requests whose URL signature does not match a public key in one of those groups.

The \`TrustedKeyGroups\` field already existed on \`DistributionConfig\`, but the underlying **\`PublicKey\`** and **\`KeyGroup\`** resources had no CRUD surface. As a result terraform / pulumi / alchemy could not even stand up the configuration end-to-end. This PR fills in the management plane.

## Endpoints

| Method | Path | Op |
|---|---|---|
| POST   | \`/2020-05-31/public-key\` | CreatePublicKey |
| GET    | \`/2020-05-31/public-key\` | ListPublicKeys |
| GET    | \`/2020-05-31/public-key/{id}\` | GetPublicKey |
| DELETE | \`/2020-05-31/public-key/{id}\` | DeletePublicKey |
| POST   | \`/2020-05-31/key-group\` | CreateKeyGroup |
| GET    | \`/2020-05-31/key-group\` | ListKeyGroups |
| GET    | \`/2020-05-31/key-group/{id}\` | GetKeyGroup |
| DELETE | \`/2020-05-31/key-group/{id}\` | DeleteKeyGroup |

## Referential safety (matches real CloudFront)

| Action | Status | Code |
|---|---|---|
| CreateKeyGroup with Items pointing at unknown PublicKey | 404 | NoSuchPublicKey |
| DeletePublicKey while still in any KeyGroup | 409 | PublicKeyInUse |
| DeleteKeyGroup while still in any Distribution's TrustedKeyGroups | 409 | ResourceInUse |
| Duplicate CallerReference on CreatePublicKey | 409 | PublicKeyAlreadyExists |
| Duplicate Name on CreateKeyGroup | 409 | KeyGroupAlreadyExists |

## Out of scope (planned follow-up)

**Actual signature verification at the edge handler is intentionally not in this PR.** With the management plane landed, a follow-up can hook into the edge cache layer (\`internal/service/cloudfront/edge\` from #583) and reject unsigned / invalid-signature requests on distributions whose CacheBehavior has \`TrustedKeyGroups.Enabled=true\`.

The split keeps the diff reviewable: this is pure CRUD + ref-counting against existing types, no crypto.

## Files added

- \`internal/service/cloudfront/types_signing.go\` — model + XML wire types
- \`internal/service/cloudfront/storage_signing.go\` — in-memory CRUD with referential safety
- \`internal/service/cloudfront/handlers_signing.go\` — HTTP handlers + helper

The signing data lives in a \`signing\` field on \`MemoryStorage\`, zero-initialised lazily so JSON state files predating this change still load cleanly.

## Test plan

- [x] \`go test ./internal/service/cloudfront/\` — 5 tests:
  - \`TestPublicKey_CreateGetListDelete\` — round-trip + 404 after delete
  - \`TestPublicKey_DuplicateCallerReferenceConflicts\` — 409
  - \`TestKeyGroup_CreateRejectsUnknownPublicKey\` — 404
  - \`TestKeyGroup_CreateGetListAndPublicKeyInUseBlock\` — 409 on PublicKey delete while referenced
  - \`TestKeyGroup_DeleteWhileReferencedByDistributionFails\` — 409
- [x] Full suite \`go test ./...\` — green
- [x] \`make lint\` — clean