### PR TITLE
feat(sns): implement GetSubscriptionAttributes

### DIFF
--- a/internal/service/sns/handlers.go
+++ b/internal/service/sns/handlers.go
@@ -437,40 +437,38 @@ func writeTopicError(w http.ResponseWriter, code, message string, status int) {
 	})
 }
 
+// actionHandlers returns a map of action names to handler functions.
+func (s *Service) actionHandlers() map[string]func(http.ResponseWriter, *http.Request) {
+	return map[string]func(http.ResponseWriter, *http.Request){
+		"CreateTopic":               s.CreateTopic,
+		"DeleteTopic":               s.DeleteTopic,
+		"ListTopics":                s.ListTopics,
+		"Subscribe":                 s.Subscribe,
+		"Unsubscribe":               s.Unsubscribe,
+		"Publish":                   s.Publish,
+		"ListSubscriptions":         s.ListSubscriptions,
+		"ListSubscriptionsByTopic":  s.ListSubscriptionsByTopic,
+		"GetSubscriptionAttributes": s.GetSubscriptionAttributes,
+		"GetTopicAttributes":        s.GetTopicAttributes,
+		"SetTopicAttributes":        s.SetTopicAttributes,
+		"ListTagsForResource":       s.ListTagsForResource,
+		"TagResource":               s.TagResource,
+		"UntagResource":             s.UntagResource,
+	}
+}
+
 // DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.
 // This method implements the JSONProtocolService interface.
 func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 	target := r.Header.Get("X-Amz-Target")
 	action := strings.TrimPrefix(target, "AmazonSimpleNotificationService.")
 
-	switch action {
-	case "CreateTopic":
-		s.CreateTopic(w, r)
-	case "DeleteTopic":
-		s.DeleteTopic(w, r)
-	case "ListTopics":
-		s.ListTopics(w, r)
-	case "Subscribe":
-		s.Subscribe(w, r)
-	case "Unsubscribe":
-		s.Unsubscribe(w, r)
-	case "Publish":
-		s.Publish(w, r)
-	case "ListSubscriptions":
-		s.ListSubscriptions(w, r)
-	case "ListSubscriptionsByTopic":
-		s.ListSubscriptionsByTopic(w, r)
-	case "GetTopicAttributes":
-		s.GetTopicAttributes(w, r)
-	case "SetTopicAttributes":
-		s.SetTopicAttributes(w, r)
-	case "ListTagsForResource":
-		s.ListTagsForResource(w, r)
-	case "TagResource":
-		s.TagResource(w, r)
-	case "UntagResource":
-		s.UntagResource(w, r)
-	default:
-		writeTopicError(w, errInvalidAction, "The action "+action+" is not valid", http.StatusBadRequest)
+	handlers := s.actionHandlers()
+	if handler, ok := handlers[action]; ok {
+		handler(w, r)
+
+		return
 	}
+
+	writeTopicError(w, errInvalidAction, "The action "+action+" is not valid", http.StatusBadRequest)
 }

