### PR TITLE
feat(sfn): ValidateStateMachineDefinition + Versions/Aliases/Tags stubs

### DIFF
--- a/internal/service/sfn/definition_stub.go
+++ b/internal/service/sfn/definition_stub.go
@@ -1,0 +1,52 @@
+package sfn
+
+import "net/http"
+
+// ValidateStateMachineDefinition reports the supplied definition as valid.
+//
+// terraform-provider-aws calls ValidateStateMachineDefinition during the
+// plan phase of every aws_sfn_state_machine, before issuing CreateStateMachine.
+// Without it, `tofu plan` fails with InvalidAction and the resource never
+// reaches the create path.
+//
+// Definitions are not statically validated in kumo; this stub returns OK
+// so the apply pipeline proceeds and CreateStateMachine does the real
+// shape check.
+func (s *Service) ValidateStateMachineDefinition(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(w, validateStateMachineDefinitionResponse{
+		Result:      "OK",
+		Diagnostics: []validateDiagnostic{},
+	})
+}
+
+// ListTagsForResource returns an empty tag list for any state machine.
+//
+// terraform-provider-aws calls this on every refresh; the field must be
+// present even when empty.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(w, listTagsForResourceResponse{Tags: []map[string]string{}})
+}
+
+// TagResource accepts and discards tag attachments.
+func (s *Service) TagResource(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(w, struct{}{})
+}
+
+// UntagResource accepts and discards tag detachments.
+func (s *Service) UntagResource(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(w, struct{}{})
+}
+
+// ListStateMachineVersions reports no versions for any state machine.
+//
+// Versions are not modeled in storage. terraform-provider-aws calls this
+// on every refresh; the StateMachineVersions field must be present even
+// when empty.
+func (s *Service) ListStateMachineVersions(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(w, listStateMachineVersionsResponse{StateMachineVersions: []map[string]string{}})
+}
+
+// ListStateMachineAliases reports no aliases for any state machine.
+func (s *Service) ListStateMachineAliases(w http.ResponseWriter, _ *http.Request) {
+	writeResponse(w, listStateMachineAliasesResponse{StateMachineAliases: []map[string]string{}})
+}

--- a/internal/service/sfn/handlers.go
+++ b/internal/service/sfn/handlers.go
@@ -27,6 +27,14 @@ func (s *Service) getActionHandlers() map[string]handlerFunc {
 		"SendTaskSuccess":      s.SendTaskSuccess,
 		"SendTaskFailure":      s.SendTaskFailure,
 		"SendTaskHeartbeat":    s.SendTaskHeartbeat,
+		// Tag + validation stubs — see definition_stub.go.
+		// Required by terraform-provider-aws plan/apply of aws_sfn_state_machine.
+		"ValidateStateMachineDefinition": s.ValidateStateMachineDefinition,
+		"ListStateMachineVersions":       s.ListStateMachineVersions,
+		"ListStateMachineAliases":        s.ListStateMachineAliases,
+		"ListTagsForResource":            s.ListTagsForResource,
+		"TagResource":                    s.TagResource,
+		"UntagResource":                  s.UntagResource,
 	}
 }
 

--- a/internal/service/sfn/types.go
+++ b/internal/service/sfn/types.go
@@ -355,3 +355,37 @@ type ServiceError struct {
 func (e *ServiceError) Error() string {
 	return e.Message
 }
+
+// validateStateMachineDefinitionResponse is the wire shape of
+// ValidateStateMachineDefinition. AWS returns Result="OK" plus an empty
+// diagnostics array on success; terraform-provider-aws checks Result.
+type validateStateMachineDefinitionResponse struct {
+	Result      string               `json:"result"`
+	Diagnostics []validateDiagnostic `json:"diagnostics"`
+}
+
+// validateDiagnostic is a single ValidateStateMachineDefinition diagnostic.
+type validateDiagnostic struct {
+	Severity string `json:"severity"`
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+	Location string `json:"location,omitempty"`
+}
+
+// listTagsForResourceResponse is the wire shape of ListTagsForResource;
+// the Tags field must be present even when empty.
+type listTagsForResourceResponse struct {
+	Tags []map[string]string `json:"tags"`
+}
+
+// listStateMachineVersionsResponse is the wire shape of ListStateMachineVersions.
+type listStateMachineVersionsResponse struct {
+	StateMachineVersions []map[string]string `json:"stateMachineVersions"`
+	NextToken            string              `json:"nextToken,omitempty"`
+}
+
+// listStateMachineAliasesResponse is the wire shape of ListStateMachineAliases.
+type listStateMachineAliasesResponse struct {
+	StateMachineAliases []map[string]string `json:"stateMachineAliases"`
+	NextToken           string              `json:"nextToken,omitempty"`
+}


### PR DESCRIPTION
## Summary

terraform-provider-aws calls \`ValidateStateMachineDefinition\` during plan and \`ListStateMachineVersions\` / \`ListStateMachineAliases\` / \`ListTagsForResource\` during refresh of \`aws_sfn_state_machine\`. Without them, \`tofu plan\` of any \`aws_sfn_state_machine\` fails with \`InvalidAction\` before reaching the create call, and \`tofu apply\` then errors on the post-create refresh.

Same shape as #565 / #566 / #590 / #592 / #593 — wire-level no-ops so plan/refresh paths complete, with the door open for real persistence later.

## Implementation

- \`ValidateStateMachineDefinition\` reports OK for any input. Definitions are not statically validated in kumo; the real shape check happens in \`CreateStateMachine\`.
- \`ListStateMachineVersions\` / \`ListStateMachineAliases\` return empty arrays (the field must be present even when empty so terraform can parse it).
- \`ListTagsForResource\` returns an empty Tags array. \`TagResource\` / \`UntagResource\` accept and discard their payload.

## Test plan

- [x] \`go test ./internal/service/sfn/...\` — green.
- [x] \`make lint\` — clean.
- [x] End-to-end: tofu \`apply\` + \`destroy\` of a minimal Pass-state \`aws_sfn_state_machine\` against \`kumo serve\` — both succeed; before this PR \`plan\` errored on \`ValidateStateMachineDefinition\`, and after that fix \`apply\` errored on \`ListStateMachineVersions\`.

Cross-ref: #416, #589.