### PR TITLE
fix(sqs): avoid nil map panic in ReceiveMessage after persisted reload

### DIFF
--- a/internal/service/sqs/storage.go
+++ b/internal/service/sqs/storage.go
@@ -147,6 +147,26 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 		s.Queues = make(map[string]*QueueData)
 	}
 
+	// Non-persisted fields (json:"-" / unexported) are zero after unmarshal;
+	// re-init so ReceiveMessage doesn't panic on a nil map.
+	for _, qd := range s.Queues {
+		if qd == nil {
+			continue
+		}
+
+		if qd.Inflight == nil {
+			qd.Inflight = make(map[string]*Message)
+		}
+
+		if qd.notify == nil {
+			qd.notify = make(chan struct{}, 1)
+		}
+
+		if qd.Queue != nil && qd.Queue.FifoQueue && qd.DeduplicationCache == nil {
+			qd.DeduplicationCache = make(map[string]DeduplicationEntry)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/service/sqs/storage_test.go
+++ b/internal/service/sqs/storage_test.go
@@ -139,3 +139,76 @@ func TestMemoryStorage_TagsLifecycle(t *testing.T) {
 		t.Fatalf("unexpected tags after untag: %#v", tags)
 	}
 }
+
+func TestMemoryStorage_ReceiveMessageAfterPersistedReload(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ctx := t.Context()
+
+	s1 := NewMemoryStorage("http://localhost:4566", WithDataDir(dir))
+	if _, err := s1.CreateQueue(ctx, "reload-queue", nil, nil); err != nil {
+		t.Fatalf("CreateQueue() error = %v", err)
+	}
+
+	queueURL := "http://localhost:4566/000000000000/reload-queue"
+	if _, err := s1.SendMessage(ctx, queueURL, "hello", 0, nil, "", ""); err != nil {
+		t.Fatalf("SendMessage() error = %v", err)
+	}
+
+	if err := s1.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	s2 := NewMemoryStorage("http://localhost:4566", WithDataDir(dir))
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ReceiveMessage() panicked after reload: %v", r)
+		}
+	}()
+
+	msgs, err := s2.ReceiveMessage(ctx, queueURL, 10, 0, 0)
+	if err != nil {
+		t.Fatalf("ReceiveMessage() error = %v", err)
+	}
+
+	if len(msgs) != 1 || msgs[0].Body != "hello" {
+		t.Fatalf("unexpected messages after reload: %#v", msgs)
+	}
+}
+
+func TestMemoryStorage_FIFODeduplicationCacheAfterReload(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ctx := t.Context()
+
+	attrs := map[string]string{"FifoQueue": "true"}
+
+	s1 := NewMemoryStorage("http://localhost:4566", WithDataDir(dir))
+	if _, err := s1.CreateQueue(ctx, "reload-queue.fifo", attrs, nil); err != nil {
+		t.Fatalf("CreateQueue() error = %v", err)
+	}
+
+	queueURL := "http://localhost:4566/000000000000/reload-queue.fifo"
+	if _, err := s1.SendMessage(ctx, queueURL, "first", 0, nil, "group-1", "dedup-1"); err != nil {
+		t.Fatalf("SendMessage() error = %v", err)
+	}
+
+	if err := s1.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	s2 := NewMemoryStorage("http://localhost:4566", WithDataDir(dir))
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("SendMessage() panicked after reload: %v", r)
+		}
+	}()
+
+	if _, err := s2.SendMessage(ctx, queueURL, "second", 0, nil, "group-1", "dedup-2"); err != nil {
+		t.Fatalf("SendMessage() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`MemoryStorage.ReceiveMessage` panics with `assignment to entry in nil map` after kumo is restarted with `KUMO_DATA_DIR` configured. Once persisted state is loaded back, the SQS endpoint stops serving and any SQS-backed flow stalls until the data dir is wiped.

## Problem

`QueueData` keeps three fields out of the JSON snapshot:

```go
type QueueData struct {
    Queue              *Queue                        `json:"queue"`
    Messages           []*Message                    `json:"messages"`
    Inflight           map[string]*Message           `json:"-"`               // not serialized
    DeduplicationCache map[string]DeduplicationEntry `json:"-"`               // not serialized
    SequenceCounter    uint64                        `json:"sequenceCounter"`
    notify             chan struct{}                 // unexported, not serialized
}
```

`UnmarshalJSON` only re-creates `s.Queues` when nil, so each loaded `QueueData` ends up with `Inflight == nil`, `DeduplicationCache == nil`, and `notify == nil`. `CreateQueue` is idempotent — when the init scripts re-run after a restart it returns early on the existing queue without ever taking the path that initializes these fields. The next `ReceiveMessage` reaches `deliverMessage`, which does:

```go
qd.Inflight[msg.ReceiptHandle] = msg  // assignment to entry in nil map
```

and panics. FIFO queues hit the same class of bug in `validateFIFO` writing to `qd.DeduplicationCache`, and long polling would block forever on a nil `notify` channel.

### Reproduction

1. Start kumo with `KUMO_DATA_DIR=/data`.
2. Create a queue, send a message.
3. Restart kumo (state is restored from `/data/sqs.json`).
4. `ReceiveMessage` → `panic: assignment to entry in nil map` in `internal/service/sqs/storage.go:deliverMessage`.

Goroutine trace from the failure:

```
github.com/sivchari/kumo/internal/service/sqs.(*MemoryStorage).deliverMessage
    .../internal/service/sqs/storage.go:628
github.com/sivchari/kumo/internal/service/sqs.(*MemoryStorage).receiveMessagesLocked
    .../internal/service/sqs/storage.go:595
github.com/sivchari/kumo/internal/service/sqs.(*MemoryStorage).ReceiveMessage
    .../internal/service/sqs/storage.go:518
```

## Fix

In `internal/service/sqs/storage.go`:

- At the end of `UnmarshalJSON`, walk every loaded `QueueData` and re-initialize `Inflight`, `notify`, and (for FIFO queues) `DeduplicationCache` if they are nil. This mirrors what `CreateQueue` does on first creation, but only fills in fields that the snapshot does not cover.
- Add regression tests in `storage_test.go`:
  - `TestMemoryStorage_ReceiveMessageAfterPersistedReload` — standard queue: `CreateQueue` → `SendMessage` → `Close` → fresh `NewMemoryStorage` with the same data dir → `ReceiveMessage` no longer panics and returns the original message.
  - `TestMemoryStorage_FIFODeduplicationCacheAfterReload` — FIFO queue: `SendMessage` with a dedup id → `Close` → reload → another `SendMessage` no longer panics on the dedup cache.

Both tests panic on the unpatched code with `assignment to entry in nil map`, and pass with the fix.

## Test plan

- [x] `go build ./...`
- [x] `make test` → all packages pass, including the two new regression tests
- [x] `make lint` → 0 issues
- [x] Verified the new tests fail on the unpatched code with `assignment to entry in nil map`, and pass with the fix applied
