### PR TITLE
feat(sns): implement SetSubscriptionAttributes

### DIFF
--- a/internal/service/sns/handlers.go
+++ b/internal/service/sns/handlers.go
@@ -449,6 +449,7 @@ func (s *Service) actionHandlers() map[string]func(http.ResponseWriter, *http.Re
 		"ListSubscriptions":         s.ListSubscriptions,
 		"ListSubscriptionsByTopic":  s.ListSubscriptionsByTopic,
 		"GetSubscriptionAttributes": s.GetSubscriptionAttributes,
+		"SetSubscriptionAttributes": s.SetSubscriptionAttributes,
 		"GetTopicAttributes":        s.GetTopicAttributes,
 		"SetTopicAttributes":        s.SetTopicAttributes,
 		"ListTagsForResource":       s.ListTagsForResource,

--- a/internal/service/sns/service.go
+++ b/internal/service/sns/service.go
@@ -61,6 +61,7 @@ func (s *Service) Actions() []string {
 		"ListSubscriptions",
 		"ListSubscriptionsByTopic",
 		"GetSubscriptionAttributes",
+		"SetSubscriptionAttributes",
 		"GetTopicAttributes",
 		"SetTopicAttributes",
 		"ListTagsForResource",

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -33,6 +33,7 @@ type Storage interface {
 	ListTopics(ctx context.Context, nextToken string) ([]*Topic, string, error)
 	Subscribe(ctx context.Context, topicARN, protocol, endpoint string, attributes map[string]string) (*Subscription, error)
 	GetSubscription(ctx context.Context, subscriptionARN string) (*Subscription, error)
+	SetSubscriptionAttribute(ctx context.Context, subscriptionARN, name, value string) error
 	Unsubscribe(ctx context.Context, subscriptionARN string) error
 	Publish(ctx context.Context, topicARN, message, subject string, attributes map[string]MessageAttribute) (string, error)
 	ListSubscriptions(ctx context.Context, nextToken string) ([]*Subscription, string, error)
@@ -341,6 +342,28 @@ func (m *MemoryStorage) GetSubscription(_ context.Context, subscriptionARN strin
 	}
 
 	return subscription, nil
+}
+
+// SetSubscriptionAttribute sets a single attribute on a subscription.
+func (m *MemoryStorage) SetSubscriptionAttribute(_ context.Context, subscriptionARN, name, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	subscription, exists := m.Subscriptions[subscriptionARN]
+	if !exists {
+		return &TopicError{
+			Code:    "NotFound",
+			Message: fmt.Sprintf("Subscription does not exist: %s", subscriptionARN),
+		}
+	}
+
+	if subscription.SubscriptionAttributes == nil {
+		subscription.SubscriptionAttributes = make(map[string]string)
+	}
+
+	subscription.SubscriptionAttributes[name] = value
+
+	return nil
 }
 
 // Unsubscribe removes a subscription.

--- a/internal/service/sns/subscription_attributes.go
+++ b/internal/service/sns/subscription_attributes.go
@@ -49,6 +49,42 @@ func (s *Service) GetSubscriptionAttributes(w http.ResponseWriter, r *http.Reque
 	})
 }
 
