### PR TITLE
fix(ssm): implement ParameterFilters in DescribeParameters

### DIFF
--- a/internal/service/ssm/handlers.go
+++ b/internal/service/ssm/handlers.go
@@ -206,7 +206,7 @@ func (s *Service) DescribeParameters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params, nextToken, err := s.storage.DescribeParameters(r.Context(), req.MaxResults, req.NextToken)
+	params, nextToken, err := s.storage.DescribeParameters(r.Context(), req.ParameterFilters, req.MaxResults, req.NextToken)
 	if err != nil {
 		writeSSMError(w, ErrServiceException, "Internal server error", http.StatusInternalServerError)
 

--- a/internal/service/ssm/storage.go
+++ b/internal/service/ssm/storage.go
@@ -20,7 +20,7 @@ type Storage interface {
 	GetParametersByPath(ctx context.Context, path string, recursive bool, maxResults int, nextToken string) ([]*Parameter, string, error)
 	DeleteParameter(ctx context.Context, name string) error
 	DeleteParameters(ctx context.Context, names []string) ([]string, []string, error)
-	DescribeParameters(ctx context.Context, maxResults int, nextToken string) ([]*Parameter, string, error)
+	DescribeParameters(ctx context.Context, filters []ParameterFilter, maxResults int, nextToken string) ([]*Parameter, string, error)
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -330,7 +330,7 @@ func (s *MemoryStorage) DeleteParameters(_ context.Context, names []string) ([]s
 }
 
 // DescribeParameters lists all parameters with metadata.
-func (s *MemoryStorage) DescribeParameters(_ context.Context, maxResults int, nextToken string) ([]*Parameter, string, error) {
+func (s *MemoryStorage) DescribeParameters(_ context.Context, filters []ParameterFilter, maxResults int, nextToken string) ([]*Parameter, string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -338,10 +338,13 @@ func (s *MemoryStorage) DescribeParameters(_ context.Context, maxResults int, ne
 		maxResults = 50
 	}
 
-	// Collect all parameters
+	// Collect all parameters, applying filters.
 	params := make([]*Parameter, 0, len(s.Parameters))
+
 	for _, p := range s.Parameters {
-		params = append(params, p)
+		if matchParameterFilters(p, filters) {
+			params = append(params, p)
+		}
 	}
 
 	// Sort by name for consistent pagination
@@ -375,4 +378,46 @@ func (s *MemoryStorage) DescribeParameters(_ context.Context, maxResults int, ne
 	}
 
 	return result, newNextToken, nil
+}
+
+// matchParameterFilters checks if a parameter matches all filters.
+// Supports Key=Name with Option=Equals (default), BeginsWith, and Contains.
+func matchParameterFilters(p *Parameter, filters []ParameterFilter) bool {
+	for _, f := range filters {
+		if f.Key != "Name" || len(f.Values) == 0 {
+			continue
+		}
+
+		option := f.Option
+		if option == "" {
+			option = "Equals"
+		}
+
+		if !matchNameFilter(p.Name, f.Values, option) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchNameFilter(name string, values []string, option string) bool {
+	for _, v := range values {
+		switch option {
+		case "Equals":
+			if name == v {
+				return true
+			}
+		case "BeginsWith":
+			if strings.HasPrefix(name, v) {
+				return true
+			}
+		case "Contains":
+			if strings.Contains(name, v) {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/internal/service/ssm/types.go
+++ b/internal/service/ssm/types.go
@@ -125,10 +125,18 @@ type DeleteParametersResponse struct {
 	InvalidParameters []string `json:"InvalidParameters,omitempty"`
 }
 
+// ParameterFilter is a filter for DescribeParameters.
+type ParameterFilter struct {
+	Key    string   `json:"Key"`
+	Values []string `json:"Values,omitempty"`
+	Option string   `json:"Option,omitempty"`
+}
+
 // DescribeParametersRequest is the request for DescribeParameters.
 type DescribeParametersRequest struct {
-	MaxResults int    `json:"MaxResults,omitempty"`
-	NextToken  string `json:"NextToken,omitempty"`
+	ParameterFilters []ParameterFilter `json:"ParameterFilters,omitempty"`
+	MaxResults       int               `json:"MaxResults,omitempty"`
+	NextToken        string            `json:"NextToken,omitempty"`
 }
 
 // DescribeParametersResponse is the response for DescribeParameters.

--- a/test/integration/ssm_test.go
+++ b/test/integration/ssm_test.go
@@ -353,6 +353,70 @@ func TestSSM_DescribeParameters(t *testing.T) {
 	}
 }
 
+func TestSSM_DescribeParametersWithFilter(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := t.Context()
+
+	params := []struct {
+		name  string
+		value string
+	}{
+		{"/test/filter/alpha", "a"},
+		{"/test/filter/beta", "b"},
+	}
+
+	for _, p := range params {
+		_, err := client.PutParameter(ctx, &ssm.PutParameterInput{
+			Name:  aws.String(p.name),
+			Value: aws.String(p.value),
+			Type:  types.ParameterTypeString,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Cleanup(func() {
+		names := make([]string, len(params))
+		for i, p := range params {
+			names[i] = p.name
+		}
+
+		_, _ = client.DeleteParameters(context.Background(), &ssm.DeleteParametersInput{
+			Names: names,
+		})
+	})
+
+	// Filter by exact name.
+	descOutput, err := client.DescribeParameters(ctx, &ssm.DescribeParametersInput{
+		ParameterFilters: []types.ParameterStringFilter{
+			{
+				Key:    aws.String("Name"),
+				Values: []string{"/test/filter/alpha"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("LastModifiedDate", "ResultMetadata")).Assert(t.Name()+"_exact", descOutput)
+
+	// Filter by prefix.
+	descOutput2, err := client.DescribeParameters(ctx, &ssm.DescribeParametersInput{
+		ParameterFilters: []types.ParameterStringFilter{
+			{
+				Key:    aws.String("Name"),
+				Option: aws.String("BeginsWith"),
+				Values: []string{"/test/filter/"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("LastModifiedDate", "ResultMetadata")).Assert(t.Name()+"_prefix", descOutput2)
+}
+
 func TestSSM_GetParameter_NotFound(t *testing.T) {
 	client := newSSMClient(t)
 	ctx := t.Context()

--- a/test/integration/testdata/ssm_test_TestSSM_DescribeParametersWithFilter_TestSSM_DescribeParametersWithFilter_exact.golden.go
+++ b/test/integration/testdata/ssm_test_TestSSM_DescribeParametersWithFilter_TestSSM_DescribeParametersWithFilter_exact.golden.go
@@ -1,0 +1,20 @@
+{
+  "NextToken": null,
+  "Parameters": [
+    {
+      "ARN": null,
+      "AllowedPattern": null,
+      "DataType": "text",
+      "Description": null,
+      "KeyId": null,
+      "LastModifiedDate": "2026-05-13T06:44:02.657Z",
+      "LastModifiedUser": null,
+      "Name": "/test/filter/alpha",
+      "Policies": null,
+      "Tier": "Standard",
+      "Type": "String",
+      "Version": 1
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/ssm_test_TestSSM_DescribeParametersWithFilter_TestSSM_DescribeParametersWithFilter_prefix.golden.go
+++ b/test/integration/testdata/ssm_test_TestSSM_DescribeParametersWithFilter_TestSSM_DescribeParametersWithFilter_prefix.golden.go
@@ -1,0 +1,34 @@
+{
+  "NextToken": null,
+  "Parameters": [
+    {
+      "ARN": null,
+      "AllowedPattern": null,
+      "DataType": "text",
+      "Description": null,
+      "KeyId": null,
+      "LastModifiedDate": "2026-05-13T06:44:02.657Z",
+      "LastModifiedUser": null,
+      "Name": "/test/filter/alpha",
+      "Policies": null,
+      "Tier": "Standard",
+      "Type": "String",
+      "Version": 1
+    },
+    {
+      "ARN": null,
+      "AllowedPattern": null,
+      "DataType": "text",
+      "Description": null,
+      "KeyId": null,
+      "LastModifiedDate": "2026-05-13T06:44:02.658Z",
+      "LastModifiedUser": null,
+      "Name": "/test/filter/beta",
+      "Policies": null,
+      "Tier": "Standard",
+      "Type": "String",
+      "Version": 1
+    }
+  ],
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add `ParameterFilters` field to `DescribeParametersRequest`
- Add `ParameterFilter` type with `Key`, `Values`, and `Option` fields
- Implement filtering in `MemoryStorage.DescribeParameters` with support for `Name` key and `Equals` (default), `BeginsWith`, `Contains` options
- Add integration tests with golden file assertions for exact and prefix filters

terraform-provider-aws calls `DescribeParameters` with `ParameterFilters` `Key=Name` to find a specific parameter after `PutParameter`. Without filtering, all parameters are returned and the provider fails with "too many results: wanted 1, got 2".

Closes #635
Ref: #416

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/service/ssm/`
- [x] Integration test `TestSSM_DescribeParametersWithFilter` passes (exact + prefix)