### PR TITLE
fix(s3): support x-amz-tagging header and SSE-KMS in PutObject

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -725,17 +725,7 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	metadata := make(map[string]string)
-	if ct := r.Header.Get("Content-Type"); ct != "" {
-		metadata["Content-Type"] = ct
-	}
-
-	// Extract x-amz-meta-* headers
-	for name, values := range r.Header {
-		if metaKey, found := strings.CutPrefix(strings.ToLower(name), "x-amz-meta-"); found {
-			metadata[metaKey] = values[0]
-		}
-	}
+	metadata := extractObjectMetadata(r)
 
 	obj, err := s.storage.PutObject(r.Context(), bucket, key, r.Body, metadata)
 	if err != nil {
@@ -749,6 +739,14 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
 
 		return
+	}
+
+	// Store tags from x-amz-tagging header (URL-encoded query string format).
+	if taggingHeader := r.Header.Get("X-Amz-Tagging"); taggingHeader != "" {
+		tags := parseTaggingHeader(taggingHeader)
+		if len(tags) > 0 {
+			_ = s.storage.PutObjectTagging(r.Context(), bucket, key, tags)
+		}
 	}
 
 	w.Header().Set("ETag", obj.ETag)
@@ -1036,6 +1034,14 @@ func writeObjectResponse(w http.ResponseWriter, obj *Object) {
 		}
 	}
 
+	if obj.ServerSideEncryption != "" {
+		w.Header().Set("x-amz-server-side-encryption", obj.ServerSideEncryption)
+	}
+
+	if obj.SSEKMSKeyID != "" {
+		w.Header().Set("x-amz-server-side-encryption-aws-kms-key-id", obj.SSEKMSKeyID)
+	}
+
 	w.WriteHeader(http.StatusOK)
 
 	_, _ = w.Write(obj.Body)
@@ -1217,6 +1223,14 @@ func (s *Service) HeadObject(w http.ResponseWriter, r *http.Request) {
 		if k != contentTypeHeader {
 			w.Header().Set("x-amz-meta-"+k, v)
 		}
+	}
+
+	if obj.ServerSideEncryption != "" {
+		w.Header().Set("x-amz-server-side-encryption", obj.ServerSideEncryption)
+	}
+
+	if obj.SSEKMSKeyID != "" {
+		w.Header().Set("x-amz-server-side-encryption-aws-kms-key-id", obj.SSEKMSKeyID)
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -2335,6 +2349,48 @@ func handleMultipartError(w http.ResponseWriter, r *http.Request, err error) {
 	}
 
 	writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+}
+
+// extractObjectMetadata builds the metadata map from request headers.
+func extractObjectMetadata(r *http.Request) map[string]string {
+	metadata := make(map[string]string)
+
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		metadata["Content-Type"] = ct
+	}
+
+	for name, values := range r.Header {
+		if metaKey, found := strings.CutPrefix(strings.ToLower(name), "x-amz-meta-"); found {
+			metadata[metaKey] = values[0]
+		}
+	}
+
+	if sse := r.Header.Get("X-Amz-Server-Side-Encryption"); sse != "" {
+		metadata["x-amz-server-side-encryption"] = sse
+	}
+
+	if sseKey := r.Header.Get("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id"); sseKey != "" {
+		metadata["x-amz-server-side-encryption-aws-kms-key-id"] = sseKey
+	}
+
+	return metadata
+}
+
+// parseTaggingHeader parses the x-amz-tagging header value.
+// Format: URL-encoded query string, e.g. "key1=value1&key2=value2".
+func parseTaggingHeader(header string) map[string]string {
+	tags := make(map[string]string)
+
+	for _, pair := range strings.Split(header, "&") {
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok || k == "" {
+			continue
+		}
+
+		tags[k] = v
+	}
+
+	return tags
 }
 
 // PutObjectTagging handles PUT /{bucket}/{key}?tagging.

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -332,6 +332,8 @@ func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io
 		if ct, ok := metadata["Content-Type"]; ok {
 			obj.ContentType = ct
 		}
