### PR TITLE
feat(cloudwatch): register Query dispatcher + XML responses + tag stubs

### DIFF
--- a/internal/server/awsquery.go
+++ b/internal/server/awsquery.go
@@ -148,6 +148,10 @@ func (d *QueryProtocolDispatcher) resolveByFallback(action string) (queryHandler
 // parseServiceFromUserAgent extracts the service identifier from the AWS SDK v2 User-Agent header.
 // The User-Agent contains a token like "api/rds#1.5.0"; this function returns "rds".
 // Returns empty string if no api/ token is found.
+//
+// terraform-provider-aws (and a few other SDK consumers) sometimes use "/"
+// instead of "#" as the version separator (e.g. "api/monitoring/1.0"), so
+// both are accepted.
 func parseServiceFromUserAgent(userAgent string) string {
 	for _, token := range strings.Split(userAgent, " ") {
 		after, found := strings.CutPrefix(token, "api/")
@@ -155,8 +159,9 @@ func parseServiceFromUserAgent(userAgent string) string {
 			continue
 		}
 
-		// Strip version suffix: "rds#1.5.0" -> "rds"
+		// Strip version suffix: "rds#1.5.0" / "rds/1.5.0" -> "rds"
 		name, _, _ := strings.Cut(after, "#")
+		name, _, _ = strings.Cut(name, "/")
 
 		return name
 	}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -139,6 +139,10 @@ func (r *Router) wrapHandler(method, pattern string, handler http.HandlerFunc) h
 			attrs = append(attrs, "action", action)
 		}
 
+		if ua := req.Header.Get("User-Agent"); ua != "" {
+			attrs = append(attrs, "ua", ua)
+		}
+
 		r.logger.Info("request", attrs...)
 
 		// Log request body at debug level.

--- a/internal/service/cloudwatch/handlers.go
+++ b/internal/service/cloudwatch/handlers.go
@@ -178,8 +178,12 @@ func (s *Service) PutMetricAlarm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// PutMetricAlarm returns an empty response on success.
-	writeJSONResponse(w, struct{}{})
+	// PutMetricAlarm returns an empty response on success — XML for the
+	// Query-protocol path that terraform-provider-aws uses.
+	writeCloudWatchXML(w, xmlPutMetricAlarmResponse{
+		Xmlns:            cloudWatchXMLNS,
+		ResponseMetadata: xmlResponseMetadata{RequestID: uuid.New().String()},
+	})
 }
 
 // DeleteAlarms handles the DeleteAlarms action.
@@ -203,8 +207,12 @@ func (s *Service) DeleteAlarms(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// DeleteAlarms returns an empty response on success.
-	writeJSONResponse(w, struct{}{})
+	// DeleteAlarms returns an empty response on success — XML for the
+	// Query-protocol path that terraform-provider-aws uses.
+	writeCloudWatchXML(w, xmlDeleteAlarmsResponse{
+		Xmlns:            cloudWatchXMLNS,
+		ResponseMetadata: xmlResponseMetadata{RequestID: uuid.New().String()},
+	})
 }
 
 // DescribeAlarms handles the DescribeAlarms action.
