### PR TITLE
feat(secretsmanager): GetResourcePolicy / Put / Delete stubs

### DIFF
--- a/internal/service/secretsmanager/handlers.go
+++ b/internal/service/secretsmanager/handlers.go
@@ -484,6 +484,12 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 		s.UpdateSecret(w, r)
 	case "GetRandomPassword":
 		s.GetRandomPassword(w, r)
+	case "GetResourcePolicy":
+		s.GetResourcePolicy(w, r)
+	case "PutResourcePolicy":
+		s.PutResourcePolicy(w, r)
+	case "DeleteResourcePolicy":
+		s.DeleteResourcePolicy(w, r)
 	default:
 		writeSecretsManagerError(w, errInvalidAction, "The action "+action+" is not valid", http.StatusBadRequest)
 	}

--- a/internal/service/secretsmanager/policy_stub.go
+++ b/internal/service/secretsmanager/policy_stub.go
@@ -1,0 +1,61 @@
+package secretsmanager
+
+import (
+	"errors"
+	"net/http"
+)
+
+// GetResourcePolicy returns an empty resource policy for an existing secret.
+//
+// terraform-provider-aws calls GetResourcePolicy on every refresh of
+// aws_secretsmanager_secret. Resource policies are not modeled in storage
+// yet; this stub exists so the refresh path completes. The response shape
+// matches AWS: ARN + Name + null ResourcePolicy.
+func (s *Service) GetResourcePolicy(w http.ResponseWriter, r *http.Request) {
+	var req getResourcePolicyRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.SecretID == "" {
+		writeSecretsManagerError(w, errInvalidParameter, "You must provide a value for the SecretId parameter.", http.StatusBadRequest)
+
+		return
+	}
+
+	secret, err := s.storage.DescribeSecret(r.Context(), req.SecretID)
+	if err != nil {
+		var sErr *SecretError
+		if errors.As(err, &sErr) {
+			status := http.StatusBadRequest
+			if sErr.Code == errResourceNotFound {
+				status = http.StatusNotFound
+			}
+
+			writeSecretsManagerError(w, sErr.Code, sErr.Message, status)
+
+			return
+		}
+
+		writeSecretsManagerError(w, errInternalServiceError, "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, getResourcePolicyResponse{
+		ARN:  secret.ARN,
+		Name: secret.Name,
+	})
+}
+
+// PutResourcePolicy accepts and discards a policy attachment.
+func (s *Service) PutResourcePolicy(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, struct{}{})
+}
+
+// DeleteResourcePolicy accepts and discards a policy detachment.
+func (s *Service) DeleteResourcePolicy(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, struct{}{})
+}

--- a/internal/service/secretsmanager/policy_stub_test.go
+++ b/internal/service/secretsmanager/policy_stub_test.go
@@ -1,0 +1,89 @@
+package secretsmanager
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGetResourcePolicy_ExistingSecret(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage("http://localhost:4566")
+	svc := New(store, "http://localhost:4566")
+
+	if _, err := store.CreateSecret(t.Context(), &CreateSecretRequest{
+		Name:         "policy-existing",
+		SecretString: "value",
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"SecretId":"policy-existing"}`))
+	req.Header.Set("X-Amz-Target", "secretsmanager.GetResourcePolicy")
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp getResourcePolicyResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Name != "policy-existing" {
+		t.Errorf("Name: got %q, want %q", resp.Name, "policy-existing")
+	}
+
+	if resp.ARN == "" {
+		t.Error("ARN: empty (terraform reads ARN from refresh response)")
+	}
+
+	if resp.ResourcePolicy != "" {
+		t.Errorf("ResourcePolicy: got %q, want empty (no policy modeled)", resp.ResourcePolicy)
+	}
+}
+
+func TestGetResourcePolicy_MissingSecret(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage("http://localhost:4566"), "http://localhost:4566")
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"SecretId":"does-not-exist"}`))
+	req.Header.Set("X-Amz-Target", "secretsmanager.GetResourcePolicy")
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestPutAndDeleteResourcePolicy_NoOp(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage("http://localhost:4566"), "http://localhost:4566")
+
+	for _, action := range []string{"PutResourcePolicy", "DeleteResourcePolicy"} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/",
+				strings.NewReader(`{"SecretId":"x","ResourcePolicy":"{}"}`))
+			req.Header.Set("X-Amz-Target", "secretsmanager."+action)
+
+			w := httptest.NewRecorder()
+			svc.DispatchAction(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status: got %d, body=%s", w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/service/secretsmanager/types.go
+++ b/internal/service/secretsmanager/types.go
@@ -271,3 +271,20 @@ type ExternalSecretRotationMetadataItem struct {
 	Key   string `json:"Key,omitempty"`
 	Value string `json:"Value,omitempty"`
 }
+
+// getResourcePolicyRequest is the wire shape of GetResourcePolicy / PutResourcePolicy / DeleteResourcePolicy.
+type getResourcePolicyRequest struct {
+	SecretID       string `json:"SecretId"`
+	ResourcePolicy string `json:"ResourcePolicy,omitempty"`
+}
+
+// getResourcePolicyResponse is the wire shape of GetResourcePolicy.
+//
+// AWS responds with ARN + Name and omits the ResourcePolicy field when no
+// policy is attached. terraform-provider-aws treats the missing field as
+// "no policy attached".
+type getResourcePolicyResponse struct {
+	ARN            string `json:"ARN"`
+	Name           string `json:"Name"`
+	ResourcePolicy string `json:"ResourcePolicy,omitempty"`
+}


### PR DESCRIPTION
## Summary

terraform-provider-aws calls \`GetResourcePolicy\` on every refresh of \`aws_secretsmanager_secret\`. Without it, \`tofu apply\` of any SecretsManager resource fails with \`InvalidAction\` immediately after the secret is created (the secret exists in storage but state cannot be refreshed, blocking destroy as well).

Same shape as #565 (ecr) / #566 (logs) / #590 (dynamodb) — wire-level no-ops so refresh paths complete, with the door open for real persistence later.

## Implementation

- \`GetResourcePolicy\` returns \`ARN\` + \`Name\` with no \`ResourcePolicy\` field when no policy is attached, matching AWS behaviour. Returns \`ResourceNotFoundException\` for missing secrets.
- \`PutResourcePolicy\` / \`DeleteResourcePolicy\` accept and discard the payload.
- Wire types live in \`types.go\` (covered by the existing tagliatelle exemption).

## Test plan

- [x] \`go test ./internal/service/secretsmanager/...\` — green (3 new tests + sub-tests).
- [x] \`make lint\` — clean.
- [x] End-to-end: tofu \`apply\` + \`destroy\` of \`aws_secretsmanager_secret\` against \`kumo serve\` — both succeed; before this PR \`apply\` errored on \`GetResourcePolicy\` after creating the secret.

Cross-ref: #416, #589.