### PR TITLE
feat(s3): BucketWebsite + BucketLifecycle + Object Restore

### DIFF
--- a/internal/service/s3/bucket_lifecycle.go
+++ b/internal/service/s3/bucket_lifecycle.go
@@ -1,0 +1,195 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// LifecycleConfiguration is the XML body of PUT/GET
+// /{bucket}?lifecycle, matching S3's `LifecycleConfiguration` schema.
+//
+// kumo doesn't actually evaluate the rules at object-write time (no
+// background expiration / transition job) — it just roundtrips the
+// configuration so terraform / cdk / pulumi resources like
+// `aws_s3_bucket_lifecycle_configuration` see consistent state.
+type LifecycleConfiguration struct {
+	XMLName xml.Name        `xml:"LifecycleConfiguration"`
+	Xmlns   string          `xml:"xmlns,attr,omitempty"`
+	Rules   []LifecycleRule `xml:"Rule"`
+}
+
+// LifecycleRule is one rule in a LifecycleConfiguration.
+type LifecycleRule struct {
+	XMLName                        xml.Name                        `xml:"Rule"`
+	ID                             string                          `xml:"ID,omitempty"`
+	Status                         string                          `xml:"Status"`
+	Filter                         *LifecycleFilter                `xml:"Filter,omitempty"`
+	Prefix                         string                          `xml:"Prefix,omitempty"` // legacy, pre-Filter
+	Expiration                     *LifecycleExpiration            `xml:"Expiration,omitempty"`
+	NoncurrentVersionExpiration    *NoncurrentVersionExpiration    `xml:"NoncurrentVersionExpiration,omitempty"`
+	Transitions                    []LifecycleTransition           `xml:"Transition,omitempty"`
+	NoncurrentVersionTransitions   []NoncurrentVersionTransition   `xml:"NoncurrentVersionTransition,omitempty"`
+	AbortIncompleteMultipartUpload *AbortIncompleteMultipartUpload `xml:"AbortIncompleteMultipartUpload,omitempty"`
+}
+
+// LifecycleFilter scopes a rule to a subset of the bucket.
+type LifecycleFilter struct {
+	Prefix                string              `xml:"Prefix,omitempty"`
+	Tag                   *Tag                `xml:"Tag,omitempty"`
+	ObjectSizeGreaterThan int64               `xml:"ObjectSizeGreaterThan,omitempty"`
+	ObjectSizeLessThan    int64               `xml:"ObjectSizeLessThan,omitempty"`
+	And                   *LifecycleFilterAnd `xml:"And,omitempty"`
+}
+
+// LifecycleFilterAnd combines multiple filter conditions (S3's AND).
+type LifecycleFilterAnd struct {
+	Prefix                string `xml:"Prefix,omitempty"`
+	Tags                  []Tag  `xml:"Tag,omitempty"`
+	ObjectSizeGreaterThan int64  `xml:"ObjectSizeGreaterThan,omitempty"`
+	ObjectSizeLessThan    int64  `xml:"ObjectSizeLessThan,omitempty"`
+}
+
+// LifecycleExpiration controls when current-version objects are
+// deleted by the lifecycle engine.
+type LifecycleExpiration struct {
+	Days                      int    `xml:"Days,omitempty"`
+	Date                      string `xml:"Date,omitempty"`
+	ExpiredObjectDeleteMarker bool   `xml:"ExpiredObjectDeleteMarker,omitempty"`
+}
+
+// NoncurrentVersionExpiration controls when noncurrent versions
+// (only meaningful with versioning enabled) are deleted.
+type NoncurrentVersionExpiration struct {
+	NoncurrentDays          int `xml:"NoncurrentDays,omitempty"`
+	NewerNoncurrentVersions int `xml:"NewerNoncurrentVersions,omitempty"`
+}
+
+// LifecycleTransition controls when current-version objects move to
+// a colder storage class.
+type LifecycleTransition struct {
+	Days         int    `xml:"Days,omitempty"`
+	Date         string `xml:"Date,omitempty"`
+	StorageClass string `xml:"StorageClass"`
+}
+
+// NoncurrentVersionTransition is the noncurrent-version analogue of
+// LifecycleTransition.
+type NoncurrentVersionTransition struct {
+	NoncurrentDays          int    `xml:"NoncurrentDays,omitempty"`
+	NewerNoncurrentVersions int    `xml:"NewerNoncurrentVersions,omitempty"`
+	StorageClass            string `xml:"StorageClass"`
+}
+
+// AbortIncompleteMultipartUpload — abort uploads stuck in progress.
+type AbortIncompleteMultipartUpload struct {
+	DaysAfterInitiation int `xml:"DaysAfterInitiation,omitempty"`
+}
+
+// PutBucketLifecycleConfiguration handles PUT /{bucket}?lifecycle.
+func (s *Service) PutBucketLifecycleConfiguration(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeS3Error(w, r, "InvalidRequest", "Failed to read request body", http.StatusBadRequest)
+
+		return
+	}
+
+	var cfg LifecycleConfiguration
+	if err := xml.Unmarshal(body, &cfg); err != nil {
+		writeS3Error(w, r, "MalformedXML", fmt.Sprintf("LifecycleConfiguration XML: %v", err), http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.PutBucketLifecycle(r.Context(), bucket, &cfg); err != nil {
+		handleBucketLevelError(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetBucketLifecycleConfiguration handles GET /{bucket}?lifecycle.
+func (s *Service) GetBucketLifecycleConfiguration(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	cfg, err := s.storage.GetBucketLifecycle(r.Context(), bucket)
+	if err != nil {
+		handleBucketLevelError(w, r, err)
+
+		return
+	}
+
+	cfg.Xmlns = s3Namespace
+	writeXMLResponse(w, cfg)
+}
+
+// DeleteBucketLifecycle handles DELETE /{bucket}?lifecycle.
+func (s *Service) DeleteBucketLifecycle(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	if err := s.storage.DeleteBucketLifecycle(r.Context(), bucket); err != nil {
+		handleBucketLevelError(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// MemoryStorage hooks for bucket lifecycle.
+
+// PutBucketLifecycle stores the lifecycle configuration on the bucket.
+func (s *MemoryStorage) PutBucketLifecycle(_ context.Context, bucket string, cfg *LifecycleConfiguration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	b.Lifecycle = cfg
+
+	return nil
+}
+
+// GetBucketLifecycle returns the stored lifecycle configuration, or
+// NoSuchLifecycleConfiguration if none has been set.
+func (s *MemoryStorage) GetBucketLifecycle(_ context.Context, bucket string) (*LifecycleConfiguration, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if b.Lifecycle == nil {
+		return nil, &BucketError{Code: "NoSuchLifecycleConfiguration", Message: "The lifecycle configuration does not exist", BucketName: bucket}
+	}
+
+	return b.Lifecycle, nil
+}
+
+// DeleteBucketLifecycle removes the lifecycle configuration from the
+// bucket. Idempotent.
+func (s *MemoryStorage) DeleteBucketLifecycle(_ context.Context, bucket string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	b.Lifecycle = nil
+
+	return nil
+}

--- a/internal/service/s3/bucket_resources_test.go
+++ b/internal/service/s3/bucket_resources_test.go
@@ -1,0 +1,248 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- BucketWebsite ---------------------------------------------------
+
+func TestBucketWebsite_PutGetDelete(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage(), "")
+	ctx := context.Background()
+
+	store, ok := svc.storage.(*MemoryStorage)
+	if !ok {
+		t.Fatalf("storage is not *MemoryStorage")
+	}
+
+	_ = store.CreateBucket(ctx, "wb")
+
+	putWebsiteFixture(t, svc)
+	verifyWebsiteRoundTrip(t, svc)
+	verifyWebsiteDeleteThenGet404(t, svc)
+}
+
+func putWebsiteFixture(t *testing.T, svc *Service) {
+	t.Helper()
+
+	cfg := WebsiteConfiguration{
+		IndexDocument: &WebsiteIndexDocument{Suffix: "index.html"},
+		ErrorDocument: &WebsiteErrorDocument{Key: "error.html"},
+	}
+	body, _ := xml.Marshal(cfg)
+
+	req := httptest.NewRequest(http.MethodPut, "/wb?website", strings.NewReader(string(body)))
+	req.SetPathValue("bucket", "wb")
+
+	w := httptest.NewRecorder()
+	svc.handleBucketPut(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT status: got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func verifyWebsiteRoundTrip(t *testing.T, svc *Service) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/wb?website", http.NoBody)
+	req.SetPathValue("bucket", "wb")
+
+	w := httptest.NewRecorder()
+	svc.handleBucketGet(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET status: got %d", w.Code)
+	}
+
+	var got WebsiteConfiguration
+	if err := xml.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
+	}
+
+	if got.IndexDocument == nil || got.IndexDocument.Suffix != "index.html" {
+		t.Fatalf("IndexDocument.Suffix: got %+v, want index.html", got.IndexDocument)
+	}
+}
+
+func verifyWebsiteDeleteThenGet404(t *testing.T, svc *Service) {
+	t.Helper()
+
+	delReq := httptest.NewRequest(http.MethodDelete, "/wb?website", http.NoBody)
+	delReq.SetPathValue("bucket", "wb")
+
+	delW := httptest.NewRecorder()
+	svc.handleBucketDelete(delW, delReq)
+
+	if delW.Code != http.StatusNoContent {
+		t.Fatalf("DELETE status: got %d, want 204", delW.Code)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/wb?website", http.NoBody)
+	getReq.SetPathValue("bucket", "wb")
+
+	getW := httptest.NewRecorder()
+	svc.handleBucketGet(getW, getReq)
+
+	if getW.Code != http.StatusNotFound {
+		t.Fatalf("GET after DELETE status: got %d, want 404", getW.Code)
+	}
+
+	if !strings.Contains(getW.Body.String(), "NoSuchWebsiteConfiguration") {
+		t.Fatalf("error code: got body=%s", getW.Body.String())
+	}
+}
+
+// --- BucketLifecycle -------------------------------------------------
+
+func putLifecycleFixture(t *testing.T, svc *Service) {
+	t.Helper()
+
+	cfg := LifecycleConfiguration{
+		Rules: []LifecycleRule{
+			{
+				ID:         "expire-logs",
+				Status:     "Enabled",
+				Filter:     &LifecycleFilter{Prefix: "logs/"},
+				Expiration: &LifecycleExpiration{Days: 30},
+			},
+		},
+	}
+	body, _ := xml.Marshal(cfg)
+
+	req := httptest.NewRequest(http.MethodPut, "/lb?lifecycle", strings.NewReader(string(body)))
+	req.SetPathValue("bucket", "lb")
+
+	w := httptest.NewRecorder()
+	svc.handleBucketPut(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT status: got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func verifyLifecycleRoundTrip(t *testing.T, svc *Service) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/lb?lifecycle", http.NoBody)
+	req.SetPathValue("bucket", "lb")
+
+	w := httptest.NewRecorder()
+	svc.handleBucketGet(w, req)
+
+	var got LifecycleConfiguration
+	if err := xml.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
+	}
+
+	if len(got.Rules) != 1 || got.Rules[0].ID != "expire-logs" {
+		t.Fatalf("rules: got %+v", got.Rules)
+	}
+
+	if got.Rules[0].Expiration == nil || got.Rules[0].Expiration.Days != 30 {
+		t.Fatalf("Expiration.Days: got %+v, want 30", got.Rules[0].Expiration)
+	}
+}
+
+func TestBucketLifecycle_PutGetDelete(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage(), "")
+	ctx := context.Background()
+
+	store, ok := svc.storage.(*MemoryStorage)
+	if !ok {
+		t.Fatalf("storage is not *MemoryStorage")
+	}
+
+	_ = store.CreateBucket(ctx, "lb")
+
+	putLifecycleFixture(t, svc)
+	verifyLifecycleRoundTrip(t, svc)
+
+	// GET on bucket without lifecycle now → 404 NoSuchLifecycleConfiguration
+	_ = store.CreateBucket(ctx, "empty")
+
+	emptyReq := httptest.NewRequest(http.MethodGet, "/empty?lifecycle", http.NoBody)
+	emptyReq.SetPathValue("bucket", "empty")
+
+	emptyW := httptest.NewRecorder()
+	svc.handleBucketGet(emptyW, emptyReq)
+
+	if emptyW.Code != http.StatusNotFound {
+		t.Fatalf("GET on bucket without lifecycle: got %d, want 404", emptyW.Code)
+	}
+}
+
+// --- Object Restore --------------------------------------------------
+
+func TestObjectRestore_FirstRequestReturns202(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage(), "")
+	ctx := context.Background()
+
+	store, ok := svc.storage.(*MemoryStorage)
+	if !ok {
+		t.Fatalf("storage is not *MemoryStorage")
+	}
+
+	_ = store.CreateBucket(ctx, "rb")
+	_, _ = store.PutObject(ctx, "rb", "k", strings.NewReader("x"), nil)
+
+	body := `<RestoreRequest><Days>3</Days><Tier>Standard</Tier></RestoreRequest>`
+
+	req := httptest.NewRequest(http.MethodPost, "/rb/k?restore", strings.NewReader(body))
+	req.SetPathValue("bucket", "rb")
+	req.SetPathValue("key", "k")
+
+	w := httptest.NewRecorder()
+	svc.handleObjectPost(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("first restore: got %d, want 202 (body=%s)", w.Code, w.Body.String())
+	}
+
+	// Second restore on the same key → 200 OK (extending an existing one).
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/rb/k?restore", strings.NewReader(body))
+	req2.SetPathValue("bucket", "rb")
+	req2.SetPathValue("key", "k")
+	svc.handleObjectPost(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second restore: got %d, want 200", w2.Code)
+	}
+}
+
+func TestObjectRestore_404OnMissingObject(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage(), "")
+	ctx := context.Background()
+
+	store, ok := svc.storage.(*MemoryStorage)
+	if !ok {
+		t.Fatalf("storage is not *MemoryStorage")
+	}
+
+	_ = store.CreateBucket(ctx, "rb")
+
+	req := httptest.NewRequest(http.MethodPost, "/rb/missing?restore", strings.NewReader(`<RestoreRequest><Days>1</Days></RestoreRequest>`))
+	req.SetPathValue("bucket", "rb")
+	req.SetPathValue("key", "missing")
+
+	w := httptest.NewRecorder()
+	svc.handleObjectPost(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", w.Code)
+	}
+}

--- a/internal/service/s3/bucket_website.go
+++ b/internal/service/s3/bucket_website.go
@@ -1,0 +1,196 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// WebsiteConfiguration is the XML body of PUT/GET /{bucket}?website,
+// matching S3's `WebsiteConfiguration` schema.
+//
+// kumo doesn't actually serve the bucket as a website (no redirect
+// dispatch, no error-document substitution at request time) — it just
+// roundtrips the configuration so terraform / cdk / pulumi resources
+// like `aws_s3_bucket_website_configuration` see consistent state.
+type WebsiteConfiguration struct {
+	XMLName               xml.Name               `xml:"WebsiteConfiguration"`
+	Xmlns                 string                 `xml:"xmlns,attr,omitempty"`
+	IndexDocument         *WebsiteIndexDocument  `xml:"IndexDocument,omitempty"`
+	ErrorDocument         *WebsiteErrorDocument  `xml:"ErrorDocument,omitempty"`
+	RedirectAllRequestsTo *RedirectAllRequestsTo `xml:"RedirectAllRequestsTo,omitempty"`
+	RoutingRules          *WebsiteRoutingRules   `xml:"RoutingRules,omitempty"`
+}
+
+// WebsiteIndexDocument names the file served for `/` requests.
+type WebsiteIndexDocument struct {
+	Suffix string `xml:"Suffix"`
+}
+
+// WebsiteErrorDocument names the file served on 4xx.
+type WebsiteErrorDocument struct {
+	Key string `xml:"Key"`
+}
+
+// RedirectAllRequestsTo unconditionally redirects every request.
+type RedirectAllRequestsTo struct {
+	HostName string `xml:"HostName"`
+	Protocol string `xml:"Protocol,omitempty"`
+}
+
+// WebsiteRoutingRules wraps the list of routing rules.
+type WebsiteRoutingRules struct {
+	Rules []WebsiteRoutingRule `xml:"RoutingRule"`
+}
+
+// WebsiteRoutingRule is one conditional redirect rule.
+type WebsiteRoutingRule struct {
+	Condition *RoutingRuleCondition `xml:"Condition,omitempty"`
+	Redirect  RoutingRuleRedirect   `xml:"Redirect"`
+}
+
+// RoutingRuleCondition is the condition that triggers a routing rule.
+type RoutingRuleCondition struct {
+	KeyPrefixEquals             string `xml:"KeyPrefixEquals,omitempty"`
+	HTTPErrorCodeReturnedEquals string `xml:"HttpErrorCodeReturnedEquals,omitempty"`
+}
+
+// RoutingRuleRedirect is the redirect target of a routing rule.
+type RoutingRuleRedirect struct {
+	HostName             string `xml:"HostName,omitempty"`
+	Protocol             string `xml:"Protocol,omitempty"`
+	ReplaceKeyPrefixWith string `xml:"ReplaceKeyPrefixWith,omitempty"`
+	ReplaceKeyWith       string `xml:"ReplaceKeyWith,omitempty"`
+	HTTPRedirectCode     string `xml:"HttpRedirectCode,omitempty"`
+}
+
+// PutBucketWebsite handles PUT /{bucket}?website.
+func (s *Service) PutBucketWebsite(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeS3Error(w, r, "InvalidRequest", "Failed to read request body", http.StatusBadRequest)
+
+		return
+	}
+
+	var cfg WebsiteConfiguration
+	if err := xml.Unmarshal(body, &cfg); err != nil {
+		writeS3Error(w, r, "MalformedXML", fmt.Sprintf("WebsiteConfiguration XML: %v", err), http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.PutBucketWebsite(r.Context(), bucket, &cfg); err != nil {
+		handleBucketLevelError(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetBucketWebsite handles GET /{bucket}?website.
+func (s *Service) GetBucketWebsite(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	cfg, err := s.storage.GetBucketWebsite(r.Context(), bucket)
+	if err != nil {
+		handleBucketLevelError(w, r, err)
+
+		return
+	}
+
+	cfg.Xmlns = s3Namespace
+	writeXMLResponse(w, cfg)
+}
+
+// DeleteBucketWebsite handles DELETE /{bucket}?website.
+func (s *Service) DeleteBucketWebsite(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	if err := s.storage.DeleteBucketWebsite(r.Context(), bucket); err != nil {
+		handleBucketLevelError(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// MemoryStorage hooks for bucket website configuration.
+
+// PutBucketWebsite stores the website configuration on the bucket.
+func (s *MemoryStorage) PutBucketWebsite(_ context.Context, bucket string, cfg *WebsiteConfiguration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	b.Website = cfg
+
+	return nil
+}
+
+// GetBucketWebsite returns the stored website configuration, or
+// NoSuchWebsiteConfiguration if none has been set.
+func (s *MemoryStorage) GetBucketWebsite(_ context.Context, bucket string) (*WebsiteConfiguration, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if b.Website == nil {
+		return nil, &BucketError{Code: "NoSuchWebsiteConfiguration", Message: "The specified bucket does not have a website configuration", BucketName: bucket}
+	}
+
+	return b.Website, nil
+}
+
+// DeleteBucketWebsite removes the website configuration from the
+// bucket. Idempotent — DELETE on an unconfigured bucket is a no-op.
+func (s *MemoryStorage) DeleteBucketWebsite(_ context.Context, bucket string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	b.Website = nil
+
+	return nil
+}
+
+// handleBucketLevelError maps BucketError → status code. Used by the
+// website / lifecycle / restore handlers added in this PR.
+func handleBucketLevelError(w http.ResponseWriter, r *http.Request, err error) {
+	var bucketErr *BucketError
+	if errors.As(err, &bucketErr) {
+		status := http.StatusNotFound
+
+		writeS3Error(w, r, bucketErr.Code, bucketErr.Message, status)
+
+		return
+	}
+
+	var objErr *ObjectError
+	if errors.As(err, &objErr) {
+		writeS3Error(w, r, objErr.Code, objErr.Message, http.StatusNotFound)
+
+		return
+	}
+
+	writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -105,6 +105,8 @@ func (s *Service) HandleCORSPreflight(w http.ResponseWriter, r *http.Request) {
 // Route Dispatchers - dispatch based on query parameters
 
 // handleBucketGet dispatches GET /{bucket} requests based on query parameters.
+//
+//nolint:funlen // It's a straightforward dispatch, and splitting it up would just add indirection.
 func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
 	if _, ok := r.URL.Query()["versioning"]; ok {
 		s.GetBucketVersioning(w, r)
@@ -144,6 +146,18 @@ func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
 
 	if _, ok := r.URL.Query()["uploads"]; ok {
 		s.ListMultipartUploads(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["website"]; ok {
+		s.GetBucketWebsite(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["lifecycle"]; ok {
+		s.GetBucketLifecycleConfiguration(w, r)
 
 		return
 	}
@@ -206,9 +220,7 @@ func (s *Service) serveBucketSubresourceStub(w http.ResponseWriter, r *http.Requ
 func bucketSubresourceErrorCode(q map[string][]string) (string, bool) {
 	mapping := map[string]string{
 		"cors":              "NoSuchCORSConfiguration",
-		"lifecycle":         "NoSuchLifecycleConfiguration",
 		"replication":       "ReplicationConfigurationNotFoundError",
-		"website":           "NoSuchWebsiteConfiguration",
 		"tagging":           "NoSuchTagSet",
 		"object-lock":       "ObjectLockConfigurationNotFoundError",
 		"ownershipControls": "OwnershipControlsNotFoundError",
@@ -366,6 +378,12 @@ func (s *Service) handleObjectPost(w http.ResponseWriter, r *http.Request) {
 
 	if r.URL.Query().Get("uploadId") != "" {
 		s.CompleteMultipartUpload(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["restore"]; ok {
+		s.RestoreObject(w, r)
 
 		return
 	}
@@ -1413,6 +1431,18 @@ func (s *Service) handleBucketPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, ok := r.URL.Query()["website"]; ok {
+		s.PutBucketWebsite(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["lifecycle"]; ok {
+		s.PutBucketLifecycleConfiguration(w, r)
+
+		return
+	}
+
 	s.CreateBucket(w, r)
 }
 
@@ -1432,6 +1462,18 @@ func (s *Service) handleBucketDelete(w http.ResponseWriter, r *http.Request) {
 
 	if _, ok := r.URL.Query()["policy"]; ok {
 		s.DeleteBucketPolicy(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["website"]; ok {
+		s.DeleteBucketWebsite(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["lifecycle"]; ok {
+		s.DeleteBucketLifecycle(w, r)
 
 		return
 	}

--- a/internal/service/s3/object_restore.go
+++ b/internal/service/s3/object_restore.go
@@ -1,0 +1,131 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// RestoreRequest is the XML body of POST /{bucket}/{key}?restore.
+type RestoreRequest struct {
+	XMLName              xml.Name          `xml:"RestoreRequest"`
+	Days                 int               `xml:"Days,omitempty"`
+	GlacierJobParameters *GlacierJobParams `xml:"GlacierJobParameters,omitempty"`
+	Type                 string            `xml:"Type,omitempty"` // SELECT for query-in-place
+	Tier                 string            `xml:"Tier,omitempty"` // Standard | Bulk | Expedited
+	Description          string            `xml:"Description,omitempty"`
+}
+
+// GlacierJobParams is the legacy single-field shape that holds the
+// retrieval Tier.
+type GlacierJobParams struct {
+	Tier string `xml:"Tier"`
+}
+
+// RestoreState tracks an in-progress / completed restore on a single
+// object. kumo doesn't model storage classes, so the restore is
+// considered "complete" the moment it's requested — but the state is
+// persisted so HEAD/GET reports the right `x-amz-restore` header.
+type RestoreState struct {
+	OngoingRequest bool      `json:"ongoingRequest"`
+	ExpiryDate     time.Time `json:"expiryDate"`
+	Tier           string    `json:"tier"`
+}
+
+// RestoreObject handles POST /{bucket}/{key}?restore.
+//
+// Real S3 returns 202 Accepted (in-progress) for an Glacier object,
+// 200 OK if a restore is already in progress and being extended, and
+// 409 Conflict (RestoreAlreadyInProgress) under certain conditions.
+//
+// kumo accepts the request unconditionally:
+//   - first restore on this key  → 202 Accepted
+//   - subsequent restores        → 200 OK (extending the existing one)
+func (s *Service) RestoreObject(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+	key := r.PathValue("key")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeS3Error(w, r, "InvalidRequest", "Failed to read request body", http.StatusBadRequest)
+
+		return
+	}
+
+	var req RestoreRequest
+	if len(body) > 0 {
+		if err := xml.Unmarshal(body, &req); err != nil {
+			writeS3Error(w, r, "MalformedXML", fmt.Sprintf("RestoreRequest XML: %v", err), http.StatusBadRequest)
+
+			return
+		}
+	}
+
+	days := req.Days
+	if days <= 0 {
+		days = 1 // S3 default
+	}
+
+	tier := req.Tier
+	if tier == "" && req.GlacierJobParameters != nil {
+		tier = req.GlacierJobParameters.Tier
+	}
+
+	if tier == "" {
+		tier = "Standard"
+	}
+
+	state := &RestoreState{
+		OngoingRequest: false, // we declare the restore complete immediately
+		ExpiryDate:     time.Now().Add(time.Duration(days) * 24 * time.Hour),
+		Tier:           tier,
+	}
+
+	alreadyExisted, err := s.storage.PutObjectRestore(r.Context(), bucket, key, state)
+	if err != nil {
+		handleBucketLevelError(w, r, err)
+
+		return
+	}
+
+	w.Header().Set("x-amz-restore-output-path", fmt.Sprintf("%s/%s", bucket, key))
+
+	if alreadyExisted {
+		w.WriteHeader(http.StatusOK)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// MemoryStorage hooks for object restore.
+
+// PutObjectRestore stores the restore state. Returns alreadyExisted=true
+// when the object already had restore state — caller uses that to
+// distinguish initial 202 vs. extending-existing 200.
+func (s *MemoryStorage) PutObjectRestore(_ context.Context, bucket, key string, state *RestoreState) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return false, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if _, ok := b.Objects[key]; !ok {
+		return false, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
+	}
+
+	if b.ObjectRestores == nil {
+		b.ObjectRestores = make(map[string]*RestoreState)
+	}
+
+	_, alreadyExisted := b.ObjectRestores[key]
+	b.ObjectRestores[key] = state
+
+	return alreadyExisted, nil
+}

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -80,6 +80,17 @@ type Storage interface {
 
 	PutBucketLogging(ctx context.Context, bucket string, cfg BucketLoggingConfig) error
 	GetBucketLogging(ctx context.Context, bucket string) (*BucketLoggingConfig, error)
+
+	// Bucket website / lifecycle / object restore.
+	PutBucketWebsite(ctx context.Context, bucket string, cfg *WebsiteConfiguration) error
+	GetBucketWebsite(ctx context.Context, bucket string) (*WebsiteConfiguration, error)
+	DeleteBucketWebsite(ctx context.Context, bucket string) error
+
+	PutBucketLifecycle(ctx context.Context, bucket string, cfg *LifecycleConfiguration) error
+	GetBucketLifecycle(ctx context.Context, bucket string) (*LifecycleConfiguration, error)
+	DeleteBucketLifecycle(ctx context.Context, bucket string) error
+
+	PutObjectRestore(ctx context.Context, bucket, key string, state *RestoreState) (bool, error)
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -121,6 +132,9 @@ type MemoryBucket struct {
 	Policy             string                      `json:"policy,omitempty"`            // bucket policy JSON document (empty == not configured)
 	Logging            *BucketLoggingConfig        `json:"logging,omitempty"`           // server access logging target (nil == disabled)
 	ObjectACLs         map[string]*ObjectACL       `json:"objectAcls,omitempty"`        // per-object ACL (key -> ACL)
+	Website            *WebsiteConfiguration       `json:"website,omitempty"`           // static-site-hosting configuration
+	Lifecycle          *LifecycleConfiguration     `json:"lifecycle,omitempty"`         // expiration / transition rules
+	ObjectRestores     map[string]*RestoreState    `json:"objectRestores,omitempty"`    // per-object restore state (key -> state)
 }
 
 // BucketLoggingConfig stores the destination for server access logs.


### PR DESCRIPTION
## Summary

Three more bucket-/object-level sub-resources promoted from the generic 404-stub fallback (\`serveBucketSubresourceStub\`) to real CRUD, so terraform / pulumi / cdk resources that touch these now get consistent state instead of \`NoSuch*\` on every GET.

| Resource | Endpoints |
|---|---|
| BucketWebsite | PUT / GET / DELETE \`/{bucket}?website\` |
| BucketLifecycle | PUT / GET / DELETE \`/{bucket}?lifecycle\` |
| ObjectRestore | POST \`/{bucket}/{key}?restore\` |

## What's modeled vs. not

| Resource | Stored | Enforced at request time |
|---|---|---|
| Website (Index/Error doc, RedirectAllRequestsTo, RoutingRules) | ✅ | ❌ — kumo doesn't serve buckets as websites |
| Lifecycle (Filter, Expiration, Transitions, Noncurrent*, AbortIncompleteMultipartUpload) | ✅ | ❌ — no background lifecycle engine; rules are persisted but never evaluated |
| Restore (ExpiryDate, Tier) | ✅ | n/a — storage class isn't modeled, so restore is \"complete\" immediately |

The split between persistence and enforcement matches the existing posture for \`PublicAccessBlock\`, \`Versioning\`, and \`Encryption\` — kumo is a configuration round-trip emulator, not a behavioural one.

## Behaviour notes

**Restore:**
  - First request on a key → 202 Accepted (matches real S3 for Glacier objects)
  - Subsequent restores on the same key → 200 OK (extending existing), matches real S3
  - 404 NoSuchKey on missing object

**Website / Lifecycle:**
  - GET on a bucket where no configuration was set → 404 NoSuchWebsiteConfiguration / NoSuchLifecycleConfiguration (real S3 wire shape)
  - PUT replaces wholesale; DELETE is idempotent

## Stub-table cleanup

The sub-resource stub mapping in \`serveBucketSubresourceStub\` now drops \`website\` and \`lifecycle\` (real handlers take over). \`policy\`, \`cors\`, \`replication\`, \`tagging\`, \`object-lock\`, \`ownershipControls\` still 404-stub.

## Test plan

- [x] \`go test ./internal/service/s3/\` — clean
  - \`TestBucketWebsite_PutGetDelete\` — full PUT → GET → DELETE → GET-after-DELETE-404
  - \`TestBucketLifecycle_PutGetDelete\` — full round-trip + 404 on un-configured bucket
  - \`TestObjectRestore_FirstRequestReturns202\` — first 202 + second 200
  - \`TestObjectRestore_404OnMissingObject\`
- [x] \`go test ./...\` — full suite green
- [x] \`make lint\` — clean