### PR TITLE
feat(glue): GetTags / TagResource / UntagResource stubs

### DIFF
--- a/internal/service/glue/handlers.go
+++ b/internal/service/glue/handlers.go
@@ -30,39 +30,35 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 
 	operation := parts[1]
 
-	switch operation {
-	case "CreateDatabase":
-		s.CreateDatabase(w, r)
-	case "GetDatabase":
-		s.GetDatabase(w, r)
-	case "GetDatabases":
-		s.GetDatabases(w, r)
-	case "DeleteDatabase":
-		s.DeleteDatabase(w, r)
-	case "CreateTable":
-		s.CreateTable(w, r)
-	case "GetTable":
-		s.GetTable(w, r)
-	case "GetTables":
-		s.GetTables(w, r)
-	case "DeleteTable":
-		s.DeleteTable(w, r)
-	case "CreateJob":
-		s.CreateJob(w, r)
-	case "DeleteJob":
-		s.DeleteJob(w, r)
-	case "StartJobRun":
-		s.StartJobRun(w, r)
-	// Tag stubs — see tag_stubs.go.
-	// Required by terraform-provider-aws after CreateDatabase / CreateTable.
-	case "GetTags":
-		s.GetTags(w, r)
-	case "TagResource":
-		s.TagResource(w, r)
-	case "UntagResource":
-		s.UntagResource(w, r)
-	default:
+	handler, ok := s.actionHandlers()[operation]
+	if !ok {
 		writeError(w, errInvalidInput, fmt.Sprintf("Unknown operation: %s", operation), http.StatusBadRequest)
+
+		return
+	}
+
+	handler(w, r)
+}
+
+// actionHandlers returns the operation → handler map.
+func (s *Service) actionHandlers() map[string]http.HandlerFunc {
+	return map[string]http.HandlerFunc{
+		"CreateDatabase": s.CreateDatabase,
+		"GetDatabase":    s.GetDatabase,
+		"GetDatabases":   s.GetDatabases,
+		"DeleteDatabase": s.DeleteDatabase,
+		"CreateTable":    s.CreateTable,
+		"GetTable":       s.GetTable,
+		"GetTables":      s.GetTables,
+		"DeleteTable":    s.DeleteTable,
+		"CreateJob":      s.CreateJob,
+		"DeleteJob":      s.DeleteJob,
+		"StartJobRun":    s.StartJobRun,
+		// Tag stubs — see tag_stubs.go.
+		// Required by terraform-provider-aws after CreateDatabase / CreateTable.
+		"GetTags":       s.GetTags,
+		"TagResource":   s.TagResource,
+		"UntagResource": s.UntagResource,
 	}
 }
 

--- a/internal/service/glue/handlers.go
+++ b/internal/service/glue/handlers.go
@@ -53,6 +53,14 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 		s.DeleteJob(w, r)
 	case "StartJobRun":
 		s.StartJobRun(w, r)
+	// Tag stubs — see tag_stubs.go.
+	// Required by terraform-provider-aws after CreateDatabase / CreateTable.
+	case "GetTags":
+		s.GetTags(w, r)
+	case "TagResource":
+		s.TagResource(w, r)
+	case "UntagResource":
+		s.UntagResource(w, r)
 	default:
 		writeError(w, errInvalidInput, fmt.Sprintf("Unknown operation: %s", operation), http.StatusBadRequest)
 	}

--- a/internal/service/glue/tag_stubs.go
+++ b/internal/service/glue/tag_stubs.go
@@ -1,0 +1,29 @@
+package glue
+
+import "net/http"
+
+// GetTags returns an empty Tags map for any resource ARN.
+//
+// Required for terraform compatibility — terraform-provider-aws calls
+// GetTags on every refresh of aws_glue_catalog_database /
+// aws_glue_catalog_table / aws_glue_job. Without it, `tofu apply` of any
+// Glue resource fails with `Unknown operation` immediately after the
+// resource is created and destroy is also blocked.
+//
+// Tags are not modeled in the storage layer yet; this stub exists so the
+// refresh path completes. Same shape as the ecr / logs / dynamodb /
+// route53 / elbv2 stubs — wire-level no-op with the door open for real
+// persistence later.
+func (s *Service) GetTags(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, getTagsResponse{Tags: map[string]string{}})
+}
+
+// TagResource accepts and discards tag attachments.
+func (s *Service) TagResource(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, struct{}{})
+}
+
+// UntagResource accepts and discards tag detachments.
+func (s *Service) UntagResource(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, struct{}{})
+}

--- a/internal/service/glue/types.go
+++ b/internal/service/glue/types.go
@@ -376,3 +376,10 @@ type Error struct {
 func (e *Error) Error() string {
 	return e.Message
 }
+
+// getTagsResponse is the wire shape of GetTags. Glue uses a Tags map (not
+// the array-of-{Key,Value} shape AWS uses elsewhere), and the field must
+// be present even when empty for terraform-provider-aws to parse it.
+type getTagsResponse struct {
+	Tags map[string]string `json:"Tags"`
+}


### PR DESCRIPTION
## Summary

**Required for terraform compatibility.** terraform-provider-aws calls \`GetTags\` on every refresh of \`aws_glue_catalog_database\` / \`aws_glue_catalog_table\` / \`aws_glue_job\`. Without it, \`tofu apply\` of any Glue resource fails with \`Unknown operation\` immediately after the resource is created and destroy is also blocked.

Found while running tofu against Glue for #589.

## Implementation

- \`GetTags\` returns an empty Tags map. Glue uses a Tags map (\`{\"Tags\": {}}\`), not the array-of-{Key,Value} shape AWS uses elsewhere; the field must be present even when empty for the provider to parse it.
- \`TagResource\` / \`UntagResource\` accept and discard the payload.
- Tags are not modeled in the storage layer yet. Same shape as the ecr / logs / dynamodb / route53 / elbv2 stubs — wire-level no-op with the door open for real persistence later.

**Drive-by**: extracted the \`DispatchAction\` switch into an \`actionHandlers()\` map after cyclop tripped on the new cases (15 → 18). Same pattern as the EventBridge / DynamoDB / IAM dispatchers.

## Test plan

- [x] \`go test ./internal/service/glue/...\` — green.
- [x] \`make lint\` — clean.
- [x] End-to-end: tofu \`apply\` + \`destroy\` of \`aws_glue_catalog_database { name = ... }\` against \`kumo serve\` — both succeed; before this PR \`apply\` errored with \`Unknown operation: GetTags\` immediately after \`CreateDatabase\`.

Cross-ref: #416, #589.