### PR TITLE
feat(dynamodb): no-op stubs for ListTagsOfResource / Tag / Untag / DescribeContinuousBackups

### DIFF
--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -732,6 +732,12 @@ func (s *Service) actionHandlers() map[string]func(http.ResponseWriter, *http.Re
 		"TransactGetItems":   s.TransactGetItems,
 		"BatchWriteItem":     s.BatchWriteItem,
 		"BatchGetItem":       s.BatchGetItem,
+		// Tag and continuous-backup stubs — see tag_backup_stubs.go.
+		// Required for terraform / pulumi / CDK refresh paths after CreateTable.
+		"ListTagsOfResource":        s.ListTagsOfResource,
+		"TagResource":               s.TagResource,
+		"UntagResource":             s.UntagResource,
+		"DescribeContinuousBackups": s.DescribeContinuousBackups,
 	}
 }
 

--- a/internal/service/dynamodb/tag_backup_stubs.go
+++ b/internal/service/dynamodb/tag_backup_stubs.go
@@ -1,0 +1,54 @@
+package dynamodb
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const continuousBackupsDisabled = "DISABLED"
+
+// ListTagsOfResource returns an empty tag list for any resource.
+//
+// Tags are not modeled in the storage layer yet; this stub exists so reads
+// from clients that refresh table state after CreateTable (terraform, pulumi,
+// CDK) do not fail with UnknownOperationException.
+func (s *Service) ListTagsOfResource(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, listTagsOfResourceResponse{Tags: []map[string]string{}})
+}
+
+// TagResource accepts and discards tag attachments.
+func (s *Service) TagResource(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, struct{}{})
+}
+
+// UntagResource accepts and discards tag detachments.
+func (s *Service) UntagResource(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, struct{}{})
+}
+
+// DescribeContinuousBackups reports continuous backups as DISABLED for any
+// existing table, returning TableNotFoundException for missing tables to
+// match AWS semantics that terraform refresh paths depend on.
+func (s *Service) DescribeContinuousBackups(w http.ResponseWriter, r *http.Request) {
+	var req describeContinuousBackupsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.TableName == "" {
+		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if _, err := s.storage.DescribeTable(r.Context(), req.TableName); err != nil {
+		writeDynamoDBError(w, "TableNotFoundException", "Table not found: "+req.TableName, http.StatusBadRequest)
+
+		return
+	}
+
+	writeJSONResponse(w, describeContinuousBackupsResponse{
+		ContinuousBackupsDescription: continuousBackupsDescription{
+			ContinuousBackupsStatus: continuousBackupsDisabled,
+			PointInTimeRecoveryDescription: pointInTimeRecoveryDescription{
+				PointInTimeRecoveryStatus: continuousBackupsDisabled,
+			},
+		},
+	})
+}

--- a/internal/service/dynamodb/tag_backup_stubs_test.go
+++ b/internal/service/dynamodb/tag_backup_stubs_test.go
@@ -1,0 +1,128 @@
+package dynamodb
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListTagsOfResource_EmptyArray(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage("http://localhost:4566"))
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"ResourceArn":"arn:aws:dynamodb:us-east-1:000000000000:table/foo"}`))
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.ListTagsOfResource")
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	tags, ok := resp["Tags"]
+	if !ok {
+		t.Fatalf("response missing Tags field; body=%s (terraform-provider-aws requires the field even when empty)", w.Body.String())
+	}
+
+	tagsSlice, ok := tags.([]any)
+	if !ok {
+		t.Fatalf("Tags is %T, want []any", tags)
+	}
+
+	if len(tagsSlice) != 0 {
+		t.Fatalf("Tags = %v, want empty array", tagsSlice)
+	}
+}
+
+func TestTagResource_NoOp(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage("http://localhost:4566"))
+
+	for _, action := range []string{"TagResource", "UntagResource"} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/",
+				strings.NewReader(`{"ResourceArn":"arn:aws:dynamodb:us-east-1:000000000000:table/foo","Tags":[{"Key":"k","Value":"v"}]}`))
+			req.Header.Set("X-Amz-Target", "DynamoDB_20120810."+action)
+
+			w := httptest.NewRecorder()
+			svc.DispatchAction(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status: got %d, body=%s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestDescribeContinuousBackups_DisabledForExistingTable(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage("http://localhost:4566")
+	svc := New(store)
+
+	if _, err := store.CreateTable(t.Context(), &CreateTableRequest{
+		TableName: "items",
+		KeySchema: []KeySchemaElement{{AttributeName: "id", KeyType: "HASH"}},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "id", AttributeType: "S"},
+		},
+		BillingMode: "PAY_PER_REQUEST",
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"TableName":"items"}`))
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.DescribeContinuousBackups")
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp describeContinuousBackupsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got, want := resp.ContinuousBackupsDescription.ContinuousBackupsStatus, continuousBackupsDisabled; got != want {
+		t.Errorf("ContinuousBackupsStatus: got %q, want %q", got, want)
+	}
+
+	if got, want := resp.ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus, continuousBackupsDisabled; got != want {
+		t.Errorf("PointInTimeRecoveryStatus: got %q, want %q", got, want)
+	}
+}
+
+func TestDescribeContinuousBackups_TableNotFound(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage("http://localhost:4566"))
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"TableName":"missing"}`))
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.DescribeContinuousBackups")
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400, body=%s", w.Code, w.Body.String())
+	}
+
+	if !strings.Contains(w.Body.String(), "TableNotFoundException") {
+		t.Fatalf("expected TableNotFoundException, got %s", w.Body.String())
+	}
+}

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -598,3 +598,32 @@ type TableError struct {
 func (e *TableError) Error() string {
 	return e.Message
 }
+
+// listTagsOfResourceResponse is the wire shape for ListTagsOfResource.
+//
+// AWS returns at minimum an empty array; clients (notably terraform-provider-aws)
+// require the field to be present even when no tags exist.
+type listTagsOfResourceResponse struct {
+	Tags      []map[string]string `json:"Tags"`
+	NextToken string              `json:"NextToken,omitempty"`
+}
+
+// describeContinuousBackupsResponse mirrors the AWS shape required by clients
+// reading point-in-time-recovery state after CreateTable.
+type describeContinuousBackupsResponse struct {
+	ContinuousBackupsDescription continuousBackupsDescription `json:"ContinuousBackupsDescription"`
+}
+
+type continuousBackupsDescription struct {
+	ContinuousBackupsStatus        string                         `json:"ContinuousBackupsStatus"`
+	PointInTimeRecoveryDescription pointInTimeRecoveryDescription `json:"PointInTimeRecoveryDescription"`
+}
+
+type pointInTimeRecoveryDescription struct {
+	PointInTimeRecoveryStatus string `json:"PointInTimeRecoveryStatus"`
+}
+
+// describeContinuousBackupsRequest decodes the TableName the request targets.
+type describeContinuousBackupsRequest struct {
+	TableName string `json:"TableName"`
+}


### PR DESCRIPTION
## Summary

terraform-provider-aws (and pulumi / CDK) refresh DynamoDB table state after `CreateTable` by calling `ListTagsOfResource` and `DescribeContinuousBackups`. Without these, the very first `terraform apply` of an `aws_dynamodb_table` resource fails after the table is created — kumo replied with `UnknownOperationException` so the plan was unrecoverable in-place (the table existed but state could not be refreshed, blocking destroy as well).

Same shape as #565 (ecr) / #566 (logs): wire-level no-ops so refresh paths complete, with the door open for real persistence later.

## Implementation

- `ListTagsOfResource` returns `{\"Tags\":[]}` — the field must be present even when empty; some clients fail to parse missing-Tags responses.
- `TagResource` / `UntagResource` accept and discard the payload.
- `DescribeContinuousBackups` returns `ContinuousBackupsStatus=DISABLED` (and the same for `PointInTimeRecoveryStatus`) for any existing table and `TableNotFoundException` for missing ones, matching AWS semantics that terraform refresh paths depend on.
- Wire types live in `internal/service/dynamodb/types.go` (covered by the existing tagliatelle exemption for AWS PascalCase JSON), handlers in a new `tag_backup_stubs.go`.

## Test plan

- [x] `go test ./internal/service/dynamodb/...` — green (4 new tests, including TableNotFoundException path).
- [x] `make lint` — clean.
- [x] End-to-end: `tofu apply` + `tofu destroy` of `aws_dynamodb_table { billing_mode = \"PAY_PER_REQUEST\"; hash_key = \"id\"; ... }` against `kumo serve` — both succeed; before this PR `apply` errored on `ListTagsOfResource` after creating the table, and `destroy` then errored on the same call during refresh.

Cross-ref: #416, #589.