### PR TITLE
Improve S3 object and notification compatibility

### DIFF
--- a/internal/service/s3/bucket_notification_lambda_test.go
+++ b/internal/service/s3/bucket_notification_lambda_test.go
@@ -1,0 +1,229 @@
+package s3
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type lambdaInvocation struct {
+	Path           string
+	InvocationType string
+	Body           []byte
+}
+
+func TestBucketNotification_LambdaConfigurationRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	if err := store.CreateBucket(t.Context(), "lambda-bucket"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	body := `<NotificationConfiguration><CloudFunctionConfiguration><Id>lambda-images</Id><CloudFunction>arn:aws:lambda:us-east-1:000000000000:function:image-handler</CloudFunction><Event>s3:ObjectCreated:*</Event><Filter><S3Key><FilterRule><Name>suffix</Name><Value>.jpg</Value></FilterRule></S3Key></Filter></CloudFunctionConfiguration></NotificationConfiguration>`
+	putReq := httptest.NewRequest(http.MethodPut, "/lambda-bucket?notification", strings.NewReader(body))
+	putReq.SetPathValue("bucket", "lambda-bucket")
+
+	putW := httptest.NewRecorder()
+	svc.PutBucketNotificationConfiguration(putW, putReq)
+
+	if putW.Code != http.StatusOK {
+		t.Fatalf("PUT notification status: got %d, want 200 (body=%s)", putW.Code, putW.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/lambda-bucket?notification", http.NoBody)
+	getReq.SetPathValue("bucket", "lambda-bucket")
+
+	getW := httptest.NewRecorder()
+	svc.GetBucketNotificationConfiguration(getW, getReq)
+
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GET notification status: got %d, want 200 (body=%s)", getW.Code, getW.Body.String())
+	}
+
+	var got NotificationConfiguration
+	if err := xml.Unmarshal(getW.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal notification: %v body=%s", err, getW.Body.String())
+	}
+
+	if len(got.LambdaFunctionConfigurations) != 1 {
+		t.Fatalf("lambda configs: got %d, want 1", len(got.LambdaFunctionConfigurations))
+	}
+
+	if got.LambdaFunctionConfigurations[0].CloudFunction != "arn:aws:lambda:us-east-1:000000000000:function:image-handler" {
+		t.Fatalf("lambda ARN: got %q", got.LambdaFunctionConfigurations[0].CloudFunction)
+	}
+}
+
+func TestObjectCreatedEvents_DeliverLambdaNotifications(t *testing.T) {
+	t.Parallel()
+
+	lambdaServer, invocations := newLambdaInvocationCaptureServer(t)
+	defer lambdaServer.Close()
+
+	store := NewMemoryStorage()
+	svc := New(store, lambdaServer.URL)
+
+	if err := store.CreateBucket(t.Context(), "lambda-notify-bucket"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	putLambdaNotificationConfig(t, svc, "lambda-notify-bucket", "image-handler")
+	putObjectForLambdaNotification(t, svc, "lambda-notify-bucket", "images/source.jpg")
+	assertLambdaNotification(t, receiveLambdaInvocation(t, invocations), "ObjectCreated:Put", "images/source.jpg")
+
+	copyObjectForLambdaNotification(t, svc, "lambda-notify-bucket", "images/source.jpg", "images/copy.jpg")
+	assertLambdaNotification(t, receiveLambdaInvocation(t, invocations), "ObjectCreated:Copy", "images/copy.jpg")
+
+	completeMultipartForLambdaNotification(t, store, svc, "lambda-notify-bucket", "images/multipart.jpg")
+	assertLambdaNotification(t, receiveLambdaInvocation(t, invocations), "ObjectCreated:CompleteMultipartUpload", "images/multipart.jpg")
+}
+
+func newLambdaInvocationCaptureServer(t *testing.T) (*httptest.Server, <-chan lambdaInvocation) {
+	t.Helper()
+
+	invocations := make(chan lambdaInvocation, 3)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read Lambda invocation body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+
+		invocations <- lambdaInvocation{
+			Path:           r.URL.Path,
+			InvocationType: r.Header.Get("X-Amz-Invocation-Type"),
+			Body:           body,
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("{}"))
+	}))
+
+	return server, invocations
+}
+
+func putLambdaNotificationConfig(t *testing.T, svc *Service, bucket, functionName string) {
+	t.Helper()
+
+	body := `<NotificationConfiguration><CloudFunctionConfiguration><Id>all-created</Id><CloudFunction>arn:aws:lambda:us-east-1:000000000000:function:` +
+		functionName +
+		`</CloudFunction><Event>s3:ObjectCreated:*</Event><Filter><S3Key><FilterRule><Name>prefix</Name><Value>images/</Value></FilterRule></S3Key></Filter></CloudFunctionConfiguration></NotificationConfiguration>`
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?notification", strings.NewReader(body))
+	req.SetPathValue("bucket", bucket)
+
+	w := httptest.NewRecorder()
+	svc.PutBucketNotificationConfiguration(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT notification status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func putObjectForLambdaNotification(t *testing.T, svc *Service, bucket, key string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"/"+key, strings.NewReader("body"))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+
+	w := httptest.NewRecorder()
+	svc.PutObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func copyObjectForLambdaNotification(t *testing.T, svc *Service, bucket, srcKey, dstKey string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"/"+dstKey, http.NoBody)
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", dstKey)
+	req.Header.Set("X-Amz-Copy-Source", "/"+bucket+"/"+srcKey)
+
+	w := httptest.NewRecorder()
+	svc.CopyObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func completeMultipartForLambdaNotification(t *testing.T, store *MemoryStorage, svc *Service, bucket, key string) {
+	t.Helper()
+
+	upload, err := store.CreateMultipartUpload(t.Context(), bucket, key)
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	part, err := store.UploadPart(t.Context(), bucket, key, upload.UploadID, 1, strings.NewReader("part"))
+	if err != nil {
+		t.Fatalf("UploadPart: %v", err)
+	}
+
+	body := `<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>` + part.ETag + `</ETag></Part></CompleteMultipartUpload>`
+	req := httptest.NewRequest(http.MethodPost, "/"+bucket+"/"+key+"?uploadId="+upload.UploadID, strings.NewReader(body))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+
+	w := httptest.NewRecorder()
+	svc.CompleteMultipartUpload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CompleteMultipartUpload status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func receiveLambdaInvocation(t *testing.T, invocations <-chan lambdaInvocation) lambdaInvocation {
+	t.Helper()
+
+	select {
+	case invocation := <-invocations:
+		return invocation
+	case <-time.After(750 * time.Millisecond):
+		t.Fatal("timed out waiting for Lambda invocation")
+	}
+
+	return lambdaInvocation{}
+}
+
+func assertLambdaNotification(t *testing.T, invocation lambdaInvocation, eventName, key string) {
+	t.Helper()
+
+	if invocation.Path != "/lambda/2015-03-31/functions/image-handler/invocations" {
+		t.Fatalf("Lambda invocation path: got %q", invocation.Path)
+	}
+
+	if invocation.InvocationType != "Event" {
+		t.Fatalf("Lambda invocation type: got %q, want Event", invocation.InvocationType)
+	}
+
+	var envelope s3NotificationEnvelope
+	if err := json.Unmarshal(invocation.Body, &envelope); err != nil {
+		t.Fatalf("unmarshal Lambda notification: %v body=%s", err, string(invocation.Body))
+	}
+
+	if len(envelope.Records) != 1 {
+		t.Fatalf("Records: got %d, want 1", len(envelope.Records))
+	}
+
+	if envelope.Records[0].EventName != eventName {
+		t.Fatalf("eventName: got %q, want %q", envelope.Records[0].EventName, eventName)
+	}
+
+	if envelope.Records[0].S3.Object.Key != key {
+		t.Fatalf("object key: got %q, want %q", envelope.Records[0].S3.Object.Key, key)
+	}
+}

--- a/internal/service/s3/bucket_notification_test.go
+++ b/internal/service/s3/bucket_notification_test.go
@@ -1,0 +1,205 @@
+package s3
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type sqsNotificationRequest struct {
+	QueueURL    string `json:"QueueUrl"`    //nolint:tagliatelle // AWS JSON protocol uses QueueUrl.
+	MessageBody string `json:"MessageBody"` //nolint:tagliatelle // AWS JSON protocol uses MessageBody.
+}
+
+type s3NotificationEnvelope struct {
+	Records []s3NotificationRecord `json:"Records"` //nolint:tagliatelle // S3 notification payload uses Records.
+}
+
+type s3NotificationRecord struct {
+	EventName string `json:"eventName"`
+	S3        struct {
+		Bucket struct {
+			Name string `json:"name"`
+		} `json:"bucket"`
+		Object struct {
+			Key string `json:"key"`
+		} `json:"object"`
+	} `json:"s3"`
+}
+
+func TestBucketNotification_QueueConfigurationRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	if err := store.CreateBucket(t.Context(), "nb"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	body := `<NotificationConfiguration><QueueConfiguration><Id>images</Id><Queue>arn:aws:sqs:us-east-1:000000000000:image-events</Queue><Event>s3:ObjectCreated:*</Event><Filter><S3Key><FilterRule><Name>prefix</Name><Value>images/</Value></FilterRule></S3Key></Filter></QueueConfiguration></NotificationConfiguration>`
+	putReq := httptest.NewRequest(http.MethodPut, "/nb?notification", strings.NewReader(body))
+	putReq.SetPathValue("bucket", "nb")
+
+	putW := httptest.NewRecorder()
+	svc.PutBucketNotificationConfiguration(putW, putReq)
+
+	if putW.Code != http.StatusOK {
+		t.Fatalf("PUT notification status: got %d, want 200 (body=%s)", putW.Code, putW.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/nb?notification", http.NoBody)
+	getReq.SetPathValue("bucket", "nb")
+
+	getW := httptest.NewRecorder()
+	svc.GetBucketNotificationConfiguration(getW, getReq)
+
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GET notification status: got %d, want 200 (body=%s)", getW.Code, getW.Body.String())
+	}
+
+	var got NotificationConfiguration
+	if err := xml.Unmarshal(getW.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal notification: %v body=%s", err, getW.Body.String())
+	}
+
+	if len(got.QueueConfigurations) != 1 {
+		t.Fatalf("queue configs: got %d, want 1", len(got.QueueConfigurations))
+	}
+
+	if got.QueueConfigurations[0].Queue != "arn:aws:sqs:us-east-1:000000000000:image-events" {
+		t.Fatalf("queue ARN: got %q", got.QueueConfigurations[0].Queue)
+	}
+
+	if got.QueueConfigurations[0].Events[0] != "s3:ObjectCreated:*" {
+		t.Fatalf("event: got %q", got.QueueConfigurations[0].Events[0])
+	}
+}
+
+func TestPutObject_DeliversQueueNotification(t *testing.T) {
+	t.Parallel()
+
+	sqsServer, requests := newSQSNotificationCaptureServer(t)
+	defer sqsServer.Close()
+
+	store := NewMemoryStorage()
+	svc := New(store, sqsServer.URL)
+
+	if err := store.CreateBucket(t.Context(), "notify-bucket"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	putBucketNotificationConfig(t, svc, "notify-bucket", "s3-events")
+	putObjectForQueueNotification(t, svc, "notify-bucket", "images/cat.jpg")
+
+	req := receiveSQSNotificationRequest(t, requests)
+	if req.QueueURL != sqsServer.URL+"/000000000000/s3-events" {
+		t.Fatalf("QueueUrl: got %q", req.QueueURL)
+	}
+
+	assertObjectCreatedNotification(t, req.MessageBody, "notify-bucket", "images/cat.jpg")
+}
+
+func newSQSNotificationCaptureServer(t *testing.T) (*httptest.Server, <-chan sqsNotificationRequest) {
+	t.Helper()
+
+	requests := make(chan sqsNotificationRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Amz-Target"); got != "AmazonSQS.SendMessage" {
+			t.Errorf("X-Amz-Target: got %q, want AmazonSQS.SendMessage", got)
+		}
+
+		var req sqsNotificationRequest
+
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode SQS request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+
+		requests <- req
+
+		_, _ = w.Write([]byte(`{"MessageId":"msg-1","MD5OfMessageBody":"d41d8cd98f00b204e9800998ecf8427e"}`))
+	}))
+
+	return server, requests
+}
+
+func putBucketNotificationConfig(t *testing.T, svc *Service, bucket, queueName string) {
+	t.Helper()
+
+	body := fmt.Sprintf(
+		`<NotificationConfiguration><QueueConfiguration><Id>all-created</Id><Queue>arn:aws:sqs:us-east-1:000000000000:%s</Queue><Event>s3:ObjectCreated:*</Event></QueueConfiguration></NotificationConfiguration>`,
+		queueName,
+	)
+	putReq := httptest.NewRequest(http.MethodPut, "/"+bucket+"?notification", strings.NewReader(body))
+	putReq.SetPathValue("bucket", bucket)
+
+	w := httptest.NewRecorder()
+	svc.PutBucketNotificationConfiguration(w, putReq)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT notification status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func putObjectForQueueNotification(t *testing.T, svc *Service, bucket, key string) {
+	t.Helper()
+
+	putReq := httptest.NewRequest(http.MethodPut, "/"+bucket+"/"+key, strings.NewReader("jpeg"))
+	putReq.SetPathValue("bucket", bucket)
+	putReq.SetPathValue("key", key)
+
+	w := httptest.NewRecorder()
+	svc.PutObject(w, putReq)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func receiveSQSNotificationRequest(t *testing.T, requests <-chan sqsNotificationRequest) sqsNotificationRequest {
+	t.Helper()
+
+	select {
+	case req := <-requests:
+		return req
+	case <-time.After(750 * time.Millisecond):
+		t.Fatal("timed out waiting for SQS notification")
+	}
+
+	return sqsNotificationRequest{}
+}
+
+func assertObjectCreatedNotification(t *testing.T, body, bucket, key string) {
+	t.Helper()
+
+	var envelope s3NotificationEnvelope
+
+	if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+		t.Fatalf("unmarshal message body: %v body=%s", err, body)
+	}
+
+	if len(envelope.Records) != 1 {
+		t.Fatalf("Records: got %d, want 1", len(envelope.Records))
+	}
+
+	record := envelope.Records[0]
+	if record.EventName != "ObjectCreated:Put" {
+		t.Fatalf("eventName: got %q, want ObjectCreated:Put", record.EventName)
+	}
+
+	if record.S3.Bucket.Name != bucket {
+		t.Fatalf("bucket name: got %q", record.S3.Bucket.Name)
+	}
+
+	if record.S3.Object.Key != key {
+		t.Fatalf("object key: got %q", record.S3.Object.Key)
+	}
+}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -26,7 +26,14 @@ const (
 	// contentTypeHeader is the canonical "Content-Type" string. Hoisted
 	// to a const because the metadata-pass loop excludes it in three
 	// different handlers — goconst was flagging the literal.
-	contentTypeHeader = "Content-Type"
+	contentTypeHeader                  = "Content-Type"
+	objectTaggingHeader                = "x-amz-tagging"
+	sseAlgorithmHeader                 = "x-amz-server-side-encryption"
+	sseKMSKeyIDHeader                  = "x-amz-server-side-encryption-aws-kms-key-id"
+	sseBucketKeyEnabledHeader          = "x-amz-server-side-encryption-bucket-key-enabled"
+	canonicalSSEAlgorithmHeader        = "x-amz-server-side-encryption"
+	canonicalSSEKMSKeyIDHeader         = "x-amz-server-side-encryption-aws-kms-key-id"
+	canonicalSSEBucketKeyEnabledHeader = "x-amz-server-side-encryption-bucket-key-enabled"
 )
 
 // applyCORSHeaders sets CORS response headers if the bucket has CORS configured and the request Origin matches.
@@ -159,6 +166,12 @@ func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
 
 	if _, ok := r.URL.Query()["lifecycle"]; ok {
 		s.GetBucketLifecycleConfiguration(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["notification"]; ok {
+		s.GetBucketNotificationConfiguration(w, r)
 
 		return
 	}
@@ -710,34 +723,22 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bucket := r.PathValue("bucket")
-	key := r.PathValue("key")
+	bucket, key, ok := putObjectTarget(w, r)
+	if !ok {
+		return
+	}
 
-	if bucket == "" {
-		writeS3Error(w, r, "InvalidBucketName", "The specified bucket is not valid.", http.StatusBadRequest)
+	tags, hasTags, err := parseObjectTaggingHeader(r.Header.Get(objectTaggingHeader))
+	if err != nil {
+		writeS3Error(w, r, "InvalidTag", "The Tagging header is not valid", http.StatusBadRequest)
 
 		return
 	}
 
-	if key == "" {
-		writeS3Error(w, r, "InvalidArgument", "Invalid key", http.StatusBadRequest)
+	metadata := objectMetadataFromHeaders(r.Header)
+	putOptions := objectSSEOptionsFromHeaders(r.Header)
 
-		return
-	}
-
-	metadata := make(map[string]string)
-	if ct := r.Header.Get("Content-Type"); ct != "" {
-		metadata["Content-Type"] = ct
-	}
-
-	// Extract x-amz-meta-* headers
-	for name, values := range r.Header {
-		if metaKey, found := strings.CutPrefix(strings.ToLower(name), "x-amz-meta-"); found {
-			metadata[metaKey] = values[0]
-		}
-	}
-
-	obj, err := s.storage.PutObject(r.Context(), bucket, key, r.Body, metadata)
+	obj, err := s.storage.PutObject(r.Context(), bucket, key, r.Body, metadata, putOptions)
 	if err != nil {
 		var bucketErr *BucketError
 		if errors.As(err, &bucketErr) {
@@ -751,7 +752,12 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if hasTags && !s.storeObjectTaggingHeader(w, r, bucket, key, tags) {
+		return
+	}
+
 	w.Header().Set("ETag", obj.ETag)
+	writeObjectSSEHeaders(w, obj)
 
 	if obj.VersionID != "" {
 		w.Header().Set("x-amz-version-id", obj.VersionID)
@@ -761,6 +767,89 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 
 	// Emit EventBridge notification if enabled.
 	go s.emitObjectCreatedEvent(context.Background(), bucket, key, obj.Size, obj.ETag)
+}
+
+func putObjectTarget(w http.ResponseWriter, r *http.Request) (string, string, bool) {
+	bucket := r.PathValue("bucket")
+	key := r.PathValue("key")
+
+	if bucket == "" {
+		writeS3Error(w, r, "InvalidBucketName", "The specified bucket is not valid.", http.StatusBadRequest)
+
+		return "", "", false
+	}
+
+	if key == "" {
+		writeS3Error(w, r, "InvalidArgument", "Invalid key", http.StatusBadRequest)
+
+		return "", "", false
+	}
+
+	return bucket, key, true
+}
+
+func objectMetadataFromHeaders(headers http.Header) map[string]string {
+	metadata := make(map[string]string)
+	if ct := headers.Get("Content-Type"); ct != "" {
+		metadata["Content-Type"] = ct
+	}
+
+	for name, values := range headers {
+		if metaKey, found := strings.CutPrefix(strings.ToLower(name), "x-amz-meta-"); found {
+			metadata[metaKey] = values[0]
+		}
+	}
+
+	return metadata
+}
+
+func (s *Service) storeObjectTaggingHeader(w http.ResponseWriter, r *http.Request, bucket, key string, tags map[string]string) bool {
+	if err := s.storage.PutObjectTagging(r.Context(), bucket, key, tags); err != nil {
+		var bucketErr *BucketError
+		if errors.As(err, &bucketErr) {
+			writeS3Error(w, r, bucketErr.Code, bucketErr.Message, http.StatusNotFound)
+
+			return false
+		}
+
+		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return false
+	}
+
+	return true
+}
+
+func parseObjectTaggingHeader(raw string) (map[string]string, bool, error) {
+	if raw == "" {
+		return nil, false, nil
+	}
+
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return nil, false, fmt.Errorf("parse tagging header: %w", err)
+	}
+
+	tags := make(map[string]string, len(values))
+
+	for key, vals := range values {
+		value := ""
+		if len(vals) > 0 {
+			value = vals[0]
+		}
+
+		tags[key] = value
+	}
+
+	return tags, true, nil
+}
+
+func objectSSEOptionsFromHeaders(headers http.Header) PutObjectOptions {
+	return PutObjectOptions{
+		ServerSideEncryption:   headers.Get(sseAlgorithmHeader),
+		SSEKMSKeyID:            headers.Get(sseKMSKeyIDHeader),
+		SSEBucketKeyEnabledRaw: headers.Get(sseBucketKeyEnabledHeader),
+	}
 }
 
 // CopyObject handles PUT /{bucket}/{key} with X-Amz-Copy-Source header.
@@ -935,6 +1024,7 @@ func writePartialObjectResponse(w http.ResponseWriter, obj *Object, start, end i
 	w.Header().Set("Accept-Ranges", "bytes")
 	w.Header().Set("ETag", obj.ETag)
 	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(timeFormatHTTP))
+	writeObjectSSEHeaders(w, obj)
 
 	if obj.VersionID != "" {
 		w.Header().Set("x-amz-version-id", obj.VersionID)
@@ -1025,6 +1115,7 @@ func writeObjectResponse(w http.ResponseWriter, obj *Object) {
 	w.Header().Set("ETag", obj.ETag)
 	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(timeFormatHTTP))
 	w.Header().Set("Accept-Ranges", "bytes")
+	writeObjectSSEHeaders(w, obj)
 
 	if obj.VersionID != "" {
 		w.Header().Set("x-amz-version-id", obj.VersionID)
@@ -1039,6 +1130,20 @@ func writeObjectResponse(w http.ResponseWriter, obj *Object) {
 	w.WriteHeader(http.StatusOK)
 
 	_, _ = w.Write(obj.Body)
+}
+
+func writeObjectSSEHeaders(w http.ResponseWriter, obj *Object) {
+	if obj.ServerSideEncryption != "" {
+		w.Header().Set(canonicalSSEAlgorithmHeader, obj.ServerSideEncryption)
+	}
+
+	if obj.SSEKMSKeyID != "" {
+		w.Header().Set(canonicalSSEKMSKeyIDHeader, obj.SSEKMSKeyID)
+	}
+
+	if obj.SSEBucketKeyEnabledRaw != "" {
+		w.Header().Set(canonicalSSEBucketKeyEnabledHeader, obj.SSEBucketKeyEnabledRaw)
+	}
 }
 
 // DeleteObject handles DELETE /{bucket}/{key...} - delete an object.
@@ -1211,6 +1316,7 @@ func (s *Service) HeadObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("ETag", obj.ETag)
 	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(timeFormatHTTP))
 	w.Header().Set("Accept-Ranges", "bytes")
+	writeObjectSSEHeaders(w, obj)
 
 	// Set metadata headers
 	for k, v := range obj.Metadata {
@@ -2268,10 +2374,41 @@ func (s *Service) PutBucketNotificationConfiguration(w http.ResponseWriter, r *h
 		return
 	}
 
-	enabled := config.EventBridgeConfig != nil
-	s.storage.SetEventBridgeNotification(r.Context(), bucket, enabled)
+	if err := s.storage.PutBucketNotificationConfiguration(r.Context(), bucket, &config); err != nil {
+		var bucketErr *BucketError
+		if errors.As(err, &bucketErr) {
+			writeS3Error(w, r, bucketErr.Code, bucketErr.Message, http.StatusNotFound)
+
+			return
+		}
+
+		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// GetBucketNotificationConfiguration handles GET /{bucket}?notification.
+func (s *Service) GetBucketNotificationConfiguration(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	config, err := s.storage.GetBucketNotificationConfiguration(r.Context(), bucket)
+	if err != nil {
+		var bucketErr *BucketError
+		if errors.As(err, &bucketErr) {
+			writeS3Error(w, r, bucketErr.Code, bucketErr.Message, http.StatusNotFound)
+
+			return
+		}
+
+		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeXMLResponse(w, config)
 }
 
 // PutBucketCors handles PUT /{bucket}?cors.

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -766,7 +766,7 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
 	// Emit EventBridge notification if enabled.
-	go s.emitObjectCreatedEvent(context.Background(), bucket, key, obj.Size, obj.ETag)
+	go s.emitObjectCreatedEvent(context.Background(), bucket, key, obj.Size, obj.ETag, objectCreatedPutEvent)
 }
 
 func putObjectTarget(w http.ResponseWriter, r *http.Request) (string, string, bool) {
@@ -857,29 +857,22 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 	dstBucket := r.PathValue("bucket")
 	dstKey := r.PathValue("key")
 
-	copySource := r.Header.Get("X-Amz-Copy-Source")
-	srcBucket, srcKey := parseCopySource(copySource)
-
-	if srcBucket == "" || srcKey == "" {
-		writeS3Error(w, r, "InvalidArgument", "Invalid copy source", http.StatusBadRequest)
-
+	srcObj, ok := s.copyObjectSource(w, r)
+	if !ok {
 		return
 	}
 
-	srcObj, err := s.storage.GetObject(r.Context(), srcBucket, srcKey)
+	metadata := copyObjectMetadata(r.Header, srcObj)
+	putOptions := copyObjectSSEOptions(r.Header, srcObj)
+
+	tags, err := copyObjectTags(r.Header, srcObj)
 	if err != nil {
-		handleGetObjectError(w, r, err)
+		writeS3Error(w, r, "InvalidTag", "The Tagging header is not valid", http.StatusBadRequest)
 
 		return
 	}
 
-	if !evalCopySourcePreconditions(r.Header, srcObj.ETag, srcObj.LastModified) {
-		writeS3Error(w, r, "PreconditionFailed", "At least one of the preconditions you specified did not hold.", http.StatusPreconditionFailed)
-
-		return
-	}
-
-	dstObj, err := s.storage.PutObject(r.Context(), dstBucket, dstKey, bytes.NewReader(srcObj.Body), srcObj.Metadata)
+	dstObj, err := s.storage.PutObject(r.Context(), dstBucket, dstKey, bytes.NewReader(srcObj.Body), metadata, putOptions)
 	if err != nil {
 		var bucketErr *BucketError
 		if errors.As(err, &bucketErr) {
@@ -893,14 +886,98 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(tags) > 0 && !s.storeObjectTaggingHeader(w, r, dstBucket, dstKey, tags) {
+		return
+	}
+
 	result := CopyObjectResult{
 		ETag:         dstObj.ETag,
 		LastModified: dstObj.LastModified.Format(timeFormatISO),
 	}
 
+	writeObjectSSEHeaders(w, dstObj)
 	writeXMLResponse(w, result)
 
-	go s.emitObjectCreatedEvent(context.Background(), dstBucket, dstKey, dstObj.Size, dstObj.ETag)
+	go s.emitObjectCreatedEvent(context.Background(), dstBucket, dstKey, dstObj.Size, dstObj.ETag, objectCreatedCopyEvent)
+}
+
+func (s *Service) copyObjectSource(w http.ResponseWriter, r *http.Request) (*Object, bool) {
+	copySource := r.Header.Get("X-Amz-Copy-Source")
+	srcBucket, srcKey := parseCopySource(copySource)
+
+	if srcBucket == "" || srcKey == "" {
+		writeS3Error(w, r, "InvalidArgument", "Invalid copy source", http.StatusBadRequest)
+
+		return nil, false
+	}
+
+	srcObj, err := s.storage.GetObject(r.Context(), srcBucket, srcKey)
+	if err != nil {
+		handleGetObjectError(w, r, err)
+
+		return nil, false
+	}
+
+	if !evalCopySourcePreconditions(r.Header, srcObj.ETag, srcObj.LastModified) {
+		writeS3Error(w, r, "PreconditionFailed", "At least one of the preconditions you specified did not hold.", http.StatusPreconditionFailed)
+
+		return nil, false
+	}
+
+	return srcObj, true
+}
+
+func copyObjectMetadata(headers http.Header, srcObj *Object) map[string]string {
+	if strings.EqualFold(headers.Get("x-amz-metadata-directive"), "REPLACE") {
+		return objectMetadataFromHeaders(headers)
+	}
+
+	return cloneStringMap(srcObj.Metadata)
+}
+
+func copyObjectSSEOptions(headers http.Header, srcObj *Object) PutObjectOptions {
+	options := objectSSEOptionsFromObject(srcObj)
+	replacement := objectSSEOptionsFromHeaders(headers)
+
+	if replacement.ServerSideEncryption != "" {
+		options.ServerSideEncryption = replacement.ServerSideEncryption
+	}
+
+	if replacement.SSEKMSKeyID != "" {
+		options.SSEKMSKeyID = replacement.SSEKMSKeyID
+	}
+
+	if replacement.SSEBucketKeyEnabledRaw != "" {
+		options.SSEBucketKeyEnabledRaw = replacement.SSEBucketKeyEnabledRaw
+	}
+
+	return options
+}
+
+func objectSSEOptionsFromObject(obj *Object) PutObjectOptions {
+	return PutObjectOptions{
+		ServerSideEncryption:   obj.ServerSideEncryption,
+		SSEKMSKeyID:            obj.SSEKMSKeyID,
+		SSEBucketKeyEnabledRaw: obj.SSEBucketKeyEnabledRaw,
+	}
+}
+
+func copyObjectTags(headers http.Header, srcObj *Object) (map[string]string, error) {
+	tags := cloneStringMap(srcObj.Tags)
+
+	if strings.EqualFold(headers.Get("x-amz-tagging-directive"), "REPLACE") {
+		parsed, hasTags, err := parseObjectTaggingHeader(headers.Get(objectTaggingHeader))
+		if err != nil {
+			return nil, err
+		}
+
+		tags = map[string]string{}
+		if hasTags {
+			tags = parsed
+		}
+	}
+
+	return tags, nil
 }
 
 // parseCopySource parses the X-Amz-Copy-Source header value.
@@ -1133,16 +1210,20 @@ func writeObjectResponse(w http.ResponseWriter, obj *Object) {
 }
 
 func writeObjectSSEHeaders(w http.ResponseWriter, obj *Object) {
-	if obj.ServerSideEncryption != "" {
-		w.Header().Set(canonicalSSEAlgorithmHeader, obj.ServerSideEncryption)
+	writePutObjectOptionsSSEHeaders(w, objectSSEOptionsFromObject(obj))
+}
+
+func writePutObjectOptionsSSEHeaders(w http.ResponseWriter, options PutObjectOptions) {
+	if options.ServerSideEncryption != "" {
+		w.Header().Set(canonicalSSEAlgorithmHeader, options.ServerSideEncryption)
 	}
 
-	if obj.SSEKMSKeyID != "" {
-		w.Header().Set(canonicalSSEKMSKeyIDHeader, obj.SSEKMSKeyID)
+	if options.SSEKMSKeyID != "" {
+		w.Header().Set(canonicalSSEKMSKeyIDHeader, options.SSEKMSKeyID)
 	}
 
-	if obj.SSEBucketKeyEnabledRaw != "" {
-		w.Header().Set(canonicalSSEBucketKeyEnabledHeader, obj.SSEBucketKeyEnabledRaw)
+	if options.SSEBucketKeyEnabledRaw != "" {
+		w.Header().Set(canonicalSSEBucketKeyEnabledHeader, options.SSEBucketKeyEnabledRaw)
 	}
 }
 
@@ -2010,7 +2091,20 @@ func (s *Service) CreateMultipartUpload(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	upload, err := s.storage.CreateMultipartUpload(r.Context(), bucket, key)
+	tags, _, err := parseObjectTaggingHeader(r.Header.Get(objectTaggingHeader))
+	if err != nil {
+		writeS3Error(w, r, "InvalidTag", "The Tagging header is not valid", http.StatusBadRequest)
+
+		return
+	}
+
+	options := CreateMultipartUploadOptions{
+		Metadata:   objectMetadataFromHeaders(r.Header),
+		Tags:       tags,
+		PutOptions: objectSSEOptionsFromHeaders(r.Header),
+	}
+
+	upload, err := s.storage.CreateMultipartUpload(r.Context(), bucket, key, options)
 	if err != nil {
 		var bucketErr *BucketError
 		if errors.As(err, &bucketErr) {
@@ -2031,6 +2125,7 @@ func (s *Service) CreateMultipartUpload(w http.ResponseWriter, r *http.Request) 
 		UploadID: upload.UploadID,
 	}
 
+	writePutObjectOptionsSSEHeaders(w, upload.PutOptions)
 	writeXMLResponse(w, result)
 }
 
@@ -2211,7 +2306,10 @@ func (s *Service) CompleteMultipartUpload(w http.ResponseWriter, r *http.Request
 		ETag:     obj.ETag,
 	}
 
+	writeObjectSSEHeaders(w, obj)
 	writeXMLResponse(w, result)
+
+	go s.emitObjectCreatedEvent(context.Background(), bucket, key, obj.Size, obj.ETag, objectCreatedCompleteMultipartUploadEvent)
 }
 
 // AbortMultipartUpload handles DELETE /{bucket}/{key}?uploadId={uploadId} - abort a multipart upload.

--- a/internal/service/s3/object_copy_multipart_headers_test.go
+++ b/internal/service/s3/object_copy_multipart_headers_test.go
@@ -1,0 +1,195 @@
+package s3
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCopyObject_CopiesTagsAndSSEHeaders(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	if err := store.CreateBucket(t.Context(), "copy-bucket"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	putObjectWithTagsAndSSE(t, svc, "copy-bucket", "source")
+	copyObject(t, svc, "copy-bucket", "source", "dest")
+	assertObjectTags(t, svc, "copy-bucket", "dest", map[string]string{"env": "dev", "team": "platform"})
+	assertObjectSSE(t, svc, "copy-bucket", "dest")
+}
+
+func TestMultipartUpload_TagsAndSSEHeadersRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	if err := store.CreateBucket(t.Context(), "multipart-bucket"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	uploadID := createMultipartUploadWithTagsAndSSE(t, svc, "multipart-bucket", "large-object")
+	partETag := uploadPart(t, svc, "multipart-bucket", "large-object", uploadID, "payload")
+	completeMultipartUpload(t, svc, "multipart-bucket", "large-object", uploadID, partETag)
+
+	assertObjectTags(t, svc, "multipart-bucket", "large-object", map[string]string{"env": "prod"})
+	assertObjectSSE(t, svc, "multipart-bucket", "large-object")
+}
+
+func putObjectWithTagsAndSSE(t *testing.T, svc *Service, bucket, key string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"/"+key, strings.NewReader("body"))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+	req.Header.Set("X-Amz-Tagging", "env=dev&team=platform")
+	setSSEKMSRequestHeaders(req)
+
+	w := httptest.NewRecorder()
+	svc.PutObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func copyObject(t *testing.T, svc *Service, bucket, srcKey, dstKey string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"/"+dstKey, http.NoBody)
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", dstKey)
+	req.Header.Set("X-Amz-Copy-Source", "/"+bucket+"/"+srcKey)
+
+	w := httptest.NewRecorder()
+	svc.CopyObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func createMultipartUploadWithTagsAndSSE(t *testing.T, svc *Service, bucket, key string) string {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/"+bucket+"/"+key+"?uploads", http.NoBody)
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+	req.Header.Set("X-Amz-Tagging", "env=prod")
+	setSSEKMSRequestHeaders(req)
+
+	w := httptest.NewRecorder()
+	svc.CreateMultipartUpload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateMultipartUpload status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	var result InitiateMultipartUploadResult
+	if err := xml.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal initiate multipart: %v body=%s", err, w.Body.String())
+	}
+
+	if result.UploadID == "" {
+		t.Fatal("UploadId is empty")
+	}
+
+	assertSSEKMSHeaders(t, "CreateMultipartUpload", w.Header())
+
+	return result.UploadID
+}
+
+func uploadPart(t *testing.T, svc *Service, bucket, key, uploadID, body string) string {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"/"+key+"?partNumber=1&uploadId="+uploadID, strings.NewReader(body))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+
+	w := httptest.NewRecorder()
+	svc.UploadPart(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("UploadPart status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	return w.Header().Get("ETag")
+}
+
+func completeMultipartUpload(t *testing.T, svc *Service, bucket, key, uploadID, etag string) {
+	t.Helper()
+
+	body := `<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>` + etag + `</ETag></Part></CompleteMultipartUpload>`
+	req := httptest.NewRequest(http.MethodPost, "/"+bucket+"/"+key+"?uploadId="+uploadID, strings.NewReader(body))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+
+	w := httptest.NewRecorder()
+	svc.CompleteMultipartUpload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CompleteMultipartUpload status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	assertSSEKMSHeaders(t, "CompleteMultipartUpload", w.Header())
+}
+
+func assertObjectTags(t *testing.T, svc *Service, bucket, key string, want map[string]string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/"+bucket+"/"+key+"?tagging", http.NoBody)
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+
+	w := httptest.NewRecorder()
+	svc.GetObjectTagging(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetObjectTagging status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	var got Tagging
+	if err := xml.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal tagging: %v body=%s", err, w.Body.String())
+	}
+
+	gotTags := make(map[string]string, len(got.TagSet.Tags))
+	for _, tag := range got.TagSet.Tags {
+		gotTags[tag.Key] = tag.Value
+	}
+
+	for key, value := range want {
+		if gotTags[key] != value {
+			t.Fatalf("tag %q: got %q, want %q (all=%v)", key, gotTags[key], value, gotTags)
+		}
+	}
+}
+
+func assertObjectSSE(t *testing.T, svc *Service, bucket, key string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodHead, "/"+bucket+"/"+key, http.NoBody)
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+
+	w := httptest.NewRecorder()
+	svc.HeadObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("HeadObject status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	assertSSEKMSHeaders(t, "HeadObject", w.Header())
+}
+
+func setSSEKMSRequestHeaders(req *http.Request) {
+	req.Header.Set("X-Amz-Server-Side-Encryption", sseKMSAlgorithm)
+	req.Header.Set("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id", sseKMSKeyID)
+	req.Header.Set("X-Amz-Server-Side-Encryption-Bucket-Key-Enabled", "true")
+}

--- a/internal/service/s3/object_put_headers_test.go
+++ b/internal/service/s3/object_put_headers_test.go
@@ -1,0 +1,167 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPutObject_TaggingHeaderIsReturnedByGetObjectTagging(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	if err := store.CreateBucket(ctx, "tag-bucket"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	putReq := httptest.NewRequest(http.MethodPut, "/tag-bucket/k", strings.NewReader("body"))
+	putReq.SetPathValue("bucket", "tag-bucket")
+	putReq.SetPathValue("key", "k")
+	putReq.Header.Set("X-Amz-Tagging", "env=dev&space=a%20b")
+
+	putW := httptest.NewRecorder()
+	svc.PutObject(putW, putReq)
+
+	if putW.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want 200 (body=%s)", putW.Code, putW.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/tag-bucket/k?tagging", http.NoBody)
+	getReq.SetPathValue("bucket", "tag-bucket")
+	getReq.SetPathValue("key", "k")
+
+	getW := httptest.NewRecorder()
+	svc.GetObjectTagging(getW, getReq)
+
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GetObjectTagging status: got %d, want 200 (body=%s)", getW.Code, getW.Body.String())
+	}
+
+	var got Tagging
+	if err := xml.Unmarshal(getW.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal tagging: %v body=%s", err, getW.Body.String())
+	}
+
+	want := map[string]string{"env": "dev", "space": "a b"}
+	gotTags := make(map[string]string, len(got.TagSet.Tags))
+
+	for _, tag := range got.TagSet.Tags {
+		gotTags[tag.Key] = tag.Value
+	}
+
+	for key, wantValue := range want {
+		if gotTags[key] != wantValue {
+			t.Fatalf("tag %q: got %q, want %q (all=%v)", key, gotTags[key], wantValue, gotTags)
+		}
+	}
+}
+
+func TestPutObject_SSEKMSHeadersRoundTripThroughHeadAndGet(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	if err := store.CreateBucket(ctx, "sse-bucket"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	putObjectWithSSEKMSHeaders(t, svc)
+
+	for _, tc := range []struct {
+		name string
+		call func(*testing.T, *Service) *httptest.ResponseRecorder
+	}{
+		{
+			name: "HeadObject",
+			call: recordSSEKMSHeadObject,
+		},
+		{
+			name: "GetObject",
+			call: recordSSEKMSGetObject,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := tc.call(t, svc)
+			if w.Code != http.StatusOK {
+				t.Fatalf("%s status: got %d, want 200 (body=%s)", tc.name, w.Code, w.Body.String())
+			}
+
+			assertSSEKMSHeaders(t, tc.name, w.Header())
+		})
+	}
+}
+
+const (
+	sseKMSBucketName = "sse-bucket"
+	sseKMSObjectKey  = "k"
+	sseKMSAlgorithm  = "aws:kms"
+	sseKMSKeyID      = "arn:aws:kms:us-east-1:123456789012:key/test"
+)
+
+func putObjectWithSSEKMSHeaders(t *testing.T, svc *Service) {
+	t.Helper()
+
+	putReq := httptest.NewRequest(http.MethodPut, "/sse-bucket/k", strings.NewReader("body"))
+	putReq.SetPathValue("bucket", sseKMSBucketName)
+	putReq.SetPathValue("key", sseKMSObjectKey)
+	putReq.Header.Set("X-Amz-Server-Side-Encryption", sseKMSAlgorithm)
+	putReq.Header.Set("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id", sseKMSKeyID)
+	putReq.Header.Set("X-Amz-Server-Side-Encryption-Bucket-Key-Enabled", "true")
+
+	putW := httptest.NewRecorder()
+	svc.PutObject(putW, putReq)
+
+	if putW.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want 200 (body=%s)", putW.Code, putW.Body.String())
+	}
+}
+
+func recordSSEKMSHeadObject(t *testing.T, svc *Service) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodHead, "/sse-bucket/k", http.NoBody)
+	req.SetPathValue("bucket", sseKMSBucketName)
+	req.SetPathValue("key", sseKMSObjectKey)
+
+	w := httptest.NewRecorder()
+	svc.HeadObject(w, req)
+
+	return w
+}
+
+func recordSSEKMSGetObject(t *testing.T, svc *Service) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/sse-bucket/k", http.NoBody)
+	req.SetPathValue("bucket", sseKMSBucketName)
+	req.SetPathValue("key", sseKMSObjectKey)
+
+	w := httptest.NewRecorder()
+	svc.GetObject(w, req)
+
+	return w
+}
+
+func assertSSEKMSHeaders(t *testing.T, name string, headers http.Header) {
+	t.Helper()
+
+	if got := headers.Get("x-amz-server-side-encryption"); got != sseKMSAlgorithm {
+		t.Fatalf("%s SSE algorithm: got %q, want %q", name, got, sseKMSAlgorithm)
+	}
+
+	if got := headers.Get("x-amz-server-side-encryption-aws-kms-key-id"); got != sseKMSKeyID {
+		t.Fatalf("%s SSE KMS key id: got %q, want %q", name, got, sseKMSKeyID)
+	}
+
+	if got := headers.Get("x-amz-server-side-encryption-bucket-key-enabled"); got != "true" {
+		t.Fatalf("%s bucket key enabled: got %q, want true", name, got)
+	}
+}

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -18,6 +19,12 @@ import (
 )
 
 const defaultBaseURL = "http://localhost:4566"
+
+const (
+	objectCreatedPutEvent                     = "s3:ObjectCreated:Put"
+	objectCreatedCopyEvent                    = "s3:ObjectCreated:Copy"
+	objectCreatedCompleteMultipartUploadEvent = "s3:ObjectCreated:CompleteMultipartUpload"
+)
 
 // Compile-time check that Service implements io.Closer.
 var _ io.Closer = (*Service)(nil)
@@ -101,12 +108,13 @@ func (s *Service) Close() error {
 }
 
 // emitObjectCreatedEvent sends an S3 Object Created event to configured bucket notifications.
-func (s *Service) emitObjectCreatedEvent(ctx context.Context, bucket, key string, size int64, etag string) {
+func (s *Service) emitObjectCreatedEvent(ctx context.Context, bucket, key string, size int64, etag, event string) {
 	if s.storage.IsEventBridgeEnabled(ctx, bucket) {
 		s.emitObjectCreatedEventBridgeEvent(ctx, bucket, key, size, etag)
 	}
 
-	s.emitObjectCreatedQueueNotifications(ctx, bucket, key, size, etag)
+	s.emitObjectCreatedQueueNotifications(ctx, bucket, key, size, etag, event)
+	s.emitObjectCreatedLambdaNotifications(ctx, bucket, key, size, etag, event)
 }
 
 func (s *Service) emitObjectCreatedEventBridgeEvent(ctx context.Context, bucket, key string, size int64, etag string) {
@@ -133,14 +141,14 @@ func (s *Service) emitObjectCreatedEventBridgeEvent(ctx context.Context, bucket,
 	s.putEvents(ctx, body, bucket, key)
 }
 
-func (s *Service) emitObjectCreatedQueueNotifications(ctx context.Context, bucket, key string, size int64, etag string) {
+func (s *Service) emitObjectCreatedQueueNotifications(ctx context.Context, bucket, key string, size int64, etag, event string) {
 	cfg, err := s.storage.GetBucketNotificationConfiguration(ctx, bucket)
 	if err != nil || cfg == nil {
 		return
 	}
 
 	for _, queueConfig := range cfg.QueueConfigurations {
-		if !notificationEventsMatch(queueConfig.Events, "s3:ObjectCreated:Put") {
+		if !notificationEventsMatch(queueConfig.Events, event) {
 			continue
 		}
 
@@ -148,26 +156,7 @@ func (s *Service) emitObjectCreatedQueueNotifications(ctx context.Context, bucke
 			continue
 		}
 
-		payload, err := json.Marshal(map[string]any{
-			"Records": []map[string]any{{
-				"eventVersion": "2.1",
-				"eventSource":  "aws:s3",
-				"awsRegion":    "us-east-1",
-				"eventTime":    time.Now().UTC().Format(time.RFC3339),
-				"eventName":    "ObjectCreated:Put",
-				"s3": map[string]any{
-					"bucket": map[string]string{
-						"name": bucket,
-						"arn":  "arn:aws:s3:::" + bucket,
-					},
-					"object": map[string]any{
-						"key":  key,
-						"size": size,
-						"eTag": strings.Trim(etag, `"`),
-					},
-				},
-			}},
-		})
+		payload, err := objectCreatedNotificationPayload(bucket, key, size, etag, event)
 		if err != nil {
 			s.logger.Error("failed to marshal S3 queue notification", "error", err)
 
@@ -176,6 +165,60 @@ func (s *Service) emitObjectCreatedQueueNotifications(ctx context.Context, bucke
 
 		s.sendSQSNotification(ctx, queueConfig.Queue, payload)
 	}
+}
+
+func (s *Service) emitObjectCreatedLambdaNotifications(ctx context.Context, bucket, key string, size int64, etag, event string) {
+	cfg, err := s.storage.GetBucketNotificationConfiguration(ctx, bucket)
+	if err != nil || cfg == nil {
+		return
+	}
+
+	for _, lambdaConfig := range cfg.LambdaFunctionConfigurations {
+		if !notificationEventsMatch(lambdaConfig.Events, event) {
+			continue
+		}
+
+		if !notificationFilterMatches(lambdaConfig.Filter, key) {
+			continue
+		}
+
+		payload, err := objectCreatedNotificationPayload(bucket, key, size, etag, event)
+		if err != nil {
+			s.logger.Error("failed to marshal S3 Lambda notification", "error", err)
+
+			continue
+		}
+
+		s.sendLambdaNotification(ctx, lambdaConfig.CloudFunction, payload)
+	}
+}
+
+func objectCreatedNotificationPayload(bucket, key string, size int64, etag, event string) ([]byte, error) {
+	body, err := json.Marshal(map[string]any{
+		"Records": []map[string]any{{
+			"eventVersion": "2.1",
+			"eventSource":  "aws:s3",
+			"awsRegion":    "us-east-1",
+			"eventTime":    time.Now().UTC().Format(time.RFC3339),
+			"eventName":    strings.TrimPrefix(event, "s3:"),
+			"s3": map[string]any{
+				"bucket": map[string]string{
+					"name": bucket,
+					"arn":  "arn:aws:s3:::" + bucket,
+				},
+				"object": map[string]any{
+					"key":  key,
+					"size": size,
+					"eTag": strings.Trim(etag, `"`),
+				},
+			},
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal object created notification: %w", err)
+	}
+
+	return body, nil
 }
 
 func notificationEventsMatch(events []string, event string) bool {
@@ -243,6 +286,47 @@ func (s *Service) sendSQSNotification(ctx context.Context, queueARN string, payl
 	}
 
 	_ = resp.Body.Close()
+}
+
+func (s *Service) sendLambdaNotification(ctx context.Context, functionARN string, payload []byte) {
+	functionName := lambdaFunctionName(functionARN)
+	if functionName == "" {
+		return
+	}
+
+	endpoint := s.baseURL + "/lambda/2015-03-31/functions/" + url.PathEscape(functionName) + "/invocations"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		s.logger.Error("failed to create Lambda invoke request", "error", err, "function", functionName)
+
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Amz-Invocation-Type", "Event")
+
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	if err != nil {
+		s.logger.Error("failed to deliver S3 notification to Lambda", "error", err, "function", functionName)
+
+		return
+	}
+
+	_ = resp.Body.Close()
+}
+
+func lambdaFunctionName(functionARN string) string {
+	if !strings.HasPrefix(functionARN, "arn:") {
+		return functionARN
+	}
+
+	parts := strings.Split(functionARN, ":")
+	if len(parts) < 7 || parts[5] != "function" {
+		return ""
+	}
+
+	return parts[6]
 }
 
 func (s *Service) sqsQueueURL(queueARN string) string {

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -99,12 +100,16 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// emitObjectCreatedEvent sends an S3 Object Created event to EventBridge.
+// emitObjectCreatedEvent sends an S3 Object Created event to configured bucket notifications.
 func (s *Service) emitObjectCreatedEvent(ctx context.Context, bucket, key string, size int64, etag string) {
-	if !s.storage.IsEventBridgeEnabled(ctx, bucket) {
-		return
+	if s.storage.IsEventBridgeEnabled(ctx, bucket) {
+		s.emitObjectCreatedEventBridgeEvent(ctx, bucket, key, size, etag)
 	}
 
+	s.emitObjectCreatedQueueNotifications(ctx, bucket, key, size, etag)
+}
+
+func (s *Service) emitObjectCreatedEventBridgeEvent(ctx context.Context, bucket, key string, size int64, etag string) {
 	detail := map[string]any{
 		"version":    "0",
 		"bucket":     map[string]string{"name": bucket},
@@ -126,6 +131,131 @@ func (s *Service) emitObjectCreatedEvent(ctx context.Context, bucket, key string
 	})
 
 	s.putEvents(ctx, body, bucket, key)
+}
+
+func (s *Service) emitObjectCreatedQueueNotifications(ctx context.Context, bucket, key string, size int64, etag string) {
+	cfg, err := s.storage.GetBucketNotificationConfiguration(ctx, bucket)
+	if err != nil || cfg == nil {
+		return
+	}
+
+	for _, queueConfig := range cfg.QueueConfigurations {
+		if !notificationEventsMatch(queueConfig.Events, "s3:ObjectCreated:Put") {
+			continue
+		}
+
+		if !notificationFilterMatches(queueConfig.Filter, key) {
+			continue
+		}
+
+		payload, err := json.Marshal(map[string]any{
+			"Records": []map[string]any{{
+				"eventVersion": "2.1",
+				"eventSource":  "aws:s3",
+				"awsRegion":    "us-east-1",
+				"eventTime":    time.Now().UTC().Format(time.RFC3339),
+				"eventName":    "ObjectCreated:Put",
+				"s3": map[string]any{
+					"bucket": map[string]string{
+						"name": bucket,
+						"arn":  "arn:aws:s3:::" + bucket,
+					},
+					"object": map[string]any{
+						"key":  key,
+						"size": size,
+						"eTag": strings.Trim(etag, `"`),
+					},
+				},
+			}},
+		})
+		if err != nil {
+			s.logger.Error("failed to marshal S3 queue notification", "error", err)
+
+			continue
+		}
+
+		s.sendSQSNotification(ctx, queueConfig.Queue, payload)
+	}
+}
+
+func notificationEventsMatch(events []string, event string) bool {
+	for _, configured := range events {
+		if configured == event || configured == "s3:ObjectCreated:*" || configured == "s3:*" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func notificationFilterMatches(filter *NotificationFilter, key string) bool {
+	if filter == nil || filter.S3Key == nil {
+		return true
+	}
+
+	for _, rule := range filter.S3Key.Rules {
+		switch strings.ToLower(rule.Name) {
+		case "prefix":
+			if !strings.HasPrefix(key, rule.Value) {
+				return false
+			}
+		case "suffix":
+			if !strings.HasSuffix(key, rule.Value) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func (s *Service) sendSQSNotification(ctx context.Context, queueARN string, payload []byte) {
+	queueURL := s.sqsQueueURL(queueARN)
+	if queueURL == "" {
+		return
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"QueueUrl":    queueURL,
+		"MessageBody": string(payload),
+	})
+	if err != nil {
+		s.logger.Error("failed to marshal SQS SendMessage request", "error", err)
+
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+"/", bytes.NewReader(body))
+	if err != nil {
+		s.logger.Error("failed to create SQS SendMessage request", "error", err)
+
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AmazonSQS.SendMessage")
+
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	if err != nil {
+		s.logger.Error("failed to deliver S3 notification to SQS", "error", err, "queue", queueARN)
+
+		return
+	}
+
+	_ = resp.Body.Close()
+}
+
+func (s *Service) sqsQueueURL(queueARN string) string {
+	if !strings.HasPrefix(queueARN, "arn:") {
+		return queueARN
+	}
+
+	parts := strings.Split(queueARN, ":")
+	if len(parts) < 6 {
+		return ""
+	}
+
+	return s.baseURL + "/" + parts[4] + "/" + parts[5]
 }
 
 // putEvents sends a PutEvents request to the internal EventBridge endpoint.

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -31,7 +31,7 @@ type Storage interface {
 	BucketExists(ctx context.Context, name string) (bool, error)
 
 	// Object operations
-	PutObject(ctx context.Context, bucket, key string, body io.Reader, metadata map[string]string) (*Object, error)
+	PutObject(ctx context.Context, bucket, key string, body io.Reader, metadata map[string]string, options ...PutObjectOptions) (*Object, error)
 	GetObject(ctx context.Context, bucket, key string) (*Object, error)
 	GetObjectVersion(ctx context.Context, bucket, key, versionID string) (*Object, error)
 	DeleteObject(ctx context.Context, bucket, key string) (*Object, error)
@@ -64,6 +64,8 @@ type Storage interface {
 	// Notification and CORS
 	SetEventBridgeNotification(ctx context.Context, bucket string, enabled bool)
 	IsEventBridgeEnabled(ctx context.Context, bucket string) bool
+	PutBucketNotificationConfiguration(ctx context.Context, bucket string, cfg *NotificationConfiguration) error
+	GetBucketNotificationConfiguration(ctx context.Context, bucket string) (*NotificationConfiguration, error)
 	SetCORSConfiguration(ctx context.Context, bucket string, rules []CORSRule)
 	GetCORSRules(ctx context.Context, bucket string) []CORSRule
 
@@ -126,6 +128,7 @@ type MemoryBucket struct {
 	VersionIDCounter   uint64                      `json:"versionIdcounter"`            // counter for generating version IDs
 	MultipartUploads   map[string]*MultipartUpload `json:"-"`                           // uploadID -> MultipartUpload
 	EventBridgeEnabled bool                        `json:"eventBridgeEnabled"`          // EventBridge notification
+	Notification       *NotificationConfiguration  `json:"notification,omitempty"`      // bucket notification targets
 	CORSRules          []CORSRule                  `json:"corsRules,omitempty"`         // CORS configuration
 	PublicAccessBlock  *PublicAccessBlockConfig    `json:"publicAccessBlock,omitempty"` // public access block configuration
 	Encryption         *ServerSideEncryptionConfig `json:"encryption,omitempty"`        // server-side encryption configuration
@@ -303,7 +306,7 @@ func (s *MemoryStorage) BucketExists(_ context.Context, name string) (bool, erro
 }
 
 // PutObject stores an object.
-func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io.Reader, metadata map[string]string) (*Object, error) {
+func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io.Reader, metadata map[string]string, options ...PutObjectOptions) (*Object, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -338,6 +341,8 @@ func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io
 		obj.ContentType = "application/octet-stream"
 	}
 
+	applyPutObjectOptions(obj, options)
+
 	// Handle versioning
 	switch b.VersioningStatus {
 	case VersioningEnabled:
@@ -368,6 +373,16 @@ func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io
 	b.Objects[key] = obj
 
 	return obj, nil
+}
+
+func applyPutObjectOptions(obj *Object, options []PutObjectOptions) {
+	if len(options) == 0 {
+		return
+	}
+
+	obj.ServerSideEncryption = options[0].ServerSideEncryption
+	obj.SSEKMSKeyID = options[0].SSEKMSKeyID
+	obj.SSEBucketKeyEnabledRaw = options[0].SSEBucketKeyEnabledRaw
 }
 
 // GetObject retrieves an object.
@@ -577,12 +592,15 @@ func (s *MemoryStorage) HeadObject(_ context.Context, bucket, key string) (*Obje
 
 	// Return metadata only (no body)
 	return &Object{
-		Key:          obj.Key,
-		ContentType:  obj.ContentType,
-		ETag:         obj.ETag,
-		Size:         obj.Size,
-		LastModified: obj.LastModified,
-		Metadata:     obj.Metadata,
+		Key:                    obj.Key,
+		ContentType:            obj.ContentType,
+		ETag:                   obj.ETag,
+		Size:                   obj.Size,
+		LastModified:           obj.LastModified,
+		Metadata:               obj.Metadata,
+		ServerSideEncryption:   obj.ServerSideEncryption,
+		SSEKMSKeyID:            obj.SSEKMSKeyID,
+		SSEBucketKeyEnabledRaw: obj.SSEBucketKeyEnabledRaw,
 	}, nil
 }
 
@@ -1177,6 +1195,15 @@ func (s *MemoryStorage) SetEventBridgeNotification(_ context.Context, bucket str
 
 	if b, exists := s.Buckets[bucket]; exists {
 		b.EventBridgeEnabled = enabled
+		if b.Notification == nil {
+			b.Notification = &NotificationConfiguration{}
+		}
+
+		if enabled {
+			b.Notification.EventBridgeConfig = &EventBridgeConfig{}
+		} else {
+			b.Notification.EventBridgeConfig = nil
+		}
 	}
 }
 
@@ -1190,6 +1217,74 @@ func (s *MemoryStorage) IsEventBridgeEnabled(_ context.Context, bucket string) b
 	}
 
 	return false
+}
+
+// PutBucketNotificationConfiguration stores bucket notification targets.
+func (s *MemoryStorage) PutBucketNotificationConfiguration(_ context.Context, bucket string, cfg *NotificationConfiguration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	cloned := cloneNotificationConfiguration(cfg)
+	b.Notification = cloned
+	b.EventBridgeEnabled = cloned.EventBridgeConfig != nil
+
+	return nil
+}
+
+// GetBucketNotificationConfiguration returns the bucket notification config.
+func (s *MemoryStorage) GetBucketNotificationConfiguration(_ context.Context, bucket string) (*NotificationConfiguration, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, exists := s.Buckets[bucket]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	return cloneNotificationConfiguration(b.Notification), nil
+}
+
+func cloneNotificationConfiguration(cfg *NotificationConfiguration) *NotificationConfiguration {
+	if cfg == nil {
+		return &NotificationConfiguration{}
+	}
+
+	out := &NotificationConfiguration{}
+	if cfg.EventBridgeConfig != nil {
+		out.EventBridgeConfig = &EventBridgeConfig{}
+	}
+
+	if len(cfg.QueueConfigurations) > 0 {
+		out.QueueConfigurations = make([]QueueNotificationConfiguration, len(cfg.QueueConfigurations))
+		for i, q := range cfg.QueueConfigurations {
+			out.QueueConfigurations[i] = QueueNotificationConfiguration{
+				ID:     q.ID,
+				Queue:  q.Queue,
+				Events: append([]string(nil), q.Events...),
+				Filter: cloneNotificationFilter(q.Filter),
+			}
+		}
+	}
+
+	return out
+}
+
+func cloneNotificationFilter(filter *NotificationFilter) *NotificationFilter {
+	if filter == nil {
+		return nil
+	}
+
+	out := &NotificationFilter{}
+	if filter.S3Key != nil {
+		out.S3Key = &KeyFilter{Rules: append([]FilterRule(nil), filter.S3Key.Rules...)}
+	}
+
+	return out
 }
 
 // SetCORSConfiguration sets the CORS configuration for a bucket.

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -45,7 +45,7 @@ type Storage interface {
 	ListObjectVersions(ctx context.Context, bucket, prefix, delimiter string, maxKeys int) ([]Object, []string, error)
 
 	// Multipart upload operations
-	CreateMultipartUpload(ctx context.Context, bucket, key string) (*MultipartUpload, error)
+	CreateMultipartUpload(ctx context.Context, bucket, key string, options ...CreateMultipartUploadOptions) (*MultipartUpload, error)
 	UploadPart(ctx context.Context, bucket, key, uploadID string, partNumber int, body io.Reader) (*Part, error)
 	CompleteMultipartUpload(ctx context.Context, bucket, key, uploadID string, parts []PartRequest) (*Object, error)
 	AbortMultipartUpload(ctx context.Context, bucket, key, uploadID string) error
@@ -385,6 +385,19 @@ func applyPutObjectOptions(obj *Object, options []PutObjectOptions) {
 	obj.SSEBucketKeyEnabledRaw = options[0].SSEBucketKeyEnabledRaw
 }
 
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+
+	return out
+}
+
 // GetObject retrieves an object.
 func (s *MemoryStorage) GetObject(_ context.Context, bucket, key string) (*Object, error) {
 	s.mu.RLock()
@@ -447,7 +460,7 @@ func (s *MemoryStorage) PutObjectTagging(_ context.Context, bucket, key string, 
 		return &BucketError{Code: "NoSuchKey", Message: "The specified key does not exist."}
 	}
 
-	obj.Tags = tags
+	obj.Tags = cloneStringMap(tags)
 	bd.Objects[key] = obj
 
 	return nil
@@ -472,7 +485,7 @@ func (s *MemoryStorage) GetObjectTagging(_ context.Context, bucket, key string) 
 		return map[string]string{}, nil
 	}
 
-	return obj.Tags, nil
+	return cloneStringMap(obj.Tags), nil
 }
 
 // DeleteObject deletes an object.
@@ -597,7 +610,7 @@ func (s *MemoryStorage) HeadObject(_ context.Context, bucket, key string) (*Obje
 		ETag:                   obj.ETag,
 		Size:                   obj.Size,
 		LastModified:           obj.LastModified,
-		Metadata:               obj.Metadata,
+		Metadata:               cloneStringMap(obj.Metadata),
 		ServerSideEncryption:   obj.ServerSideEncryption,
 		SSEKMSKeyID:            obj.SSEKMSKeyID,
 		SSEBucketKeyEnabledRaw: obj.SSEBucketKeyEnabledRaw,
@@ -875,7 +888,7 @@ func (e *MultipartError) Error() string {
 }
 
 // CreateMultipartUpload creates a new multipart upload.
-func (s *MemoryStorage) CreateMultipartUpload(_ context.Context, bucket, key string) (*MultipartUpload, error) {
+func (s *MemoryStorage) CreateMultipartUpload(_ context.Context, bucket, key string, options ...CreateMultipartUploadOptions) (*MultipartUpload, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -892,10 +905,21 @@ func (s *MemoryStorage) CreateMultipartUpload(_ context.Context, bucket, key str
 		Initiated: time.Now(),
 		Parts:     make(map[int]*Part),
 	}
+	applyCreateMultipartUploadOptions(upload, options)
 
 	b.MultipartUploads[uploadID] = upload
 
 	return upload, nil
+}
+
+func applyCreateMultipartUploadOptions(upload *MultipartUpload, options []CreateMultipartUploadOptions) {
+	if len(options) == 0 {
+		return
+	}
+
+	upload.Metadata = cloneStringMap(options[0].Metadata)
+	upload.Tags = cloneStringMap(options[0].Tags)
+	upload.PutOptions = options[0].PutOptions
 }
 
 // UploadPart uploads a part of a multipart upload.
@@ -1037,6 +1061,13 @@ func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, 
 		Size:         int64(len(combinedBody)),
 		LastModified: time.Now(),
 		ContentType:  "application/octet-stream",
+		Metadata:     cloneStringMap(upload.Metadata),
+		Tags:         cloneStringMap(upload.Tags),
+	}
+	applyPutObjectOptions(obj, []PutObjectOptions{upload.PutOptions})
+
+	if ct := obj.Metadata["Content-Type"]; ct != "" {
+		obj.ContentType = ct
 	}
 
 	b.Objects[key] = obj
@@ -1257,6 +1288,18 @@ func cloneNotificationConfiguration(cfg *NotificationConfiguration) *Notificatio
 	out := &NotificationConfiguration{}
 	if cfg.EventBridgeConfig != nil {
 		out.EventBridgeConfig = &EventBridgeConfig{}
+	}
+
+	if len(cfg.LambdaFunctionConfigurations) > 0 {
+		out.LambdaFunctionConfigurations = make([]LambdaFunctionNotificationConfiguration, len(cfg.LambdaFunctionConfigurations))
+		for i, l := range cfg.LambdaFunctionConfigurations {
+			out.LambdaFunctionConfigurations[i] = LambdaFunctionNotificationConfiguration{
+				ID:            l.ID,
+				CloudFunction: l.CloudFunction,
+				Events:        append([]string(nil), l.Events...),
+				Filter:        cloneNotificationFilter(l.Filter),
+			}
+		}
 	}
 
 	if len(cfg.QueueConfigurations) > 0 {

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -53,6 +53,13 @@ type PutObjectOptions struct {
 	SSEBucketKeyEnabledRaw string
 }
 
+// CreateMultipartUploadOptions carries object metadata set at initiate time.
+type CreateMultipartUploadOptions struct {
+	Metadata   map[string]string
+	Tags       map[string]string
+	PutOptions PutObjectOptions
+}
+
 // Tagging represents the XML structure for S3 object tagging.
 type Tagging struct {
 	XMLName xml.Name `xml:"Tagging"`
@@ -251,11 +258,14 @@ type DeleteObjectError struct {
 
 // MultipartUpload represents an in-progress multipart upload.
 type MultipartUpload struct {
-	Bucket    string
-	Key       string
-	UploadID  string
-	Initiated time.Time
-	Parts     map[int]*Part // partNumber -> Part
+	Bucket     string
+	Key        string
+	UploadID   string
+	Initiated  time.Time
+	Parts      map[int]*Part // partNumber -> Part
+	Metadata   map[string]string
+	Tags       map[string]string
+	PutOptions PutObjectOptions
 }
 
 // Part represents a part in a multipart upload.
@@ -366,9 +376,10 @@ type CopyRange struct {
 
 // NotificationConfiguration represents S3 bucket notification configuration.
 type NotificationConfiguration struct {
-	XMLName             xml.Name                         `xml:"NotificationConfiguration"`
-	EventBridgeConfig   *EventBridgeConfig               `xml:"EventBridgeConfiguration,omitempty"`
-	QueueConfigurations []QueueNotificationConfiguration `xml:"QueueConfiguration,omitempty"`
+	XMLName                      xml.Name                                  `xml:"NotificationConfiguration"`
+	EventBridgeConfig            *EventBridgeConfig                        `xml:"EventBridgeConfiguration,omitempty"`
+	LambdaFunctionConfigurations []LambdaFunctionNotificationConfiguration `xml:"CloudFunctionConfiguration,omitempty"`
+	QueueConfigurations          []QueueNotificationConfiguration          `xml:"QueueConfiguration,omitempty"`
 }
 
 // EventBridgeConfig represents EventBridge notification configuration.
@@ -380,6 +391,14 @@ type QueueNotificationConfiguration struct {
 	Queue  string              `xml:"Queue"`
 	Events []string            `xml:"Event"`
 	Filter *NotificationFilter `xml:"Filter,omitempty"`
+}
+
+// LambdaFunctionNotificationConfiguration represents an S3 notification target for Lambda.
+type LambdaFunctionNotificationConfiguration struct {
+	ID            string              `xml:"Id,omitempty"`
+	CloudFunction string              `xml:"CloudFunction"`
+	Events        []string            `xml:"Event"`
+	Filter        *NotificationFilter `xml:"Filter,omitempty"`
 }
 
 // NotificationFilter scopes an S3 notification to matching object keys.

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -31,16 +31,26 @@ type LoggingEnabledStatus struct {
 
 // Object represents an S3 object.
 type Object struct {
-	Key            string
-	Body           []byte
-	ETag           string
-	Size           int64
-	LastModified   time.Time
-	ContentType    string
-	Metadata       map[string]string
-	Tags           map[string]string
-	VersionID      string
-	IsDeleteMarker bool
+	Key                    string
+	Body                   []byte
+	ETag                   string
+	Size                   int64
+	LastModified           time.Time
+	ContentType            string
+	Metadata               map[string]string
+	Tags                   map[string]string
+	VersionID              string
+	IsDeleteMarker         bool
+	ServerSideEncryption   string
+	SSEKMSKeyID            string
+	SSEBucketKeyEnabledRaw string
+}
+
+// PutObjectOptions carries optional headers that affect stored object metadata.
+type PutObjectOptions struct {
+	ServerSideEncryption   string
+	SSEKMSKeyID            string
+	SSEBucketKeyEnabledRaw string
 }
 
 // Tagging represents the XML structure for S3 object tagging.
@@ -356,12 +366,37 @@ type CopyRange struct {
 
 // NotificationConfiguration represents S3 bucket notification configuration.
 type NotificationConfiguration struct {
-	XMLName           xml.Name           `xml:"NotificationConfiguration"`
-	EventBridgeConfig *EventBridgeConfig `xml:"EventBridgeConfiguration,omitempty"`
+	XMLName             xml.Name                         `xml:"NotificationConfiguration"`
+	EventBridgeConfig   *EventBridgeConfig               `xml:"EventBridgeConfiguration,omitempty"`
+	QueueConfigurations []QueueNotificationConfiguration `xml:"QueueConfiguration,omitempty"`
 }
 
 // EventBridgeConfig represents EventBridge notification configuration.
 type EventBridgeConfig struct{}
+
+// QueueNotificationConfiguration represents an S3 notification target for SQS.
+type QueueNotificationConfiguration struct {
+	ID     string              `xml:"Id,omitempty"`
+	Queue  string              `xml:"Queue"`
+	Events []string            `xml:"Event"`
+	Filter *NotificationFilter `xml:"Filter,omitempty"`
+}
+
+// NotificationFilter scopes an S3 notification to matching object keys.
+type NotificationFilter struct {
+	S3Key *KeyFilter `xml:"S3Key,omitempty"`
+}
+
+// KeyFilter contains prefix/suffix filter rules.
+type KeyFilter struct {
+	Rules []FilterRule `xml:"FilterRule"`
+}
+
+// FilterRule represents a single S3 notification key filter rule.
+type FilterRule struct {
+	Name  string `xml:"Name"`
+	Value string `xml:"Value"`
+}
 
 // CORSConfiguration represents S3 bucket CORS configuration (XML request body).
 type CORSConfiguration struct {

--- a/test/integration/s3_notification_test.go
+++ b/test/integration/s3_notification_test.go
@@ -6,7 +6,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -149,6 +153,237 @@ func TestS3_QueueNotificationToSQS(t *testing.T) {
 
 	if record.S3.Bucket.Name != bucket {
 		t.Fatalf("bucket = %q, want %q", record.S3.Bucket.Name, bucket)
+	}
+
+	if record.S3.Object.Key != key {
+		t.Fatalf("key = %q, want %q", record.S3.Object.Key, key)
+	}
+}
+
+func TestS3_LambdaNotificationForObjectCreatedEvents(t *testing.T) {
+	s3Client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-s3-lambda-notification"
+	functionName := "test-s3-lambda-notification"
+
+	lambdaBackend, invocations := newLambdaBackend(t, 3)
+	defer lambdaBackend.Close()
+
+	createLambdaFunction(t, ctx, functionName, lambdaBackend.URL)
+	t.Cleanup(func() {
+		deleteLambdaFunction(t, functionName)
+	})
+
+	_, err := s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		for _, key := range []string{"images/source.jpg", "images/copy.jpg", "images/multipart.jpg"} {
+			_, _ = s3Client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String(key),
+			})
+		}
+		_, _ = s3Client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+			Bucket: aws.String(bucket),
+		})
+	})
+
+	_, err = s3Client.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
+		Bucket: aws.String(bucket),
+		NotificationConfiguration: &s3types.NotificationConfiguration{
+			LambdaFunctionConfigurations: []s3types.LambdaFunctionConfiguration{
+				{
+					Id:                aws.String("lambda-images"),
+					LambdaFunctionArn: aws.String("arn:aws:lambda:us-east-1:000000000000:function:" + functionName),
+					Events:            []s3types.Event{s3types.EventS3ObjectCreated},
+					Filter: &s3types.NotificationConfigurationFilter{
+						Key: &s3types.S3KeyFilter{
+							FilterRules: []s3types.FilterRule{
+								{
+									Name:  s3types.FilterRuleNamePrefix,
+									Value: aws.String("images/"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String("images/source.jpg"),
+		Body:   bytes.NewReader([]byte("source")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertS3LambdaEvent(t, receiveLambdaBackendInvocation(t, invocations), "ObjectCreated:Put", "images/source.jpg")
+
+	_, err = s3Client.CopyObject(ctx, &s3.CopyObjectInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String("images/copy.jpg"),
+		CopySource: aws.String(bucket + "/images/source.jpg"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertS3LambdaEvent(t, receiveLambdaBackendInvocation(t, invocations), "ObjectCreated:Copy", "images/copy.jpg")
+
+	completeMultipartForS3LambdaNotification(t, s3Client, bucket, "images/multipart.jpg")
+	assertS3LambdaEvent(t, receiveLambdaBackendInvocation(t, invocations), "ObjectCreated:CompleteMultipartUpload", "images/multipart.jpg")
+}
+
+func newLambdaBackend(t *testing.T, capacity int) (*httptest.Server, <-chan []byte) {
+	t.Helper()
+
+	invocations := make(chan []byte, capacity)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read Lambda backend body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+
+		invocations <- body
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	return server, invocations
+}
+
+func createLambdaFunction(t *testing.T, ctx context.Context, functionName, endpoint string) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]any{
+		"FunctionName":   functionName,
+		"Runtime":        "python3.12",
+		"Role":           "arn:aws:iam::000000000000:role/test-role",
+		"Handler":        "index.handler",
+		"InvokeEndpoint": endpoint,
+		"Code":           map[string]any{"ZipFile": []byte("fake-zip")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://localhost:4566/lambda/2015-03-31/functions", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("CreateFunction status = %d, want 201", resp.StatusCode)
+	}
+}
+
+func deleteLambdaFunction(t *testing.T, functionName string) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, "http://localhost:4566/lambda/2015-03-31/functions/"+functionName, http.NoBody)
+	if err != nil {
+		t.Errorf("delete lambda request: %v", err)
+
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Errorf("delete lambda function: %v", err)
+
+		return
+	}
+
+	_ = resp.Body.Close()
+}
+
+func completeMultipartForS3LambdaNotification(t *testing.T, client *s3.Client, bucket, key string) {
+	t.Helper()
+
+	ctx := t.Context()
+	createOutput, err := client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	uploadPartOutput, err := client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String(key),
+		UploadId:   createOutput.UploadId,
+		PartNumber: aws.Int32(1),
+		Body:       bytes.NewReader([]byte("multipart")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String(key),
+		UploadId: createOutput.UploadId,
+		MultipartUpload: &s3types.CompletedMultipartUpload{
+			Parts: []s3types.CompletedPart{
+				{
+					ETag:       uploadPartOutput.ETag,
+					PartNumber: aws.Int32(1),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func receiveLambdaBackendInvocation(t *testing.T, invocations <-chan []byte) []byte {
+	t.Helper()
+
+	select {
+	case body := <-invocations:
+		return body
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Lambda backend invocation")
+	}
+
+	return nil
+}
+
+func assertS3LambdaEvent(t *testing.T, body []byte, eventName, key string) {
+	t.Helper()
+
+	var envelope s3QueueNotificationEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("unmarshal Lambda event: %v body=%s", err, string(body))
+	}
+
+	if len(envelope.Records) != 1 {
+		t.Fatalf("Records length = %d, want 1", len(envelope.Records))
+	}
+
+	record := envelope.Records[0]
+	if record.EventName != eventName {
+		t.Fatalf("eventName = %q, want %q", record.EventName, eventName)
 	}
 
 	if record.S3.Object.Key != key {

--- a/test/integration/s3_notification_test.go
+++ b/test/integration/s3_notification_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+type s3QueueNotificationEnvelope struct {
+	Records []s3QueueNotificationRecord `json:"Records"` //nolint:tagliatelle // S3 notification payload uses Records.
+}
+
+type s3QueueNotificationRecord struct {
+	EventName string `json:"eventName"`
+	S3        struct {
+		Bucket struct {
+			Name string `json:"name"`
+		} `json:"bucket"`
+		Object struct {
+			Key string `json:"key"`
+		} `json:"object"`
+	} `json:"s3"`
+}
+
+func TestS3_QueueNotificationToSQS(t *testing.T) {
+	s3Client := newS3Client(t)
+	sqsClient := newSQSClient(t)
+	ctx := t.Context()
+	bucket := "test-s3-queue-notification"
+	key := "images/cat.jpg"
+	queueName := "test-s3-queue-notification"
+
+	_, err := s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createQueueOutput, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = s3Client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		_, _ = s3Client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+			Bucket: aws.String(bucket),
+		})
+		_, _ = sqsClient.DeleteQueue(context.Background(), &sqs.DeleteQueueInput{
+			QueueUrl: createQueueOutput.QueueUrl,
+		})
+	})
+
+	queueARN := "arn:aws:sqs:us-east-1:000000000000:" + queueName
+	_, err = s3Client.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
+		Bucket: aws.String(bucket),
+		NotificationConfiguration: &s3types.NotificationConfiguration{
+			QueueConfigurations: []s3types.QueueConfiguration{
+				{
+					Id:       aws.String("images"),
+					QueueArn: aws.String(queueARN),
+					Events:   []s3types.Event{s3types.EventS3ObjectCreatedPut},
+					Filter: &s3types.NotificationConfigurationFilter{
+						Key: &s3types.S3KeyFilter{
+							FilterRules: []s3types.FilterRule{
+								{
+									Name:  s3types.FilterRuleNamePrefix,
+									Value: aws.String("images/"),
+								},
+								{
+									Name:  s3types.FilterRuleNameSuffix,
+									Value: aws.String(".jpg"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getConfigOutput, err := s3Client.GetBucketNotificationConfiguration(ctx, &s3.GetBucketNotificationConfigurationInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(getConfigOutput.QueueConfigurations) != 1 {
+		t.Fatalf("QueueConfigurations length = %d, want 1", len(getConfigOutput.QueueConfigurations))
+	}
+
+	if aws.ToString(getConfigOutput.QueueConfigurations[0].QueueArn) != queueARN {
+		t.Fatalf("QueueArn = %q, want %q", aws.ToString(getConfigOutput.QueueConfigurations[0].QueueArn), queueARN)
+	}
+
+	_, err = s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader([]byte("jpeg")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receiveOutput, err := sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:        createQueueOutput.QueueUrl,
+		WaitTimeSeconds: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(receiveOutput.Messages) != 1 {
+		t.Fatalf("received messages = %d, want 1", len(receiveOutput.Messages))
+	}
+
+	var envelope s3QueueNotificationEnvelope
+
+	if err := json.Unmarshal([]byte(aws.ToString(receiveOutput.Messages[0].Body)), &envelope); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(envelope.Records) != 1 {
+		t.Fatalf("Records length = %d, want 1", len(envelope.Records))
+	}
+
+	record := envelope.Records[0]
+	if record.EventName != "ObjectCreated:Put" {
+		t.Fatalf("eventName = %q, want ObjectCreated:Put", record.EventName)
+	}
+
+	if record.S3.Bucket.Name != bucket {
+		t.Fatalf("bucket = %q, want %q", record.S3.Bucket.Name, bucket)
+	}
+
+	if record.S3.Object.Key != key {
+		t.Fatalf("key = %q, want %q", record.S3.Object.Key, key)
+	}
+}

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1600,6 +1600,184 @@ func TestS3_PutObjectSSEKMSHeaders(t *testing.T) {
 	}
 }
 
+func TestS3_CopyObjectCopiesTagsAndSSEKMSHeaders(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-copy-object-tags-sse"
+	srcKey := "source"
+	dstKey := "dest"
+	kmsKeyID := "arn:aws:kms:us-east-1:123456789012:key/copy"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(srcKey),
+		})
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(dstKey),
+		})
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+			Bucket: aws.String(bucket),
+		})
+	})
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:               aws.String(bucket),
+		Key:                  aws.String(srcKey),
+		Body:                 strings.NewReader("copy-source"),
+		Tagging:              aws.String("env=dev&team=platform"),
+		ServerSideEncryption: types.ServerSideEncryptionAwsKms,
+		SSEKMSKeyId:          aws.String(kmsKeyID),
+		BucketKeyEnabled:     aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.CopyObject(ctx, &s3.CopyObjectInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String(dstKey),
+		CopySource: aws.String(bucket + "/" + srcKey),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertS3ObjectTags(t, client, bucket, dstKey, map[string]string{"env": "dev", "team": "platform"})
+	assertS3ObjectSSEKMS(t, client, bucket, dstKey, kmsKeyID)
+}
+
+func TestS3_MultipartUploadTagsAndSSEKMSHeaders(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-multipart-tags-sse"
+	key := "large-object"
+	kmsKeyID := "arn:aws:kms:us-east-1:123456789012:key/multipart"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+			Bucket: aws.String(bucket),
+		})
+	})
+
+	createOutput, err := client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket:               aws.String(bucket),
+		Key:                  aws.String(key),
+		Tagging:              aws.String("env=prod"),
+		ServerSideEncryption: types.ServerSideEncryptionAwsKms,
+		SSEKMSKeyId:          aws.String(kmsKeyID),
+		BucketKeyEnabled:     aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if createOutput.ServerSideEncryption != types.ServerSideEncryptionAwsKms {
+		t.Fatalf("CreateMultipartUpload SSE = %q, want %q", createOutput.ServerSideEncryption, types.ServerSideEncryptionAwsKms)
+	}
+
+	uploadPartOutput, err := client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:     aws.String(bucket),
+		Key:        aws.String(key),
+		UploadId:   createOutput.UploadId,
+		PartNumber: aws.Int32(1),
+		Body:       strings.NewReader("multipart-body"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	completeOutput, err := client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:   aws.String(bucket),
+		Key:      aws.String(key),
+		UploadId: createOutput.UploadId,
+		MultipartUpload: &types.CompletedMultipartUpload{
+			Parts: []types.CompletedPart{
+				{
+					ETag:       uploadPartOutput.ETag,
+					PartNumber: aws.Int32(1),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if completeOutput.ServerSideEncryption != types.ServerSideEncryptionAwsKms {
+		t.Fatalf("CompleteMultipartUpload SSE = %q, want %q", completeOutput.ServerSideEncryption, types.ServerSideEncryptionAwsKms)
+	}
+
+	assertS3ObjectTags(t, client, bucket, key, map[string]string{"env": "prod"})
+	assertS3ObjectSSEKMS(t, client, bucket, key, kmsKeyID)
+}
+
+func assertS3ObjectTags(t *testing.T, client *s3.Client, bucket, key string, want map[string]string) {
+	t.Helper()
+
+	output, err := client.GetObjectTagging(t.Context(), &s3.GetObjectTaggingInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]string{}
+	for _, tag := range output.TagSet {
+		got[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("tag %q = %q, want %q (all=%v)", key, got[key], value, got)
+		}
+	}
+}
+
+func assertS3ObjectSSEKMS(t *testing.T, client *s3.Client, bucket, key, kmsKeyID string) {
+	t.Helper()
+
+	output, err := client.HeadObject(t.Context(), &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if output.ServerSideEncryption != types.ServerSideEncryptionAwsKms {
+		t.Fatalf("HeadObject SSE = %q, want %q", output.ServerSideEncryption, types.ServerSideEncryptionAwsKms)
+	}
+
+	if aws.ToString(output.SSEKMSKeyId) != kmsKeyID {
+		t.Fatalf("HeadObject SSEKMSKeyId = %q, want %q", aws.ToString(output.SSEKMSKeyId), kmsKeyID)
+	}
+
+	if !aws.ToBool(output.BucketKeyEnabled) {
+		t.Fatal("HeadObject BucketKeyEnabled = false, want true")
+	}
+}
+
 func TestS3_PutObject_KeyWithLeadingSlash(t *testing.T) {
 	client := newS3Client(t)
 	ctx := t.Context()

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1471,6 +1471,135 @@ func TestS3_PutAndGetObjectTagging(t *testing.T) {
 	}
 }
 
+func TestS3_PutObjectTaggingHeader(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-put-object-tagging-header"
+	key := "test-object"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+			Bucket: aws.String(bucket),
+		})
+	})
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String(key),
+		Body:    strings.NewReader("tagged-body"),
+		Tagging: aws.String("env=dev&team=platform"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tagOutput, err := client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]string{}
+	for _, tag := range tagOutput.TagSet {
+		got[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+
+	if got["env"] != "dev" || got["team"] != "platform" {
+		t.Fatalf("tags = %#v, want env=dev team=platform", got)
+	}
+}
+
+func TestS3_PutObjectSSEKMSHeaders(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-put-object-sse-kms"
+	key := "kms-object"
+	kmsKeyID := "arn:aws:kms:us-east-1:123456789012:key/test"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+			Bucket: aws.String(bucket),
+		})
+	})
+
+	putOutput, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:               aws.String(bucket),
+		Key:                  aws.String(key),
+		Body:                 strings.NewReader("encrypted-body"),
+		ServerSideEncryption: types.ServerSideEncryptionAwsKms,
+		SSEKMSKeyId:          aws.String(kmsKeyID),
+		BucketKeyEnabled:     aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if putOutput.ServerSideEncryption != types.ServerSideEncryptionAwsKms {
+		t.Fatalf("PutObject SSE = %q, want %q", putOutput.ServerSideEncryption, types.ServerSideEncryptionAwsKms)
+	}
+
+	headOutput, err := client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if headOutput.ServerSideEncryption != types.ServerSideEncryptionAwsKms {
+		t.Fatalf("HeadObject SSE = %q, want %q", headOutput.ServerSideEncryption, types.ServerSideEncryptionAwsKms)
+	}
+
+	if aws.ToString(headOutput.SSEKMSKeyId) != kmsKeyID {
+		t.Fatalf("HeadObject SSEKMSKeyId = %q, want %q", aws.ToString(headOutput.SSEKMSKeyId), kmsKeyID)
+	}
+
+	if !aws.ToBool(headOutput.BucketKeyEnabled) {
+		t.Fatal("HeadObject BucketKeyEnabled = false, want true")
+	}
+
+	getOutput, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer getOutput.Body.Close()
+
+	if getOutput.ServerSideEncryption != types.ServerSideEncryptionAwsKms {
+		t.Fatalf("GetObject SSE = %q, want %q", getOutput.ServerSideEncryption, types.ServerSideEncryptionAwsKms)
+	}
+
+	if aws.ToString(getOutput.SSEKMSKeyId) != kmsKeyID {
+		t.Fatalf("GetObject SSEKMSKeyId = %q, want %q", aws.ToString(getOutput.SSEKMSKeyId), kmsKeyID)
+	}
+}
+
 func TestS3_PutObject_KeyWithLeadingSlash(t *testing.T) {
 	client := newS3Client(t)
 	ctx := t.Context()


### PR DESCRIPTION
## Summary
- Persist tags from the PutObject x-amz-tagging header and expose them through GetObjectTagging.
- Store and return SSE-KMS object headers on PutObject, HeadObject, and GetObject.
- Store S3 bucket queue notification configuration and deliver ObjectCreated notifications to SQS, including prefix/suffix filters.
- Store S3 Lambda notification configuration and invoke Lambda asynchronously for PutObject, CopyObject, and CompleteMultipartUpload events.
- Preserve tags, metadata, and SSE-KMS headers through CopyObject and multipart upload completion.

## Tests
- go test ./internal/service/s3 -count=1
- go test ./...
- make lint
- go test -tags=integration ./integration -run '^$' -count=1
- go test -tags=integration ./integration -run 'TestS3_(LambdaNotificationForObjectCreatedEvents|CopyObjectCopiesTagsAndSSEKMSHeaders|MultipartUploadTagsAndSSEKMSHeaders|QueueNotificationToSQS)' -count=1 -v