+// SetSubscriptionAttributes sets a single attribute on a subscription.
+//
+// terraform-provider-aws calls this after Subscribe to set attributes
+// like RawMessageDelivery, FilterPolicy, etc.
+func (s *Service) SetSubscriptionAttributes(w http.ResponseWriter, r *http.Request) {
+	var req setSubscriptionAttributesRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.SubscriptionArn == "" {
+		writeTopicError(w, errInvalidParameter, "SubscriptionArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.AttributeName == "" {
+		writeTopicError(w, errInvalidParameter, "AttributeName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.SetSubscriptionAttribute(r.Context(), req.SubscriptionArn, req.AttributeName, req.AttributeValue.String()); err != nil {
+		handleTopicError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, XMLSetSubscriptionAttributesResponse{
+		Xmlns:            snsXMLNS,
+		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
+	})
+}
+
 // buildSubscriptionAttributeView returns the attribute map terraform expects.
 func buildSubscriptionAttributeView(sub *Subscription) map[string]string {
 	attrs := map[string]string{

--- a/internal/service/sns/types.go
+++ b/internal/service/sns/types.go
@@ -376,6 +376,20 @@ type getSubscriptionAttributesRequest struct {
 	SubscriptionArn string `json:"SubscriptionArn"`
 }
 
+// setSubscriptionAttributesRequest is the request for SetSubscriptionAttributes.
+type setSubscriptionAttributesRequest struct {
+	SubscriptionArn string     `json:"SubscriptionArn"`
+	AttributeName   string     `json:"AttributeName"`
+	AttributeValue  flexString `json:"AttributeValue"`
+}
+
+// XMLSetSubscriptionAttributesResponse is the XML response for SetSubscriptionAttributes.
+type XMLSetSubscriptionAttributesResponse struct {
+	XMLName          struct{}         `xml:"SetSubscriptionAttributesResponse"`
+	Xmlns            string           `xml:"xmlns,attr"`
+	ResponseMetadata ResponseMetadata `xml:"ResponseMetadata"`
+}
+
 // XMLGetSubscriptionAttributesResponse is the XML response for GetSubscriptionAttributes.
 type XMLGetSubscriptionAttributesResponse struct {
 	XMLName                         struct{}                           `xml:"GetSubscriptionAttributesResponse"`

--- a/test/integration/sns_test.go
+++ b/test/integration/sns_test.go
@@ -345,3 +345,58 @@ func TestSNS_GetSubscriptionAttributes(t *testing.T) {
 		"SubscriptionArn", "TopicArn", "ResultMetadata",
 	)).Assert(t.Name(), getOutput)
 }
+
+func TestSNS_SetSubscriptionAttributes(t *testing.T) {
+	client := newSNSClient(t)
+	ctx := t.Context()
+	topicName := "test-set-sub-attrs"
+
+	topicOutput, err := client.CreateTopic(ctx, &sns.CreateTopicInput{
+		Name: aws.String(topicName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTopic(context.Background(), &sns.DeleteTopicInput{
+			TopicArn: topicOutput.TopicArn,
+		})
+	})
+
+	subOutput, err := client.Subscribe(ctx, &sns.SubscribeInput{
+		TopicArn: topicOutput.TopicArn,
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String("arn:aws:sqs:us-east-1:000000000000:test-queue-attrs"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.Unsubscribe(context.Background(), &sns.UnsubscribeInput{
+			SubscriptionArn: subOutput.SubscriptionArn,
+		})
+	})
+
+	// Set RawMessageDelivery attribute.
+	_, err = client.SetSubscriptionAttributes(ctx, &sns.SetSubscriptionAttributesInput{
+		SubscriptionArn: subOutput.SubscriptionArn,
+		AttributeName:   aws.String("RawMessageDelivery"),
+		AttributeValue:  aws.String("true"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// GetSubscriptionAttributes should reflect the change.
+	getOutput, err := client.GetSubscriptionAttributes(ctx, &sns.GetSubscriptionAttributesInput{
+		SubscriptionArn: subOutput.SubscriptionArn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields(
+		"SubscriptionArn", "TopicArn", "ResultMetadata",
+	)).Assert(t.Name(), getOutput)
+}

--- a/test/integration/testdata/sns_test_TestSNS_SetSubscriptionAttributes_TestSNS_SetSubscriptionAttributes.golden.go
+++ b/test/integration/testdata/sns_test_TestSNS_SetSubscriptionAttributes_TestSNS_SetSubscriptionAttributes.golden.go
@@ -1,0 +1,13 @@
+{
+  "Attributes": {
+    "ConfirmationWasAuthenticated": "true",
+    "Endpoint": "arn:aws:sqs:us-east-1:000000000000:test-queue-attrs",
+    "Owner": "000000000000",
+    "PendingConfirmation": "false",
+    "Protocol": "sqs",
+    "RawMessageDelivery": "true",
+    "SubscriptionArn": "arn:aws:sns:us-east-1:000000000000:test-set-sub-attrs:1057be02-2751-41cb-aa96-47337121bd4b",
+    "TopicArn": "arn:aws:sns:us-east-1:000000000000:test-set-sub-attrs"
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add `SetSubscriptionAttributes` handler, dispatch entry, and `Actions()` entry
- Add `SetSubscriptionAttribute` to Storage interface and MemoryStorage
- Stores attribute on the subscription so `GetSubscriptionAttributes` reflects the change
- Add integration test with golden file assertion

terraform-provider-aws calls `SetSubscriptionAttributes` after `Subscribe` to set `RawMessageDelivery`, `FilterPolicy`, etc. Without this, kumo returns `UnknownError` and `terraform apply` fails on `aws_sns_topic_subscription` resources.

Closes #637
Ref: #416

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/service/sns/`
- [x] Integration test `TestSNS_SetSubscriptionAttributes` passes with golden assertion