### PR TITLE
fix(s3): decode URL-encoded x-amz-copy-source before parsing

### DIFF
--- a/internal/service/s3/copysource_test.go
+++ b/internal/service/s3/copysource_test.go
@@ -1,0 +1,38 @@
+package s3
+
+import "testing"
+
+// TestParseCopySource covers the shapes AWS clients send in the
+// x-amz-copy-source header: plain, leading-slash, and URL-encoded.
+// AWS S3 accepts all of these so kumo must too.
+func TestParseCopySource(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		source     string
+		wantBucket string
+		wantKey    string
+	}{
+		{"plain", "bucket/key.txt", "bucket", "key.txt"},
+		{"leading slash", "/bucket/key.txt", "bucket", "key.txt"},
+		{"encoded separator", "bucket%2Fkey.txt", "bucket", "key.txt"},
+		{"encoded subpath", "bucket/path%2Fto%2Fkey.txt", "bucket", "path/to/key.txt"},
+		{"fully encoded with leading slash", "%2Fbucket%2Fkey.txt", "bucket", "key.txt"},
+		{"plus preserved", "bucket/file+name.txt", "bucket", "file+name.txt"},
+		{"no separator", "bucket", "", ""},
+		{"empty", "", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotBucket, gotKey := parseCopySource(tc.source)
+			if gotBucket != tc.wantBucket || gotKey != tc.wantKey {
+				t.Errorf("parseCopySource(%q) = (%q, %q), want (%q, %q)",
+					tc.source, gotBucket, gotKey, tc.wantBucket, tc.wantKey)
+			}
+		})
+	}
+}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -647,6 +648,14 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 // parseCopySource parses the X-Amz-Copy-Source header value.
 // Format: /bucket/key or bucket/key (URL-encoded).
 func parseCopySource(source string) (bucket, key string) {
+	// AWS accepts both plain ("bucket/key") and URL-encoded
+	// ("bucket%2Fkey") forms. Decode first so a single split handles
+	// both. PathUnescape (not QueryUnescape) preserves '+' which is a
+	// valid S3 key character.
+	if decoded, err := url.PathUnescape(source); err == nil {
+		source = decoded
+	}
+
 	source = strings.TrimPrefix(source, "/")
 
 	idx := strings.IndexByte(source, '/')

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -1336,6 +1337,63 @@ func TestS3_CopyObject(t *testing.T) {
 		"ETag", "LastModified", "ResultMetadata",
 		"ServerSideEncryption", "CopySourceVersionId",
 	)).Assert(t.Name(), copyOutput)
+}
+
+// TestS3_CopyObject_URLEncodedSource verifies that the URL-encoded
+// form of x-amz-copy-source is accepted, matching AWS S3 behavior.
+// Some AWS Go SDK callers escape the entire "bucket/key" string with
+// url.PathEscape to be safe with keys containing '/', '+', or spaces.
+func TestS3_CopyObject_URLEncodedSource(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucketName := "test-copy-encoded-source-bucket"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("dir/source.txt"),
+		Body:   bytes.NewReader([]byte("encoded copy")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// url.PathEscape encodes '/' as %2F so the entire path becomes
+	// percent-encoded — this is the form that previously failed.
+	encoded := url.PathEscape(bucketName + "/dir/source.txt")
+
+	_, err = client.CopyObject(ctx, &s3.CopyObjectInput{
+		Bucket:     aws.String(bucketName),
+		Key:        aws.String("dir/dest.txt"),
+		CopySource: aws.String(encoded),
+	})
+	if err != nil {
+		t.Fatalf("CopyObject with URL-encoded source should succeed: %v", err)
+	}
+
+	got, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("dir/dest.txt"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer got.Body.Close()
+
+	body, err := io.ReadAll(got.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(body) != "encoded copy" {
+		t.Errorf("unexpected body: got=%q want=%q", string(body), "encoded copy")
+	}
 }
 
 func TestS3_PutAndGetObjectTagging(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #616: `S3.CopyObject` rejected requests whose `x-amz-copy-source` header was sent in URL-encoded form (`bucket%2Fkey`), even though AWS S3 itself accepts both URL-encoded and plain forms. The existing comment on `parseCopySource` already documented the intent ("Format: /bucket/key or bucket/key (URL-encoded)"), but the implementation split on a literal `/` without decoding first, so the encoded form fell through to the "no separator" branch and returned empty strings — surfacing as `InvalidArgument: Invalid copy source`.

## Fix

URL-decode the header value with `url.PathUnescape` before splitting. `PathUnescape` (not `QueryUnescape`) is used so that `+` is preserved as a valid S3 key character.

```go
if decoded, err := url.PathUnescape(source); err == nil {
    source = decoded
}
source = strings.TrimPrefix(source, "/")
idx := strings.IndexByte(source, '/')
```

The same `parseCopySource` is reused by `UploadPartCopy`, so the fix applies there transparently.

## Behavior matrix

| Input | Before | After |
|---|---|---|
| `bucket/key.txt` | ✅ ok | ✅ ok |
| `/bucket/key.txt` | ✅ ok | ✅ ok |
| `bucket%2Fkey.txt` | ❌ `InvalidArgument` | ✅ ok |
| `bucket/path%2Fto%2Fkey.txt` | ❌ key returned as `path%2Fto%2Fkey.txt` | ✅ decoded to `path/to/key.txt` |
| `bucket/file+name.txt` | ✅ ok | ✅ `+` preserved |

## Changes

- `internal/service/s3/handlers.go`: decode source before splitting in `parseCopySource`.
- `internal/service/s3/copysource_test.go` (new): table-driven unit tests covering plain / leading-slash / encoded-separator / encoded-subpath / fully-encoded / plus-preserved / no-separator / empty.
- `test/integration/s3_test.go`: added `TestS3_CopyObject_URLEncodedSource` which builds CopySource via `url.PathEscape` (the form the AWS Go SDK callers in the wild produce) and round-trips through `PutObject` → `CopyObject` → `GetObject`.

## Test plan

- [x] `make test` — unit tests pass
- [x] `go test ./internal/service/s3/...` — all S3 unit tests pass including new `TestParseCopySource` (8 sub-cases)
- [x] `go vet -tags=integration ./test/integration/...` — clean
- [ ] `make test-integration` — please run in CI (requires Docker)
- [ ] `make lint` — please run in CI (golangci-lint not installed locally)