### PR TITLE
feat(route53): ListTagsForResource / ChangeTagsForResource stubs

### DIFF
--- a/internal/service/route53/service.go
+++ b/internal/service/route53/service.go
@@ -51,6 +51,12 @@ func (s *Service) RegisterRoutes(r service.Router) {
 
 	// Changes
 	r.Handle("GET", "/2013-04-01/change/{id}", s.GetChange)
+
+	// Tags — see tag_stubs.go.
+	// terraform-provider-aws calls these on every refresh of aws_route53_zone;
+	// without them the apply errors on a 404 immediately after CreateHostedZone.
+	r.Handle("GET", "/2013-04-01/tags/{type}/{id}", s.ListTagsForResource)
+	r.Handle("POST", "/2013-04-01/tags/{type}/{id}", s.ChangeTagsForResource)
 }
 
 // Close saves the storage state if persistence is enabled.

--- a/internal/service/route53/tag_stubs.go
+++ b/internal/service/route53/tag_stubs.go
@@ -1,0 +1,31 @@
+package route53
+
+import (
+	"net/http"
+)
+
+// ListTagsForResource returns an empty tag list for any resource.
+//
+// terraform-provider-aws calls this on every refresh of aws_route53_zone
+// (URL `/2013-04-01/tags/hostedzone/{Id}`). Without it, `tofu apply` of
+// any Route53 zone fails with a 404 right after the zone is created.
+//
+// Tags are not modeled in the storage layer yet; this stub exists so the
+// refresh path completes. Same shape as the ecr / logs / dynamodb /
+// eventbridge tag stubs — wire-level no-op with a future-extensible door.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, _ *http.Request) {
+	writeXMLResponse(w, http.StatusOK, ListTagsForResourceXMLResponse{
+		XMLNS: xmlns,
+		ResourceTagSet: ResourceTagSet{
+			ResourceType: "hostedzone",
+			Tags:         TagList{},
+		},
+	})
+}
+
+// ChangeTagsForResource accepts and discards tag mutations.
+func (s *Service) ChangeTagsForResource(w http.ResponseWriter, _ *http.Request) {
+	writeXMLResponse(w, http.StatusOK, ChangeTagsForResourceXMLResponse{
+		XMLNS: xmlns,
+	})
+}

--- a/internal/service/route53/types.go
+++ b/internal/service/route53/types.go
@@ -175,3 +175,34 @@ type Error struct {
 	Code    string `xml:"Code"`
 	Message string `xml:"Message"`
 }
+
+// ListTagsForResourceXMLResponse is the XML response for ListTagsForResource.
+type ListTagsForResourceXMLResponse struct {
+	XMLName        struct{}       `xml:"ListTagsForResourceResponse"`
+	XMLNS          string         `xml:"xmlns,attr"`
+	ResourceTagSet ResourceTagSet `xml:"ResourceTagSet"`
+}
+
+// ChangeTagsForResourceXMLResponse is the XML response for ChangeTagsForResource.
+type ChangeTagsForResourceXMLResponse struct {
+	XMLName struct{} `xml:"ChangeTagsForResourceResponse"`
+	XMLNS   string   `xml:"xmlns,attr"`
+}
+
+// ResourceTagSet is the tag set for a Route53 resource.
+type ResourceTagSet struct {
+	ResourceType string  `xml:"ResourceType"`
+	ResourceID   string  `xml:"ResourceId"`
+	Tags         TagList `xml:"Tags"`
+}
+
+// TagList wraps tag members.
+type TagList struct {
+	Tag []Tag `xml:"Tag"`
+}
+
+// Tag is a single Route53 tag.
+type Tag struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}


### PR DESCRIPTION
## Summary

**Required for terraform compatibility.** terraform-provider-aws calls \`ListTagsForResource\` on every refresh of \`aws_route53_zone\` (URL \`GET /2013-04-01/tags/hostedzone/{Id}\`). Without it, \`tofu apply\` of any Route53 zone fails with a 404 right after \`CreateHostedZone\` returns; the zone exists in storage but state cannot be refreshed, so destroy is also blocked.

Found while running tofu against Route53 for #589.

## Implementation

- \`ListTagsForResource\` returns an empty \`Tags\` element wrapped in the standard \`ResourceTagSet\` shape (\`ResourceType=\"hostedzone\"\`).
- \`ChangeTagsForResource\` accepts and discards the payload.
- Routes registered at \`/2013-04-01/tags/{type}/{id}\` (GET + POST), matching the AWS Route53 REST URL layout the SDK uses.
- Tags are not modeled in the storage layer yet. Same shape as the ecr (#565) / logs (#566) / dynamodb (#590) / eventbridge (#591) stubs — wire-level no-ops so refresh paths complete, with the door open for real persistence later.

## Test plan

- [x] \`go test ./internal/service/route53/...\` — green.
- [x] \`make lint\` — clean.
- [x] End-to-end: tofu \`apply\` + \`destroy\` of \`aws_route53_zone { name = \"example.local\" }\` against \`kumo serve\` — both succeed; before this PR \`apply\` errored with a 404 on \`ListTagsForResource\` immediately after creating the zone.

Cross-ref: #416, #589.