+
+		applySSEMetadata(obj, metadata)
 	}
 
 	if obj.ContentType == "" {
@@ -368,6 +370,15 @@ func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io
 	b.Objects[key] = obj
 
 	return obj, nil
+}
+
+// applySSEMetadata extracts SSE headers from metadata and sets them on the object.
+func applySSEMetadata(obj *Object, metadata map[string]string) {
+	obj.ServerSideEncryption = metadata["x-amz-server-side-encryption"]
+	delete(metadata, "x-amz-server-side-encryption")
+
+	obj.SSEKMSKeyID = metadata["x-amz-server-side-encryption-aws-kms-key-id"]
+	delete(metadata, "x-amz-server-side-encryption-aws-kms-key-id")
 }
 
 // GetObject retrieves an object.
@@ -577,12 +588,15 @@ func (s *MemoryStorage) HeadObject(_ context.Context, bucket, key string) (*Obje
 
 	// Return metadata only (no body)
 	return &Object{
-		Key:          obj.Key,
-		ContentType:  obj.ContentType,
-		ETag:         obj.ETag,
-		Size:         obj.Size,
-		LastModified: obj.LastModified,
-		Metadata:     obj.Metadata,
+		Key:                  obj.Key,
+		ContentType:          obj.ContentType,
+		ETag:                 obj.ETag,
+		Size:                 obj.Size,
+		LastModified:         obj.LastModified,
+		Metadata:             obj.Metadata,
+		VersionID:            obj.VersionID,
+		ServerSideEncryption: obj.ServerSideEncryption,
+		SSEKMSKeyID:          obj.SSEKMSKeyID,
 	}, nil
 }
 

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -31,16 +31,18 @@ type LoggingEnabledStatus struct {
 
 // Object represents an S3 object.
 type Object struct {
-	Key            string
-	Body           []byte
-	ETag           string
-	Size           int64
-	LastModified   time.Time
-	ContentType    string
-	Metadata       map[string]string
-	Tags           map[string]string
-	VersionID      string
-	IsDeleteMarker bool
+	Key                  string
+	Body                 []byte
+	ETag                 string
+	Size                 int64
+	LastModified         time.Time
+	ContentType          string
+	Metadata             map[string]string
+	Tags                 map[string]string
+	VersionID            string
+	IsDeleteMarker       bool
+	ServerSideEncryption string
+	SSEKMSKeyID          string
 }
 
 // Tagging represents the XML structure for S3 object tagging.

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1769,3 +1769,87 @@ func TestS3_BucketCors(t *testing.T) {
 	}
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), getOutput)
 }
+
+func TestS3_PutObjectWithTagging(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-put-object-tagging"
+	key := "tagged-object.txt"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)})
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	})
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String(key),
+		Body:    strings.NewReader("hello"),
+		Tagging: aws.String("env=test&team=infra"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tagOutput, err := client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), tagOutput)
+}
+
+func TestS3_PutObjectWithSSEKMS(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-put-object-sse"
+	key := "encrypted.txt"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)})
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	})
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:               aws.String(bucket),
+		Key:                  aws.String(key),
+		Body:                 strings.NewReader("secret"),
+		ServerSideEncryption: types.ServerSideEncryptionAwsKms,
+		SSEKMSKeyId:          aws.String("arn:aws:kms:us-east-1:000000000000:key/test-key"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	headOutput, err := client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if headOutput.ServerSideEncryption != types.ServerSideEncryptionAwsKms {
+		t.Errorf("expected SSE algorithm aws:kms, got %s", headOutput.ServerSideEncryption)
+	}
+
+	if aws.ToString(headOutput.SSEKMSKeyId) == "" {
+		t.Error("expected SSEKMSKeyId to be set")
+	}
+}

--- a/test/integration/testdata/s3_test_TestS3_PutObjectWithTagging_TestS3_PutObjectWithTagging.golden.go
+++ b/test/integration/testdata/s3_test_TestS3_PutObjectWithTagging_TestS3_PutObjectWithTagging.golden.go
@@ -1,0 +1,14 @@
+{
+  "TagSet": [
+    {
+      "Key": "env",
+      "Value": "test"
+    },
+    {
+      "Key": "team",
+      "Value": "infra"
+    }
+  ],
+  "VersionId": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Parse `x-amz-tagging` header on PutObject and store tags via PutObjectTagging
- Store `x-amz-server-side-encryption` and `x-amz-server-side-encryption-aws-kms-key-id` from PutObject
- Return SSE headers in HeadObject and GetObject
- Fix HeadObject to copy VersionID and SSE fields from stored object
- Add integration tests with golden assertions

Closes #647, #655, Ref: #416