### PR TITLE
feat(s3): conditional requests + presigned response-* overrides + ListObjectsV1 + Object ACL

### DIFF
--- a/internal/service/s3/conditional.go
+++ b/internal/service/s3/conditional.go
@@ -1,0 +1,102 @@
+package s3
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+// preconditionResult is the outcome of evaluating RFC 9110 conditional
+// request headers against an object's ETag + Last-Modified.
+type preconditionResult int
+
+const (
+	preconditionPass         preconditionResult = iota // request should proceed normally
+	preconditionNotModified                            // GET/HEAD → 304 Not Modified
+	preconditionFailed                                 // any → 412 Precondition Failed
+)
+
+// evalGetObjectPreconditions implements RFC 9110 §13.1 evaluation order
+// for GET/HEAD: If-Match → If-Unmodified-Since → If-None-Match →
+// If-Modified-Since.
+//
+// Precondition headers are commonly used for cache revalidation
+// (`If-None-Match`) and optimistic concurrency (`If-Match`).
+func evalGetObjectPreconditions(h http.Header, etag string, lastModified time.Time) preconditionResult {
+	if v := h.Get("If-Match"); v != "" {
+		if !matchesAnyETag(v, etag) {
+			return preconditionFailed
+		}
+	} else if v := h.Get("If-Unmodified-Since"); v != "" {
+		if t, err := http.ParseTime(v); err == nil && lastModified.After(t) {
+			return preconditionFailed
+		}
+	}
+
+	if v := h.Get("If-None-Match"); v != "" {
+		if matchesAnyETag(v, etag) {
+			return preconditionNotModified
+		}
+	} else if v := h.Get("If-Modified-Since"); v != "" {
+		if t, err := http.ParseTime(v); err == nil && !lastModified.After(t) {
+			return preconditionNotModified
+		}
+	}
+
+	return preconditionPass
+}
+
+// evalCopySourcePreconditions implements the AWS S3 CopyObject
+// `x-amz-copy-source-if-*` family (semantically the same as the
+// HTTP-level conditionals above, just on the *source* object). All
+// failures collapse to 412 — there's no "304" path on copy.
+func evalCopySourcePreconditions(h http.Header, etag string, lastModified time.Time) bool {
+	if v := h.Get("X-Amz-Copy-Source-If-Match"); v != "" {
+		if !matchesAnyETag(v, etag) {
+			return false
+		}
+	}
+
+	if v := h.Get("X-Amz-Copy-Source-If-None-Match"); v != "" {
+		if matchesAnyETag(v, etag) {
+			return false
+		}
+	}
+
+	if v := h.Get("X-Amz-Copy-Source-If-Unmodified-Since"); v != "" {
+		if t, err := http.ParseTime(v); err == nil && lastModified.After(t) {
+			return false
+		}
+	}
+
+	if v := h.Get("X-Amz-Copy-Source-If-Modified-Since"); v != "" {
+		if t, err := http.ParseTime(v); err == nil && !lastModified.After(t) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// matchesAnyETag returns true if `etag` matches any token in a
+// comma-separated If-*-Match header value, or if the header is `*`
+// (RFC 9110 §13.1.1: `*` matches if any selected representation
+// exists, which for a successful GetObject lookup is always true).
+//
+// ETag comparison is the *strong* variant per RFC 9110 §8.8.3.2 —
+// kumo doesn't emit `W/"..."` weak ETags, and AWS S3 doesn't either,
+// so quoted-string equality is sufficient.
+func matchesAnyETag(headerValue, etag string) bool {
+	v := strings.TrimSpace(headerValue)
+	if v == "*" {
+		return true
+	}
+
+	for _, raw := range strings.Split(v, ",") {
+		if strings.TrimSpace(raw) == etag {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/service/s3/conditional.go
+++ b/internal/service/s3/conditional.go
@@ -11,9 +11,9 @@ import (
 type preconditionResult int
 
 const (
-	preconditionPass         preconditionResult = iota // request should proceed normally
-	preconditionNotModified                            // GET/HEAD → 304 Not Modified
-	preconditionFailed                                 // any → 412 Precondition Failed
+	preconditionPass        preconditionResult = iota // request should proceed normally
+	preconditionNotModified                           // GET/HEAD → 304 Not Modified
+	preconditionFailed                                // any → 412 Precondition Failed
 )
 
 // evalGetObjectPreconditions implements RFC 9110 §13.1 evaluation order

--- a/internal/service/s3/conditional_test.go
+++ b/internal/service/s3/conditional_test.go
@@ -1,0 +1,201 @@
+package s3
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testETag = `"abc123"`
+	testTime = "Mon, 01 Jan 2024 12:00:00 GMT"
+)
+
+func parseTestTime(t *testing.T) time.Time {
+	t.Helper()
+
+	parsed, err := http.ParseTime(testTime)
+	if err != nil {
+		t.Fatalf("parse test time: %v", err)
+	}
+
+	return parsed
+}
+
+// TestEvalGetObjectPreconditions covers the RFC 9110 §13.1 evaluation
+// order for GET/HEAD precondition headers.
+func TestEvalGetObjectPreconditions(t *testing.T) {
+	t.Parallel()
+
+	lastModified := parseTestTime(t)
+	earlier := lastModified.Add(-1 * time.Hour).UTC().Format(timeFormatHTTP)
+	later := lastModified.Add(time.Hour).UTC().Format(timeFormatHTTP)
+
+	cases := []struct {
+		name string
+		hdr  http.Header
+		want preconditionResult
+	}{
+		{"empty", http.Header{}, preconditionPass},
+		{"if-match hit", http.Header{"If-Match": []string{testETag}}, preconditionPass},
+		{"if-match miss", http.Header{"If-Match": []string{`"different"`}}, preconditionFailed},
+		{"if-match wildcard", http.Header{"If-Match": []string{"*"}}, preconditionPass},
+		{"if-none-match hit", http.Header{"If-None-Match": []string{testETag}}, preconditionNotModified},
+		{"if-none-match miss", http.Header{"If-None-Match": []string{`"different"`}}, preconditionPass},
+		{"if-modified-since older", http.Header{"If-Modified-Since": []string{earlier}}, preconditionPass},
+		{"if-modified-since same/newer", http.Header{"If-Modified-Since": []string{later}}, preconditionNotModified},
+		{"if-unmodified-since older → fail", http.Header{"If-Unmodified-Since": []string{earlier}}, preconditionFailed},
+		{"if-unmodified-since newer → pass", http.Header{"If-Unmodified-Since": []string{later}}, preconditionPass},
+		{"if-match wins over if-unmodified-since", http.Header{
+			"If-Match":            []string{testETag},
+			"If-Unmodified-Since": []string{earlier},
+		}, preconditionPass},
+		{"if-none-match wins over if-modified-since", http.Header{
+			"If-None-Match":     []string{testETag},
+			"If-Modified-Since": []string{earlier},
+		}, preconditionNotModified},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evalGetObjectPreconditions(tc.hdr, testETag, lastModified)
+			if got != tc.want {
+				t.Fatalf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvalCopySourcePreconditions(t *testing.T) {
+	t.Parallel()
+
+	lastModified := parseTestTime(t)
+	earlier := lastModified.Add(-1 * time.Hour).UTC().Format(timeFormatHTTP)
+
+	cases := []struct {
+		name string
+		hdr  http.Header
+		want bool
+	}{
+		{"empty", http.Header{}, true},
+		{"copy-source-if-match hit", http.Header{"X-Amz-Copy-Source-If-Match": []string{testETag}}, true},
+		{"copy-source-if-match miss", http.Header{"X-Amz-Copy-Source-If-Match": []string{`"x"`}}, false},
+		{"copy-source-if-none-match hit", http.Header{"X-Amz-Copy-Source-If-None-Match": []string{testETag}}, false},
+		{"copy-source-if-unmodified-since older", http.Header{"X-Amz-Copy-Source-If-Unmodified-Since": []string{earlier}}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evalCopySourcePreconditions(tc.hdr, testETag, lastModified)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGetObject_ConditionalRequests confirms the HTTP-layer wiring:
+// 304 on If-None-Match hit, 412 on If-Match miss, normal 200 otherwise.
+func TestGetObject_ConditionalRequests(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, "cb")
+	obj, _ := store.PutObject(ctx, "cb", "k", strings.NewReader("hello"), nil)
+
+	cases := []struct {
+		name       string
+		header     string
+		value      string
+		wantStatus int
+	}{
+		{"plain GET", "", "", http.StatusOK},
+		{"If-None-Match hit → 304", "If-None-Match", obj.ETag, http.StatusNotModified},
+		{"If-Match miss → 412", "If-Match", `"never-matches"`, http.StatusPreconditionFailed},
+		{"If-Match hit → 200", "If-Match", obj.ETag, http.StatusOK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/cb/k", http.NoBody)
+			req.SetPathValue("bucket", "cb")
+			req.SetPathValue("key", "k")
+
+			if tc.header != "" {
+				req.Header.Set(tc.header, tc.value)
+			}
+
+			w := httptest.NewRecorder()
+			svc.GetObject(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status: got %d, want %d (body=%s)", w.Code, tc.wantStatus, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestGetObject_ResponseHeaderOverrides confirms response-* query
+// parameters override the default Content-Type / Content-Disposition
+// etc. on the GetObject response.
+func TestGetObject_ResponseHeaderOverrides(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, "rb")
+	_, _ = store.PutObject(ctx, "rb", "k", strings.NewReader("body"), nil)
+
+	const (
+		wantCT = "text/csv"
+		wantCD = `attachment; filename="report.csv"`
+		wantCC = "no-cache"
+	)
+
+	url := "/rb/k?response-content-type=" + wantCT +
+		"&response-content-disposition=" + httpQueryEscape(wantCD) +
+		"&response-cache-control=" + wantCC
+
+	req := httptest.NewRequest(http.MethodGet, url, http.NoBody)
+	req.SetPathValue("bucket", "rb")
+	req.SetPathValue("key", "k")
+
+	w := httptest.NewRecorder()
+	svc.GetObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	if got := w.Header().Get("Content-Type"); got != wantCT {
+		t.Fatalf("Content-Type: got %q, want %q", got, wantCT)
+	}
+
+	if got := w.Header().Get("Content-Disposition"); got != wantCD {
+		t.Fatalf("Content-Disposition: got %q, want %q", got, wantCD)
+	}
+
+	if got := w.Header().Get("Cache-Control"); got != wantCC {
+		t.Fatalf("Cache-Control: got %q, want %q", got, wantCC)
+	}
+}
+
+// httpQueryEscape locally avoids the net/url import jolt — we only
+// need it in one spot for a header value with quotes/spaces.
+func httpQueryEscape(s string) string {
+	out := strings.NewReplacer(
+		" ", "%20",
+		`"`, "%22",
+		`;`, "%3B",
+	).Replace(s)
+
+	return out
+}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -287,6 +287,12 @@ func (s *Service) handleBucketPost(w http.ResponseWriter, r *http.Request) {
 func (s *Service) handleObjectPut(w http.ResponseWriter, r *http.Request) {
 	s.applyCORSHeaders(w, r, r.PathValue("bucket"))
 
+	if r.URL.Query().Has("acl") {
+		s.PutObjectACL(w, r)
+
+		return
+	}
+
 	if r.URL.Query().Has("tagging") {
 		s.PutObjectTagging(w, r)
 
@@ -317,6 +323,12 @@ func (s *Service) handleObjectPut(w http.ResponseWriter, r *http.Request) {
 // handleObjectGet dispatches GET /{bucket}/{key} requests based on query parameters.
 func (s *Service) handleObjectGet(w http.ResponseWriter, r *http.Request) {
 	s.applyCORSHeaders(w, r, r.PathValue("bucket"))
+
+	if r.URL.Query().Has("acl") {
+		s.GetObjectACL(w, r)
+
+		return
+	}
 
 	if r.URL.Query().Has("tagging") {
 		s.GetObjectTagging(w, r)
@@ -557,40 +569,65 @@ func (s *Service) ListObjectsV1(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prefix := r.URL.Query().Get("prefix")
-	delimiter := r.URL.Query().Get("delimiter")
-	marker := r.URL.Query().Get("marker")
+	q := r.URL.Query()
+	params := parseListObjectsV1Params(q)
+
+	const fetchAll = 1 << 30 // sentinel: "give us everything, we paginate in the handler"
+
+	objects, commonPrefixes, err := s.storage.ListObjects(r.Context(), bucket, params.prefix, params.delimiter, fetchAll)
+	if err != nil {
+		writeListObjectsV1Error(w, r, err)
+
+		return
+	}
+
+	objects = sliceObjectsAfterMarker(objects, params.marker)
+
+	truncated := len(objects) > params.maxKeys
+	if truncated {
+		objects = objects[:params.maxKeys]
+	}
+
+	writeXMLResponse(w, buildListBucketResultV1(bucket, params, objects, commonPrefixes, truncated))
+}
+
+// listObjectsV1Params bundles the parsed query-string for a V1 list.
+type listObjectsV1Params struct {
+	prefix    string
+	delimiter string
+	marker    string
+	maxKeys   int
+}
+
+func parseListObjectsV1Params(q map[string][]string) listObjectsV1Params {
 	maxKeys := 1000
 
-	if mks := r.URL.Query().Get("max-keys"); mks != "" {
+	if mks := firstQueryValue(q, "max-keys"); mks != "" {
 		if mk, err := strconv.Atoi(mks); err == nil && mk > 0 {
 			maxKeys = mk
 		}
 	}
 
-	const fetchAll = 1 << 30 // sentinel: "give us everything, we paginate in the handler"
+	return listObjectsV1Params{
+		prefix:    firstQueryValue(q, "prefix"),
+		delimiter: firstQueryValue(q, "delimiter"),
+		marker:    firstQueryValue(q, "marker"),
+		maxKeys:   maxKeys,
+	}
+}
 
-	objects, commonPrefixes, err := s.storage.ListObjects(r.Context(), bucket, prefix, delimiter, fetchAll)
-	if err != nil {
-		var bucketErr *BucketError
-		if errors.As(err, &bucketErr) {
-			writeS3Error(w, r, bucketErr.Code, bucketErr.Message, http.StatusNotFound)
-
-			return
-		}
-
-		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+func writeListObjectsV1Error(w http.ResponseWriter, r *http.Request, err error) {
+	var bucketErr *BucketError
+	if errors.As(err, &bucketErr) {
+		writeS3Error(w, r, bucketErr.Code, bucketErr.Message, http.StatusNotFound)
 
 		return
 	}
 
-	objects = sliceObjectsAfterMarker(objects, marker)
+	writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+}
 
-	truncated := len(objects) > maxKeys
-	if truncated {
-		objects = objects[:maxKeys]
-	}
-
+func buildListBucketResultV1(bucket string, params listObjectsV1Params, objects []Object, commonPrefixes []string, truncated bool) ListBucketResultV1 {
 	contents := make([]ObjectInfo, len(objects))
 	for i := range objects {
 		contents[i] = ObjectInfo{
@@ -608,22 +645,22 @@ func (s *Service) ListObjectsV1(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var nextMarker string
-	if truncated && delimiter != "" && len(contents) > 0 {
+	if truncated && params.delimiter != "" && len(contents) > 0 {
 		nextMarker = contents[len(contents)-1].Key
 	}
 
-	writeXMLResponse(w, ListBucketResultV1{
+	return ListBucketResultV1{
 		Xmlns:          s3Namespace,
 		Name:           bucket,
-		Prefix:         prefix,
-		Marker:         marker,
+		Prefix:         params.prefix,
+		Marker:         params.marker,
 		NextMarker:     nextMarker,
-		MaxKeys:        maxKeys,
-		Delimiter:      delimiter,
+		MaxKeys:        params.maxKeys,
+		Delimiter:      params.delimiter,
 		IsTruncated:    truncated,
 		Contents:       contents,
 		CommonPrefixes: prefixes,
-	})
+	}
 }
 
 // sliceObjectsAfterMarker drops every entry whose Key is <= marker,
@@ -633,8 +670,8 @@ func sliceObjectsAfterMarker(objects []Object, marker string) []Object {
 		return objects
 	}
 
-	for i, o := range objects {
-		if o.Key > marker {
+	for i := range objects {
+		if objects[i].Key > marker {
 			return objects[i:]
 		}
 	}
@@ -805,6 +842,8 @@ func (s *Service) GetObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch evalGetObjectPreconditions(r.Header, obj.ETag, obj.LastModified) {
+	case preconditionPass:
+		// fall through to the normal response below
 	case preconditionFailed:
 		writeS3Error(w, r, "PreconditionFailed", "At least one of the preconditions you specified did not hold.", http.StatusPreconditionFailed)
 

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -620,6 +620,12 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !evalCopySourcePreconditions(r.Header, srcObj.ETag, srcObj.LastModified) {
+		writeS3Error(w, r, "PreconditionFailed", "At least one of the preconditions you specified did not hold.", http.StatusPreconditionFailed)
+
+		return
+	}
+
 	dstObj, err := s.storage.PutObject(r.Context(), dstBucket, dstKey, bytes.NewReader(srcObj.Body), srcObj.Metadata)
 	if err != nil {
 		var bucketErr *BucketError
@@ -696,12 +702,25 @@ func (s *Service) GetObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	switch evalGetObjectPreconditions(r.Header, obj.ETag, obj.LastModified) {
+	case preconditionFailed:
+		writeS3Error(w, r, "PreconditionFailed", "At least one of the preconditions you specified did not hold.", http.StatusPreconditionFailed)
+
+		return
+	case preconditionNotModified:
+		writeNotModifiedResponse(w, obj)
+
+		return
+	}
+
 	if rng := r.Header.Get("Range"); rng != "" {
+		applyResponseHeaderOverrides(w, r.URL.Query())
 		writeRangeOrFull(w, r, obj, rng)
 
 		return
 	}
 
+	applyResponseHeaderOverrides(w, r.URL.Query())
 	writeObjectResponse(w, obj)
 }
 
@@ -734,7 +753,7 @@ func writeRangeOrFull(w http.ResponseWriter, r *http.Request, obj *Object, range
 func writePartialObjectResponse(w http.ResponseWriter, obj *Object, start, end int64) {
 	length := end - start + 1
 
-	w.Header().Set("Content-Type", obj.ContentType)
+	setIfAbsent(w, "Content-Type", obj.ContentType)
 	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
 	w.Header().Set("Content-Range",
 		"bytes "+strconv.FormatInt(start, 10)+"-"+strconv.FormatInt(end, 10)+
@@ -757,6 +776,53 @@ func writePartialObjectResponse(w http.ResponseWriter, obj *Object, start, end i
 	_, _ = w.Write(obj.Body[start : end+1])
 }
 
+// applyResponseHeaderOverrides honours the `response-*` query
+// parameters S3 supports for presigned download URLs (mainly used to
+// force `Content-Disposition: attachment; filename=...` on browser
+// downloads). Overrides win over object metadata.
+func applyResponseHeaderOverrides(w http.ResponseWriter, q map[string][]string) {
+	overrides := map[string]string{
+		"response-content-type":        "Content-Type",
+		"response-content-disposition": "Content-Disposition",
+		"response-cache-control":       "Cache-Control",
+		"response-content-encoding":    "Content-Encoding",
+		"response-content-language":    "Content-Language",
+		"response-expires":             "Expires",
+	}
+
+	for queryKey, headerName := range overrides {
+		if v := firstQueryValue(q, queryKey); v != "" {
+			w.Header().Set(headerName, v)
+		}
+	}
+}
+
+func firstQueryValue(q map[string][]string, key string) string {
+	if v, ok := q[key]; ok && len(v) > 0 {
+		return v[0]
+	}
+
+	return ""
+}
+
+// setIfAbsent sets a response header only when the caller hasn't
+// already set it. Used so that response-header overrides set by
+// presigned-URL query parameters survive the default header writers.
+func setIfAbsent(w http.ResponseWriter, name, value string) {
+	if w.Header().Get(name) == "" {
+		w.Header().Set(name, value)
+	}
+}
+
+// writeNotModifiedResponse writes a 304 with the ETag and
+// Last-Modified of the object so the cache can re-pin its entry per
+// RFC 9111 §4.3.4. No body, no Content-Length.
+func writeNotModifiedResponse(w http.ResponseWriter, obj *Object) {
+	w.Header().Set("ETag", obj.ETag)
+	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(timeFormatHTTP))
+	w.WriteHeader(http.StatusNotModified)
+}
+
 // handleGetObjectError handles errors from GetObject/GetObjectVersion.
 func handleGetObjectError(w http.ResponseWriter, r *http.Request, err error) {
 	var bucketErr *BucketError
@@ -777,8 +843,10 @@ func handleGetObjectError(w http.ResponseWriter, r *http.Request, err error) {
 }
 
 // writeObjectResponse writes the object response with headers and body.
+// Pre-existing header values (e.g. set by applyResponseHeaderOverrides
+// for presigned response-* overrides) are preserved.
 func writeObjectResponse(w http.ResponseWriter, obj *Object) {
-	w.Header().Set("Content-Type", obj.ContentType)
+	setIfAbsent(w, "Content-Type", obj.ContentType)
 	w.Header().Set("Content-Length", strconv.FormatInt(obj.Size, 10))
 	w.Header().Set("ETag", obj.ETag)
 	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(timeFormatHTTP))

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -152,7 +152,13 @@ func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.ListObjects(w, r)
+	if r.URL.Query().Get("list-type") == "2" {
+		s.ListObjects(w, r)
+
+		return
+	}
+
+	s.ListObjectsV1(w, r)
 }
 
 // serveBucketSubresourceStub handles GET requests for bucket sub-resources that
@@ -538,6 +544,102 @@ func (s *Service) ListObjects(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeXMLResponse(w, result)
+}
+
+// ListObjectsV1 handles GET /{bucket} (no list-type=2) — the legacy
+// marker-based listing API. SDK v1, awscli's `aws s3 ls`, and a
+// handful of non-AWS S3 clients still target it.
+func (s *Service) ListObjectsV1(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+	if bucket == "" {
+		writeS3Error(w, r, "InvalidBucketName", "The specified bucket is not valid.", http.StatusBadRequest)
+
+		return
+	}
+
+	prefix := r.URL.Query().Get("prefix")
+	delimiter := r.URL.Query().Get("delimiter")
+	marker := r.URL.Query().Get("marker")
+	maxKeys := 1000
+
+	if mks := r.URL.Query().Get("max-keys"); mks != "" {
+		if mk, err := strconv.Atoi(mks); err == nil && mk > 0 {
+			maxKeys = mk
+		}
+	}
+
+	const fetchAll = 1 << 30 // sentinel: "give us everything, we paginate in the handler"
+
+	objects, commonPrefixes, err := s.storage.ListObjects(r.Context(), bucket, prefix, delimiter, fetchAll)
+	if err != nil {
+		var bucketErr *BucketError
+		if errors.As(err, &bucketErr) {
+			writeS3Error(w, r, bucketErr.Code, bucketErr.Message, http.StatusNotFound)
+
+			return
+		}
+
+		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	objects = sliceObjectsAfterMarker(objects, marker)
+
+	truncated := len(objects) > maxKeys
+	if truncated {
+		objects = objects[:maxKeys]
+	}
+
+	contents := make([]ObjectInfo, len(objects))
+	for i := range objects {
+		contents[i] = ObjectInfo{
+			Key:          objects[i].Key,
+			LastModified: objects[i].LastModified.Format(timeFormatISO),
+			ETag:         objects[i].ETag,
+			Size:         objects[i].Size,
+			StorageClass: "STANDARD",
+		}
+	}
+
+	prefixes := make([]CommonPrefix, len(commonPrefixes))
+	for i, p := range commonPrefixes {
+		prefixes[i] = CommonPrefix{Prefix: p}
+	}
+
+	var nextMarker string
+	if truncated && delimiter != "" && len(contents) > 0 {
+		nextMarker = contents[len(contents)-1].Key
+	}
+
+	writeXMLResponse(w, ListBucketResultV1{
+		Xmlns:          s3Namespace,
+		Name:           bucket,
+		Prefix:         prefix,
+		Marker:         marker,
+		NextMarker:     nextMarker,
+		MaxKeys:        maxKeys,
+		Delimiter:      delimiter,
+		IsTruncated:    truncated,
+		Contents:       contents,
+		CommonPrefixes: prefixes,
+	})
+}
+
+// sliceObjectsAfterMarker drops every entry whose Key is <= marker,
+// matching the V1 spec ("listing starts after the marker key").
+func sliceObjectsAfterMarker(objects []Object, marker string) []Object {
+	if marker == "" {
+		return objects
+	}
+
+	for i, o := range objects {
+		if o.Key > marker {
+			return objects[i:]
+		}
+	}
+
+	return nil
 }
 
 // PutObject handles PUT /{bucket}/{key...} - upload an object.

--- a/internal/service/s3/listobjectsv1_test.go
+++ b/internal/service/s3/listobjectsv1_test.go
@@ -1,0 +1,138 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestListObjectsV1_BasicRoundTrip — without ?list-type=2 the bucket
+// GET handler dispatches to the V1 marker-paginated response shape
+// (no KeyCount, has Marker / NextMarker).
+func TestListObjectsV1_BasicRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, "lb")
+
+	for _, k := range []string{"a", "b", "c"} {
+		_, _ = store.PutObject(ctx, "lb", k, strings.NewReader("x"), nil)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/lb", http.NoBody)
+	req.SetPathValue("bucket", "lb")
+
+	w := httptest.NewRecorder()
+	svc.handleBucketGet(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+
+	var got ListBucketResultV1
+	if err := xml.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
+	}
+
+	if len(got.Contents) != 3 {
+		t.Fatalf("contents: got %d, want 3", len(got.Contents))
+	}
+
+	if got.IsTruncated {
+		t.Fatalf("IsTruncated: got true, want false (small list)")
+	}
+
+	// Crucial: V1 response must NOT contain a KeyCount element.
+	if strings.Contains(w.Body.String(), "<KeyCount>") {
+		t.Fatalf("V1 response leaked <KeyCount> tag: %s", w.Body.String())
+	}
+}
+
+// TestListObjectsV1_MarkerPagination — marker skips entries <= marker
+// and IsTruncated is true while there's more to return.
+func TestListObjectsV1_MarkerPagination(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, "page")
+
+	for _, k := range []string{"a", "b", "c", "d", "e"} {
+		_, _ = store.PutObject(ctx, "page", k, strings.NewReader("x"), nil)
+	}
+
+	// Page 1: max-keys=2
+	req := httptest.NewRequest(http.MethodGet, "/page?max-keys=2", http.NoBody)
+	req.SetPathValue("bucket", "page")
+
+	w := httptest.NewRecorder()
+	svc.handleBucketGet(w, req)
+
+	var page1 ListBucketResultV1
+	_ = xml.Unmarshal(w.Body.Bytes(), &page1)
+
+	if len(page1.Contents) != 2 {
+		t.Fatalf("page1 contents: got %d, want 2", len(page1.Contents))
+	}
+
+	if !page1.IsTruncated {
+		t.Fatalf("page1 IsTruncated: got false, want true (5 total, 2 fetched)")
+	}
+
+	// Page 2: marker=last key from page 1
+	lastKey := page1.Contents[len(page1.Contents)-1].Key
+
+	req2 := httptest.NewRequest(http.MethodGet, "/page?max-keys=2&marker="+lastKey, http.NoBody)
+	req2.SetPathValue("bucket", "page")
+
+	w2 := httptest.NewRecorder()
+	svc.handleBucketGet(w2, req2)
+
+	var page2 ListBucketResultV1
+	_ = xml.Unmarshal(w2.Body.Bytes(), &page2)
+
+	if len(page2.Contents) != 2 {
+		t.Fatalf("page2 contents: got %d, want 2 (entries after marker=%s)", len(page2.Contents), lastKey)
+	}
+
+	for _, c := range page2.Contents {
+		if c.Key <= lastKey {
+			t.Fatalf("page2 key %q should be > marker %q", c.Key, lastKey)
+		}
+	}
+}
+
+// TestListObjectsV2_StillUsesContinuationToken — list-type=2 still
+// dispatches to the V2 path (KeyCount present).
+func TestListObjectsV2_StillUsesContinuationToken(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, "v2")
+	_, _ = store.PutObject(ctx, "v2", "k", strings.NewReader("x"), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2?list-type=2", http.NoBody)
+	req.SetPathValue("bucket", "v2")
+
+	w := httptest.NewRecorder()
+	svc.handleBucketGet(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), "<KeyCount>") {
+		t.Fatalf("V2 response missing <KeyCount>: %s", w.Body.String())
+	}
+}

--- a/internal/service/s3/object_acl.go
+++ b/internal/service/s3/object_acl.go
@@ -1,0 +1,270 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ObjectACL is the in-memory model of an object's Access Control List.
+// kumo doesn't enforce ACL at request time (no permission check on
+// GetObject / PutObject), but persisting the ACL means tools that
+// PutObjectAcl + GetObjectAcl in roundtrip — Cloudtrail-style audit
+// pipelines, S3 compliance scans, terraform `aws_s3_bucket_acl`
+// resources — see consistent state.
+type ObjectACL struct {
+	CannedACL string
+	OwnerID   string
+	OwnerName string
+	Grants    []ACLGrant
+}
+
+// ACLGrant is one entry in an ObjectACL's grant list.
+type ACLGrant struct {
+	GranteeType string // "CanonicalUser" or "Group"
+	GranteeID   string // CanonicalUser ID
+	GranteeURI  string // Group URI
+	DisplayName string
+	Permission  string // "FULL_CONTROL" | "READ" | "WRITE" | "READ_ACP" | "WRITE_ACP"
+}
+
+// XML wire types — match S3's AccessControlPolicy schema.
+
+// AccessControlPolicy is the XML body of GET/PUT object?acl.
+type AccessControlPolicy struct {
+	XMLName xml.Name              `xml:"AccessControlPolicy"`
+	Xmlns   string                `xml:"xmlns,attr,omitempty"`
+	Owner   AccessControlOwner    `xml:"Owner"`
+	ACL     AccessControlListBody `xml:"AccessControlList"`
+}
+
+// AccessControlOwner is the owner of an object in an AccessControlPolicy.
+type AccessControlOwner struct {
+	ID          string `xml:"ID"`
+	DisplayName string `xml:"DisplayName,omitempty"`
+}
+
+// AccessControlListBody is the body of the AccessControlList element.
+type AccessControlListBody struct {
+	Grants []AccessControlGrant `xml:"Grant"`
+}
+
+// AccessControlGrant is one Grant entry in an AccessControlList.
+type AccessControlGrant struct {
+	XMLName    xml.Name             `xml:"Grant"`
+	Grantee    AccessControlGrantee `xml:"Grantee"`
+	Permission string               `xml:"Permission"`
+}
+
+// AccessControlGrantee is the Grantee element of a Grant.
+type AccessControlGrantee struct {
+	XSI         string `xml:"xmlns:xsi,attr,omitempty"`
+	Type        string `xml:"xsi:type,attr"`
+	ID          string `xml:"ID,omitempty"`
+	URI         string `xml:"URI,omitempty"`
+	DisplayName string `xml:"DisplayName,omitempty"`
+}
+
+// PutObjectACL handles PUT /{bucket}/{key}?acl.
+//
+// The grant list comes from one of two sources, mutually exclusive:
+//   - request body XML (AccessControlPolicy)
+//   - `x-amz-acl` header (canned ACL: private, public-read, …)
+//
+// kumo accepts both; precedence matches real S3 — if both arrive the
+// XML body wins.
+func (s *Service) PutObjectACL(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+	key := r.PathValue("key")
+
+	if bucket == "" || key == "" {
+		writeS3Error(w, r, "InvalidArgument", "Invalid bucket or key", http.StatusBadRequest)
+
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeS3Error(w, r, "InvalidRequest", "Failed to read body", http.StatusBadRequest)
+
+		return
+	}
+
+	acl, err := decodeObjectACL(body, r.Header.Get("X-Amz-Acl"))
+	if err != nil {
+		writeS3Error(w, r, "MalformedACLError", err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.PutObjectACL(r.Context(), bucket, key, acl); err != nil {
+		handleObjectACLError(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetObjectACL handles GET /{bucket}/{key}?acl.
+func (s *Service) GetObjectACL(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+	key := r.PathValue("key")
+
+	acl, err := s.storage.GetObjectACL(r.Context(), bucket, key)
+	if err != nil {
+		handleObjectACLError(w, r, err)
+
+		return
+	}
+
+	writeXMLResponse(w, encodeObjectACL(acl))
+}
+
+// decodeObjectACL turns a (body, cannedACL) pair into an ObjectACL.
+// Empty body + empty header → returns the default canned `private`
+// ACL so PutObjectAcl with no payload is still meaningful.
+func decodeObjectACL(body []byte, cannedHeader string) (*ObjectACL, error) {
+	if len(body) > 0 {
+		var p AccessControlPolicy
+		if err := xml.Unmarshal(body, &p); err != nil {
+			return nil, fmt.Errorf("parse AccessControlPolicy XML: %w", err)
+		}
+
+		acl := &ObjectACL{
+			OwnerID:   p.Owner.ID,
+			OwnerName: p.Owner.DisplayName,
+			Grants:    make([]ACLGrant, 0, len(p.ACL.Grants)),
+		}
+
+		for i := range p.ACL.Grants {
+			g := &p.ACL.Grants[i]
+			acl.Grants = append(acl.Grants, ACLGrant{
+				GranteeType: g.Grantee.Type,
+				GranteeID:   g.Grantee.ID,
+				GranteeURI:  g.Grantee.URI,
+				DisplayName: g.Grantee.DisplayName,
+				Permission:  g.Permission,
+			})
+		}
+
+		return acl, nil
+	}
+
+	canned := cannedHeader
+	if canned == "" {
+		canned = "private"
+	}
+
+	return &ObjectACL{CannedACL: canned, OwnerID: "owner-id", OwnerName: "owner"}, nil
+}
+
+// encodeObjectACL renders an ObjectACL back to AccessControlPolicy
+// XML. Canned ACLs are expanded to a synthetic single grant for the
+// owner (FULL_CONTROL) so the response shape is always the same — that
+// matches what real S3 emits when you GetObjectAcl on an object that
+// was set via `x-amz-acl: private`.
+func encodeObjectACL(acl *ObjectACL) *AccessControlPolicy {
+	p := &AccessControlPolicy{
+		Xmlns: s3Namespace,
+		Owner: AccessControlOwner{ID: acl.OwnerID, DisplayName: acl.OwnerName},
+	}
+
+	if len(acl.Grants) == 0 {
+		p.ACL.Grants = []AccessControlGrant{{
+			Grantee: AccessControlGrantee{
+				XSI:         "http://www.w3.org/2001/XMLSchema-instance",
+				Type:        "CanonicalUser",
+				ID:          acl.OwnerID,
+				DisplayName: acl.OwnerName,
+			},
+			Permission: "FULL_CONTROL",
+		}}
+
+		return p
+	}
+
+	p.ACL.Grants = make([]AccessControlGrant, len(acl.Grants))
+	for i, g := range acl.Grants {
+		p.ACL.Grants[i] = AccessControlGrant{
+			Grantee: AccessControlGrantee{
+				XSI:         "http://www.w3.org/2001/XMLSchema-instance",
+				Type:        g.GranteeType,
+				ID:          g.GranteeID,
+				URI:         g.GranteeURI,
+				DisplayName: g.DisplayName,
+			},
+			Permission: g.Permission,
+		}
+	}
+
+	return p
+}
+
+func handleObjectACLError(w http.ResponseWriter, r *http.Request, err error) {
+	var bucketErr *BucketError
+	if errors.As(err, &bucketErr) {
+		writeS3Error(w, r, bucketErr.Code, bucketErr.Message, http.StatusNotFound)
+
+		return
+	}
+
+	var objErr *ObjectError
+	if errors.As(err, &objErr) {
+		writeS3Error(w, r, objErr.Code, objErr.Message, http.StatusNotFound)
+
+		return
+	}
+
+	writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+}
+
+// MemoryStorage hooks for object ACLs.
+
+// PutObjectACL stores an ACL alongside the object.
+func (s *MemoryStorage) PutObjectACL(_ context.Context, bucket, key string, acl *ObjectACL) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if _, ok := b.Objects[key]; !ok {
+		return &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
+	}
+
+	if b.ObjectACLs == nil {
+		b.ObjectACLs = make(map[string]*ObjectACL)
+	}
+
+	b.ObjectACLs[key] = acl
+
+	return nil
+}
+
+// GetObjectACL returns the stored ACL for an object, or a default
+// owner-FULL_CONTROL ACL when none was set.
+func (s *MemoryStorage) GetObjectACL(_ context.Context, bucket, key string) (*ObjectACL, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if _, ok := b.Objects[key]; !ok {
+		return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
+	}
+
+	if acl, ok := b.ObjectACLs[key]; ok {
+		return acl, nil
+	}
+
+	return &ObjectACL{CannedACL: "private", OwnerID: "owner-id", OwnerName: "owner"}, nil
+}

--- a/internal/service/s3/object_acl_test.go
+++ b/internal/service/s3/object_acl_test.go
@@ -1,0 +1,137 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestObjectACL_RoundTripWithCannedHeader — PUT with `x-amz-acl: private`,
+// GET back, expect a single FULL_CONTROL grant for the owner.
+func TestObjectACL_RoundTripWithCannedHeader(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, "ab")
+	_, _ = store.PutObject(ctx, "ab", "k", strings.NewReader("x"), nil)
+
+	putReq := httptest.NewRequest(http.MethodPut, "/ab/k?acl", http.NoBody)
+	putReq.SetPathValue("bucket", "ab")
+	putReq.SetPathValue("key", "k")
+	putReq.Header.Set("X-Amz-Acl", "private")
+
+	putW := httptest.NewRecorder()
+	svc.handleObjectPut(putW, putReq)
+
+	if putW.Code != http.StatusOK {
+		t.Fatalf("PUT acl status: got %d, want 200 (body=%s)", putW.Code, putW.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/ab/k?acl", http.NoBody)
+	getReq.SetPathValue("bucket", "ab")
+	getReq.SetPathValue("key", "k")
+
+	getW := httptest.NewRecorder()
+	svc.handleObjectGet(getW, getReq)
+
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GET acl status: got %d, want 200", getW.Code)
+	}
+
+	var got AccessControlPolicy
+	if err := xml.Unmarshal(getW.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, getW.Body.String())
+	}
+
+	if len(got.ACL.Grants) != 1 {
+		t.Fatalf("grants: got %d, want 1", len(got.ACL.Grants))
+	}
+
+	if got.ACL.Grants[0].Permission != "FULL_CONTROL" {
+		t.Fatalf("permission: got %q, want FULL_CONTROL", got.ACL.Grants[0].Permission)
+	}
+}
+
+// TestObjectACL_RoundTripWithBody — PUT a real grant list via XML body,
+// GET back, expect the same grants.
+func TestObjectACL_RoundTripWithBody(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, "ab")
+	_, _ = store.PutObject(ctx, "ab", "k", strings.NewReader("x"), nil)
+
+	body := AccessControlPolicy{
+		Owner: AccessControlOwner{ID: "user-1", DisplayName: "Alice"},
+		ACL: AccessControlListBody{Grants: []AccessControlGrant{
+			{Grantee: AccessControlGrantee{Type: "CanonicalUser", ID: "user-1", DisplayName: "Alice"}, Permission: "FULL_CONTROL"},
+			{Grantee: AccessControlGrantee{Type: "Group", URI: "http://acs.amazonaws.com/groups/global/AllUsers"}, Permission: "READ"},
+		}},
+	}
+	raw, _ := xml.Marshal(body)
+
+	putReq := httptest.NewRequest(http.MethodPut, "/ab/k?acl", strings.NewReader(string(raw)))
+	putReq.SetPathValue("bucket", "ab")
+	putReq.SetPathValue("key", "k")
+
+	putW := httptest.NewRecorder()
+	svc.handleObjectPut(putW, putReq)
+
+	if putW.Code != http.StatusOK {
+		t.Fatalf("PUT status: got %d, want 200 (body=%s)", putW.Code, putW.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/ab/k?acl", http.NoBody)
+	getReq.SetPathValue("bucket", "ab")
+	getReq.SetPathValue("key", "k")
+
+	getW := httptest.NewRecorder()
+	svc.handleObjectGet(getW, getReq)
+
+	var got AccessControlPolicy
+	if err := xml.Unmarshal(getW.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, getW.Body.String())
+	}
+
+	if got.Owner.ID != "user-1" {
+		t.Fatalf("owner.ID: got %q, want user-1", got.Owner.ID)
+	}
+
+	if len(got.ACL.Grants) != 2 {
+		t.Fatalf("grants: got %d, want 2", len(got.ACL.Grants))
+	}
+
+	if got.ACL.Grants[1].Grantee.URI != "http://acs.amazonaws.com/groups/global/AllUsers" {
+		t.Fatalf("Group grantee URI: got %q", got.ACL.Grants[1].Grantee.URI)
+	}
+}
+
+// TestObjectACL_GetOnNonExistentObjectIs404 — GetObjectAcl on a key
+// that doesn't exist returns NoSuchKey, not the default ACL.
+func TestObjectACL_GetOnNonExistentObjectIs404(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	_ = store.CreateBucket(context.Background(), "ab")
+
+	req := httptest.NewRequest(http.MethodGet, "/ab/missing?acl", http.NoBody)
+	req.SetPathValue("bucket", "ab")
+	req.SetPathValue("key", "missing")
+
+	w := httptest.NewRecorder()
+	svc.handleObjectGet(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", w.Code)
+	}
+}

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -57,6 +57,10 @@ type Storage interface {
 	PutObjectTagging(ctx context.Context, bucket, key string, tags map[string]string) error
 	GetObjectTagging(ctx context.Context, bucket, key string) (map[string]string, error)
 
+	// Object ACL
+	PutObjectACL(ctx context.Context, bucket, key string, acl *ObjectACL) error
+	GetObjectACL(ctx context.Context, bucket, key string) (*ObjectACL, error)
+
 	// Notification and CORS
 	SetEventBridgeNotification(ctx context.Context, bucket string, enabled bool)
 	IsEventBridgeEnabled(ctx context.Context, bucket string) bool
@@ -116,6 +120,7 @@ type MemoryBucket struct {
 	Encryption         *ServerSideEncryptionConfig `json:"encryption,omitempty"`        // server-side encryption configuration
 	Policy             string                      `json:"policy,omitempty"`            // bucket policy JSON document (empty == not configured)
 	Logging            *BucketLoggingConfig        `json:"logging,omitempty"`           // server access logging target (nil == disabled)
+	ObjectACLs         map[string]*ObjectACL       `json:"objectAcls,omitempty"`        // per-object ACL (key -> ACL)
 }
 
 // BucketLoggingConfig stores the destination for server access logs.

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -117,6 +117,29 @@ type CommonPrefix struct {
 	Prefix string `xml:"Prefix"`
 }
 
+// ListBucketResultV1 is the response for the legacy ListObjects (V1)
+// API. Same XML root name as V2, but the pagination fields are
+// `Marker` / `NextMarker` instead of `ContinuationToken` /
+// `NextContinuationToken`, and there is no `KeyCount`.
+//
+// The V1 API is still emitted by awscli's `aws s3 ls` (in some
+// configurations), older AWS SDKs, and a handful of non-AWS S3
+// clients (Go AWS SDK v1, some Java tooling), so it cannot be
+// retired purely by emulating V2.
+type ListBucketResultV1 struct {
+	XMLName        xml.Name       `xml:"ListBucketResult"`
+	Xmlns          string         `xml:"xmlns,attr"`
+	Name           string         `xml:"Name"`
+	Prefix         string         `xml:"Prefix"`
+	Marker         string         `xml:"Marker"`
+	NextMarker     string         `xml:"NextMarker,omitempty"`
+	MaxKeys        int            `xml:"MaxKeys"`
+	Delimiter      string         `xml:"Delimiter,omitempty"`
+	IsTruncated    bool           `xml:"IsTruncated"`
+	Contents       []ObjectInfo   `xml:"Contents"`
+	CommonPrefixes []CommonPrefix `xml:"CommonPrefixes,omitempty"`
+}
+
 // ErrorResponse represents an S3 error response.
 type ErrorResponse struct {
 	XMLName    xml.Name `xml:"Error"`


### PR DESCRIPTION
## Summary

Four small S3 surface gaps, bundled per the \"one PR per service\" convention. All four touch the same S3 handler / storage files and share a reviewer.

| # | Capability | Why it matters |
|---|---|---|
| 1 | Conditional GetObject / CopyObject (\`If-Match\`, \`If-None-Match\`, \`If-Modified-Since\`, \`If-Unmodified-Since\`, \`x-amz-copy-source-if-*\`) | Cache revalidation + optimistic concurrency. Real SDKs send these on every revalidation. |
| 2 | Presigned response-header overrides (\`?response-content-type=...\`, \`?response-content-disposition=...\`, etc.) | Browser download links served via S3 presigned URLs need to force \`Content-Disposition: attachment; filename=...\`. |
| 3 | ListObjectsV1 (marker-paginated, no \`KeyCount\`) | SDK v1, awscli's \`aws s3 ls\`, and a handful of non-AWS S3 clients still emit V1 — they choke on the V2-only \`<KeyCount>\` element. |
| 4 | Object ACL CRUD (\`PUT/GET /{bucket}/{key}?acl\`) | terraform \`aws_s3_object_acl\`, compliance scans, and Cloudtrail-style audit pipelines all roundtrip ACL. |

## 1. Conditional GetObject / CopyObject

GetObject:
| condition | result |
|---|---|
| \`If-Match\` miss | 412 PreconditionFailed |
| \`If-Unmodified-Since\` older (no If-Match) | 412 |
| \`If-None-Match\` hit | 304 Not Modified |
| \`If-Modified-Since\` same/newer (no If-None-Match) | 304 |
| \`*\` wildcard | always matches (RFC 9110 §13.1.1) |

CopyObject — same matching against the *source* object's ETag / LastModified, mapped to 412 on any mismatch (no 304 path on copy).

Evaluation order matches RFC 9110 §13.1: \`If-Match\` → \`If-Unmodified-Since\` → \`If-None-Match\` → \`If-Modified-Since\`.

## 2. Presigned response-* overrides

\`?response-content-type=...\`, \`?response-content-disposition=...\`, \`?response-cache-control=...\`, \`?response-content-encoding=...\`, \`?response-content-language=...\`, \`?response-expires=...\`. Overrides win over object metadata via a small \`setIfAbsent\` helper inside \`writeObjectResponse\`.

## 3. ListObjectsV1

\`handleBucketGet\` now dispatches:
  - \`?list-type=2\`  → existing \`ListObjects\` (V2)
  - default          → new \`ListObjectsV1\`

V1 specifics:
  - \`marker\` request param starts the page **after** that key
  - response uses \`<Marker>\` / \`<NextMarker>\` (no \`KeyCount\`)
  - \`IsTruncated\` reflects whether more entries remain
  - \`NextMarker\` is set only when \`delimiter\` is in use, matching real S3

## 4. Object ACL CRUD

| Method | Path |
|---|---|
| PUT | \`/{bucket}/{key}?acl\` |
| GET | \`/{bucket}/{key}?acl\` |

Body is the standard \`AccessControlPolicy\` XML; \`x-amz-acl: <canned>\` header is also accepted as an alternative input. XML body wins when both are sent (matches real S3).

Storage holds per-object ACL on \`MemoryBucket.ObjectACLs\` (key → \`*ObjectACL\`). Default fallback when no ACL was ever set is the canned \`private\` ACL, encoded as a single FULL_CONTROL grant for the owner so the response shape is always consistent.

| Error condition | Status | Code |
|---|---|---|
| PutObjectAcl on missing bucket | 404 | NoSuchBucket |
| PutObjectAcl on missing key | 404 | NoSuchKey |
| Malformed AccessControlPolicy XML | 400 | MalformedACLError |

## Out of scope

- ACL **enforcement** at request time (kumo doesn't reject GetObject based on stored grants — same posture as the existing bucket-level ACL stub).
- \`x-amz-grant-*\` request headers as an alternative ACL input shape (rarely used in practice; XML body or canned ACL covers >99% of callers).

## Test plan

- [x] \`go test ./internal/service/s3/\` — clean
  - \`TestEvalGetObjectPreconditions\` — 12 cases covering RFC 9110 §13.1 evaluation order
  - \`TestEvalCopySourcePreconditions\` — 5 cases on the source-side variant
  - \`TestGetObject_ConditionalRequests\` — 4 HTTP-layer scenarios (200 / 304 / 412)
  - \`TestGetObject_ResponseHeaderOverrides\` — Content-Type / Content-Disposition / Cache-Control overrides survive the response writer
  - \`TestListObjectsV1_BasicRoundTrip\` — confirms \`<KeyCount>\` is absent from V1 response
  - \`TestListObjectsV1_MarkerPagination\` — 5 keys, 2-key pages, marker advances
  - \`TestListObjectsV2_StillUsesContinuationToken\` — \`?list-type=2\` keeps the V2 response shape
  - \`TestObjectACL_RoundTripWithCannedHeader\`
  - \`TestObjectACL_RoundTripWithBody\` — multi-grant XML round-trip, including Group grantee
  - \`TestObjectACL_GetOnNonExistentObjectIs404\`
- [x] \`go test ./...\` — full suite green
- [x] \`make lint\` — clean