### PR TITLE
feat(dynamodb): support StreamSpecification in CreateTable and TableDescription

### DIFF
--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -456,6 +456,14 @@ func tableToDescription(table *Table) TableDescription {
 		ItemCount:                 table.ItemCount,
 		TableSizeBytes:            table.TableSizeBytes,
 		DeletionProtectionEnabled: table.DeletionProtection,
+		LatestStreamArn:           table.LatestStreamArn,
+	}
+
+	if table.StreamEnabled {
+		desc.StreamSpecification = &StreamSpecification{
+			StreamEnabled:  true,
+			StreamViewType: table.StreamViewType,
+		}
 	}
 
 	if table.ProvisionedThroughput != nil {

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -224,6 +224,12 @@ func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) 
 		DeletionProtection:     req.DeletionProtectionEnabled,
 	}
 
+	if req.StreamSpecification != nil && req.StreamSpecification.StreamEnabled {
+		table.StreamEnabled = true
+		table.StreamViewType = req.StreamSpecification.StreamViewType
+		table.LatestStreamArn = fmt.Sprintf("%s/stream/%s", table.TableARN, time.Now().Format("2006-01-02T15:04:05.000"))
+	}
+
 	m.Tables[req.TableName] = &tableData{
 		Table: table,
 		Items: make(map[string]Item),

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -210,6 +210,15 @@ type Table struct {
 	DeletionProtection     bool
 	TTLAttributeName       string
 	TTLEnabled             bool
+	StreamEnabled          bool
+	StreamViewType         string
+	LatestStreamArn        string
+}
+
+// StreamSpecification represents DynamoDB stream settings.
+type StreamSpecification struct {
+	StreamEnabled  bool   `json:"StreamEnabled"`
+	StreamViewType string `json:"StreamViewType,omitempty"`
 }
 
 // TableDescription represents a table description in responses.
@@ -227,6 +236,8 @@ type TableDescription struct {
 	ItemCount                 int64                             `json:"ItemCount"`
 	TableSizeBytes            int64                             `json:"TableSizeBytes"`
 	BillingModeSummary        *BillingModeSummary               `json:"BillingModeSummary,omitempty"`
+	StreamSpecification       *StreamSpecification              `json:"StreamSpecification,omitempty"`
+	LatestStreamArn           string                            `json:"LatestStreamArn,omitempty"`
 	DeletionProtectionEnabled bool                              `json:"DeletionProtectionEnabled"`
 }
 
@@ -251,6 +262,7 @@ type CreateTableRequest struct {
 	LocalSecondaryIndexes     []LocalSecondaryIndex  `json:"LocalSecondaryIndexes,omitempty"`
 	BillingMode               string                 `json:"BillingMode,omitempty"`
 	DeletionProtectionEnabled bool                   `json:"DeletionProtectionEnabled,omitempty"`
+	StreamSpecification       *StreamSpecification   `json:"StreamSpecification,omitempty"`
 }
 
 // CreateTableResponse is the response for CreateTable.

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -1411,3 +1411,54 @@ func TestDynamoDB_UpdateTable(t *testing.T) {
 		"TableArn", "TableId", "CreationDateTime", "TableSizeBytes", "ItemCount", "ResultMetadata",
 	)).Assert(t.Name(), updateOutput)
 }
+
+func TestDynamoDB_StreamSpecification(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-stream-spec"
+
+	createOutput, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String(tableName),
+		BillingMode: types.BillingModePayPerRequest,
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		StreamSpecification: &types.StreamSpecification{
+			StreamEnabled:  aws.Bool(true),
+			StreamViewType: types.StreamViewTypeNewAndOldImages,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	golden.New(t, golden.WithIgnoreFields(
+		"TableArn", "TableId", "CreationDateTime", "LatestStreamArn",
+		"TableSizeBytes", "ItemCount", "ResultMetadata",
+	)).Assert(t.Name()+"_create", createOutput)
+
+	// DescribeTable should also include stream info.
+	descOutput, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if descOutput.Table.LatestStreamArn == nil || *descOutput.Table.LatestStreamArn == "" {
+		t.Error("expected LatestStreamArn to be set")
+	}
+
+	if descOutput.Table.StreamSpecification == nil || !*descOutput.Table.StreamSpecification.StreamEnabled {
+		t.Error("expected StreamSpecification.StreamEnabled to be true")
+	}
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_StreamSpecification_TestDynamoDB_StreamSpecification_create.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_StreamSpecification_TestDynamoDB_StreamSpecification_create.golden.go
@@ -1,0 +1,49 @@
+{
+  "TableDescription": {
+    "ArchivalSummary": null,
+    "AttributeDefinitions": [
+      {
+        "AttributeName": "pk",
+        "AttributeType": "S"
+      }
+    ],
+    "BillingModeSummary": {
+      "BillingMode": "PAY_PER_REQUEST",
+      "LastUpdateToPayPerRequestDateTime": null
+    },
+    "CreationDateTime": "2026-05-13T07:41:02Z",
+    "DeletionProtectionEnabled": false,
+    "GlobalSecondaryIndexes": null,
+    "GlobalTableSettingsReplicationMode": "",
+    "GlobalTableVersion": null,
+    "GlobalTableWitnesses": null,
+    "ItemCount": 0,
+    "KeySchema": [
+      {
+        "AttributeName": "pk",
+        "KeyType": "HASH"
+      }
+    ],
+    "LatestStreamArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-stream-spec/stream/2026-05-13T16:41:02.021",
+    "LatestStreamLabel": null,
+    "LocalSecondaryIndexes": null,
+    "MultiRegionConsistency": "",
+    "OnDemandThroughput": null,
+    "ProvisionedThroughput": null,
+    "Replicas": null,
+    "RestoreSummary": null,
+    "SSEDescription": null,
+    "StreamSpecification": {
+      "StreamEnabled": true,
+      "StreamViewType": "NEW_AND_OLD_IMAGES"
+    },
+    "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-stream-spec",
+    "TableClassSummary": null,
+    "TableId": "7a088cd1-f11d-461b-bd4c-c02a23dd8b93",
+    "TableName": "test-stream-spec",
+    "TableSizeBytes": 0,
+    "TableStatus": "ACTIVE",
+    "WarmThroughput": null
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add `StreamSpecification` type with `StreamEnabled` and `StreamViewType`
- Add `StreamEnabled`, `StreamViewType`, `LatestStreamArn` fields to `Table` struct
- `CreateTable` stores stream config and generates `LatestStreamArn` when enabled
- `TableDescription` includes `StreamSpecification` and `LatestStreamArn` in responses
- Add integration test with golden file assertion

This unblocks terraform output `dynamodb_stream_arn` which was empty, causing all SDK tests in the aws-emulator-comparison harness to fail with "missing AWS_TEST_DYNAMODB_STREAM_ARN".

Closes #641
Ref: #416

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/service/dynamodb/`
- [x] Integration test `TestDynamoDB_StreamSpecification` passes with golden assertion