### PR TITLE
feat(eventbridge): Lambda targets + content filters + tag stubs

### DIFF
--- a/internal/service/eventbridge/handlers.go
+++ b/internal/service/eventbridge/handlers.go
@@ -33,6 +33,11 @@ func (s *Service) getActionHandlers() map[string]handlerFunc {
 		"CreateApiDestination":   s.CreateAPIDestination,
 		"DescribeApiDestination": s.DescribeAPIDestination,
 		"DeleteApiDestination":   s.DeleteAPIDestination,
+		// Tag stubs — see tag_stubs.go.
+		// Required by terraform-provider-aws after CreateEventBus.
+		"ListTagsForResource": s.ListTagsForResource,
+		"TagResource":         s.TagResource,
+		"UntagResource":       s.UntagResource,
 	}
 }
 

--- a/internal/service/eventbridge/pattern.go
+++ b/internal/service/eventbridge/pattern.go
@@ -1,14 +1,20 @@
 package eventbridge
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 )
 
 // matchEventPattern checks if an event matches an EventPattern.
 // EventPattern is a JSON object where each key maps to an array of acceptable values.
+// Pattern array elements can be literals (string/number) or content filter objects:
+//
+//	{"prefix": "x"}, {"suffix": "y"}, {"exists": true},
+//	{"anything-but": [...]}, {"numeric": [">", 0, "<", 10]},
+//	{"equals-ignore-case": "abc"}.
+//
 // An event matches if ALL keys in the pattern match.