--- a/internal/service/sns/service.go
+++ b/internal/service/sns/service.go
@@ -60,6 +60,7 @@ func (s *Service) Actions() []string {
 		"Publish",
 		"ListSubscriptions",
 		"ListSubscriptionsByTopic",
+		"GetSubscriptionAttributes",
 		"GetTopicAttributes",
 		"SetTopicAttributes",
 		"ListTagsForResource",

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -32,6 +32,7 @@ type Storage interface {
 	DeleteTopic(ctx context.Context, topicARN string) error
 	ListTopics(ctx context.Context, nextToken string) ([]*Topic, string, error)
 	Subscribe(ctx context.Context, topicARN, protocol, endpoint string, attributes map[string]string) (*Subscription, error)
+	GetSubscription(ctx context.Context, subscriptionARN string) (*Subscription, error)
 	Unsubscribe(ctx context.Context, subscriptionARN string) error
 	Publish(ctx context.Context, topicARN, message, subject string, attributes map[string]MessageAttribute) (string, error)
 	ListSubscriptions(ctx context.Context, nextToken string) ([]*Subscription, string, error)
@@ -322,6 +323,22 @@ func (m *MemoryStorage) Subscribe(_ context.Context, topicARN, protocol, endpoin
 
 	m.Subscriptions[subscriptionARN] = subscription
 	topic.Subscriptions[subscriptionARN] = subscription
+
+	return subscription, nil
+}
+
+// GetSubscription returns a subscription by ARN.
+func (m *MemoryStorage) GetSubscription(_ context.Context, subscriptionARN string) (*Subscription, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	subscription, exists := m.Subscriptions[subscriptionARN]
+	if !exists {
+		return nil, &TopicError{
+			Code:    "NotFound",
+			Message: fmt.Sprintf("Subscription does not exist: %s", subscriptionARN),
+		}
+	}
 
 	return subscription, nil
 }

--- a/internal/service/sns/subscription_attributes.go
+++ b/internal/service/sns/subscription_attributes.go
@@ -1,0 +1,69 @@
+package sns
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// GetSubscriptionAttributes returns attributes for a subscription.
+//
+// terraform-provider-aws polls this after Subscribe to confirm the
+// subscription is active. Without this handler, kumo returns
+// InvalidAction and terraform apply fails on all
+// aws_sns_topic_subscription resources.
+func (s *Service) GetSubscriptionAttributes(w http.ResponseWriter, r *http.Request) {
+	var req getSubscriptionAttributesRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.SubscriptionArn == "" {
+		writeTopicError(w, errInvalidParameter, "SubscriptionArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	sub, err := s.storage.GetSubscription(r.Context(), req.SubscriptionArn)
+	if err != nil {
+		handleTopicError(w, err)
+
+		return
+	}
+
+	attrs := buildSubscriptionAttributeView(sub)
+
+	entries := make([]XMLAttributeEntry, 0, len(attrs))
+	for k, v := range attrs {
+		entries = append(entries, XMLAttributeEntry{Key: k, Value: v})
+	}
+
+	writeXMLResponse(w, XMLGetSubscriptionAttributesResponse{
+		Xmlns: snsXMLNS,
+		GetSubscriptionAttributesResult: XMLGetSubscriptionAttributesResult{
+			Attributes: XMLAttributesMap{Entry: entries},
+		},
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
+// buildSubscriptionAttributeView returns the attribute map terraform expects.
+func buildSubscriptionAttributeView(sub *Subscription) map[string]string {
+	attrs := map[string]string{
+		"SubscriptionArn":              sub.ARN,
+		"TopicArn":                     sub.TopicARN,
+		"Protocol":                     sub.Protocol,
+		"Endpoint":                     sub.Endpoint,
+		"Owner":                        sub.Owner,
+		"PendingConfirmation":          "false",
+		"ConfirmationWasAuthenticated": "true",
+	}
+
+	for k, v := range sub.SubscriptionAttributes {
+		attrs[k] = v
+	}
+
+	return attrs
+}

--- a/internal/service/sns/types.go
+++ b/internal/service/sns/types.go
@@ -371,6 +371,24 @@ type XMLUntagResourceResponse struct {
 	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
 }
 
+// getSubscriptionAttributesRequest is the request for GetSubscriptionAttributes.
+type getSubscriptionAttributesRequest struct {
+	SubscriptionArn string `json:"SubscriptionArn"`
+}
+
+// XMLGetSubscriptionAttributesResponse is the XML response for GetSubscriptionAttributes.
+type XMLGetSubscriptionAttributesResponse struct {
+	XMLName                         struct{}                           `xml:"GetSubscriptionAttributesResponse"`
+	Xmlns                           string                             `xml:"xmlns,attr"`
+	GetSubscriptionAttributesResult XMLGetSubscriptionAttributesResult `xml:"GetSubscriptionAttributesResult"`
+	ResponseMetadata                ResponseMetadata                   `xml:"ResponseMetadata"`
+}
+
+// XMLGetSubscriptionAttributesResult contains the attribute map.
+type XMLGetSubscriptionAttributesResult struct {
+	Attributes XMLAttributesMap `xml:"Attributes"`
+}
+
 // setTopicAttributesRequest is the wire shape after the Query dispatcher
 // converts terraform's form-encoded body to JSON.
 //

--- a/test/integration/sns_test.go
+++ b/test/integration/sns_test.go
@@ -298,3 +298,50 @@ func TestSNS_CreateTopicIdempotent(t *testing.T) {
 			*createOutput1.TopicArn, *createOutput2.TopicArn)
 	}
 }
+
+func TestSNS_GetSubscriptionAttributes(t *testing.T) {
+	client := newSNSClient(t)
+	ctx := t.Context()
+	topicName := "test-get-sub-attrs"
+
+	// Create topic.
+	topicOutput, err := client.CreateTopic(ctx, &sns.CreateTopicInput{
+		Name: aws.String(topicName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTopic(context.Background(), &sns.DeleteTopicInput{
+			TopicArn: topicOutput.TopicArn,
+		})
+	})
+
+	// Subscribe with SQS protocol.
+	subOutput, err := client.Subscribe(ctx, &sns.SubscribeInput{
+		TopicArn: topicOutput.TopicArn,
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String("arn:aws:sqs:us-east-1:000000000000:test-queue"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.Unsubscribe(context.Background(), &sns.UnsubscribeInput{
+			SubscriptionArn: subOutput.SubscriptionArn,
+		})
+	})
+
+	// GetSubscriptionAttributes.
+	getOutput, err := client.GetSubscriptionAttributes(ctx, &sns.GetSubscriptionAttributesInput{
+		SubscriptionArn: subOutput.SubscriptionArn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields(
+		"SubscriptionArn", "TopicArn", "ResultMetadata",
+	)).Assert(t.Name(), getOutput)
+}

--- a/test/integration/testdata/sns_test_TestSNS_GetSubscriptionAttributes_TestSNS_GetSubscriptionAttributes.golden.go
+++ b/test/integration/testdata/sns_test_TestSNS_GetSubscriptionAttributes_TestSNS_GetSubscriptionAttributes.golden.go
@@ -1,0 +1,12 @@
+{
+  "Attributes": {
+    "ConfirmationWasAuthenticated": "true",
+    "Endpoint": "arn:aws:sqs:us-east-1:000000000000:test-queue",
+    "Owner": "000000000000",
+    "PendingConfirmation": "false",
+    "Protocol": "sqs",
+    "SubscriptionArn": "arn:aws:sns:us-east-1:000000000000:test-get-sub-attrs:39123197-2506-477e-9f29-f5ddfafe7c56",
+    "TopicArn": "arn:aws:sns:us-east-1:000000000000:test-get-sub-attrs"
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add `GetSubscriptionAttributes` handler, dispatch case, and `Actions()` entry
- Add `GetSubscription` method to Storage interface and MemoryStorage
- Returns subscription attributes including `PendingConfirmation=false` so terraform considers the subscription confirmed
- Add integration test with golden file assertion

terraform-provider-aws polls `GetSubscriptionAttributes` after `Subscribe` to confirm the subscription is active. Without this, kumo returns `InvalidAction` and `terraform apply` fails on all `aws_sns_topic_subscription` resources.

Closes #629
Ref: #416

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/service/sns/`
- [x] Integration test `TestSNS_GetSubscriptionAttributes` passes with golden assertion