### PR TITLE
fix(ec2): make terraform destroy work for IGW + subnet

### DIFF
--- a/internal/service/ec2/handlers.go
+++ b/internal/service/ec2/handlers.go
@@ -1423,7 +1423,11 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 		// Internet gateway operations
 		"CreateInternetGateway":    s.CreateInternetGateway,
 		"AttachInternetGateway":    s.AttachInternetGateway,
+		"DetachInternetGateway":    s.DetachInternetGateway,
+		"DeleteInternetGateway":    s.DeleteInternetGateway,
 		"DescribeInternetGateways": s.DescribeInternetGateways,
+		// Network interface — destroy-time stub
+		"DescribeNetworkInterfaces": s.DescribeNetworkInterfaces,
 		// Route table operations
 		"CreateRouteTable":    s.CreateRouteTable,
 		"CreateRoute":         s.CreateRoute,

--- a/internal/service/ec2/igw_destroy.go
+++ b/internal/service/ec2/igw_destroy.go
@@ -1,0 +1,87 @@
+package ec2
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// DetachInternetGateway handles the DetachInternetGateway action.
+//
+// terraform-provider-aws calls this during destroy of aws_internet_gateway,
+// after which it issues DeleteInternetGateway. Without this handler the
+// destroy fails with InvalidAction and the IGW leaks in kumo.
+func (s *Service) DetachInternetGateway(w http.ResponseWriter, r *http.Request) {
+	var req AttachInternetGatewayRequest
+	if err := readEC2JSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.InternetGatewayID == "" {
+		writeError(w, errInvalidParameter, "InternetGatewayId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.VpcID == "" {
+		writeError(w, errInvalidParameter, "VpcId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DetachInternetGateway(r.Context(), req.InternetGatewayID, req.VpcID); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeEC2XMLResponse(w, XMLDetachInternetGatewayResponse{
+		Xmlns:     ec2XMLNS,
+		RequestID: uuid.New().String(),
+		Return:    true,
+	})
+}
+
+// DeleteInternetGateway handles the DeleteInternetGateway action.
+func (s *Service) DeleteInternetGateway(w http.ResponseWriter, r *http.Request) {
+	var req DeleteInternetGatewayRequest
+	if err := readEC2JSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.InternetGatewayID == "" {
+		writeError(w, errInvalidParameter, "InternetGatewayId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteInternetGateway(r.Context(), req.InternetGatewayID); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeEC2XMLResponse(w, XMLDeleteInternetGatewayResponse{
+		Xmlns:     ec2XMLNS,
+		RequestID: uuid.New().String(),
+		Return:    true,
+	})
+}
+
+// DescribeNetworkInterfaces returns an empty NetworkInterfaceSet.
+//
+// terraform-provider-aws calls this during destroy of any subnet / IGW to
+// check for dangling ENIs that would block the delete (lingering
+// load-balancer ENIs, lambda VPC ENIs, etc.). kumo does not model ENIs
+// yet; reporting "no ENIs" lets destroy proceed.
+func (s *Service) DescribeNetworkInterfaces(w http.ResponseWriter, _ *http.Request) {
+	writeEC2XMLResponse(w, XMLDescribeNetworkInterfacesResponse{
+		Xmlns:               ec2XMLNS,
+		RequestID:           uuid.New().String(),
+		NetworkInterfaceSet: XMLNetworkInterfaceSet{Items: []XMLNetworkInterface{}},
+	})
+}

--- a/internal/service/ec2/service.go
+++ b/internal/service/ec2/service.go
@@ -80,7 +80,11 @@ func (s *Service) Actions() []string {
 		// Internet Gateway operations
 		"CreateInternetGateway",
 		"AttachInternetGateway",
+		"DetachInternetGateway",
+		"DeleteInternetGateway",
 		"DescribeInternetGateways",
+		// Network interface — destroy-time stub
+		"DescribeNetworkInterfaces",
 		// Route Table operations
 		"CreateRouteTable",
 		"CreateRoute",

--- a/internal/service/ec2/storage.go
+++ b/internal/service/ec2/storage.go
@@ -94,6 +94,8 @@ type Storage interface {
 	// Internet Gateway operations
 	CreateInternetGateway(ctx context.Context, req *CreateInternetGatewayRequest) (*InternetGateway, error)
 	AttachInternetGateway(ctx context.Context, igwID, vpcID string) error
+	DetachInternetGateway(ctx context.Context, igwID, vpcID string) error
+	DeleteInternetGateway(ctx context.Context, igwID string) error
 	DescribeInternetGateways(ctx context.Context, igwIDs []string) ([]*InternetGateway, error)
 
 	// Route Table operations
@@ -1007,6 +1009,58 @@ func (m *MemoryStorage) AttachInternetGateway(_ context.Context, igwID, vpcID st
 		VpcID: vpcID,
 		State: "available",
 	})
+
+	return nil
+}
+
+// DetachInternetGateway detaches an internet gateway from a VPC.
+func (m *MemoryStorage) DetachInternetGateway(_ context.Context, igwID, vpcID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	igw, exists := m.InternetGateways[igwID]
+	if !exists {
+		return &Error{
+			Code:    "InvalidInternetGatewayID.NotFound",
+			Message: fmt.Sprintf("The internetGateway ID '%s' does not exist", igwID),
+		}
+	}
+
+	for i, attachment := range igw.Attachments {
+		if attachment.VpcID == vpcID {
+			igw.Attachments = append(igw.Attachments[:i], igw.Attachments[i+1:]...)
+
+			return nil
+		}
+	}
+
+	return &Error{
+		Code:    "Gateway.NotAttached",
+		Message: fmt.Sprintf("Internet gateway '%s' is not attached to vpc '%s'", igwID, vpcID),
+	}
+}
+
+// DeleteInternetGateway deletes an internet gateway.
+func (m *MemoryStorage) DeleteInternetGateway(_ context.Context, igwID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	igw, exists := m.InternetGateways[igwID]
+	if !exists {
+		return &Error{
+			Code:    "InvalidInternetGatewayID.NotFound",
+			Message: fmt.Sprintf("The internetGateway ID '%s' does not exist", igwID),
+		}
+	}
+
+	if len(igw.Attachments) > 0 {
+		return &Error{
+			Code:    "DependencyViolation",
+			Message: fmt.Sprintf("Internet gateway '%s' has attachments and cannot be deleted", igwID),
+		}
+	}
+
+	delete(m.InternetGateways, igwID)
 
 	return nil
 }

--- a/internal/service/ec2/types.go
+++ b/internal/service/ec2/types.go
@@ -835,3 +835,45 @@ type XMLTagDescription struct {
 	Key          string `xml:"key"`
 	Value        string `xml:"value"`
 }
+
+// DeleteInternetGatewayRequest represents a DeleteInternetGateway request.
+type DeleteInternetGatewayRequest struct {
+	InternetGatewayID string `json:"InternetGatewayId"`
+}
+
+// XMLDetachInternetGatewayResponse is the XML response for DetachInternetGateway.
+type XMLDetachInternetGatewayResponse struct {
+	XMLName   xml.Name `xml:"DetachInternetGatewayResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+// XMLDeleteInternetGatewayResponse is the XML response for DeleteInternetGateway.
+type XMLDeleteInternetGatewayResponse struct {
+	XMLName   xml.Name `xml:"DeleteInternetGatewayResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+// XMLDescribeNetworkInterfacesResponse is the XML response for DescribeNetworkInterfaces.
+type XMLDescribeNetworkInterfacesResponse struct {
+	XMLName             xml.Name               `xml:"DescribeNetworkInterfacesResponse"`
+	Xmlns               string                 `xml:"xmlns,attr"`
+	RequestID           string                 `xml:"requestId"`
+	NetworkInterfaceSet XMLNetworkInterfaceSet `xml:"networkInterfaceSet"`
+}
+
+// XMLNetworkInterfaceSet wraps the network interface members.
+type XMLNetworkInterfaceSet struct {
+	Items []XMLNetworkInterface `xml:"item"`
+}
+
+// XMLNetworkInterface is a single network interface description.
+type XMLNetworkInterface struct {
+	NetworkInterfaceID string `xml:"networkInterfaceId"`
+	VpcID              string `xml:"vpcId,omitempty"`
+	SubnetID           string `xml:"subnetId,omitempty"`
+	Status             string `xml:"status,omitempty"`
+}


### PR DESCRIPTION
## Summary

terraform-provider-aws destroy of \`aws_internet_gateway\` issues \`DetachInternetGateway\` then \`DeleteInternetGateway\`, and destroy of \`aws_subnet\` first calls \`DescribeNetworkInterfaces\` to surface dangling ENIs that would block the delete. None of the three actions were implemented in kumo, so destroy of any IGW or subnet failed with \`InvalidAction\` even when apply had succeeded.

Found while running tofu against EC2 for #589.

## Implementation

- **DetachInternetGateway / DeleteInternetGateway** use the same request shape as Attach / Create. Storage gains:
  - \`DetachInternetGateway\` — pops the matching attachment from the IGW's \`Attachments\` slice; returns \`Gateway.NotAttached\` when not attached, matching AWS.
  - \`DeleteInternetGateway\` — returns \`DependencyViolation\` when still attached, \`InvalidInternetGatewayID.NotFound\` when missing.
- **DescribeNetworkInterfaces** returns an empty \`NetworkInterfaceSet\`. ENIs are not modeled in storage yet; reporting \"no ENIs\" lets destroy proceed for resources whose deletion otherwise blocks on dangling ENIs (load-balancer ENIs, lambda VPC ENIs, etc.). Real ENI emulation is a separate, larger piece of work; this stub unblocks destroy paths for the resources that already work on the create side.

All three actions are wired into both \`getActionHandler\` (direct \`/ec2/\` access) and \`Actions()\` (the unified Query dispatcher served at \`/\`).

## Test plan

- [x] \`go test ./internal/service/ec2/...\` — green.
- [x] \`make lint\` — clean.
- [x] End-to-end: tofu \`apply\` + \`destroy\` of \`aws_vpc\` + \`aws_internet_gateway\` + \`aws_subnet\` against \`kumo serve\` — both succeed cleanly; before this PR \`destroy\` errored on \`DetachInternetGateway\` and \`DescribeNetworkInterfaces\` and the IGW + subnet leaked.

Cross-ref: #416, #589.