### PR TITLE
feat(kms): GetKeyPolicy / ListResourceTags / GetKeyRotationStatus stubs

### DIFF
--- a/internal/service/kms/handlers.go
+++ b/internal/service/kms/handlers.go
@@ -28,6 +28,15 @@ func (s *Service) getActionHandlers() map[string]handlerFunc {
 		"CreateAlias":         s.CreateAlias,
 		"DeleteAlias":         s.DeleteAlias,
 		"ListAliases":         s.ListAliases,
+		// Key policy + tag stubs — see policy_tag_stubs.go.
+		// Required by terraform-provider-aws after CreateKey.
+		"GetKeyPolicy":         s.GetKeyPolicy,
+		"PutKeyPolicy":         s.PutKeyPolicy,
+		"ListKeyPolicies":      s.ListKeyPolicies,
+		"ListResourceTags":     s.ListResourceTags,
+		"TagResource":          s.TagResource,
+		"UntagResource":        s.UntagResource,
+		"GetKeyRotationStatus": s.GetKeyRotationStatus,
 	}
 }
 

--- a/internal/service/kms/policy_tag_stubs.go
+++ b/internal/service/kms/policy_tag_stubs.go
@@ -1,0 +1,76 @@
+package kms
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// defaultKeyPolicy is the AWS-default key policy returned for any key when
+// no explicit policy has been set. terraform-provider-aws hashes this for
+// drift detection so it must be a stable JSON document with the standard
+// AccountRootEnable statement.
+const defaultKeyPolicy = `{"Version":"2012-10-17","Id":"key-default-1","Statement":[{"Sid":"Enable IAM User Permissions","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::000000000000:root"},"Action":"kms:*","Resource":"*"}]}`
+
+// GetKeyPolicy returns the default key policy for any existing key.
+//
+// terraform-provider-aws calls GetKeyPolicy on every refresh of aws_kms_key
+// (and immediately after CreateKey) to populate the `policy` attribute.
+// Without it, `tofu apply` errors out before the create call returns.
+//
+// Key policies are not modeled in storage yet; this stub returns the AWS
+// default policy so refresh paths complete and drift detection stays stable.
+func (s *Service) GetKeyPolicy(w http.ResponseWriter, r *http.Request) {
+	var req getKeyPolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.KeyID == "" {
+		writeKMSError(w, "ValidationException", "KeyId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if _, err := s.storage.GetKey(r.Context(), req.KeyID); err != nil {
+		handleKMSError(w, err)
+
+		return
+	}
+
+	writeKMSResponse(w, getKeyPolicyResponse{
+		Policy:     defaultKeyPolicy,
+		PolicyName: "default",
+	})
+}
+
+// PutKeyPolicy accepts and discards a key policy update.
+func (s *Service) PutKeyPolicy(w http.ResponseWriter, _ *http.Request) {
+	writeKMSResponse(w, struct{}{})
+}
+
+// ListKeyPolicies reports the single "default" policy name AWS exposes.
+func (s *Service) ListKeyPolicies(w http.ResponseWriter, _ *http.Request) {
+	writeKMSResponse(w, listKeyPoliciesResponse{PolicyNames: []string{"default"}})
+}
+
+// ListResourceTags returns an empty tag list for any key.
+//
+// terraform-provider-aws calls this on every refresh; the field must be
+// present even when empty.
+func (s *Service) ListResourceTags(w http.ResponseWriter, _ *http.Request) {
+	writeKMSResponse(w, listResourceTagsResponse{Tags: []map[string]string{}})
+}
+
+// TagResource accepts and discards tag attachments.
+func (s *Service) TagResource(w http.ResponseWriter, _ *http.Request) {
+	writeKMSResponse(w, struct{}{})
+}
+
+// UntagResource accepts and discards tag detachments.
+func (s *Service) UntagResource(w http.ResponseWriter, _ *http.Request) {
+	writeKMSResponse(w, struct{}{})
+}
+
+// GetKeyRotationStatus reports rotation as disabled for any key.
+//
+// terraform-provider-aws calls this on every refresh to populate the
+// `enable_key_rotation` attribute. Rotation is not modeled in storage.
+func (s *Service) GetKeyRotationStatus(w http.ResponseWriter, _ *http.Request) {
+	writeKMSResponse(w, getKeyRotationStatusResponse{KeyRotationEnabled: false})
+}

--- a/internal/service/kms/types.go
+++ b/internal/service/kms/types.go
@@ -347,3 +347,31 @@ type ServiceError struct {
 func (e *ServiceError) Error() string {
 	return e.Message
 }
+
+// getKeyPolicyRequest is the wire shape of GetKeyPolicy / PutKeyPolicy.
+type getKeyPolicyRequest struct {
+	KeyID      string `json:"KeyId"`
+	PolicyName string `json:"PolicyName,omitempty"`
+}
+
+// getKeyPolicyResponse is the wire shape of GetKeyPolicy.
+type getKeyPolicyResponse struct {
+	Policy     string `json:"Policy"`
+	PolicyName string `json:"PolicyName"`
+}
+
+// listKeyPoliciesResponse is the wire shape of ListKeyPolicies.
+type listKeyPoliciesResponse struct {
+	PolicyNames []string `json:"PolicyNames"`
+}
+
+// listResourceTagsResponse mirrors AWS — the Tags field must be present
+// even when empty so terraform-provider-aws can parse it.
+type listResourceTagsResponse struct {
+	Tags []map[string]string `json:"Tags"`
+}
+
+// getKeyRotationStatusResponse is the wire shape of GetKeyRotationStatus.
+type getKeyRotationStatusResponse struct {
+	KeyRotationEnabled bool `json:"KeyRotationEnabled"`
+}


### PR DESCRIPTION
## Summary

terraform-provider-aws calls \`GetKeyPolicy\`, \`ListResourceTags\`, and \`GetKeyRotationStatus\` on every refresh of \`aws_kms_key\` (and immediately after CreateKey). Without them, \`tofu apply\` of any KMS resource fails with \`InvalidAction\` before the create call returns.

Same shape as #565 / #566 / #590 / #592 — wire-level no-ops so refresh paths complete, with the door open for real persistence later.

## Implementation

- \`GetKeyPolicy\` returns the AWS-default key policy (standard AccountRootEnable statement) so terraform's drift hash stays stable across applies.
- \`ListKeyPolicies\` reports the single \`default\` name AWS exposes.
- \`ListResourceTags\` returns an empty Tags array (the field must be present even when empty so terraform can parse it).
- \`GetKeyRotationStatus\` reports rotation as disabled.
- \`PutKeyPolicy\` / \`TagResource\` / \`UntagResource\` accept and discard their payload.

## Test plan

- [x] \`go test ./internal/service/kms/...\` — green.
- [x] \`make lint\` — clean.
- [x] End-to-end: tofu \`apply\` + \`destroy\` of \`aws_kms_key { description = ...; deletion_window_in_days = 7 }\` against \`kumo serve\` — both succeed; before this PR \`apply\` errored on \`GetKeyPolicy\` after creating the key.

Cross-ref: #416, #589.