### PR TITLE
fix(dynamodb): cli accepts object form for --local/global-secondary-indexes

### DIFF
--- a/cli/dynamodb.go
+++ b/cli/dynamodb.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -67,11 +68,21 @@ func newDynamoDBCreateTableCmd() *cobra.Command {
 			}
 
 			if gsiJSON != "" {
-				input.GlobalSecondaryIndexes = parseGSI(gsiJSON)
+				gsis, err := parseGSI(gsiJSON)
+				if err != nil {
+					return err
+				}
+
+				input.GlobalSecondaryIndexes = gsis
 			}
 
 			if lsiJSON != "" {
-				input.LocalSecondaryIndexes = parseLSI(lsiJSON)
+				lsis, err := parseLSI(lsiJSON)
+				if err != nil {
+					return err
+				}
+
+				input.LocalSecondaryIndexes = lsis
 			}
 
 			out, err := client.CreateTable(cmd.Context(), input)
@@ -189,7 +200,18 @@ func parseProvisionedThroughput(s string) *ddbTypes.ProvisionedThroughput {
 	}
 }
 
-func parseGSI(s string) []ddbTypes.GlobalSecondaryIndex {
+// normalizeIndexJSON accepts either a JSON array (`[{...}]`) or a single JSON
+// object (`{...}`) and returns the array form. aws CLI normalizes object input
+// the same way before sending the DynamoDB request.
+func normalizeIndexJSON(s string) string {
+	if strings.HasPrefix(strings.TrimLeftFunc(s, unicode.IsSpace), "{") {
+		return "[" + s + "]"
+	}
+
+	return s
+}
+
+func parseGSI(s string) ([]ddbTypes.GlobalSecondaryIndex, error) {
 	//nolint:tagliatelle // AWS CLI JSON format uses PascalCase.
 	var raw []struct {
 		IndexName string `json:"IndexName"`
@@ -206,7 +228,10 @@ func parseGSI(s string) []ddbTypes.GlobalSecondaryIndex {
 		} `json:"ProvisionedThroughput,omitempty"`
 	}
 
-	_ = json.Unmarshal([]byte(s), &raw)
+	normalized := normalizeIndexJSON(s)
+	if err := json.Unmarshal([]byte(normalized), &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse --global-secondary-indexes: invalid json: %w received: %s", err, s)
+	}
 
 	gsis := make([]ddbTypes.GlobalSecondaryIndex, 0, len(raw))
 
@@ -233,10 +258,10 @@ func parseGSI(s string) []ddbTypes.GlobalSecondaryIndex {
 		gsis = append(gsis, gsi)
 	}
 
-	return gsis
+	return gsis, nil
 }
 
-func parseLSI(s string) []ddbTypes.LocalSecondaryIndex {
+func parseLSI(s string) ([]ddbTypes.LocalSecondaryIndex, error) {
 	//nolint:tagliatelle // AWS CLI JSON format uses PascalCase.
 	var raw []struct {
 		IndexName string `json:"IndexName"`
@@ -249,7 +274,10 @@ func parseLSI(s string) []ddbTypes.LocalSecondaryIndex {
 		} `json:"Projection"`
 	}
 
-	_ = json.Unmarshal([]byte(s), &raw)
+	normalized := normalizeIndexJSON(s)
+	if err := json.Unmarshal([]byte(normalized), &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse --local-secondary-indexes: invalid json: %w received: %s", err, s)
+	}
 
 	lsis := make([]ddbTypes.LocalSecondaryIndex, 0, len(raw))
 
@@ -269,7 +297,7 @@ func parseLSI(s string) []ddbTypes.LocalSecondaryIndex {
 		lsis = append(lsis, lsi)
 	}
 
-	return lsis
+	return lsis, nil
 }
 
 func parseKV(s string) map[string]string {


### PR DESCRIPTION
## Summary
`kumo dynamodb create-table --local-secondary-indexes` (and `--global-secondary-indexes`) silently produced a table with no secondary indexes when the value was a single JSON object instead of an array. The same JSON works against the real AWS DynamoDB API via `aws` CLI, so kumo should accept the same input for parity.

## Problem

`parseLSI` / `parseGSI` only unmarshal into `[]struct{...}` and discard the result of `json.Unmarshal` via `_ = json.Unmarshal(...)`. Passing a single object (`{...}`) fails to unmarshal, the error is dropped, and the resulting empty slice is treated as "no indexes specified".

```bash
docker exec kumo kumo dynamodb create-table \
  --table-name lsi-via-kumo \
  --attribute-definitions AttributeName=PK,AttributeType=S \
  --attribute-definitions AttributeName=SK,AttributeType=S \
  --attribute-definitions AttributeName=Idx,AttributeType=N \
  --key-schema AttributeName=PK,KeyType=HASH \
  --key-schema AttributeName=SK,KeyType=RANGE \
  --local-secondary-indexes '{"IndexName":"IdxName","KeySchema":[...],"Projection":{"ProjectionType":"ALL"}}' \
  --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1

# describe-table afterwards:
#   .Table.LocalSecondaryIndexes == null   ❌
  ```

The same payload via `aws --endpoint-url http://localhost:4566 dynamodb create-table ...` works, because the `aws` CLI wraps a bare object into an array client-side before sending the DynamoDB API request. The kumo HTTP API already accepts the array form, so applying the same normalization in the CLI lines the two up.

## Fix

In `cli/dynamodb.go`:

- Add `normalizeIndexJSON` which wraps `{...}` into `[{...}]` (mirrors the `aws` CLI normalization).
- Change `parseLSI` / `parseGSI` to return `(values, error)` so a JSON parse failure is no longer swallowed.
- Propagate the error from `newDynamoDBCreateTableCmd` so the command exits non-zero instead of exiting 0 on failure.



  ## Test plan

  - [x] `go build ./...`
  - [x] `make lint` → 0 issues
  - [x] Manually exercised against a running kumo container at `http://localhost:4566`:
    - `--local-secondary-indexes '{...}'` (object) → `describe-table` shows the LSI ✅
    - `--local-secondary-indexes '[{...}]'` (array) → still works, no regression ✅
    - `--local-secondary-indexes '{ broken json'` → `failed to parse --local-secondary-indexes: invalid json: ...` and exit 1 ✅

