### PR TITLE
feat(server): KUMO_PPROF and KUMO_LOG_LEVEL env knobs

### DIFF
--- a/internal/server/pprof.go
+++ b/internal/server/pprof.go
@@ -22,7 +22,9 @@ func startPprofServer(logger *slog.Logger) {
 	if v == "" {
 		return
 	}
+
 	on, err := strconv.ParseBool(v)
+
 	if err != nil || !on {
 		return
 	}
@@ -49,9 +51,12 @@ func startPprofServer(logger *slog.Logger) {
 		ln, lerr := (&net.ListenConfig{}).Listen(context.Background(), "tcp", addr)
 		if lerr != nil {
 			logger.Error("pprof listen failed", "addr", addr, "err", lerr)
+
 			return
 		}
+
 		logger.Info(fmt.Sprintf("pprof endpoint enabled on %s", addr))
+
 		if serr := srv.Serve(ln); serr != nil && serr != http.ErrServerClosed {
 			logger.Error("pprof server failed", "err", serr)
 		}

--- a/internal/server/pprof.go
+++ b/internal/server/pprof.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"strconv"
+	"time"
+)
+
+// startPprofServer launches a separate HTTP server exposing /debug/pprof/*
+// when KUMO_PPROF is set to a truthy value (1/true/on). KUMO_PPROF_ADDR
+// overrides the default :6060 listen address.
+//
+// Kept on its own ServeMux so we don't pollute the main service router.
+func startPprofServer(logger *slog.Logger) {
+	v := os.Getenv("KUMO_PPROF")
+	if v == "" {
+		return
+	}
+	on, err := strconv.ParseBool(v)
+	if err != nil || !on {
+		return
+	}
+
+	addr := os.Getenv("KUMO_PPROF_ADDR")
+	if addr == "" {
+		addr = ":6060"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		ln, lerr := (&net.ListenConfig{}).Listen(context.Background(), "tcp", addr)
+		if lerr != nil {
+			logger.Error("pprof listen failed", "addr", addr, "err", lerr)
+			return
+		}
+		logger.Info(fmt.Sprintf("pprof endpoint enabled on %s", addr))
+		if serr := srv.Serve(ln); serr != nil && serr != http.ErrServerClosed {
+			logger.Error("pprof server failed", "err", serr)
+		}
+	}()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -31,11 +32,13 @@ type Config struct {
 // DefaultConfig returns the default server configuration.
 // KUMO_HOST and KUMO_PORT override the bind address when set; an
 // unparseable KUMO_PORT is ignored and the default port is kept.
+// KUMO_LOG_LEVEL (debug|info|warn|error) overrides the default INFO level —
+// useful when benchmarking, where per-request INFO logs dominate CPU.
 func DefaultConfig() Config {
 	cfg := Config{
 		Host:     "0.0.0.0",
 		Port:     4566,
-		LogLevel: slog.LevelInfo,
+		LogLevel: parseLogLevel(os.Getenv("KUMO_LOG_LEVEL"), slog.LevelInfo),
 		InitDir:  os.Getenv("KUMO_INIT_DIR"),
 	}
 
@@ -50,6 +53,21 @@ func DefaultConfig() Config {
 	}
 
 	return cfg
+}
+
+func parseLogLevel(s string, def slog.Level) slog.Level {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return def
+	}
 }
 
 // Server is the main HTTP server for kumo.
@@ -196,6 +214,9 @@ func (s *Server) Start(readyCh ...chan struct{}) error {
 	}
 
 	s.logger.Info("starting kumo server", "addr", s.Addr())
+
+	// Optional pprof endpoint (KUMO_PPROF=1).
+	startPprofServer(s.logger)
 
 	// List registered services
 	for _, name := range s.registry.Names() {


### PR DESCRIPTION
## Why

Two small operator knobs that I needed while benchmarking kumo
(1brc-style DynamoDB / S3 throughput tests) and that have general
debugging value.

### KUMO_PPROF / KUMO_PPROF_ADDR

Set \`KUMO_PPROF=1\` to start a separate http server exposing the
standard \`/debug/pprof/{,cmdline,profile,symbol,trace}\` endpoints.
\`KUMO_PPROF_ADDR\` overrides the listen address (default \`:6060\`).

It uses its own \`ServeMux\` so it does not pollute the service router,
and is only started when the env knob is set, so production builds pay
nothing if it stays off.

### KUMO_LOG_LEVEL

Accepts \`debug\`, \`info\`, \`warn\`, \`error\`. Overrides the default INFO.

The router currently logs every request at INFO. That is useful in
development but dominates CPU under throughput tests — in a 30s CPU
profile of a heavy DynamoDB scan workload, \`log/slog\` + \`syscall.write\`
together accounted for ~16% of samples. Being able to set the level
without rebuilding makes profiles representative of handler work
instead of slog overhead.

## Test

\`go test ./internal/server/...\` passes.