### PR TITLE
feat(ssm): no-op stubs for ListTagsForResource / AddTagsToResource / RemoveTagsFromResource

### DIFF
--- a/internal/service/ssm/service.go
+++ b/internal/service/ssm/service.go
@@ -75,6 +75,12 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 		s.DeleteParameters(w, r)
 	case "DescribeParameters":
 		s.DescribeParameters(w, r)
+	case "ListTagsForResource":
+		s.ListTagsForResource(w, r)
+	case "AddTagsToResource":
+		s.AddTagsToResource(w, r)
+	case "RemoveTagsFromResource":
+		s.RemoveTagsFromResource(w, r)
 	default:
 		writeSSMError(w, ErrInvalidParameterValue, "The action "+action+" is not valid", http.StatusBadRequest)
 	}

--- a/internal/service/ssm/tag_stubs.go
+++ b/internal/service/ssm/tag_stubs.go
@@ -1,0 +1,27 @@
+package ssm
+
+import "net/http"
+
+// listTagsForResourceResponse is the response for ListTagsForResource.
+type listTagsForResourceResponse struct {
+	TagList []map[string]string `json:"TagList"` //nolint:tagliatelle // AWS JSON uses PascalCase
+}
+
+// ListTagsForResource returns an empty tag list for any resource.
+//
+// Tags are not modeled in the storage layer yet; this stub exists so reads
+// from clients that refresh parameter state after PutParameter (terraform,
+// pulumi, CDK) do not fail with ValidationException.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, listTagsForResourceResponse{TagList: []map[string]string{}})
+}
+
+// AddTagsToResource accepts and discards tag attachments.
+func (s *Service) AddTagsToResource(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, struct{}{})
+}
+
+// RemoveTagsFromResource accepts and discards tag detachments.
+func (s *Service) RemoveTagsFromResource(w http.ResponseWriter, _ *http.Request) {
+	writeJSONResponse(w, struct{}{})
+}

--- a/test/integration/ssm_test.go
+++ b/test/integration/ssm_test.go
@@ -414,3 +414,59 @@ func TestSSM_SecureString_WithDecryptionFalse(t *testing.T) {
 			paramValue, aws.ToString(getOutputDecrypted.Parameter.Value))
 	}
 }
+
+func TestSSM_ListTagsForResource(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := t.Context()
+	paramName := "/test/tag-param"
+
+	// Put a parameter to tag.
+	_, err := client.PutParameter(ctx, &ssm.PutParameterInput{
+		Name:  aws.String(paramName),
+		Value: aws.String("tag-test-value"),
+		Type:  types.ParameterTypeString,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteParameter(context.Background(), &ssm.DeleteParameterInput{
+			Name: aws.String(paramName),
+		})
+	})
+
+	// ListTagsForResource should succeed with empty tag list.
+	listOutput, err := client.ListTagsForResource(ctx, &ssm.ListTagsForResourceInput{
+		ResourceType: types.ResourceTypeForTaggingParameter,
+		ResourceId:   aws.String(paramName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), listOutput)
+
+	// AddTagsToResource should succeed (no-op stub).
+	addOutput, err := client.AddTagsToResource(ctx, &ssm.AddTagsToResourceInput{
+		ResourceType: types.ResourceTypeForTaggingParameter,
+		ResourceId:   aws.String(paramName),
+		Tags: []types.Tag{
+			{Key: aws.String("env"), Value: aws.String("test")},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_add", addOutput)
+
+	// RemoveTagsFromResource should succeed (no-op stub).
+	removeOutput, err := client.RemoveTagsFromResource(ctx, &ssm.RemoveTagsFromResourceInput{
+		ResourceType: types.ResourceTypeForTaggingParameter,
+		ResourceId:   aws.String(paramName),
+		TagKeys:      []string{"env"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_remove", removeOutput)
+}

--- a/test/integration/testdata/ssm_test_TestSSM_ListTagsForResource_TestSSM_ListTagsForResource.golden.go
+++ b/test/integration/testdata/ssm_test_TestSSM_ListTagsForResource_TestSSM_ListTagsForResource.golden.go
@@ -1,0 +1,4 @@
+{
+  "TagList": [],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ssm_test_TestSSM_ListTagsForResource_TestSSM_ListTagsForResource_add.golden.go
+++ b/test/integration/testdata/ssm_test_TestSSM_ListTagsForResource_TestSSM_ListTagsForResource_add.golden.go
@@ -1,0 +1,3 @@
+{
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ssm_test_TestSSM_ListTagsForResource_TestSSM_ListTagsForResource_remove.golden.go
+++ b/test/integration/testdata/ssm_test_TestSSM_ListTagsForResource_TestSSM_ListTagsForResource_remove.golden.go
@@ -1,0 +1,3 @@
+{
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add `ListTagsForResource`, `AddTagsToResource`, `RemoveTagsFromResource` stub handlers to SSM service
- `ListTagsForResource` returns empty `TagList`; the other two accept and discard payloads
- Wire all three actions into `DispatchAction` switch
- Add integration test with golden file assertions

terraform-provider-aws calls `ListTagsForResource` after `PutParameter` to refresh parameter state. Without this stub, kumo returns `ValidationException` ("The action ListTagsForResource is not valid"), which causes `terraform apply` to fail.

Same pattern as DynamoDB (#590), EventBridge, and SNS tag stubs.

Ref: #416

## Test plan

- [x] `go build ./internal/service/ssm/`
- [x] `go vet ./internal/service/ssm/`
- [x] Integration test `TestSSM_ListTagsForResource` passes with golden assertions