@@ -223,9 +231,14 @@ func (s *Service) DescribeAlarms(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSONResponse(w, DescribeAlarmsResponse{
-		MetricAlarms: result.MetricAlarms,
-		NextToken:    result.NextToken,
+	// XML for the Query-protocol path that terraform-provider-aws uses.
+	writeCloudWatchXML(w, xmlDescribeAlarmsResponse{
+		Xmlns: cloudWatchXMLNS,
+		DescribeAlarmsResult: xmlDescribeAlarmsResult{
+			MetricAlarms: xmlMetricAlarmList{Members: metricAlarmsToXML(result.MetricAlarms)},
+			NextToken:    result.NextToken,
+		},
+		ResponseMetadata: xmlResponseMetadata{RequestID: uuid.New().String()},
 	})
 }
 
@@ -249,6 +262,12 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 		s.DeleteAlarms(w, r)
 	case "DescribeAlarms":
 		s.DescribeAlarms(w, r)
+	case "ListTagsForResource":
+		s.ListTagsForResource(w, r)
+	case "TagResource":
+		s.TagResource(w, r)
+	case "UntagResource":
+		s.UntagResource(w, r)
 	default:
 		writeCloudWatchError(w, errInvalidAction, "The action "+action+" is not valid", http.StatusBadRequest)
 	}

--- a/internal/service/cloudwatch/service.go
+++ b/internal/service/cloudwatch/service.go
@@ -54,6 +54,46 @@ func (s *Service) ServiceName() string {
 // CBORProtocol is a marker method that indicates CloudWatch uses RPC v2 CBOR protocol.
 func (s *Service) CBORProtocol() {}
 
+// TargetPrefix returns the X-Amz-Target header prefix for CloudWatch.
+//
+// The form-encoded Query protocol path uses this so the unified dispatcher
+// can wrap converted JSON requests with the right X-Amz-Target. Newer AWS
+// SDKs go through the CBOR path above; terraform-provider-aws still uses
+// the Query protocol against `/`.
+func (s *Service) TargetPrefix() string {
+	return "GraniteServiceVersion20100801"
+}
+
+// ServiceIdentifier returns the SDK service identifier sent in the User-Agent
+// header by aws-sdk-go-v2.
+//
+// Note: this is "cloudwatch" (the SDK package name) not "monitoring" (the
+// AWS service ID). terraform-provider-aws sends `api/cloudwatch#x.y.z`.
+func (s *Service) ServiceIdentifier() string {
+	return "cloudwatch"
+}
+
+// Actions returns the Query-protocol actions that DispatchAction handles.
+func (s *Service) Actions() []string {
+	return []string{
+		"PutMetricData",
+		"GetMetricData",
+		"GetMetricStatistics",
+		"ListMetrics",
+		"PutMetricAlarm",
+		"DeleteAlarms",
+		"DescribeAlarms",
+		// Tag stubs — see tag_stubs.go.
+		"ListTagsForResource",
+		"TagResource",
+		"UntagResource",
+	}
+}
+
+// QueryProtocol is a marker method that indicates CloudWatch is reachable
+// through the unified Query→JSON dispatcher in addition to CBOR.
+func (s *Service) QueryProtocol() {}
+
 // DispatchCBORAction handles RPC v2 CBOR protocol requests.
 func (s *Service) DispatchCBORAction(w http.ResponseWriter, r *http.Request, operation string) {
 	switch operation {

--- a/internal/service/cloudwatch/tag_stubs.go
+++ b/internal/service/cloudwatch/tag_stubs.go
@@ -1,0 +1,76 @@
+package cloudwatch
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// xmlListTagsForResourceResponse echoes the AWS Query shape
+// (`<ListTagsForResourceResponse><ListTagsForResourceResult><Tags>...</Tags></ListTagsForResourceResult></...>`).
+type xmlListTagsForResourceResponse struct {
+	XMLName                   xml.Name                     `xml:"ListTagsForResourceResponse"`
+	Xmlns                     string                       `xml:"xmlns,attr"`
+	ListTagsForResourceResult xmlListTagsForResourceResult `xml:"ListTagsForResourceResult"`
+	ResponseMetadata          xmlResponseMetadata          `xml:"ResponseMetadata"`
+}
+
+type xmlListTagsForResourceResult struct {
+	Tags xmlTagList `xml:"Tags"`
+}
+
+type xmlTagList struct {
+	Members []xmlTagMember `xml:"member"`
+}
+
+type xmlTagMember struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+// xmlTagResourceResponse / xmlUntagResourceResponse are the empty
+// envelopes returned for the (no-op) tag mutation actions.
+type xmlTagResourceResponse struct {
+	XMLName          xml.Name            `xml:"TagResourceResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata xmlResponseMetadata `xml:"ResponseMetadata"`
+}
+
+type xmlUntagResourceResponse struct {
+	XMLName          xml.Name            `xml:"UntagResourceResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata xmlResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// ListTagsForResource returns an empty Tags list for any alarm.
+//
+// terraform-provider-aws calls this on every refresh of
+// aws_cloudwatch_metric_alarm; without it apply errors immediately after
+// PutMetricAlarm. Tags are not modeled in storage yet — same shape as
+// the other no-op tag stubs in kumo.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, _ *http.Request) {
+	writeCloudWatchXML(w, xmlListTagsForResourceResponse{
+		Xmlns: cloudWatchXMLNS,
+		ListTagsForResourceResult: xmlListTagsForResourceResult{
+			Tags: xmlTagList{Members: []xmlTagMember{}},
+		},
+		ResponseMetadata: xmlResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// TagResource accepts and discards tag attachments.
+func (s *Service) TagResource(w http.ResponseWriter, _ *http.Request) {
+	writeCloudWatchXML(w, xmlTagResourceResponse{
+		Xmlns:            cloudWatchXMLNS,
+		ResponseMetadata: xmlResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// UntagResource accepts and discards tag detachments.
+func (s *Service) UntagResource(w http.ResponseWriter, _ *http.Request) {
+	writeCloudWatchXML(w, xmlUntagResourceResponse{
+		Xmlns:            cloudWatchXMLNS,
+		ResponseMetadata: xmlResponseMetadata{RequestID: uuid.New().String()},
+	})
+}

--- a/internal/service/cloudwatch/xml_query.go
+++ b/internal/service/cloudwatch/xml_query.go
@@ -1,0 +1,113 @@
+package cloudwatch
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// CloudWatch's Query protocol (used by terraform-provider-aws and other
+// pre-CBOR clients) wraps responses in <ActionResponse> XML envelopes.
+// The JSON DispatchAction path was originally written for non-existent
+// JSON clients; its handlers now route through these XML wrappers when
+// reached via the unified Query→JSON dispatcher.
+
+const cloudWatchXMLNS = "http://monitoring.amazonaws.com/doc/2010-08-01/"
+
+// writeCloudWatchXML writes an XML response with HTTP 200 OK.
+func writeCloudWatchXML(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(v)
+}
+
+// xmlResponseMetadata is the standard ResponseMetadata block AWS includes
+// in every Query-protocol response.
+type xmlResponseMetadata struct {
+	RequestID string `xml:"RequestId"`
+}
+
+// xmlPutMetricAlarmResponse is the empty PutMetricAlarm response envelope.
+type xmlPutMetricAlarmResponse struct {
+	XMLName          xml.Name            `xml:"PutMetricAlarmResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata xmlResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// xmlDeleteAlarmsResponse is the empty DeleteAlarms response envelope.
+type xmlDeleteAlarmsResponse struct {
+	XMLName          xml.Name            `xml:"DeleteAlarmsResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata xmlResponseMetadata `xml:"ResponseMetadata"`
+}
+
+// xmlDescribeAlarmsResponse wraps the DescribeAlarms result.
+type xmlDescribeAlarmsResponse struct {
+	XMLName              xml.Name                `xml:"DescribeAlarmsResponse"`
+	Xmlns                string                  `xml:"xmlns,attr"`
+	DescribeAlarmsResult xmlDescribeAlarmsResult `xml:"DescribeAlarmsResult"`
+	ResponseMetadata     xmlResponseMetadata     `xml:"ResponseMetadata"`
+}
+
+type xmlDescribeAlarmsResult struct {
+	MetricAlarms xmlMetricAlarmList `xml:"MetricAlarms"`
+	NextToken    string             `xml:"NextToken,omitempty"`
+}
+
+// xmlMetricAlarmList wraps the alarm members in the AWS Query shape
+// (<MetricAlarms><member>...</member>...</MetricAlarms>).
+type xmlMetricAlarmList struct {
+	Members []xmlMetricAlarm `xml:"member"`
+}
+
+// xmlMetricAlarm is a single metric alarm entry. Field set kept tight to
+// what terraform-provider-aws reads on refresh.
+type xmlMetricAlarm struct {
+	AlarmName                          string  `xml:"AlarmName"`
+	AlarmArn                           string  `xml:"AlarmArn"`
+	AlarmDescription                   string  `xml:"AlarmDescription,omitempty"`
+	MetricName                         string  `xml:"MetricName"`
+	Namespace                          string  `xml:"Namespace"`
+	Statistic                          string  `xml:"Statistic,omitempty"`
+	Period                             int32   `xml:"Period"`
+	EvaluationPeriods                  int32   `xml:"EvaluationPeriods"`
+	Threshold                          float64 `xml:"Threshold"`
+	ComparisonOperator                 string  `xml:"ComparisonOperator"`
+	ActionsEnabled                     bool    `xml:"ActionsEnabled"`
+	StateValue                         string  `xml:"StateValue"`
+	StateReason                        string  `xml:"StateReason,omitempty"`
+	StateUpdatedTimestamp              string  `xml:"StateUpdatedTimestamp,omitempty"`
+	AlarmConfigurationUpdatedTimestamp string  `xml:"AlarmConfigurationUpdatedTimestamp,omitempty"`
+}
+
+// metricAlarmsToXML converts the internal MetricAlarm slice to the XML
+// member list shape.
+func metricAlarmsToXML(alarms []MetricAlarm) []xmlMetricAlarm {
+	out := make([]xmlMetricAlarm, 0, len(alarms))
+
+	for i := range alarms {
+		a := alarms[i]
+		out = append(out, xmlMetricAlarm{
+			AlarmName:                          a.AlarmName,
+			AlarmArn:                           a.AlarmArn,
+			AlarmDescription:                   a.AlarmDescription,
+			MetricName:                         a.MetricName,
+			Namespace:                          a.Namespace,
+			Statistic:                          a.Statistic,
+			Period:                             a.Period,
+			EvaluationPeriods:                  a.EvaluationPeriods,
+			Threshold:                          a.Threshold,
+			ComparisonOperator:                 a.ComparisonOperator,
+			ActionsEnabled:                     a.ActionsEnabled,
+			StateValue:                         a.StateValue,
+			StateReason:                        a.StateReason,
+			StateUpdatedTimestamp:              a.StateUpdatedTimestamp,
+			AlarmConfigurationUpdatedTimestamp: a.AlarmConfigurationUpdatedTimestamp,
+		})
+	}
+
+	return out
+}


### PR DESCRIPTION
## Summary

**Required for terraform compatibility.** terraform-provider-aws sends \`PutMetricAlarm\` / \`DescribeAlarms\` / \`DeleteAlarms\` / \`ListTagsForResource\` through the AWS Query protocol over \`/\`. CloudWatch was registered only as a CBOR (RPC v2) service so the unified Query dispatcher returned \`UnknownService\` for every alarm action; even after registration the existing JSON handlers would have returned \`application/x-amz-json-1.0\` bodies which terraform's Query-protocol client cannot parse.

Found while running tofu against CloudWatch for #589.

## Implementation

- **QueryProtocolService on cloudwatch service**: adds \`TargetPrefix\` / \`ServiceIdentifier\` / \`Actions\` / \`QueryProtocol\`. The SDK identifier is \`\"cloudwatch\"\` (not \`\"monitoring\"\`) because terraform-provider-aws sends \`api/cloudwatch#x.y.z\` in the User-Agent — that's the SDK package name, not the AWS service ID.
- **XML response wrappers** (\`xml_query.go\`) for \`PutMetricAlarmResponse\` / \`DeleteAlarmsResponse\` / \`DescribeAlarmsResponse\` with the standard \`ResponseMetadata\` block. The JSON \`DispatchAction\` handlers now write these instead of \`application/x-amz-json-1.0\`. CBOR handlers (\`PutMetricAlarmCBOR\` etc.) are untouched and the existing CBOR integration tests continue to use them.
- **No-op stubs** for \`ListTagsForResource\` / \`TagResource\` / \`UntagResource\` (\`tag_stubs.go\`) — terraform calls \`ListTagsForResource\` on every alarm refresh and apply errors immediately after \`PutMetricAlarm\` without it.

**Drive-by**: \`server/awsquery.go\`'s \`parseServiceFromUserAgent\` now also strips at \`/\` in addition to \`#\` so \`api/<id>/<version>\` User-Agent formats route correctly. Adds a \`ua\` attribute to request logs to make this kind of routing mismatch easier to diagnose (this is what surfaced the \"cloudwatch\" vs \"monitoring\" discrepancy here).

## Test plan

- [x] \`go test ./internal/service/cloudwatch/... ./internal/server/...\` — green (existing CBOR-path tests untouched).
- [x] \`make lint\` — clean.
- [x] End-to-end: tofu \`apply\` + \`destroy\` of \`aws_cloudwatch_metric_alarm\` against \`kumo serve\` — both succeed; before this PR \`apply\` errored on \`PutMetricAlarm\` with \`UnknownService\`, then on \`ListTagsForResource\` after the dispatcher fix.

Cross-ref: #416, #589.