### PR TITLE
feat(sns): GetTopicAttributes / SetTopicAttributes / Tag stubs

### DIFF
--- a/internal/service/sns/handlers.go
+++ b/internal/service/sns/handlers.go
@@ -460,6 +460,16 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 		s.ListSubscriptions(w, r)
 	case "ListSubscriptionsByTopic":
 		s.ListSubscriptionsByTopic(w, r)
+	case "GetTopicAttributes":
+		s.GetTopicAttributes(w, r)
+	case "SetTopicAttributes":
+		s.SetTopicAttributes(w, r)
+	case "ListTagsForResource":
+		s.ListTagsForResource(w, r)
+	case "TagResource":
+		s.TagResource(w, r)
+	case "UntagResource":
+		s.UntagResource(w, r)
 	default:
 		writeTopicError(w, errInvalidAction, "The action "+action+" is not valid", http.StatusBadRequest)
 	}

--- a/internal/service/sns/service.go
+++ b/internal/service/sns/service.go
@@ -60,6 +60,11 @@ func (s *Service) Actions() []string {
 		"Publish",
 		"ListSubscriptions",
 		"ListSubscriptionsByTopic",
+		"GetTopicAttributes",
+		"SetTopicAttributes",
+		"ListTagsForResource",
+		"TagResource",
+		"UntagResource",
 	}
 }
 

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -27,6 +27,8 @@ type SQSPublisher interface {
 // Storage defines the SNS storage interface.
 type Storage interface {
 	CreateTopic(ctx context.Context, name string, attributes map[string]string) (*Topic, error)
+	GetTopic(ctx context.Context, topicARN string) (*Topic, error)
+	SetTopicAttribute(ctx context.Context, topicARN, name, value string) error
 	DeleteTopic(ctx context.Context, topicARN string) error
 	ListTopics(ctx context.Context, nextToken string) ([]*Topic, string, error)
 	Subscribe(ctx context.Context, topicARN, protocol, endpoint string, attributes map[string]string) (*Subscription, error)
@@ -166,6 +168,49 @@ func (m *MemoryStorage) CreateTopic(_ context.Context, name string, attributes m
 	m.Topics[arn] = topic
 
 	return topic, nil
+}
+
+// GetTopic returns the topic with the given ARN, or NotFound.
+func (m *MemoryStorage) GetTopic(_ context.Context, topicARN string) (*Topic, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	topic, exists := m.Topics[topicARN]
+	if !exists {
+		return nil, &TopicError{Code: "NotFound", Message: "Topic does not exist: " + topicARN}
+	}
+
+	return topic, nil
+}
+
+// SetTopicAttribute writes name=value into the topic's attribute map.
+//
+// AWS exposes a small set of mutable topic attributes via SetTopicAttributes
+// (DisplayName, Policy, DeliveryPolicy, plus the *FeedbackRoleArn and
+// *FeedbackSampleRate families). kumo does not enforce or validate any of
+// them; we just persist the write so subsequent GetTopicAttributes reflects
+// it. The DisplayName field on the topic is also updated so existing code
+// paths that read it directly stay consistent.
+func (m *MemoryStorage) SetTopicAttribute(_ context.Context, topicARN, name, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	topic, exists := m.Topics[topicARN]
+	if !exists {
+		return &TopicError{Code: "NotFound", Message: "Topic does not exist: " + topicARN}
+	}
+
+	if topic.Attributes == nil {
+		topic.Attributes = make(map[string]string)
+	}
+
+	topic.Attributes[name] = value
+
+	if name == "DisplayName" {
+		topic.DisplayName = value
+	}
+
+	return nil
 }
 
 // DeleteTopic deletes a topic.

--- a/internal/service/sns/topic_attributes.go
+++ b/internal/service/sns/topic_attributes.go
@@ -1,0 +1,212 @@
+package sns
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+// flexString accepts a JSON string, number, or boolean and stores its
+// canonical string form. Used for fields that are nominally strings on the
+// wire but the AWS Query→JSON conversion has promoted to a typed literal.
+type flexString string
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (f *flexString) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*f = ""
+
+		return nil
+	}
+
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return fmt.Errorf("flexString: %w", err)
+		}
+
+		*f = flexString(s)
+
+		return nil
+	}
+
+	var n json.Number
+	if err := json.Unmarshal(data, &n); err == nil {
+		*f = flexString(n.String())
+
+		return nil
+	}
+
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		*f = flexString(strconv.FormatBool(b))
+
+		return nil
+	}
+
+	return &json.UnsupportedTypeError{}
+}
+
+// String returns the underlying string.
+func (f flexString) String() string { return string(f) }
+
+// defaultTopicPolicy is the AWS-default access policy returned for any topic
+// when none has been set explicitly. terraform-provider-aws hashes this for
+// drift detection, so it must be a stable JSON document.
+const defaultTopicPolicy = `{"Version":"2012-10-17","Id":"__default_policy_ID","Statement":[{"Sid":"__default_statement_ID","Effect":"Allow","Principal":{"AWS":"*"},"Action":["SNS:GetTopicAttributes","SNS:SetTopicAttributes","SNS:AddPermission","SNS:RemovePermission","SNS:DeleteTopic","SNS:Subscribe","SNS:ListSubscriptionsByTopic","SNS:Publish"],"Resource":"*"}]}`
+
+// SetTopicAttributes accepts AttributeName + AttributeValue and writes them
+// onto the topic's attribute map.
+//
+// terraform-provider-aws issues this once per attribute it wants to set
+// after CreateTopic — and crucially, it sets *all* the optional feedback
+// attributes (FirehoseSuccessFeedbackSampleRate, etc.) regardless of whether
+// the resource block specifies them. Without an accepting handler, the
+// first such call fails with InvalidAction and apply errors before any
+// subsequent SetTopicAttributes is even tried.
+func (s *Service) SetTopicAttributes(w http.ResponseWriter, r *http.Request) {
+	var req setTopicAttributesRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.TopicArn == "" {
+		writeTopicError(w, errInvalidParameter, "TopicArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.AttributeName == "" {
+		writeTopicError(w, errInvalidParameter, "AttributeName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.SetTopicAttribute(r.Context(), req.TopicArn, req.AttributeName, req.AttributeValue.String()); err != nil {
+		handleTopicError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLSetTopicAttributesResponse{
+		Xmlns:            snsXMLNS,
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// GetTopicAttributes returns the topic's stored attributes plus the standard
+// AWS-managed fields (TopicArn / Owner / Policy / SubscriptionsConfirmed /
+// SubscriptionsPending / SubscriptionsDeleted) that terraform-provider-aws
+// reads on every refresh.
+func (s *Service) GetTopicAttributes(w http.ResponseWriter, r *http.Request) {
+	var req getTopicAttributesRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.TopicArn == "" {
+		writeTopicError(w, errInvalidParameter, "TopicArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	topic, err := s.storage.GetTopic(r.Context(), req.TopicArn)
+	if err != nil {
+		handleTopicError(w, err)
+
+		return
+	}
+
+	attrs := buildTopicAttributeView(topic)
+
+	entries := make([]XMLAttributeEntry, 0, len(attrs))
+	for k, v := range attrs {
+		entries = append(entries, XMLAttributeEntry{Key: k, Value: v})
+	}
+
+	writeXMLResponse(w, XMLGetTopicAttributesResponse{
+		Xmlns: snsXMLNS,
+		GetTopicAttributesResult: XMLGetTopicAttributesResult{
+			Attributes: XMLAttributesMap{Entry: entries},
+		},
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// ListTagsForResource returns an empty tag list for any topic.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, _ *http.Request) {
+	writeXMLResponse(w, XMLListTagsForResourceResponse{
+		Xmlns:            snsXMLNS,
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// TagResource accepts and discards tag attachments.
+func (s *Service) TagResource(w http.ResponseWriter, _ *http.Request) {
+	writeXMLResponse(w, XMLTagResourceResponse{
+		Xmlns:            snsXMLNS,
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// UntagResource accepts and discards tag detachments.
+func (s *Service) UntagResource(w http.ResponseWriter, _ *http.Request) {
+	writeXMLResponse(w, XMLUntagResourceResponse{
+		Xmlns:            snsXMLNS,
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// handleTopicError converts a storage error into the appropriate XML error.
+func handleTopicError(w http.ResponseWriter, err error) {
+	var tErr *TopicError
+	if errors.As(err, &tErr) {
+		status := http.StatusBadRequest
+		if tErr.Code == "NotFound" {
+			status = http.StatusNotFound
+		}
+
+		writeTopicError(w, tErr.Code, tErr.Message, status)
+
+		return
+	}
+
+	writeTopicError(w, errInternalServiceError, "Internal server error", http.StatusInternalServerError)
+}
+
+// buildTopicAttributeView merges the topic's stored attributes with the
+// AWS-managed defaults terraform-provider-aws expects to read after refresh.
+func buildTopicAttributeView(topic *Topic) map[string]string {
+	attrs := map[string]string{
+		"TopicArn":                topic.ARN,
+		"Owner":                   "000000000000",
+		"DisplayName":             topic.DisplayName,
+		"Policy":                  defaultTopicPolicy,
+		"SubscriptionsConfirmed":  "0",
+		"SubscriptionsPending":    "0",
+		"SubscriptionsDeleted":    "0",
+		"DeliveryPolicy":          "",
+		"EffectiveDeliveryPolicy": "",
+	}
+
+	for k, v := range topic.Attributes {
+		attrs[k] = v
+	}
+
+	// Always reflect the canonical fields back from the topic record, even
+	// if the user wrote a stale value into the attribute map.
+	attrs["TopicArn"] = topic.ARN
+	if topic.DisplayName != "" {
+		attrs["DisplayName"] = topic.DisplayName
+	}
+
+	return attrs
+}

--- a/internal/service/sns/types.go
+++ b/internal/service/sns/types.go
@@ -299,3 +299,94 @@ type TopicError struct {
 func (e *TopicError) Error() string {
 	return e.Message
 }
+
+// XMLSetTopicAttributesResponse is the XML response for SetTopicAttributes.
+type XMLSetTopicAttributesResponse struct {
+	XMLName          struct{}         `xml:"SetTopicAttributesResponse"`
+	Xmlns            string           `xml:"xmlns,attr"`
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// XMLGetTopicAttributesResponse is the XML response for GetTopicAttributes.
+type XMLGetTopicAttributesResponse struct {
+	XMLName                  struct{}                    `xml:"GetTopicAttributesResponse"`
+	Xmlns                    string                      `xml:"xmlns,attr"`
+	GetTopicAttributesResult XMLGetTopicAttributesResult `xml:"GetTopicAttributesResult"`
+	ResponseMetadata         ResponseMetadata            `xml:"ResponseMetadata"`
+}
+
+// XMLGetTopicAttributesResult contains the attribute map.
+type XMLGetTopicAttributesResult struct {
+	Attributes XMLAttributesMap `xml:"Attributes"`
+}
+
+// XMLAttributesMap wraps the attribute entries as the AWS Query protocol
+// expects: <Attributes><entry><key/><value/></entry>...</Attributes>.
+type XMLAttributesMap struct {
+	Entry []XMLAttributeEntry `xml:"entry"`
+}
+
+// XMLAttributeEntry is a single attribute key/value entry.
+type XMLAttributeEntry struct {
+	Key   string `xml:"key"`
+	Value string `xml:"value"`
+}
+
+// XMLListTagsForResourceResponse mirrors the AWS shape; the Tags member is
+// always an empty member list because tag storage is not modeled.
+type XMLListTagsForResourceResponse struct {
+	XMLName                   struct{}                     `xml:"ListTagsForResourceResponse"`
+	Xmlns                     string                       `xml:"xmlns,attr"`
+	ListTagsForResourceResult XMLListTagsForResourceResult `xml:"ListTagsForResourceResult"`
+	ResponseMetadata          ResponseMetadata             `xml:"ResponseMetadata"`
+}
+
+// XMLListTagsForResourceResult contains the (always empty) tag list.
+type XMLListTagsForResourceResult struct {
+	Tags XMLTagList `xml:"Tags"`
+}
+
+// XMLTagList wraps the tag members.
+type XMLTagList struct {
+	Member []XMLTag `xml:"member"`
+}
+
+// XMLTag is a single tag.
+type XMLTag struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+// XMLTagResourceResponse is the XML response for TagResource.
+type XMLTagResourceResponse struct {
+	XMLName          struct{}         `xml:"TagResourceResponse"`
+	Xmlns            string           `xml:"xmlns,attr"`
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// XMLUntagResourceResponse is the XML response for UntagResource.
+type XMLUntagResourceResponse struct {
+	XMLName          struct{}         `xml:"UntagResourceResponse"`
+	Xmlns            string           `xml:"xmlns,attr"`
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// setTopicAttributesRequest is the wire shape after the Query dispatcher
+// converts terraform's form-encoded body to JSON.
+//
+// AttributeValue uses the lenient flexString helper because the dispatcher's
+// formToJSON heuristically promotes "0" / "1" / "true" / "false" to numeric
+// or boolean JSON literals, but AWS itself sends every SetTopicAttributes
+// value as a string and clients (terraform-provider-aws) produce
+// numeric-looking sample-rate values that must round-trip as strings.
+type setTopicAttributesRequest struct {
+	TopicArn       string     `json:"TopicArn"`
+	AttributeName  string     `json:"AttributeName"`
+	AttributeValue flexString `json:"AttributeValue"`
+}
+
+// getTopicAttributesRequest mirrors GetTopicAttributes after the Query
+// dispatcher converts the form-encoded body to JSON.
+type getTopicAttributesRequest struct {
+	TopicArn string `json:"TopicArn"`
+}


### PR DESCRIPTION
## Summary

terraform-provider-aws issues \`SetTopicAttributes\` once per attribute it wants to set after \`CreateTopic\`, regardless of whether the resource block specifies them — every \`*FeedbackSampleRate\` (Firehose / Application / Lambda / HTTP / SQS) goes through. Without an accepting handler, the first such call fails with \`InvalidAction\` (the action was missing from the SNS dispatcher) and apply errors before any subsequent attribute is even tried. \`GetTopicAttributes\` and \`ListTagsForResource\` were also missing and would break the post-create refresh.

Found while running tofu against SNS for #589.

## Implementation

- **SetTopicAttributes**: accepts \`AttributeName\` + \`AttributeValue\` and persists them onto the topic's attribute map. The wire field uses a small \`flexString\` helper because the Query→JSON dispatcher promotes \`\"0\"\` / \`\"1\"\` / \`\"true\"\` / \`\"false\"\` to typed JSON literals (\`parseFormValue\` in \`internal/server/awsquery.go\`) but AWS itself sends every \`SetTopicAttributes\` value as a string. Numeric-looking sample-rate values must round-trip as strings, so \`flexString\` accepts string / number / bool and stores the canonical string form.
- **GetTopicAttributes**: returns the topic's stored attributes plus the AWS-managed defaults terraform-provider-aws reads after refresh — \`TopicArn\`, \`Owner\`, \`Policy\` (the standard \`__default_policy_ID\` statement so terraform's drift hash stays stable), \`Subscriptions*\`, \`DeliveryPolicy\` / \`EffectiveDeliveryPolicy\`.
- **ListTagsForResource** / **TagResource** / **UntagResource**: empty / no-op, same shape as the ecr/logs/dynamodb/eventbridge stubs.
- Storage extended with \`GetTopic\` and \`SetTopicAttribute\`. The five new actions are registered with the unified Query dispatcher so they're reachable from \`/\`.

## Test plan

- [x] \`go test ./internal/service/sns/...\` — green.
- [x] \`make lint\` — clean.
- [x] End-to-end: tofu \`apply\` + \`destroy\` of \`aws_sns_topic { name = ...; display_name = \"kumo demo\" }\` against \`kumo serve\` — both succeed; before this PR \`apply\` errored on \`SetTopicAttributes(FirehoseSuccessFeedbackSampleRate)\` immediately after creating the topic.

Cross-ref: #416, #589.