### PR TITLE
feat(elbv2): DescribeTags / AddTags / RemoveTags stubs

### DIFF
--- a/internal/service/elbv2/handlers.go
+++ b/internal/service/elbv2/handlers.go
@@ -870,6 +870,11 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 		"DescribeListeners":              s.DescribeListeners,
 		"ModifyListener":                 s.ModifyListener,
 		"DescribeTargetHealth":           s.DescribeTargetHealth,
+		// Tag stubs — see tag_stubs.go.
+		// Required by terraform-provider-aws after Create*.
+		"DescribeTags": s.DescribeTags,
+		"AddTags":      s.AddTags,
+		"RemoveTags":   s.RemoveTags,
 	}
 
 	return handlers[action]

--- a/internal/service/elbv2/service.go
+++ b/internal/service/elbv2/service.go
@@ -73,10 +73,10 @@ func (s *Service) Actions() []string {
 		"DescribeTargetHealth",
 		"ModifyListener",
 		"DescribeListeners",
-		"github.com/sivchari/kumo/internal/service",
-		"os",
-		"io",
-		"fmt",
+		// Tag stubs — see tag_stubs.go.
+		"DescribeTags",
+		"AddTags",
+		"RemoveTags",
 	}
 }
 

--- a/internal/service/elbv2/tag_stubs.go
+++ b/internal/service/elbv2/tag_stubs.go
@@ -1,0 +1,86 @@
+package elbv2
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// DescribeTags returns an empty TagDescription per requested ResourceArn.
+//
+// Required for terraform compatibility — terraform-provider-aws calls
+// DescribeTags on every refresh of aws_lb / aws_lb_target_group /
+// aws_lb_listener. Without it, `tofu apply` of any ELBv2 resource fails
+// with InvalidAction immediately after the resource is created.
+//
+// AWS returns one TagDescription per requested ARN even when no tags are
+// attached (the provider crashes if a requested ARN is missing from the
+// response), so this stub echoes each ResourceArns.member.N entry back
+// with an empty Tags list. Tags are not modeled in storage yet; same
+// shape as the ecr / logs / dynamodb / route53 stubs — wire-level no-op
+// with the door open for real persistence later.
+func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
+	arns := collectResourceArns(r)
+
+	items := make([]XMLTagDescription, 0, len(arns))
+	for _, arn := range arns {
+		items = append(items, XMLTagDescription{
+			ResourceArn: arn,
+			Tags:        XMLTagList{Items: []XMLTagMember{}},
+		})
+	}
+
+	writeELBXMLResponse(w, XMLDescribeTagsResponse{
+		Xmlns: elbXMLNS,
+		DescribeTagsResult: XMLDescribeTagsResult{
+			TagDescriptions: XMLTagDescriptionList{Items: items},
+		},
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// collectResourceArns reads ResourceArns.member.N from the form, then
+// falls back to a JSON ResourceArns array if the request body has been
+// converted by the unified Query→JSON dispatcher.
+func collectResourceArns(r *http.Request) []string {
+	if err := r.ParseForm(); err == nil {
+		var arns []string
+
+		for i := 1; ; i++ {
+			v := r.Form.Get(fmt.Sprintf("ResourceArns.member.%d", i))
+			if v == "" {
+				break
+			}
+
+			arns = append(arns, v)
+		}
+
+		if len(arns) > 0 {
+			return arns
+		}
+	}
+
+	var req describeTagsJSONRequest
+	if err := readELBJSONRequest(r, &req); err == nil {
+		return req.ResourceArns
+	}
+
+	return nil
+}
+
+// AddTags accepts and discards tag attachments.
+func (s *Service) AddTags(w http.ResponseWriter, _ *http.Request) {
+	writeELBXMLResponse(w, XMLAddTagsResponse{
+		Xmlns:            elbXMLNS,
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// RemoveTags accepts and discards tag detachments.
+func (s *Service) RemoveTags(w http.ResponseWriter, _ *http.Request) {
+	writeELBXMLResponse(w, XMLRemoveTagsResponse{
+		Xmlns:            elbXMLNS,
+		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
+	})
+}

--- a/internal/service/elbv2/types.go
+++ b/internal/service/elbv2/types.go
@@ -697,3 +697,58 @@ type XMLModifyListenerResponse struct {
 type XMLModifyListenerResult struct {
 	Listeners XMLListeners `xml:"Listeners"`
 }
+
+// XMLDescribeTagsResponse is the XML response for DescribeTags.
+type XMLDescribeTagsResponse struct {
+	XMLName            xml.Name              `xml:"DescribeTagsResponse"`
+	Xmlns              string                `xml:"xmlns,attr"`
+	DescribeTagsResult XMLDescribeTagsResult `xml:"DescribeTagsResult"`
+	ResponseMetadata   XMLResponseMetadata   `xml:"ResponseMetadata"`
+}
+
+// XMLDescribeTagsResult contains the DescribeTags result.
+type XMLDescribeTagsResult struct {
+	TagDescriptions XMLTagDescriptionList `xml:"TagDescriptions"`
+}
+
+// XMLTagDescriptionList wraps tag-description members.
+type XMLTagDescriptionList struct {
+	Items []XMLTagDescription `xml:"member"`
+}
+
+// XMLTagDescription is the per-resource tag list.
+type XMLTagDescription struct {
+	ResourceArn string     `xml:"ResourceArn"`
+	Tags        XMLTagList `xml:"Tags"`
+}
+
+// XMLTagList wraps tag members.
+type XMLTagList struct {
+	Items []XMLTagMember `xml:"member"`
+}
+
+// XMLTagMember is a single tag.
+type XMLTagMember struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+// XMLAddTagsResponse is the XML response for AddTags.
+type XMLAddTagsResponse struct {
+	XMLName          xml.Name            `xml:"AddTagsResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata XMLResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// XMLRemoveTagsResponse is the XML response for RemoveTags.
+type XMLRemoveTagsResponse struct {
+	XMLName          xml.Name            `xml:"RemoveTagsResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata XMLResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// describeTagsJSONRequest is the wire shape after the unified Query
+// dispatcher converts the form-encoded body to JSON.
+type describeTagsJSONRequest struct {
+	ResourceArns []string `json:"ResourceArns"`
+}


### PR DESCRIPTION
## Summary

**Required for terraform compatibility.** terraform-provider-aws calls \`DescribeTags\` on every refresh of \`aws_lb\` / \`aws_lb_target_group\` / \`aws_lb_listener\`. Without it, \`tofu apply\` of any ELBv2 resource fails with \`InvalidAction\` immediately after the resource is created and destroy is also blocked.

Found while running tofu against ELBv2 for #589.

## Implementation

- \`DescribeTags\` echoes one \`TagDescription\` per requested \`ResourceArns.member.N\` with an empty Tags list. AWS always returns one entry per requested ARN even when no tags are attached, and the provider crashes if a requested ARN is missing from the response — \`collectResourceArns\` reads both the form-encoded shape (\`ResourceArns.member.1\`, \`.2\`, ...) and the JSON shape produced by the unified Query→JSON dispatcher.
- \`AddTags\` / \`RemoveTags\` accept and discard the payload.
- Tags are not modeled in storage yet. Same shape as the ecr / logs / dynamodb / route53 stubs — wire-level no-op with the door open for real persistence later.

**Drive-by**: removed three stray import-path strings (\`\"github.com/sivchari/kumo/internal/service\"\`, \`\"os\"\`, \`\"io\"\`) from \`Actions()\` that had leaked from a prior diff and were registered as bogus action names with the unified Query dispatcher.

## Test plan

- [x] \`go test ./internal/service/elbv2/...\` — green.
- [x] \`make lint\` — clean.
- [x] End-to-end: tofu \`apply\` + \`destroy\` of \`aws_lb_target_group\` against \`kumo serve\` — both succeed; before this PR \`apply\` errored on \`DescribeTags\` immediately after \`CreateTargetGroup\`.

Cross-ref: #416, #589.