### PR TITLE
fix(sqs): enforce message group lock for FIFO queues

### DIFF
--- a/internal/service/sqs/storage.go
+++ b/internal/service/sqs/storage.go
@@ -419,6 +419,24 @@ func (qd *QueueData) validateFIFO(body, messageGroupID, messageDeduplicationID s
 	}, nil
 }
 
+// lockedMessageGroups returns the set of MessageGroupIDs that have in-flight
+// messages. Returns nil for non-FIFO queues.
+func (qd *QueueData) lockedMessageGroups() map[string]struct{} {
+	if !qd.Queue.FifoQueue {
+		return nil
+	}
+
+	locked := make(map[string]struct{})
+
+	for _, msg := range qd.Inflight {
+		if msg.MessageGroupID != "" {
+			locked[msg.MessageGroupID] = struct{}{}
+		}
+	}
+
+	return locked
+}
+
 // updateFIFOCache updates the deduplication cache with the message ID.
 func (qd *QueueData) updateFIFOCache(dedupID, messageID string) {
 	entry := qd.DeduplicationCache[dedupID]
@@ -548,6 +566,9 @@ func (s *MemoryStorage) receiveMessagesLocked(queueURL string, maxMessages, visi
 	result := make([]*Message, 0, maxMessages)
 	remaining := make([]*Message, 0, len(qd.Messages))
 
+	// For FIFO queues, track which message groups are locked (have in-flight messages).
+	lockedGroups := qd.lockedMessageGroups()
+
 	for _, msg := range qd.Messages {
 		if len(result) >= maxMessages {
 			remaining = append(remaining, msg)
@@ -561,30 +582,52 @@ func (s *MemoryStorage) receiveMessagesLocked(queueURL string, maxMessages, visi
 			continue
 		}
 
-		// Make message invisible and add to inflight.
-		msg.ReceiptHandle = uuid.New().String()
-		msg.VisibleAt = now.Add(time.Duration(visibilityTimeout) * time.Second)
-		msg.ReceiveCount++
-		msg.Attributes["ApproximateReceiveCount"] = fmt.Sprintf("%d", msg.ReceiveCount)
+		// FIFO: skip messages from groups that are locked (have in-flight messages).
+		if lockedGroups != nil && msg.MessageGroupID != "" {
+			if _, locked := lockedGroups[msg.MessageGroupID]; locked {
+				remaining = append(remaining, msg)
 
-		if msg.Attributes["ApproximateFirstReceiveTimestamp"] == "" {
-			msg.Attributes["ApproximateFirstReceiveTimestamp"] = fmt.Sprintf("%d", now.UnixMilli())
+				continue
+			}
 		}
 
-		// Check if message should be moved to DLQ.
-		if qd.Queue.MaxReceiveCount > 0 && msg.ReceiveCount > qd.Queue.MaxReceiveCount {
-			s.moveToDeadLetterQueue(qd.Queue.DeadLetterTargetArn, msg)
+		// Deliver the message: make invisible and add to inflight.
+		if s.deliverMessage(qd, msg, now, visibilityTimeout) {
+			result = append(result, msg)
 
-			continue
+			// FIFO: lock the group after delivering a message from it.
+			if lockedGroups != nil && msg.MessageGroupID != "" {
+				lockedGroups[msg.MessageGroupID] = struct{}{}
+			}
 		}
-
-		qd.Inflight[msg.ReceiptHandle] = msg
-		result = append(result, msg)
 	}
 
 	qd.Messages = remaining
 
 	return result, qd.notify, nil
+}
+
+// deliverMessage makes a message invisible and adds it to inflight.
+// Returns true if delivered, false if moved to DLQ. Must be called under lock.
+func (s *MemoryStorage) deliverMessage(qd *QueueData, msg *Message, now time.Time, visibilityTimeout int) bool {
+	msg.ReceiptHandle = uuid.New().String()
+	msg.VisibleAt = now.Add(time.Duration(visibilityTimeout) * time.Second)
+	msg.ReceiveCount++
+	msg.Attributes["ApproximateReceiveCount"] = fmt.Sprintf("%d", msg.ReceiveCount)
+
+	if msg.Attributes["ApproximateFirstReceiveTimestamp"] == "" {
+		msg.Attributes["ApproximateFirstReceiveTimestamp"] = fmt.Sprintf("%d", now.UnixMilli())
+	}
+
+	if qd.Queue.MaxReceiveCount > 0 && msg.ReceiveCount > qd.Queue.MaxReceiveCount {
+		s.moveToDeadLetterQueue(qd.Queue.DeadLetterTargetArn, msg)
+
+		return false
+	}
+
+	qd.Inflight[msg.ReceiptHandle] = msg
+
+	return true
 }
 
 // DeleteMessage deletes a message from a queue.


### PR DESCRIPTION
## Summary

Fix FIFO queue ReceiveMessage to enforce message group ordering. Messages from a MessageGroupID that already has an in-flight message were being delivered out of order.

## Problem

When multiple consumers called ReceiveMessage concurrently on a FIFO queue, messages from the same MessageGroupID could be delivered out of order because the implementation did not enforce the "message group lock" semantics.

```
Expected: ping-0, ping-1, ping-2, ping-3, ping-4, ...
Actual:   ping-0, ping-1, ping-2, ping-3, ping-5, ping-4, ...  (order violation)
```

## Fix

Add message group lock tracking in `receiveMessagesLocked`:
1. Before delivering, collect MessageGroupIDs that have in-flight messages into `lockedGroups`
2. Skip messages belonging to locked groups
3. After delivering a message, add its group to `lockedGroups`

This ensures only one message per group is in-flight at a time, preserving strict ordering within each MessageGroupID per the SQS FIFO specification.

## Test plan

- [x] `go test ./internal/service/sqs/...` pass
- [ ] layerone `TestSQSTaskWithGroupID` passes with this fix