-// For each key, the event's value must match at least one value in the pattern array.
 func matchEventPattern(patternJSON string, event *PutEventsRequestEntry) bool {
 	if patternJSON == "" {
 		return true
@@ -22,11 +28,11 @@ func matchEventPattern(patternJSON string, event *PutEventsRequestEntry) bool {
 	for key, rawValues := range pattern {
 		switch key {
 		case "source":
-			if !matchStringField(rawValues, event.Source) {
+			if !matchScalarField(rawValues, event.Source) {
 				return false
 			}
 		case "detail-type":
-			if !matchStringField(rawValues, event.DetailType) {
+			if !matchScalarField(rawValues, event.DetailType) {
 				return false
 			}
 		case "detail":
@@ -39,47 +45,40 @@ func matchEventPattern(patternJSON string, event *PutEventsRequestEntry) bool {
 	return true
 }
 
-// matchStringField checks if a field value matches any of the pattern values.
-// Pattern values can be a JSON array of strings: ["value1", "value2"].
-func matchStringField(rawValues json.RawMessage, fieldValue string) bool {
-	var values []string
-	if err := json.Unmarshal(rawValues, &values); err != nil {
+// matchScalarField checks if a top-level scalar string field matches the pattern array.
+// Top-level fields source/detail-type are always considered "exists" when non-empty.
+func matchScalarField(patternArr json.RawMessage, fieldValue string) bool {
+	exists := fieldValue != ""
+
+	value, err := json.Marshal(fieldValue)
+	if err != nil {
 		return false
 	}
 
-	for _, v := range values {
-		if v == fieldValue {
-			return true
-		}
+	if !exists {
+		return matchValueAgainstPatternArray(patternArr, nil, false)
 	}
 
-	return false
+	return matchValueAgainstPatternArray(patternArr, value, true)
 }
 
 // matchDetailField checks if an event detail matches the detail pattern.
-// The detail pattern is a nested JSON object with arrays of acceptable values.
+// The detail pattern is a nested JSON object mapping field names to arrays of pattern elements.
 func matchDetailField(rawPattern json.RawMessage, detailJSON string) bool {
-	if detailJSON == "" {
-		return false
-	}
-
 	var pattern map[string]json.RawMessage
 	if err := json.Unmarshal(rawPattern, &pattern); err != nil {
 		return false
 	}
 
-	var detail map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(detailJSON), &detail); err != nil {
-		return false
+	detail := map[string]json.RawMessage{}
+
+	if detailJSON != "" {
+		_ = json.Unmarshal([]byte(detailJSON), &detail)
 	}
 
 	for key, patternValue := range pattern {
 		detailValue, exists := detail[key]
-		if !exists {
-			return false
-		}
-
-		if !matchDetailValue(patternValue, detailValue) {
+		if !matchDetailValue(patternValue, detailValue, exists) {
 			return false
 		}
 	}
@@ -87,44 +86,259 @@ func matchDetailField(rawPattern json.RawMessage, detailJSON string) bool {
 	return true
 }
 
-// matchDetailValue checks if a detail value matches a pattern value.
-// Handles both arrays of primitive values and nested objects.
-func matchDetailValue(patternValue, detailValue json.RawMessage) bool {
-	// Try as array of strings first.
-	var strValues []string
-	if err := json.Unmarshal(patternValue, &strValues); err == nil {
-		var actual string
-		if err := json.Unmarshal(detailValue, &actual); err == nil {
-			for _, v := range strValues {
-				if v == actual {
-					return true
-				}
-			}
-
-			return false
-		}
-	}
-
-	// Try as array of numbers.
-	var numValues []float64
-	if err := json.Unmarshal(patternValue, &numValues); err == nil {
-		var actual float64
-		if err := json.Unmarshal(detailValue, &actual); err == nil {
-			for _, v := range numValues {
-				if v == actual {
-					return true
-				}
-			}
-
-			return false
-		}
-	}
-
-	// Try as nested object pattern.
+// matchDetailValue checks if a detail value (or its absence) matches a pattern value.
+// Handles nested objects and pattern element arrays.
+func matchDetailValue(patternValue, detailValue json.RawMessage, exists bool) bool {
 	patternStr := strings.TrimSpace(string(patternValue))
+
+	// Nested object pattern: requires the field to exist as an object.
 	if strings.HasPrefix(patternStr, "{") {
+		if !exists {
+			return false
+		}
+
 		return matchDetailField(patternValue, string(detailValue))
 	}
 
+	return matchValueAgainstPatternArray(patternValue, detailValue, exists)
+}
+
+// matchValueAgainstPatternArray returns true if value matches at least one element in the pattern array.
+// When exists is false, only an `{"exists": false}` element matches.
+func matchValueAgainstPatternArray(patternArr, value json.RawMessage, exists bool) bool {
+	var elements []json.RawMessage
+	if err := json.Unmarshal(patternArr, &elements); err != nil {
+		return false
+	}
+
+	for _, elem := range elements {
+		if matchPatternElement(elem, value, exists) {
+			return true
+		}
+	}
+
 	return false
+}
+
+// matchPatternElement matches a single pattern element (literal value or content filter object).
+func matchPatternElement(elem, value json.RawMessage, exists bool) bool {
+	s := strings.TrimSpace(string(elem))
+	if strings.HasPrefix(s, "{") {
+		return matchContentFilter(elem, value, exists)
+	}
+
+	if !exists {
+		return false
+	}
+
+	return literalEquals(elem, value)
+}
+
+// literalEquals compares two JSON values for equality after canonicalisation.
+func literalEquals(a, b json.RawMessage) bool {
+	var av, bv any
+	if err := json.Unmarshal(a, &av); err != nil {
+		return false
+	}
+
+	if err := json.Unmarshal(b, &bv); err != nil {
+		return false
+	}
+
+	ac, err := json.Marshal(av)
+	if err != nil {
+		return false
+	}
+
+	bc, err := json.Marshal(bv)
+	if err != nil {
+		return false
+	}
+
+	return bytes.Equal(ac, bc)
+}
+
+// matchContentFilter dispatches to the appropriate content filter matcher.
+// A filter object has exactly one key indicating the filter type.
+func matchContentFilter(filter, value json.RawMessage, exists bool) bool {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(filter, &m); err != nil {
+		return false
+	}
+
+	for op, opArg := range m {
+		switch op {
+		case "exists":
+			return matchExistsFilter(opArg, exists)
+		case "prefix":
+			return exists && matchPrefixFilter(opArg, value)
+		case "suffix":
+			return exists && matchSuffixFilter(opArg, value)
+		case "anything-but":
+			return exists && matchAnythingButFilter(opArg, value)
+		case "numeric":
+			return exists && matchNumericFilter(opArg, value)
+		case "equals-ignore-case":
+			return exists && matchEqualsIgnoreCaseFilter(opArg, value)
+		}
+	}
+
+	return false
+}
+
+// matchExistsFilter handles {"exists": true|false}.
+func matchExistsFilter(arg json.RawMessage, exists bool) bool {
+	var want bool
+	if err := json.Unmarshal(arg, &want); err != nil {
+		return false
+	}
+
+	return want == exists
+}
+
+// matchPrefixFilter handles {"prefix": "..."}.
+func matchPrefixFilter(arg, value json.RawMessage) bool {
+	var prefix, actual string
+	if err := json.Unmarshal(arg, &prefix); err != nil {
+		return false
+	}
+
+	if err := json.Unmarshal(value, &actual); err != nil {
+		return false
+	}
+
+	return strings.HasPrefix(actual, prefix)
+}
+
+// matchSuffixFilter handles {"suffix": "..."}.
+func matchSuffixFilter(arg, value json.RawMessage) bool {
+	var suffix, actual string
+	if err := json.Unmarshal(arg, &suffix); err != nil {
+		return false
+	}
+
+	if err := json.Unmarshal(value, &actual); err != nil {
+		return false
+	}
+
+	return strings.HasSuffix(actual, suffix)
+}
+
+// matchAnythingButFilter handles {"anything-but": "x"} or {"anything-but": ["x", "y"]}.
+func matchAnythingButFilter(arg, value json.RawMessage) bool {
+	// Single value form.
+	var single string
+	if err := json.Unmarshal(arg, &single); err == nil {
+		var actual string
+		if err := json.Unmarshal(value, &actual); err != nil {
+			return false
+		}
+
+		return actual != single
+	}
+
+	// Array of strings form.
+	var listStr []string
+	if err := json.Unmarshal(arg, &listStr); err == nil {
+		var actual string
+		if err := json.Unmarshal(value, &actual); err != nil {
+			return false
+		}
+
+		for _, v := range listStr {
+			if actual == v {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	// Array of numbers form.
+	var listNum []float64
+	if err := json.Unmarshal(arg, &listNum); err == nil {
+		var actual float64
+		if err := json.Unmarshal(value, &actual); err != nil {
+			return false
+		}
+
+		for _, v := range listNum {
+			if actual == v {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	return false
+}
+
+// matchNumericFilter handles {"numeric": [op, num, op, num, ...]}.
+// Supported ops: =, !=, >, >=, <, <=.
+func matchNumericFilter(arg, value json.RawMessage) bool {
+	var actual float64
+	if err := json.Unmarshal(value, &actual); err != nil {
+		return false
+	}
+
+	var raw []json.RawMessage
+	if err := json.Unmarshal(arg, &raw); err != nil {
+		return false
+	}
+
+	if len(raw)%2 != 0 {
+		return false
+	}
+
+	for i := 0; i < len(raw); i += 2 {
+		var op string
+		if err := json.Unmarshal(raw[i], &op); err != nil {
+			return false
+		}
+
+		var operand float64
+		if err := json.Unmarshal(raw[i+1], &operand); err != nil {
+			return false
+		}
+
+		if !numericCompare(actual, op, operand) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func numericCompare(actual float64, op string, operand float64) bool {
+	switch op {
+	case "=":
+		return actual == operand
+	case "!=":
+		return actual != operand
+	case ">":
+		return actual > operand
+	case ">=":
+		return actual >= operand
+	case "<":
+		return actual < operand
+	case "<=":
+		return actual <= operand
+	}
+
+	return false
+}
+
+// matchEqualsIgnoreCaseFilter handles {"equals-ignore-case": "..."}.
+func matchEqualsIgnoreCaseFilter(arg, value json.RawMessage) bool {
+	var want, actual string
+	if err := json.Unmarshal(arg, &want); err != nil {
+		return false
+	}
+
+	if err := json.Unmarshal(value, &actual); err != nil {
+		return false
+	}
+
+	return strings.EqualFold(want, actual)
 }

--- a/internal/service/eventbridge/pattern_test.go
+++ b/internal/service/eventbridge/pattern_test.go
@@ -92,6 +92,90 @@ func TestMatchEventPattern(t *testing.T) {
 			event:   PutEventsRequestEntry{Source: "my.app"},
 			want:    false,
 		},
+		{
+			name:    "prefix on source",
+			pattern: `{"source": [{"prefix": "my."}]}`,
+			event:   PutEventsRequestEntry{Source: "my.app"},
+			want:    true,
+		},
+		{
+			name:    "prefix on source mismatch",
+			pattern: `{"source": [{"prefix": "other."}]}`,
+			event:   PutEventsRequestEntry{Source: "my.app"},
+			want:    false,
+		},
+		{
+			name:    "suffix on detail field",
+			pattern: `{"detail": {"name": [{"suffix": ".png"}]}}`,
+			event:   PutEventsRequestEntry{Source: "s3", Detail: `{"name": "photo.png"}`},
+			want:    true,
+		},
+		{
+			name:    "exists true matches present field",
+			pattern: `{"detail": {"userId": [{"exists": true}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"userId": "u1"}`},
+			want:    true,
+		},
+		{
+			name:    "exists false matches missing field",
+			pattern: `{"detail": {"userId": [{"exists": false}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"orderId": "o1"}`},
+			want:    true,
+		},
+		{
+			name:    "exists true rejects missing field",
+			pattern: `{"detail": {"userId": [{"exists": true}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"orderId": "o1"}`},
+			want:    false,
+		},
+		{
+			name:    "anything-but single value",
+			pattern: `{"detail": {"status": [{"anything-but": "draft"}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"status": "published"}`},
+			want:    true,
+		},
+		{
+			name:    "anything-but single value rejects",
+			pattern: `{"detail": {"status": [{"anything-but": "draft"}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"status": "draft"}`},
+			want:    false,
+		},
+		{
+			name:    "anything-but list",
+			pattern: `{"detail": {"status": [{"anything-but": ["draft", "archived"]}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"status": "published"}`},
+			want:    true,
+		},
+		{
+			name:    "numeric range match",
+			pattern: `{"detail": {"price": [{"numeric": [">", 0, "<=", 100]}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"price": 50}`},
+			want:    true,
+		},
+		{
+			name:    "numeric range out of bounds",
+			pattern: `{"detail": {"price": [{"numeric": [">", 0, "<=", 100]}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"price": 200}`},
+			want:    false,
+		},
+		{
+			name:    "numeric equality",
+			pattern: `{"detail": {"count": [{"numeric": ["=", 5]}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"count": 5}`},
+			want:    true,
+		},
+		{
+			name:    "equals-ignore-case",
+			pattern: `{"detail": {"region": [{"equals-ignore-case": "us-east-1"}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"region": "US-EAST-1"}`},
+			want:    true,
+		},
+		{
+			name:    "literal and content filter mixed",
+			pattern: `{"detail": {"state": ["pending", {"prefix": "process"}]}}`,
+			event:   PutEventsRequestEntry{Detail: `{"state": "processing"}`},
+			want:    true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -604,6 +604,11 @@ func (s *MemoryStorage) matchAndDeliver(eventID, eventBusName string, entry *Put
 			if isSQSArn(target.Arn) {
 				go s.deliverToSQS(target, payload)
 			}
+
+			// Deliver to Lambda if the target ARN is a Lambda function.
+			if isLambdaArn(target.Arn) {
+				go s.deliverToLambda(target, payload)
+			}
 		}
 	}
 }
@@ -775,6 +780,55 @@ func (s *MemoryStorage) deliverToSQS(target *Target, payload []byte) {
 
 	s.logger.Info("delivered event to SQS",
 		"queue", queueName,
+		"status", resp.StatusCode,
+	)
+}
+
+// isLambdaArn returns true if the ARN is a Lambda function ARN.
+func isLambdaArn(arn string) bool {
+	return strings.Contains(arn, ":lambda:")
+}
+
+// deliverToLambda invokes a Lambda function asynchronously via the local kumo Lambda endpoint.
+func (s *MemoryStorage) deliverToLambda(target *Target, payload []byte) {
+	if payload == nil {
+		return
+	}
+
+	// Lambda ARN: arn:aws:lambda:region:account:function:function-name[:qualifier]
+	parts := strings.Split(target.Arn, ":")
+	if len(parts) < 7 || parts[5] != "function" {
+		s.logger.Error("invalid Lambda ARN", "arn", target.Arn)
+
+		return
+	}
+
+	functionName := parts[6]
+	endpoint := fmt.Sprintf("%s/lambda/2015-03-31/functions/%s/invocations", s.baseURL, functionName)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		s.logger.Error("failed to create Lambda invoke request", "error", err, "function", functionName)
+
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Amz-Invocation-Type", "Event")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		s.logger.Error("failed to deliver event to Lambda", "error", err, "function", functionName)
+
+		return
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	s.logger.Info("delivered event to Lambda",
+		"function", functionName,
 		"status", resp.StatusCode,
 	)
 }

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -102,10 +102,20 @@ type MemoryStorage struct {
 	dataDir         string
 	baseURL         string
 	logger          *slog.Logger
+	// httpClient is shared across delivery goroutines so the underlying
+	// transport can pool connections instead of leaking one per event.
+	httpClient *http.Client
+	// deliveryCtx is cancelled by Close so in-flight async deliveries
+	// (Lambda / SQS / API destination Invokes) abort on shutdown instead
+	// of outliving the server.
+	deliveryCtx    context.Context //nolint:containedctx // intentional: scopes background goroutines to storage lifetime
+	deliveryCancel context.CancelFunc
 }
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	s := &MemoryStorage{
 		EventBuses:      make(map[string]*EventBus),
 		Rules:           make(map[string]map[string]*Rule),
@@ -116,6 +126,9 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 		accountID:       "000000000000",
 		baseURL:         "http://localhost:4566",
 		logger:          slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		httpClient:      &http.Client{Timeout: 5 * time.Second},
+		deliveryCtx:     ctx,
+		deliveryCancel:  cancel,
 	}
 	for _, o := range opts {
 		o(s)
@@ -185,6 +198,10 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 
 // Close saves the storage state to disk if persistence is enabled.
 func (s *MemoryStorage) Close() error {
+	if s.deliveryCancel != nil {
+		s.deliveryCancel()
+	}
+
 	if s.dataDir == "" {
 		return nil
 	}
@@ -695,7 +712,7 @@ func (s *MemoryStorage) deliverToHTTP(dest *APIDestination, target *Target, payl
 		method = http.MethodPost
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), method, endpoint, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(s.deliveryCtx, method, endpoint, bytes.NewReader(payload))
 	if err != nil {
 		s.logger.Error("failed to create HTTP request for API destination", "error", err, "endpoint", endpoint)
 
@@ -706,9 +723,7 @@ func (s *MemoryStorage) deliverToHTTP(dest *APIDestination, target *Target, payl
 	req.Header.Set("User-Agent", "Amazon/EventBridge/ApiDestinations")
 	applyHTTPParameters(req, target.HTTPParameters)
 
-	client := &http.Client{Timeout: 5 * time.Second}
-
-	resp, err := client.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		s.logger.Error("failed to deliver event to API destination", "error", err, "endpoint", endpoint)
 
@@ -757,7 +772,7 @@ func (s *MemoryStorage) deliverToSQS(target *Target, payload []byte) {
 		return
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, s.baseURL+"/", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(s.deliveryCtx, http.MethodPost, s.baseURL+"/", bytes.NewReader(body))
 	if err != nil {
 		s.logger.Error("failed to create SQS request", "error", err, "queue", queueName)
 
@@ -767,9 +782,7 @@ func (s *MemoryStorage) deliverToSQS(target *Target, payload []byte) {
 	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
 	req.Header.Set("X-Amz-Target", "AmazonSQS.SendMessage")
 
-	client := &http.Client{Timeout: 5 * time.Second}
-
-	resp, err := client.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		s.logger.Error("failed to deliver event to SQS", "error", err, "queue", queueName)
 
@@ -806,7 +819,7 @@ func (s *MemoryStorage) deliverToLambda(target *Target, payload []byte) {
 	functionName := parts[6]
 	endpoint := fmt.Sprintf("%s/lambda/2015-03-31/functions/%s/invocations", s.baseURL, functionName)
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(s.deliveryCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
 		s.logger.Error("failed to create Lambda invoke request", "error", err, "function", functionName)
 
@@ -816,9 +829,7 @@ func (s *MemoryStorage) deliverToLambda(target *Target, payload []byte) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Amz-Invocation-Type", "Event")
 
-	client := &http.Client{Timeout: 5 * time.Second}
-
-	resp, err := client.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		s.logger.Error("failed to deliver event to Lambda", "error", err, "function", functionName)
 

--- a/internal/service/eventbridge/storage_test.go
+++ b/internal/service/eventbridge/storage_test.go
@@ -79,6 +79,47 @@ func TestResolveInputPath(t *testing.T) {
 	}
 }
 
+func TestIsLambdaArn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arn  string
+		want bool
+	}{
+		{
+			name: "Lambda function ARN",
+			arn:  "arn:aws:lambda:us-east-1:000000000000:function:my-func",
+			want: true,
+		},
+		{
+			name: "Lambda qualified ARN",
+			arn:  "arn:aws:lambda:us-east-1:000000000000:function:my-func:PROD",
+			want: true,
+		},
+		{
+			name: "SQS ARN",
+			arn:  "arn:aws:sqs:us-east-1:000000000000:my-queue",
+			want: false,
+		},
+		{
+			name: "empty string",
+			arn:  "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isLambdaArn(tt.arn); got != tt.want {
+				t.Errorf("isLambdaArn(%q) = %v, want %v", tt.arn, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsSQSArn(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/eventbridge/tag_stubs.go
+++ b/internal/service/eventbridge/tag_stubs.go
@@ -1,0 +1,22 @@
+package eventbridge
+
+import "net/http"
+
+// ListTagsForResource returns an empty tag list for any resource.
+//
+// Tags are not modeled in the storage layer yet; this stub exists so reads
+// from clients that refresh state after CreateEventBus / PutRule (terraform,
+// pulumi, CDK) do not fail with InvalidAction.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(w, listTagsForResourceResponse{Tags: []map[string]string{}})
+}
+
+// TagResource accepts and discards tag attachments.
+func (s *Service) TagResource(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(w, struct{}{})
+}
+
+// UntagResource accepts and discards tag detachments.
+func (s *Service) UntagResource(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(w, struct{}{})
+}

--- a/internal/service/eventbridge/types.go
+++ b/internal/service/eventbridge/types.go
@@ -518,3 +518,10 @@ type ServiceError struct {
 func (e *ServiceError) Error() string {
 	return e.Message
 }
+
+// listTagsForResourceResponse mirrors the AWS shape: a `Tags` array that
+// must be present even when empty. terraform-provider-aws fails to parse
+// missing-Tags responses.
+type listTagsForResourceResponse struct {
+	Tags []map[string]string `json:"Tags"`
+}

--- a/test/integration/eventbridge_test.go
+++ b/test/integration/eventbridge_test.go
@@ -3,10 +3,15 @@
 package integration
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -624,5 +629,150 @@ func TestEventBridge_EventBusNotFound(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for non-existent event bus")
+	}
+}
+
+func TestEventBridge_PutEvents_LambdaDelivery(t *testing.T) {
+	ebClient := newEventBridgeClient(t)
+	ctx := t.Context()
+
+	// Mock Lambda backend that records invocations.
+	var (
+		mu       sync.Mutex
+		received [][]byte
+	)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		received = append(received, body)
+		mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(mockServer.Close)
+
+	functionName := "eb-lambda-delivery-fn"
+
+	// Register Lambda function with InvokeEndpoint so that the kumo Lambda emulator
+	// forwards invocations to our mock server.
+	createReq, _ := json.Marshal(map[string]any{
+		"FunctionName":   functionName,
+		"Runtime":        "python3.12",
+		"Role":           "arn:aws:iam::000000000000:role/test-role",
+		"Handler":        "index.handler",
+		"InvokeEndpoint": mockServer.URL,
+		"Code":           map[string]any{"ZipFile": []byte("fake-zip")},
+	})
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		"http://localhost:4566/lambda/2015-03-31/functions", bytes.NewReader(createReq))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create function: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create function status: %d", resp.StatusCode)
+	}
+
+	t.Cleanup(func() {
+		delReq, _ := http.NewRequestWithContext(context.Background(), http.MethodDelete,
+			"http://localhost:4566/lambda/2015-03-31/functions/"+functionName, nil)
+
+		delResp, _ := http.DefaultClient.Do(delReq)
+		if delResp != nil {
+			delResp.Body.Close()
+		}
+	})
+
+	// Create rule using advanced pattern matchers (prefix + numeric).
+	_, err = ebClient.PutRule(ctx, &eventbridge.PutRuleInput{
+		Name:         aws.String("eb-lambda-rule"),
+		EventPattern: aws.String(`{"source": [{"prefix": "order."}], "detail": {"amount": [{"numeric": [">", 0]}]}}`),
+		State:        types.RuleStateEnabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add Lambda target.
+	_, err = ebClient.PutTargets(ctx, &eventbridge.PutTargetsInput{
+		Rule: aws.String("eb-lambda-rule"),
+		Targets: []types.Target{
+			{
+				Id:  aws.String("lambda-target"),
+				Arn: aws.String("arn:aws:lambda:us-east-1:000000000000:function:" + functionName),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put matching event.
+	_, err = ebClient.PutEvents(ctx, &eventbridge.PutEventsInput{
+		Entries: []types.PutEventsRequestEntry{
+			{
+				Source:     aws.String("order.service"),
+				DetailType: aws.String("OrderCreated"),
+				Detail:     aws.String(`{"orderId": "o-1", "amount": 42}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put non-matching event (amount <= 0 should be filtered out).
+	_, err = ebClient.PutEvents(ctx, &eventbridge.PutEventsInput{
+		Entries: []types.PutEventsRequestEntry{
+			{
+				Source:     aws.String("order.service"),
+				DetailType: aws.String("OrderCreated"),
+				Detail:     aws.String(`{"orderId": "o-2", "amount": 0}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the asynchronous delivery to complete.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		count := len(received)
+		mu.Unlock()
+
+		if count >= 1 {
+			break
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(received) != 1 {
+		t.Fatalf("expected exactly 1 Lambda invocation, got %d", len(received))
+	}
+
+	// Verify payload is the EventBridge event envelope.
+	var envelope map[string]any
+	if err := json.Unmarshal(received[0], &envelope); err != nil {
+		t.Fatalf("invalid envelope JSON: %v (body=%s)", err, string(received[0]))
+	}
+
+	if envelope["source"] != "order.service" {
+		t.Errorf("source=%v, want order.service", envelope["source"])
+	}
+
+	detail, _ := envelope["detail"].(map[string]any)
+	if detail["orderId"] != "o-1" {
+		t.Errorf("orderId=%v, want o-1", detail["orderId"])
 	}
 }


### PR DESCRIPTION
## Summary

Two related EventBridge gaps:

1. **Lambda target delivery + AWS content filter patterns** — pulled forward from a long-running local branch. PutEvents now dispatches asynchronously to Lambda targets the same way SQS targets are dispatched, and the event-pattern matcher accepts the AWS content filters (\`prefix\` / \`suffix\` / \`exists\` / \`anything-but\` / \`numeric\` / \`equals-ignore-case\`) plus mixed literal/filter arrays.
2. **Tag stubs** — discovered while running tofu against EventBridge for #589. terraform-provider-aws calls \`ListTagsForResource\` on every refresh of \`aws_cloudwatch_event_bus\` / \`aws_cloudwatch_event_rule\`; without it, \`tofu apply\` of any EventBridge resource fails with \`InvalidAction\` immediately after create.

## Implementation

### Lambda targets + content filters (commit 1)

- \`PutEvents\` resolves rule targets and, for ARNs in the \`lambda\` namespace, performs an asynchronous Invoke against the local Lambda emulator (mirrors the existing SQS dispatch path).
- \`pattern.go\` extended for the standard content-filter operators. Mixed arrays — \`{ \"detail\": { \"k\": [\"literal\", { \"prefix\": \"x\" }] } }\` — work, matching AWS semantics where any element matches.
- New unit tests in \`pattern_test.go\` and \`storage_test.go\`; integration test in \`test/integration/eventbridge_test.go\` covers the SQS + Lambda dispatch path end-to-end.

### Tag stubs (commit 2)

- \`ListTagsForResource\` returns \`{\"Tags\":[]}\` (the field must be present even when empty; some clients fail to parse missing-Tags responses).
- \`TagResource\` / \`UntagResource\` accept and discard the payload.
- Same shape as the \`ecr\` (#565) / \`logs\` (#566) / \`dynamodb\` (#590) tag stubs — wire-level no-ops so refresh paths complete, real persistence layered later.

## Test plan

- [x] \`go test ./internal/service/eventbridge/...\` — green (existing + the cherry-picked pattern_test / storage_test cases).
- [x] \`go test ./...\` — full suite green.
- [x] \`make lint\` — eventbridge package clean.
- [x] End-to-end: tofu \`apply\` and \`destroy\` of \`aws_cloudwatch_event_bus\` against \`kumo serve\` — both succeed; before this PR \`apply\` failed with \`InvalidAction\` on \`ListTagsForResource\` immediately after creating the bus.

Cross-ref: #416, #589.