### PR TITLE
feat(sqs): support Policy attribute in SetQueueAttributes / GetQueueAttributes

### DIFF
--- a/internal/service/sqs/storage.go
+++ b/internal/service/sqs/storage.go
@@ -711,6 +711,10 @@ func (s *MemoryStorage) GetQueueAttributes(_ context.Context, queueURL string, a
 		"ContentBasedDeduplication":             fmt.Sprintf("%t", q.ContentBasedDeduplication),
 	}
 
+	if q.Policy != "" {
+		allAttrs["Policy"] = q.Policy
+	}
+
 	if q.RedrivePolicy != "" {
 		allAttrs["RedrivePolicy"] = q.RedrivePolicy
 	}
@@ -762,6 +766,8 @@ func applyQueueAttributes(q *Queue, attrs map[string]string) {
 			_, _ = fmt.Sscanf(val, "%d", &q.ReceiveWaitTimeSeconds)
 		case "ContentBasedDeduplication":
 			q.ContentBasedDeduplication = val == "true"
+		case "Policy":
+			q.Policy = val
 		case "RedrivePolicy":
 			q.RedrivePolicy = val
 			parseRedrivePolicy(q, val)

--- a/internal/service/sqs/types.go
+++ b/internal/service/sqs/types.go
@@ -20,6 +20,7 @@ type Queue struct {
 	ReceiveWaitTimeSeconds    int
 	FifoQueue                 bool
 	ContentBasedDeduplication bool
+	Policy                    string // JSON string: IAM policy document
 	RedrivePolicy             string // JSON string: {"deadLetterTargetArn":"...","maxReceiveCount":"N"}
 	MaxReceiveCount           int    // Parsed from RedrivePolicy
 	DeadLetterTargetArn       string // Parsed from RedrivePolicy

--- a/test/integration/sqs_test.go
+++ b/test/integration/sqs_test.go
@@ -651,3 +651,48 @@ func TestSQS_FIFOQueue_MissingDeduplicationId(t *testing.T) {
 		t.Error("expected error when sending message without MessageDeduplicationId and ContentBasedDeduplication disabled")
 	}
 }
+
+func TestSQS_QueuePolicy(t *testing.T) {
+	client := newSQSClient(t)
+	ctx := t.Context()
+	queueName := "test-queue-policy"
+
+	// Create queue.
+	createOutput, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteQueue(context.Background(), &sqs.DeleteQueueInput{
+			QueueUrl: createOutput.QueueUrl,
+		})
+	})
+
+	policyDoc := `{"Version":"2012-10-17","Statement":[{"Sid":"AllowSNS","Effect":"Allow","Principal":{"Service":"sns.amazonaws.com"},"Action":"sqs:SendMessage","Resource":"*"}]}`
+
+	// SetQueueAttributes with Policy.
+	_, err = client.SetQueueAttributes(ctx, &sqs.SetQueueAttributesInput{
+		QueueUrl: createOutput.QueueUrl,
+		Attributes: map[string]string{
+			"Policy": policyDoc,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// GetQueueAttributes should return the Policy.
+	getOutput, err := client.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       createOutput.QueueUrl,
+		AttributeNames: []types.QueueAttributeName{types.QueueAttributeNameAll},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields(
+		"QueueArn", "CreatedTimestamp", "LastModifiedTimestamp", "ResultMetadata",
+	)).Assert(t.Name(), getOutput)
+}

--- a/test/integration/testdata/sqs_test_TestSQS_QueuePolicy_TestSQS_QueuePolicy.golden.go
+++ b/test/integration/testdata/sqs_test_TestSQS_QueuePolicy_TestSQS_QueuePolicy.golden.go
@@ -1,0 +1,18 @@
+{
+  "Attributes": {
+    "ApproximateNumberOfMessages": "0",
+    "ApproximateNumberOfMessagesNotVisible": "0",
+    "ContentBasedDeduplication": "false",
+    "CreatedTimestamp": "1778591038",
+    "DelaySeconds": "0",
+    "FifoQueue": "false",
+    "LastModifiedTimestamp": "1778591038",
+    "MaximumMessageSize": "262144",
+    "MessageRetentionPeriod": "345600",
+    "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowSNS\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"sns.amazonaws.com\"},\"Action\":\"sqs:SendMessage\",\"Resource\":\"*\"}]}",
+    "QueueArn": "arn:aws:sqs:us-east-1:000000000000:test-queue-policy",
+    "ReceiveMessageWaitTimeSeconds": "0",
+    "VisibilityTimeout": "30"
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add `Policy` field to `Queue` struct
- Store `Policy` in `SetQueueAttributes`
- Return `Policy` in `GetQueueAttributes`
- Add integration test with golden file assertion

terraform-provider-aws sets a queue policy via `SetQueueAttributes` then polls `GetQueueAttributes` until the `Policy` attribute appears. Without this, `terraform apply` hangs indefinitely on `aws_sqs_queue_policy` resources (~15 min timeout).

Ref: #416

## Test plan

- [x] `go build ./internal/service/sqs/`
- [x] `go vet ./internal/service/sqs/`
- [x] Integration test `TestSQS_QueuePolicy` passes with golden assertion