### PR TITLE
fix(server): honor KUMO_HOST/KUMO_PORT and --host/--port

### DIFF
--- a/cmd/kumo/main.go
+++ b/cmd/kumo/main.go
@@ -93,8 +93,17 @@ func main() {
 
 	// Root command starts the server when no CLI subcommand is matched.
 	// Docker uses `kumo --host 0.0.0.0 --port 4566`, so we accept these flags.
-	root.RunE = func(_ *cobra.Command, _ []string) error {
+	root.RunE = func(cmd *cobra.Command, _ []string) error {
 		cfg := server.DefaultConfig()
+
+		if host, _ := cmd.Flags().GetString("host"); host != "" {
+			cfg.Host = host
+		}
+
+		if cmd.Flags().Changed("port") {
+			cfg.Port, _ = cmd.Flags().GetInt("port")
+		}
+
 		srv := server.New(cfg)
 
 		if err := srv.Run(); err != nil {
@@ -104,14 +113,22 @@ func main() {
 		return nil
 	}
 
-	root.Flags().String("host", "", "Server host (use KUMO_HOST env var)")
-	root.Flags().String("port", "", "Server port (use KUMO_PORT env var)")
+	// Server flags live on each command that actually starts the server, not
+	// on root.PersistentFlags, so client subcommands (s3, acm, ...) do not
+	// inherit them.
+	addServerFlags := func(c *cobra.Command) {
+		c.Flags().String("host", "", "Server host (overrides KUMO_HOST)")
+		c.Flags().Int("port", 0, "Server port (overrides KUMO_PORT)")
+	}
+
+	addServerFlags(root)
 
 	serveCmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Start the kumo server",
 		RunE:  root.RunE,
 	}
+	addServerFlags(serveCmd)
 
 	root.AddCommand(serveCmd)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -28,13 +29,27 @@ type Config struct {
 }
 
 // DefaultConfig returns the default server configuration.
+// KUMO_HOST and KUMO_PORT override the bind address when set; an
+// unparseable KUMO_PORT is ignored and the default port is kept.
 func DefaultConfig() Config {
-	return Config{
+	cfg := Config{
 		Host:     "0.0.0.0",
 		Port:     4566,
 		LogLevel: slog.LevelInfo,
 		InitDir:  os.Getenv("KUMO_INIT_DIR"),
 	}
+
+	if host := os.Getenv("KUMO_HOST"); host != "" {
+		cfg.Host = host
+	}
+
+	if portStr := os.Getenv("KUMO_PORT"); portStr != "" {
+		if p, err := strconv.Atoi(portStr); err == nil {
+			cfg.Port = p
+		}
+	}
+
+	return cfg
 }
 
 // Server is the main HTTP server for kumo.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,43 @@
+package server
+
+import "testing"
+
+func TestDefaultConfig_DefaultsWhenEnvUnset(t *testing.T) {
+	t.Setenv("KUMO_HOST", "")
+	t.Setenv("KUMO_PORT", "")
+
+	cfg := DefaultConfig()
+
+	if cfg.Host != "0.0.0.0" {
+		t.Errorf("Host = %q, want 0.0.0.0", cfg.Host)
+	}
+
+	if cfg.Port != 4566 {
+		t.Errorf("Port = %d, want 4566", cfg.Port)
+	}
+}
+
+func TestDefaultConfig_HonorsEnv(t *testing.T) {
+	t.Setenv("KUMO_HOST", "127.0.0.1")
+	t.Setenv("KUMO_PORT", "18080")
+
+	cfg := DefaultConfig()
+
+	if cfg.Host != "127.0.0.1" {
+		t.Errorf("Host = %q, want 127.0.0.1", cfg.Host)
+	}
+
+	if cfg.Port != 18080 {
+		t.Errorf("Port = %d, want 18080", cfg.Port)
+	}
+}
+
+func TestDefaultConfig_IgnoresUnparseablePort(t *testing.T) {
+	t.Setenv("KUMO_PORT", "not-a-number")
+
+	cfg := DefaultConfig()
+
+	if cfg.Port != 4566 {
+		t.Errorf("Port = %d, want default 4566 when KUMO_PORT is unparseable", cfg.Port)
+	}
+}


### PR DESCRIPTION
## Why

The README documents `--host` / `--port` and `KUMO_HOST` / `KUMO_PORT`,
but `kumo` always listened on `0.0.0.0:4566` — env vars were never read
and the flags never reached `Config`. `kumo serve --port ...` also
failed as an unknown flag.

## What

- `DefaultConfig` reads `KUMO_HOST` / `KUMO_PORT` (unparseable port
  keeps the default).
- `--host` / `--port` are wired into `Config` and registered on each
  server-starting command (root, `serve`), not on
  `root.PersistentFlags`, so client subcommands like `s3` / `acm`
  do not inherit a server-only flag.
- `--port` is an `Int` flag so `pflag` rejects invalid values
  automatically.