### PR TITLE
fix(kms): store key policy in CreateKey and PutKeyPolicy

### DIFF
--- a/internal/service/kms/policy_tag_stubs.go
+++ b/internal/service/kms/policy_tag_stubs.go
@@ -11,14 +11,11 @@ import (
 // AccountRootEnable statement.
 const defaultKeyPolicy = `{"Version":"2012-10-17","Id":"key-default-1","Statement":[{"Sid":"Enable IAM User Permissions","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::000000000000:root"},"Action":"kms:*","Resource":"*"}]}`
 
-// GetKeyPolicy returns the default key policy for any existing key.
+// GetKeyPolicy returns the key policy for an existing key.
 //
 // terraform-provider-aws calls GetKeyPolicy on every refresh of aws_kms_key
 // (and immediately after CreateKey) to populate the `policy` attribute.
 // Without it, `tofu apply` errors out before the create call returns.
-//
-// Key policies are not modeled in storage yet; this stub returns the AWS
-// default policy so refresh paths complete and drift detection stays stable.
 func (s *Service) GetKeyPolicy(w http.ResponseWriter, r *http.Request) {
 	var req getKeyPolicyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.KeyID == "" {
@@ -27,20 +24,45 @@ func (s *Service) GetKeyPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := s.storage.GetKey(r.Context(), req.KeyID); err != nil {
+	key, err := s.storage.GetKey(r.Context(), req.KeyID)
+	if err != nil {
 		handleKMSError(w, err)
 
 		return
 	}
 
+	policy := key.Policy
+	if policy == "" {
+		policy = defaultKeyPolicy
+	}
+
 	writeKMSResponse(w, getKeyPolicyResponse{
-		Policy:     defaultKeyPolicy,
+		Policy:     policy,
 		PolicyName: "default",
 	})
 }
 
-// PutKeyPolicy accepts and discards a key policy update.
-func (s *Service) PutKeyPolicy(w http.ResponseWriter, _ *http.Request) {
+// PutKeyPolicy stores a key policy for an existing key.
+//
+// terraform-provider-aws calls PutKeyPolicy after CreateKey when a custom
+// policy is specified, then polls GetKeyPolicy until the policy matches.
+func (s *Service) PutKeyPolicy(w http.ResponseWriter, r *http.Request) {
+	var req putKeyPolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.KeyID == "" {
+		writeKMSError(w, "ValidationException", "KeyId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	key, err := s.storage.GetKey(r.Context(), req.KeyID)
+	if err != nil {
+		handleKMSError(w, err)
+
+		return
+	}
+
+	key.Policy = req.Policy
+
 	writeKMSResponse(w, struct{}{})
 }
 

--- a/internal/service/kms/storage.go
+++ b/internal/service/kms/storage.go
@@ -201,6 +201,11 @@ func (s *MemoryStorage) CreateKey(_ context.Context, req *CreateKeyRequest) (*Ke
 		tags[tag.TagKey] = tag.TagValue
 	}
 
+	policy := req.Policy
+	if policy == "" {
+		policy = defaultKeyPolicy
+	}
+
 	key := &Key{
 		KeyID:        keyID,
 		Arn:          arn,
@@ -214,6 +219,7 @@ func (s *MemoryStorage) CreateKey(_ context.Context, req *CreateKeyRequest) (*Ke
 		Origin:       origin,
 		MultiRegion:  req.MultiRegion,
 		Tags:         tags,
+		Policy:       policy,
 		KeyMaterial:  keyMaterial,
 	}
 

--- a/internal/service/kms/types.go
+++ b/internal/service/kms/types.go
@@ -74,6 +74,7 @@ type Key struct {
 	MultiRegionConfig     *MultiRegionConfig
 	PendingDeletionWindow int32
 	Tags                  map[string]string
+	Policy                string // IAM key policy document
 	// Simulated key material for encryption/decryption.
 	KeyMaterial []byte
 }
@@ -348,9 +349,16 @@ func (e *ServiceError) Error() string {
 	return e.Message
 }
 
-// getKeyPolicyRequest is the wire shape of GetKeyPolicy / PutKeyPolicy.
+// getKeyPolicyRequest is the wire shape of GetKeyPolicy.
 type getKeyPolicyRequest struct {
 	KeyID      string `json:"KeyId"`
+	PolicyName string `json:"PolicyName,omitempty"`
+}
+
+// putKeyPolicyRequest is the wire shape of PutKeyPolicy.
+type putKeyPolicyRequest struct {
+	KeyID      string `json:"KeyId"`
+	Policy     string `json:"Policy"`
 	PolicyName string `json:"PolicyName,omitempty"`
 }
 

--- a/test/integration/kms_test.go
+++ b/test/integration/kms_test.go
@@ -396,3 +396,55 @@ func TestKMS_EncryptWithAlias(t *testing.T) {
 		t.Errorf("plaintext mismatch: got %s, want %s", decryptOutput.Plaintext, plaintext)
 	}
 }
+
+func TestKMS_KeyPolicy(t *testing.T) {
+	client := newKMSClient(t)
+	ctx := t.Context()
+
+	customPolicy := `{"Version":"2012-10-17","Statement":[{"Sid":"Custom","Effect":"Allow","Principal":{"AWS":"*"},"Action":"kms:*","Resource":"*"}]}`
+
+	createOutput, err := client.CreateKey(ctx, &kms.CreateKeyInput{
+		Description: aws.String("test-key-policy"),
+		Policy:      aws.String(customPolicy),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyID := *createOutput.KeyMetadata.KeyId
+
+	t.Cleanup(func() {
+		_, _ = client.ScheduleKeyDeletion(context.Background(), &kms.ScheduleKeyDeletionInput{
+			KeyId:               aws.String(keyID),
+			PendingWindowInDays: aws.Int32(7),
+		})
+	})
+
+	// GetKeyPolicy should return the custom policy.
+	getOutput, err := client.GetKeyPolicy(ctx, &kms.GetKeyPolicyInput{
+		KeyId: aws.String(keyID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_get", getOutput)
+
+	// PutKeyPolicy with a new policy.
+	newPolicy := `{"Version":"2012-10-17","Statement":[{"Sid":"Updated","Effect":"Allow","Principal":{"AWS":"*"},"Action":"kms:Encrypt","Resource":"*"}]}`
+	_, err = client.PutKeyPolicy(ctx, &kms.PutKeyPolicyInput{
+		KeyId:  aws.String(keyID),
+		Policy: aws.String(newPolicy),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// GetKeyPolicy should return the updated policy.
+	getOutput2, err := client.GetKeyPolicy(ctx, &kms.GetKeyPolicyInput{
+		KeyId: aws.String(keyID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_updated", getOutput2)
+}

--- a/test/integration/testdata/kms_test_TestKMS_KeyPolicy_TestKMS_KeyPolicy_get.golden.go
+++ b/test/integration/testdata/kms_test_TestKMS_KeyPolicy_TestKMS_KeyPolicy_get.golden.go
@@ -1,0 +1,5 @@
+{
+  "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Custom\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"kms:*\",\"Resource\":\"*\"}]}",
+  "PolicyName": "default",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/kms_test_TestKMS_KeyPolicy_TestKMS_KeyPolicy_updated.golden.go
+++ b/test/integration/testdata/kms_test_TestKMS_KeyPolicy_TestKMS_KeyPolicy_updated.golden.go
@@ -1,0 +1,5 @@
+{
+  "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Updated\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"kms:Encrypt\",\"Resource\":\"*\"}]}",
+  "PolicyName": "default",
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add `Policy` field to `Key` struct
- Store policy from `CreateKey` request (defaults to AWS default policy if empty)
- `PutKeyPolicy` now persists the policy to the key
- `GetKeyPolicy` returns the stored policy instead of a hardcoded default
- Add integration test with golden file assertions for policy round-trip

terraform-provider-aws calls `PutKeyPolicy` after `CreateKey` when a custom policy is specified, then polls `GetKeyPolicy` until the policy matches. Previously `PutKeyPolicy` discarded the payload and `GetKeyPolicy` always returned the default policy, causing a 10-minute timeout on `aws_kms_key` resources.

Closes #630
Ref: #416

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/service/kms/`
- [x] Integration test `TestKMS_KeyPolicy` passes with golden assertions