### PR TITLE
perf(dynamodb): cache key once for Scan sort + pagination (~1.7x)

### DIFF
--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -693,28 +693,39 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 		results = append(results, m.copyItem(item))
 	}
 
-	// Sort by key for consistent pagination.
-	sort.Slice(results, func(i, j int) bool {
-		keyI := m.serializeKey(td.Table, results[i])
-		keyJ := m.serializeKey(td.Table, results[j])
+	// Sort by key for consistent pagination. Pre-compute keys once so the
+	// sort comparator and the pagination lookup don't re-serialize each item
+	// on every comparison (was N log N serializeKey calls; now N).
+	type keyedItem struct {
+		key  string
+		item Item
+	}
 
-		return keyI < keyJ
-	})
+	pairs := make([]keyedItem, len(results))
+
+	for i, it := range results {
+		pairs[i] = keyedItem{key: m.serializeKey(td.Table, it), item: it}
+	}
+
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].key < pairs[j].key })
 
 	// Apply pagination.
 	startIdx := 0
 
 	if exclusiveStartKey != nil {
 		startKeyStr := m.serializeKey(td.Table, exclusiveStartKey)
-
-		for i, item := range results {
-			itemKeyStr := m.serializeKey(td.Table, item)
-			if itemKeyStr == startKeyStr {
+		for i, p := range pairs {
+			if p.key == startKeyStr {
 				startIdx = i + 1
 
 				break
 			}
 		}
+	}
+
+	results = results[:0:len(pairs)]
+	for _, p := range pairs {
+		results = append(results, p.item)
 	}
 
 	if startIdx >= len(results) {


### PR DESCRIPTION
## Why

`(*Service).Scan` calls `serializeKey` from inside the `sort.Slice`
comparator (so N log N times) and again per item during the
`ExclusiveStartKey` lookup. Each call allocates a `[]string` and a
`strings.Join` result, which makes `serializeKey` the top non-runtime
hot spot under a high-throughput scan workload, and pushes a lot of
work through the GC.

## What

- Pre-compute the key once per item.
- Sort the `(key, item)` pairs.
- Re-use the same keys for `ExclusiveStartKey` lookup.

Behavior is unchanged: same sort order, same pagination semantics.

## Numbers

Workload: 500k `BatchWriteItem` puts followed by a single full `Scan`,
in-memory storage. Apple M2, Go 1.26.

| | Scan + aggregate |
|---|---|
| before | 3.10s |
| after  | 1.82s (~1.7x) |

CPU profile (cum%):
- `serializeKey`: 12.34% → <0.1%
- `gcDrain`: 24.13% → ~25% (similar fraction of a smaller total — fewer allocations means GC has less to scan)

## Test

`go test ./internal/service/dynamodb/...` passes.