### PR TITLE
fix(sns): pass MessageGroupId and MessageDeduplicationId to SQS on FIFO publish

### DIFF
--- a/internal/server/sns_sqs_wiring.go
+++ b/internal/server/sns_sqs_wiring.go
@@ -65,7 +65,7 @@ type snsToSQSPublisher struct {
 // PublishToSQS hands a single message to the SQS storage layer. The
 // MessageId / Subject attributes the SNS layer attaches are forwarded as
 // SQS message attributes (String type) so subscribers can read them.
-func (p *snsToSQSPublisher) PublishToSQS(ctx context.Context, endpoint, body string, attrs map[string]string) error {
+func (p *snsToSQSPublisher) PublishToSQS(ctx context.Context, endpoint, body, messageGroupID, messageDeduplicationID string, attrs map[string]string) error {
 	queueURL := p.endpointToQueueURL(endpoint)
 
 	mAttrs := make(map[string]sqs.MessageAttributeValue, len(attrs))
@@ -73,7 +73,7 @@ func (p *snsToSQSPublisher) PublishToSQS(ctx context.Context, endpoint, body str
 		mAttrs[k] = sqs.MessageAttributeValue{DataType: "String", StringValue: v}
 	}
 
-	_, err := p.storage.SendMessage(ctx, queueURL, body, 0, mAttrs, "", "")
+	_, err := p.storage.SendMessage(ctx, queueURL, body, 0, mAttrs, messageGroupID, messageDeduplicationID)
 	if err != nil {
 		return err //nolint:wrapcheck // adapter is a thin pass-through
 	}

--- a/internal/service/sns/handlers.go
+++ b/internal/service/sns/handlers.go
@@ -262,7 +262,7 @@ func (s *Service) Publish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	messageID, err := s.storage.Publish(r.Context(), topicARN, req.Message, req.Subject, req.MessageAttributes)
+	messageID, err := s.storage.Publish(r.Context(), topicARN, req.Message, req.Subject, req.MessageGroupID, req.MessageDeduplicationID, req.MessageAttributes)
 	if err != nil {
 		var sErr *TopicError
 		if errors.As(err, &sErr) {

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -21,7 +21,7 @@ const (
 
 // SQSPublisher is an interface for publishing messages to SQS.
 type SQSPublisher interface {
-	PublishToSQS(ctx context.Context, queueURL, messageBody string, attributes map[string]string) error
+	PublishToSQS(ctx context.Context, queueURL, messageBody, messageGroupID, messageDeduplicationID string, attributes map[string]string) error
 }
 
 // Storage defines the SNS storage interface.
@@ -35,7 +35,7 @@ type Storage interface {
 	GetSubscription(ctx context.Context, subscriptionARN string) (*Subscription, error)
 	SetSubscriptionAttribute(ctx context.Context, subscriptionARN, name, value string) error
 	Unsubscribe(ctx context.Context, subscriptionARN string) error
-	Publish(ctx context.Context, topicARN, message, subject string, attributes map[string]MessageAttribute) (string, error)
+	Publish(ctx context.Context, topicARN, message, subject, messageGroupID, messageDeduplicationID string, attributes map[string]MessageAttribute) (string, error)
 	ListSubscriptions(ctx context.Context, nextToken string) ([]*Subscription, string, error)
 	ListSubscriptionsByTopic(ctx context.Context, topicARN, nextToken string) ([]*Subscription, string, error)
 }
@@ -390,7 +390,7 @@ func (m *MemoryStorage) Unsubscribe(_ context.Context, subscriptionARN string) e
 }
 
 // Publish publishes a message to a topic.
-func (m *MemoryStorage) Publish(ctx context.Context, topicARN, message, subject string, attributes map[string]MessageAttribute) (string, error) {
+func (m *MemoryStorage) Publish(ctx context.Context, topicARN, message, subject, messageGroupID, messageDeduplicationID string, attributes map[string]MessageAttribute) (string, error) {
 	m.mu.RLock()
 
 	topic, exists := m.Topics[topicARN]
@@ -414,7 +414,7 @@ func (m *MemoryStorage) Publish(ctx context.Context, topicARN, message, subject 
 
 	// Deliver to all subscriptions.
 	for _, sub := range subscriptions {
-		if err := m.deliverMessage(ctx, sub, message, subject, messageID, attributes); err != nil {
+		if err := m.deliverMessage(ctx, sub, message, subject, messageID, messageGroupID, messageDeduplicationID, attributes); err != nil {
 			// Log error but continue delivering to other subscriptions.
 			continue
 		}
@@ -424,7 +424,7 @@ func (m *MemoryStorage) Publish(ctx context.Context, topicARN, message, subject 
 }
 
 // deliverMessage delivers a message to a subscription.
-func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, message, subject, messageID string, _ map[string]MessageAttribute) error {
+func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, message, subject, messageID, messageGroupID, messageDeduplicationID string, _ map[string]MessageAttribute) error {
 	switch sub.Protocol {
 	case "sqs":
 		if m.SqsPublisher != nil {
@@ -435,7 +435,7 @@ func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, m
 				attrs["Subject"] = subject
 			}
 
-			if err := m.SqsPublisher.PublishToSQS(ctx, sub.Endpoint, message, attrs); err != nil {
+			if err := m.SqsPublisher.PublishToSQS(ctx, sub.Endpoint, message, messageGroupID, messageDeduplicationID, attrs); err != nil {
 				return fmt.Errorf("failed to publish to SQS: %w", err)
 			}
 


### PR DESCRIPTION
## Summary

- Add `messageGroupID` and `messageDeduplicationID` params to `Publish`, `deliverMessage`, `SQSPublisher.PublishToSQS`
- Thread FIFO attributes through the entire SNS -> SQS delivery chain
- Update `sns_sqs_wiring.go` to pass them to `SendMessage`

Closes #651, Ref: #416