### PR TITLE
feat(cloudwatch): implement SetAlarmState

### DIFF
--- a/internal/service/cloudwatch/handlers.go
+++ b/internal/service/cloudwatch/handlers.go
@@ -623,6 +623,30 @@ func (s *Service) DescribeAlarmsCBOR(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// SetAlarmStateCBOR handles the SetAlarmState action via CBOR protocol.
+func (s *Service) SetAlarmStateCBOR(w http.ResponseWriter, r *http.Request) {
+	var req SetAlarmStateCBORRequest
+	if err := server.DecodeCBORRequest(r, &req); err != nil {
+		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.AlarmName == "" {
+		server.WriteCBORError(w, errInvalidParameter, "AlarmName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.SetAlarmState(r.Context(), req.AlarmName, req.StateValue, req.StateReason); err != nil {
+		handleCloudWatchCBORError(w, err)
+
+		return
+	}
+
+	server.WriteCBORResponse(w, struct{}{})
+}
+
 // handleCloudWatchCBORError handles CloudWatch errors for CBOR protocol.
 func handleCloudWatchCBORError(w http.ResponseWriter, err error) {
 	var cwErr *Error

--- a/internal/service/cloudwatch/service.go
+++ b/internal/service/cloudwatch/service.go
@@ -83,6 +83,7 @@ func (s *Service) Actions() []string {
 		"PutMetricAlarm",
 		"DeleteAlarms",
 		"DescribeAlarms",
+		"SetAlarmState",
 		// Tag stubs — see tag_stubs.go.
 		"ListTagsForResource",
 		"TagResource",
@@ -111,6 +112,8 @@ func (s *Service) DispatchCBORAction(w http.ResponseWriter, r *http.Request, ope
 		s.DeleteAlarmsCBOR(w, r)
 	case "DescribeAlarms":
 		s.DescribeAlarmsCBOR(w, r)
+	case "SetAlarmState":
+		s.SetAlarmStateCBOR(w, r)
 	default:
 		server.WriteCBORError(w, "InvalidAction", "The action "+operation+" is not valid", http.StatusBadRequest)
 	}

--- a/internal/service/cloudwatch/storage.go
+++ b/internal/service/cloudwatch/storage.go
@@ -25,6 +25,7 @@ type Storage interface {
 	PutMetricAlarm(ctx context.Context, req *PutMetricAlarmRequest) error
 	DeleteAlarms(ctx context.Context, alarmNames []string) error
 	DescribeAlarms(ctx context.Context, req *DescribeAlarmsRequest) (*DescribeAlarmsResult, error)
+	SetAlarmState(ctx context.Context, alarmName, stateValue, stateReason string) error
 }
 
 // MetricKey uniquely identifies a metric.
@@ -435,6 +436,26 @@ func (s *MemoryStorage) DeleteAlarms(_ context.Context, alarmNames []string) err
 	for _, name := range alarmNames {
 		delete(s.Alarms, name)
 	}
+
+	return nil
+}
+
+// SetAlarmState sets the state of an alarm.
+func (s *MemoryStorage) SetAlarmState(_ context.Context, alarmName, stateValue, stateReason string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	alarm, exists := s.Alarms[alarmName]
+	if !exists {
+		return &Error{
+			Code:    "ResourceNotFound",
+			Message: fmt.Sprintf("Alarm %s does not exist", alarmName),
+		}
+	}
+
+	alarm.StateValue = stateValue
+	alarm.StateReason = stateReason
+	alarm.StateUpdatedAt = time.Now().UTC().Format(time.RFC3339)
 
 	return nil
 }

--- a/internal/service/cloudwatch/types.go
+++ b/internal/service/cloudwatch/types.go
@@ -158,6 +158,20 @@ type PutMetricAlarmRequest struct {
 	OKActions          []string    `json:"OKActions,omitempty"`
 }
 
+// SetAlarmStateRequest is the request for SetAlarmState.
+type SetAlarmStateRequest struct {
+	AlarmName   string `json:"AlarmName"`
+	StateValue  string `json:"StateValue"`
+	StateReason string `json:"StateReason"`
+}
+
+// SetAlarmStateCBORRequest is the CBOR request for SetAlarmState.
+type SetAlarmStateCBORRequest struct {
+	AlarmName   string `cbor:"AlarmName"`
+	StateValue  string `cbor:"StateValue"`
+	StateReason string `cbor:"StateReason"`
+}
+
 // DeleteAlarmsRequest is the request for DeleteAlarms.
 type DeleteAlarmsRequest struct {
 	AlarmNames []string `json:"AlarmNames"`

--- a/test/integration/cloudwatch_test.go
+++ b/test/integration/cloudwatch_test.go
@@ -368,3 +368,51 @@ func TestCloudWatch_PutMetricDataWithDimensions(t *testing.T) {
 		t.Fatal("expected at least one metric with matching dimensions, got none")
 	}
 }
+
+func TestCloudWatch_SetAlarmState(t *testing.T) {
+	client := newCloudWatchClient(t)
+	ctx := t.Context()
+	alarmName := "test-set-alarm-state"
+
+	// Create alarm.
+	_, err := client.PutMetricAlarm(ctx, &cloudwatch.PutMetricAlarmInput{
+		AlarmName:          aws.String(alarmName),
+		MetricName:         aws.String("TestMetric"),
+		Namespace:          aws.String("TestNamespace"),
+		Statistic:          types.StatisticAverage,
+		Period:             aws.Int32(60),
+		EvaluationPeriods:  aws.Int32(1),
+		Threshold:          aws.Float64(50.0),
+		ComparisonOperator: types.ComparisonOperatorGreaterThanThreshold,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteAlarms(context.Background(), &cloudwatch.DeleteAlarmsInput{
+			AlarmNames: []string{alarmName},
+		})
+	})
+
+	// SetAlarmState.
+	_, err = client.SetAlarmState(ctx, &cloudwatch.SetAlarmStateInput{
+		AlarmName:   aws.String(alarmName),
+		StateValue:  types.StateValueAlarm,
+		StateReason: aws.String("Test alarm"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// DescribeAlarms should reflect the new state.
+	descOutput, err := client.DescribeAlarms(ctx, &cloudwatch.DescribeAlarmsInput{
+		AlarmNames: []string{alarmName},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields(
+		"AlarmArn", "StateUpdatedTimestamp", "AlarmConfigurationUpdatedTimestamp", "ResultMetadata",
+	)).Assert(t.Name(), descOutput)
+}

--- a/test/integration/testdata/cloudwatch_test_TestCloudWatch_SetAlarmState_TestCloudWatch_SetAlarmState.golden.go
+++ b/test/integration/testdata/cloudwatch_test_TestCloudWatch_SetAlarmState_TestCloudWatch_SetAlarmState.golden.go
@@ -1,0 +1,38 @@
+{
+  "CompositeAlarms": null,
+  "MetricAlarms": [
+    {
+      "ActionsEnabled": true,
+      "AlarmActions": null,
+      "AlarmArn": "arn:aws:cloudwatch:us-east-1:000000000000:alarm:test-set-alarm-state",
+      "AlarmConfigurationUpdatedTimestamp": "2026-05-13T20:54:13+09:00",
+      "AlarmDescription": null,
+      "AlarmName": "test-set-alarm-state",
+      "ComparisonOperator": "GreaterThanThreshold",
+      "DatapointsToAlarm": null,
+      "Dimensions": null,
+      "EvaluateLowSampleCountPercentile": null,
+      "EvaluationPeriods": 1,
+      "EvaluationState": "",
+      "ExtendedStatistic": null,
+      "InsufficientDataActions": null,
+      "MetricName": "TestMetric",
+      "Metrics": null,
+      "Namespace": "TestNamespace",
+      "OKActions": null,
+      "Period": 60,
+      "StateReason": "Test alarm",
+      "StateReasonData": null,
+      "StateTransitionedTimestamp": null,
+      "StateUpdatedTimestamp": "2026-05-13T20:54:13+09:00",
+      "StateValue": "ALARM",
+      "Statistic": "Average",
+      "Threshold": 50,
+      "ThresholdMetricId": null,
+      "TreatMissingData": null,
+      "Unit": ""
+    }
+  ],
+  "NextToken": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add `SetAlarmState` to Storage interface and MemoryStorage
- Add CBOR handler with dispatch routing
- Add to Actions() for Query protocol
- Add integration test with golden assertion

Closes #646, Ref: #416