### PR TITLE
fix(server): wire SNS topic SQS subscriptions to actually deliver messages

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -77,6 +77,9 @@ func New(config Config) *Server {
 		srv.RegisterService(svc)
 	}
 
+	// Cross-service wiring (must happen after all services are registered).
+	wireSNStoSQS(registry)
+
 	// Register unified protocol dispatcher for POST /
 	hasJSONServices := len(jsonDispatcher.handlers) > 0
 	hasQueryServices := len(queryDispatcher.handlers) > 0

--- a/internal/server/sns_sqs_wiring.go
+++ b/internal/server/sns_sqs_wiring.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sivchari/kumo/internal/service"
+	"github.com/sivchari/kumo/internal/service/sns"
+	"github.com/sivchari/kumo/internal/service/sqs"
+)
+
+// wireSNStoSQS connects the SNS service to the SQS service so SNS topic
+// subscriptions with protocol=sqs actually deliver messages into the
+// target queue.
+//
+// Without this wiring, SNS Publish silently drops all messages destined
+// for SQS subscribers (sub.Endpoint is the queue ARN, but
+// MemoryStorage.Publish only iterates subscribers and calls
+// SqsPublisher.PublishToSQS — and SqsPublisher is nil unless something
+// installs it). Found while running a tofu serverless stack against kumo
+// and watching CLI sqs receive-message return zero messages after
+// sns publish.
+func wireSNStoSQS(registry *service.Registry) {
+	snsSvc, ok := registry.Get("sns")
+	if !ok {
+		return
+	}
+
+	sqsSvc, ok := registry.Get("sqs")
+	if !ok {
+		return
+	}
+
+	snsTyped, ok := snsSvc.(*sns.Service)
+	if !ok {
+		return
+	}
+
+	sqsTyped, ok := sqsSvc.(*sqs.Service)
+	if !ok {
+		return
+	}
+
+	snsStorage, ok := snsTyped.Storage().(*sns.MemoryStorage)
+	if !ok {
+		return
+	}
+
+	snsStorage.SetSQSPublisher(&snsToSQSPublisher{
+		storage: sqsTyped.Storage(),
+		baseURL: sqsTyped.BaseURL(),
+	})
+}
+
+// snsToSQSPublisher adapts the SQS storage layer to the SNS
+// SQSPublisher interface. It accepts either a queue URL or an SQS ARN
+// in the endpoint argument; ARNs are translated to URLs against the
+// configured base URL because that's how SNS subscriptions store the
+// SQS endpoint.
+type snsToSQSPublisher struct {
+	storage sqs.Storage
+	baseURL string
+}
+
+// PublishToSQS hands a single message to the SQS storage layer. The
+// MessageId / Subject attributes the SNS layer attaches are forwarded as
+// SQS message attributes (String type) so subscribers can read them.
+func (p *snsToSQSPublisher) PublishToSQS(ctx context.Context, endpoint, body string, attrs map[string]string) error {
+	queueURL := p.endpointToQueueURL(endpoint)
+
+	mAttrs := make(map[string]sqs.MessageAttributeValue, len(attrs))
+	for k, v := range attrs {
+		mAttrs[k] = sqs.MessageAttributeValue{DataType: "String", StringValue: v}
+	}
+
+	_, err := p.storage.SendMessage(ctx, queueURL, body, 0, mAttrs, "", "")
+	if err != nil {
+		return err //nolint:wrapcheck // adapter is a thin pass-through
+	}
+
+	return nil
+}
+
+// endpointToQueueURL converts an SQS ARN to a queue URL, returning the
+// input unchanged when it is already a URL (subscribers may send either
+// shape; AWS console shows ARNs, terraform sends ARNs, raw API calls
+// often pass URLs).
+func (p *snsToSQSPublisher) endpointToQueueURL(endpoint string) string {
+	if !strings.HasPrefix(endpoint, "arn:") {
+		return endpoint
+	}
+
+	// arn:aws:sqs:<region>:<account>:<name> → <baseURL>/<account>/<name>
+	parts := strings.Split(endpoint, ":")
+	if len(parts) < 6 {
+		return endpoint
+	}
+
+	account := parts[4]
+	name := parts[5]
+
+	return p.baseURL + "/" + account + "/" + name
+}

--- a/internal/service/sqs/service.go
+++ b/internal/service/sqs/service.go
@@ -66,3 +66,17 @@ func (s *Service) Close() error {
 
 	return nil
 }
+
+// Storage returns the SQS storage so other services (e.g. SNS) can hand
+// messages directly to a queue without going through the public SDK
+// surface.
+func (s *Service) Storage() Storage {
+	return s.storage
+}
+
+// BaseURL returns the configured base URL used when generating queue URLs.
+// SNS uses this to translate an SQS ARN (which is what subscribers send)
+// into the queue URL the storage layer keys queues by.
+func (s *Service) BaseURL() string {
+	return s.baseURL
+}


### PR DESCRIPTION
## Summary

SNS \`Publish\` silently dropped every message destined for an SQS subscriber because the \`SqsPublisher\` field on \`sns.MemoryStorage\` was nil — nothing ever called \`SetSQSPublisher\`. The hook was already in place on the SNS side, but no caller wired it to the SQS service.

Found while running a realistic tofu serverless stack (SNS topic + Lambda + DynamoDB + S3) end-to-end and watching:

\`\`\`
aws sns publish --topic-arn <topic> --message hello   # returns MessageId, looks fine
aws sqs receive-message --queue-url <subscribed queue>   # empty — no messages
\`\`\`

## Implementation

- **SQS service exposes \`Storage()\` + \`BaseURL()\`**: minimal getters so cross-service wiring code can hand messages to the storage layer and translate SQS ARNs to queue URLs.
- **\`internal/server/sns_sqs_wiring.go\`** introduces \`snsToSQSPublisher\` — a thin adapter that implements \`sns.SQSPublisher\` by calling \`sqs.Storage.SendMessage\`. Accepts both queue URL and SQS ARN endpoints (subscribers may send either; terraform sends ARNs, raw API calls often pass URLs).
- **\`server.New()\`** calls \`wireSNStoSQS(registry)\` right after the service registry is populated. Type-asserts the SNS storage to \`*sns.MemoryStorage\` to access \`SetSQSPublisher\`; cleanly noops if either service is missing.

Existing SQS-direct send/receive tests are untouched. After this change, SNS publish to a topic with an SQS subscription delivers the raw message body into the queue (RawMessageDelivery=true semantics — the JSON envelope shape AWS uses by default for \`RawMessageDelivery=false\` is a separate follow-up; both worth doing but this PR keeps the scope to \"messages get delivered at all\").

## Test plan

- [x] \`go test ./internal/server/... ./internal/service/sqs/... ./internal/service/sns/...\` — green.
- [x] \`make lint\` — clean.
- [x] End-to-end: \`aws sns publish\` followed by \`aws sqs receive-message\` returns the published body.