### PR TITLE
fix(s3): implement GetBucketCors handler

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -163,6 +163,12 @@ func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, ok := r.URL.Query()["cors"]; ok {
+		s.GetBucketCors(w, r)
+
+		return
+	}
+
 	if handled := s.serveBucketSubresourceStub(w, r); handled {
 		return
 	}
@@ -2282,6 +2288,22 @@ func (s *Service) PutBucketCors(w http.ResponseWriter, r *http.Request) {
 	s.storage.SetCORSConfiguration(r.Context(), bucket, config.CORSRules)
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// GetBucketCors handles GET /{bucket}?cors. Returns the CORS configuration
+// previously set by PutBucketCors, or NoSuchCORSConfiguration if none.
+func (s *Service) GetBucketCors(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	rules := s.storage.GetCORSRules(r.Context(), bucket)
+
+	if len(rules) == 0 {
+		writeS3Error(w, r, "NoSuchCORSConfiguration", "The CORS configuration does not exist", http.StatusNotFound)
+
+		return
+	}
+
+	writeXMLResponse(w, CORSConfiguration{CORSRules: rules})
 }
 
 // handleMultipartError handles errors from multipart upload operations.

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1713,3 +1713,59 @@ func TestS3_BucketSubresourceStubs_NoSuchErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestS3_BucketCors(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-bucket-cors"
+
+	// Create bucket.
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+			Bucket: aws.String(bucket),
+		})
+	})
+
+	// GetBucketCors before setting should return error.
+	_, err = client.GetBucketCors(ctx, &s3.GetBucketCorsInput{
+		Bucket: aws.String(bucket),
+	})
+	if err == nil {
+		t.Fatal("expected NoSuchCORSConfiguration error")
+	}
+
+	// PutBucketCors.
+	_, err = client.PutBucketCors(ctx, &s3.PutBucketCorsInput{
+		Bucket: aws.String(bucket),
+		CORSConfiguration: &types.CORSConfiguration{
+			CORSRules: []types.CORSRule{
+				{
+					AllowedHeaders: []string{"*"},
+					AllowedMethods: []string{"GET", "PUT"},
+					AllowedOrigins: []string{"https://example.com"},
+					ExposeHeaders:  []string{"ETag"},
+					MaxAgeSeconds:  aws.Int32(300),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// GetBucketCors after setting should return the CORS rules.
+	getOutput, err := client.GetBucketCors(ctx, &s3.GetBucketCorsInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), getOutput)
+}

--- a/test/integration/testdata/s3_test_TestS3_BucketCors_TestS3_BucketCors.golden.go
+++ b/test/integration/testdata/s3_test_TestS3_BucketCors_TestS3_BucketCors.golden.go
@@ -1,0 +1,22 @@
+{
+  "CORSRules": [
+    {
+      "AllowedMethods": [
+        "GET",
+        "PUT"
+      ],
+      "AllowedOrigins": [
+        "https://example.com"
+      ],
+      "AllowedHeaders": [
+        "*"
+      ],
+      "ExposeHeaders": [
+        "ETag"
+      ],
+      "ID": null,
+      "MaxAgeSeconds": 300
+    }
+  ],
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add `GetBucketCors` handler that returns stored CORS rules
- Add `cors` query parameter dispatch in `handleBucketGet` before the stub fallback
- Return `NoSuchCORSConfiguration` when no CORS is configured (matching AWS behavior)
- Add integration test with golden file assertion

`PutBucketCors` correctly stored CORS rules in storage, but `GetBucketCors` was not implemented. `GET /{bucket}?cors` fell through to `serveBucketSubresourceStub` which always returned `NoSuchCORSConfiguration`, even when CORS was configured.

terraform-provider-aws polls `GetBucketCors` after `PutBucketCors` to confirm the configuration was applied. Without this, `terraform apply` fails on `aws_s3_bucket_cors_configuration` resources.

Closes #631
Ref: #416

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/service/s3/`
- [x] Integration test `TestS3_BucketCors` passes with golden assertion