### PR TITLE
Add chaos and billing emulation APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,16 @@ kumo provides additional endpoints under the `/kumo/` prefix for testing purpose
 |--------|------|-------------|
 | GET | `/kumo/ses/v2/sent-emails` | Retrieve a list of emails sent via the SES v2 `SendEmail` API |
 | GET | `/kumo/pinpointsmsvoicev2/sent-messages` | Retrieve a list of SMS messages sent via the Pinpoint SMS Voice v2 `SendTextMessage` API |
+| GET | `/kumo/chaos/services` | List service names and aliases accepted by chaos and billing rules |
+| GET | `/kumo/chaos/rules` | List active chaos rules |
+| PUT | `/kumo/chaos/rules/{id}` | Create or replace a chaos rule |
+| DELETE | `/kumo/chaos/rules/{id}` | Delete a chaos rule |
+| POST | `/kumo/chaos/reset` | Remove all chaos rules |
+| GET | `/kumo/billing/usage` | Retrieve metered API usage |
+| GET | `/kumo/billing/rate-card` | Retrieve the current billing rate card |
+| PUT | `/kumo/billing/rate-card` | Replace the billing rate card |
+| GET | `/kumo/billing/cost` | Estimate cost from metered usage and the current rate card |
+| POST | `/kumo/billing/reset` | Reset metered usage |
 
 ### Example: Retrieving sent emails
 
@@ -505,6 +515,45 @@ Response:
     }
   ]
 }
+```
+
+### Example: Injecting tail latency
+
+Chaos rules match normalized AWS service and operation names. Aliases such as `events`
+for EventBridge or `states` for Step Functions are accepted, but responses normalize
+service names to their AWS SDK-style names.
+
+```bash
+curl -X PUT http://localhost:4566/kumo/chaos/rules/s3-tail-latency \
+  -H 'content-type: application/json' \
+  -d '{
+    "enabled": true,
+    "match": {"service": "s3", "action": "PutObject"},
+    "fault": {
+      "type": "delay",
+      "latency": {"p50Ms": 20, "p95Ms": 300, "p99Ms": 1500, "maxMs": 3000}
+    }
+  }'
+```
+
+### Example: Estimating request cost
+
+The billing emulator records request counts and request/response bytes. Prices are
+provided by the caller so tests can model AWS Pricing Calculator-style scenarios
+without baking changing public AWS prices into kumo.
+
+```bash
+curl -X PUT http://localhost:4566/kumo/billing/rate-card \
+  -H 'content-type: application/json' \
+  -d '{
+    "currency": "USD",
+    "rates": [
+      {"service": "s3", "dimension": "requests.put_object", "unit": "1000_requests", "price": 0.005},
+      {"service": "s3", "dimension": "response.bytes", "unit": "GB", "price": 0.09}
+    ]
+  }'
+
+curl http://localhost:4566/kumo/billing/cost
 ```
 
 ## Development

--- a/internal/awsapi/request.go
+++ b/internal/awsapi/request.go
@@ -1,0 +1,13 @@
+// Package awsapi contains normalized request metadata shared by kumo runtime features.
+package awsapi
+
+// RequestInfo is the normalized identity of an emulated AWS API request.
+type RequestInfo struct {
+	Service  string `json:"service,omitempty"`
+	Action   string `json:"action,omitempty"`
+	Method   string `json:"method,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Pattern  string `json:"pattern,omitempty"`
+	Protocol string `json:"protocol,omitempty"`
+	Resource string `json:"resource,omitempty"`
+}

--- a/internal/billing/meter.go
+++ b/internal/billing/meter.go
@@ -1,0 +1,258 @@
+package billing
+
+import (
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/sivchari/kumo/internal/servicecatalog"
+)
+
+const defaultCurrency = "USD"
+
+// Meter stores usage events and calculates cost from a caller-provided rate card.
+type Meter struct {
+	mu       sync.Mutex
+	catalog  *servicecatalog.Catalog
+	events   []UsageEvent
+	rateCard RateCard
+}
+
+// NewMeter creates an empty meter.
+func NewMeter(catalogs ...*servicecatalog.Catalog) *Meter {
+	catalog := servicecatalog.NewDefault()
+	if len(catalogs) > 0 && catalogs[0] != nil {
+		catalog = catalogs[0]
+	}
+
+	return &Meter{
+		catalog:  catalog,
+		rateCard: RateCard{Currency: defaultCurrency},
+	}
+}
+
+// Record adds one request usage event.
+func (m *Meter) Record(usage *RequestUsage) {
+	if usage == nil {
+		return
+	}
+
+	if usage.Info.Service == "" {
+		return
+	}
+
+	serviceName := m.catalog.MustNormalize(usage.Info.Service)
+	event := UsageEvent{
+		Service:  serviceName,
+		Action:   usage.Info.Action,
+		Resource: usage.Info.Resource,
+		Status:   usage.Status,
+		Dimensions: map[string]float64{
+			"requests.total": 1,
+			"request.bytes":  float64(maxInt64(usage.RequestBytes, 0)),
+			"response.bytes": float64(maxInt64(usage.ResponseBytes, 0)),
+		},
+	}
+
+	if usage.Info.Action != "" {
+		event.Dimensions["requests."+snakeAction(usage.Info.Action)] = 1
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.events = append(m.events, event)
+}
+
+// Reset removes all usage events.
+func (m *Meter) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.events = nil
+}
+
+// Usage returns aggregated usage.
+func (m *Meter) Usage() UsageSnapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return usageSnapshot(m.events)
+}
+
+// SetRateCard replaces the current rate card.
+func (m *Meter) SetRateCard(card RateCard) {
+	if card.Currency == "" {
+		card.Currency = defaultCurrency
+	}
+
+	for i := range card.Rates {
+		card.Rates[i].Service = m.catalog.MustNormalize(card.Rates[i].Service)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.rateCard = card
+}
+
+// RateCard returns the current rate card.
+func (m *Meter) RateCard() RateCard {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.rateCard
+}
+
+// Cost calculates current usage cost from the current rate card.
+func (m *Meter) Cost() CostResponse {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	usage := usageSnapshot(m.events)
+	rates := make(map[string]Rate, len(m.rateCard.Rates))
+
+	for _, rate := range m.rateCard.Rates {
+		rates[rateKey(rate.Service, rate.Dimension)] = rate
+	}
+
+	lineItems := make([]CostLineItem, 0)
+	totalCost := 0.0
+
+	for _, item := range usage.Usage {
+		rate, ok := rates[rateKey(item.Service, item.Dimension)]
+		if !ok {
+			continue
+		}
+
+		unitCount := normalizeQuantity(item.Quantity, rate.Unit)
+		cost := unitCount * rate.Price
+		totalCost += cost
+
+		lineItems = append(lineItems, CostLineItem{
+			Service:   item.Service,
+			Action:    item.Action,
+			Resource:  item.Resource,
+			Dimension: item.Dimension,
+			Quantity:  item.Quantity,
+			Unit:      rate.Unit,
+			UnitCount: unitCount,
+			Price:     rate.Price,
+			Cost:      cost,
+		})
+	}
+
+	sort.Slice(lineItems, func(i, j int) bool {
+		if lineItems[i].Service != lineItems[j].Service {
+			return lineItems[i].Service < lineItems[j].Service
+		}
+
+		if lineItems[i].Dimension != lineItems[j].Dimension {
+			return lineItems[i].Dimension < lineItems[j].Dimension
+		}
+
+		return lineItems[i].Action < lineItems[j].Action
+	})
+
+	currency := m.rateCard.Currency
+	if currency == "" {
+		currency = defaultCurrency
+	}
+
+	return CostResponse{
+		Currency:  currency,
+		Total:     totalCost,
+		LineItems: lineItems,
+	}
+}
+
+func usageSnapshot(events []UsageEvent) UsageSnapshot {
+	totals := make(map[string]UsageTotal)
+
+	for _, event := range events {
+		for dimension, quantity := range event.Dimensions {
+			key := usageKey(event.Service, event.Action, event.Resource, dimension)
+			total := totals[key]
+			total.Service = event.Service
+			total.Action = event.Action
+			total.Resource = event.Resource
+			total.Dimension = dimension
+			total.Quantity += quantity
+			totals[key] = total
+		}
+	}
+
+	out := make([]UsageTotal, 0, len(totals))
+	for _, total := range totals {
+		out = append(out, total)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Service != out[j].Service {
+			return out[i].Service < out[j].Service
+		}
+
+		if out[i].Action != out[j].Action {
+			return out[i].Action < out[j].Action
+		}
+
+		if out[i].Dimension != out[j].Dimension {
+			return out[i].Dimension < out[j].Dimension
+		}
+
+		return out[i].Resource < out[j].Resource
+	})
+
+	return UsageSnapshot{Usage: out}
+}
+
+func normalizeQuantity(quantity float64, unit string) float64 {
+	switch unit {
+	case UnitRequest:
+		return quantity
+	case UnitThousandRequests:
+		return quantity / 1000
+	case UnitMillionRequests:
+		return quantity / 1000000
+	case UnitByte:
+		return quantity
+	case UnitKB:
+		return quantity / 1024
+	case UnitMB:
+		return quantity / (1024 * 1024)
+	case UnitGB:
+		return quantity / (1024 * 1024 * 1024)
+	default:
+		return quantity
+	}
+}
+
+func usageKey(service, action, resource, dimension string) string {
+	return service + "\x00" + action + "\x00" + resource + "\x00" + dimension
+}
+
+func rateKey(service, dimension string) string {
+	return strings.ToLower(service) + "\x00" + strings.ToLower(dimension)
+}
+
+func snakeAction(action string) string {
+	var b strings.Builder
+
+	for i, r := range action {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			b.WriteByte('_')
+		}
+
+		b.WriteRune(r)
+	}
+
+	return strings.ToLower(b.String())
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+
+	return b
+}

--- a/internal/billing/meter_test.go
+++ b/internal/billing/meter_test.go
@@ -1,0 +1,58 @@
+package billing
+
+import (
+	"testing"
+
+	"github.com/sivchari/kumo/internal/awsapi"
+)
+
+func TestMeterAggregatesUsageAndCalculatesCostFromRateCard(t *testing.T) {
+	meter := NewMeter()
+	meter.SetRateCard(RateCard{
+		Currency: "USD",
+		Rates: []Rate{
+			{
+				Service:   "s3",
+				Dimension: "requests.put_object",
+				Unit:      UnitThousandRequests,
+				Price:     0.005,
+			},
+			{
+				Service:   "s3",
+				Dimension: "response.bytes",
+				Unit:      UnitGB,
+				Price:     0.09,
+			},
+		},
+	})
+
+	for range 2 {
+		meter.Record(&RequestUsage{
+			Info: awsapi.RequestInfo{
+				Service: "s3",
+				Action:  "PutObject",
+			},
+			RequestBytes:  100,
+			ResponseBytes: 1024 * 1024 * 1024,
+			Status:        200,
+		})
+	}
+
+	usage := meter.Usage()
+	if got := usage.Quantity("s3", "PutObject", "requests.put_object"); got != 2 {
+		t.Fatalf("requests.put_object = %v, want 2", got)
+	}
+
+	if got := usage.Quantity("s3", "PutObject", "response.bytes"); got != 2*1024*1024*1024 {
+		t.Fatalf("response.bytes = %v, want %v", got, 2*1024*1024*1024)
+	}
+
+	cost := meter.Cost()
+	if cost.Currency != "USD" {
+		t.Fatalf("currency = %q, want USD", cost.Currency)
+	}
+
+	if cost.Total != 0.18001 {
+		t.Fatalf("total = %v, want 0.18001", cost.Total)
+	}
+}

--- a/internal/billing/types.go
+++ b/internal/billing/types.go
@@ -1,0 +1,98 @@
+// Package billing meters emulated AWS API usage and applies caller-provided rate cards.
+package billing
+
+import "github.com/sivchari/kumo/internal/awsapi"
+
+const (
+	// UnitRequest prices one raw request.
+	UnitRequest = "request"
+	// UnitThousandRequests prices one thousand requests.
+	UnitThousandRequests = "1000_requests"
+	// UnitMillionRequests prices one million requests.
+	UnitMillionRequests = "1000000_requests"
+	// UnitByte prices one raw byte.
+	UnitByte = "byte"
+	// UnitKB prices 1024 bytes.
+	UnitKB = "KB"
+	// UnitMB prices 1024^2 bytes.
+	UnitMB = "MB"
+	// UnitGB prices 1024^3 bytes.
+	UnitGB = "GB"
+)
+
+// RequestUsage is one metered HTTP request after it passed through kumo.
+type RequestUsage struct {
+	Info          awsapi.RequestInfo
+	RequestBytes  int64
+	ResponseBytes int64
+	Status        int
+}
+
+// UsageEvent is the append-only metering shape behind the aggregate snapshot.
+type UsageEvent struct {
+	Service    string             `json:"service"`
+	Action     string             `json:"action,omitempty"`
+	Resource   string             `json:"resource,omitempty"`
+	Status     int                `json:"status"`
+	Dimensions map[string]float64 `json:"dimensions"`
+}
+
+// UsageTotal is an aggregated usage quantity.
+type UsageTotal struct {
+	Service   string  `json:"service"`
+	Action    string  `json:"action,omitempty"`
+	Resource  string  `json:"resource,omitempty"`
+	Dimension string  `json:"dimension"`
+	Quantity  float64 `json:"quantity"`
+}
+
+// UsageSnapshot is returned by /kumo/billing/usage.
+type UsageSnapshot struct {
+	Usage []UsageTotal `json:"usage"`
+}
+
+// Quantity returns one aggregate quantity for tests and callers.
+func (s UsageSnapshot) Quantity(service, action, dimension string) float64 {
+	for _, total := range s.Usage {
+		if total.Service == service && total.Action == action && total.Dimension == dimension {
+			return total.Quantity
+		}
+	}
+
+	return 0
+}
+
+// RateCard contains caller-provided prices. kumo deliberately does not bake
+// changing AWS public prices into the binary.
+type RateCard struct {
+	Currency string `json:"currency"`
+	Rates    []Rate `json:"rates"`
+}
+
+// Rate prices one usage dimension for one service.
+type Rate struct {
+	Service   string  `json:"service"`
+	Dimension string  `json:"dimension"`
+	Unit      string  `json:"unit"`
+	Price     float64 `json:"price"`
+}
+
+// CostResponse is returned by /kumo/billing/cost.
+type CostResponse struct {
+	Currency  string         `json:"currency"`
+	Total     float64        `json:"total"`
+	LineItems []CostLineItem `json:"lineItems"`
+}
+
+// CostLineItem is one rate-applied usage total.
+type CostLineItem struct {
+	Service   string  `json:"service"`
+	Action    string  `json:"action,omitempty"`
+	Resource  string  `json:"resource,omitempty"`
+	Dimension string  `json:"dimension"`
+	Quantity  float64 `json:"quantity"`
+	Unit      string  `json:"unit"`
+	UnitCount float64 `json:"unitCount"`
+	Price     float64 `json:"price"`
+	Cost      float64 `json:"cost"`
+}

--- a/internal/chaos/engine.go
+++ b/internal/chaos/engine.go
@@ -1,0 +1,320 @@
+package chaos
+
+import (
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sivchari/kumo/internal/awsapi"
+	"github.com/sivchari/kumo/internal/servicecatalog"
+)
+
+var (
+	errInvalidLatencyProfile = errors.New("latency profile must satisfy 0 <= p50Ms <= p95Ms <= p99Ms <= maxMs")
+	errInvalidRateLimit      = errors.New("rate_limit faults require limit.rps > 0 and limit.burst > 0")
+)
+
+// Engine evaluates chaos rules against normalized AWS requests.
+type Engine struct {
+	mu       sync.Mutex
+	catalog  *servicecatalog.Catalog
+	rules    map[string]Rule
+	order    []string
+	buckets  map[string]*tokenBucket
+	rng      *rand.Rand
+	clock    func() time.Time
+	disabled bool
+}
+
+// NewEngine creates a chaos engine with no rules.
+func NewEngine(catalog *servicecatalog.Catalog) *Engine {
+	if catalog == nil {
+		catalog = servicecatalog.NewDefault()
+	}
+
+	return &Engine{
+		catalog: catalog,
+		rules:   make(map[string]Rule),
+		buckets: make(map[string]*tokenBucket),
+		rng:     newRand(time.Now().UnixNano()),
+		clock:   time.Now,
+	}
+}
+
+// SetSeed makes probability and latency sampling deterministic.
+func (e *Engine) SetSeed(seed int64) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.rng = newRand(seed)
+}
+
+// SetClock replaces the engine clock. It is intended for tests.
+func (e *Engine) SetClock(clock func() time.Time) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.clock = clock
+}
+
+// UpsertRule inserts or replaces a rule.
+func (e *Engine) UpsertRule(rule *Rule) error {
+	if rule.ID == "" {
+		return fmt.Errorf("rule id is required")
+	}
+
+	rule.Match.Service = e.catalog.MustNormalize(rule.Match.Service)
+
+	if err := validateFault(&rule.Fault); err != nil {
+		return err
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if _, exists := e.rules[rule.ID]; !exists {
+		e.order = append(e.order, rule.ID)
+		sort.Strings(e.order)
+	}
+
+	e.rules[rule.ID] = *rule
+	if rule.Fault.Type == FaultRateLimit && rule.Fault.Limit != nil {
+		e.buckets[rule.ID] = newTokenBucket(rule.Fault.Limit.RPS, rule.Fault.Limit.Burst, e.clock())
+	}
+
+	return nil
+}
+
+// DeleteRule removes a rule by id.
+func (e *Engine) DeleteRule(id string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	delete(e.rules, id)
+	delete(e.buckets, id)
+
+	for i, ruleID := range e.order {
+		if ruleID == id {
+			e.order = append(e.order[:i], e.order[i+1:]...)
+
+			return
+		}
+	}
+}
+
+// Rules returns all rules sorted by id.
+func (e *Engine) Rules() []Rule {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	out := make([]Rule, 0, len(e.order))
+	for _, id := range e.order {
+		out = append(out, e.rules[id])
+	}
+
+	return out
+}
+
+// Reset removes all rules and limiter state.
+func (e *Engine) Reset() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.rules = make(map[string]Rule)
+	e.order = nil
+	e.buckets = make(map[string]*tokenBucket)
+}
+
+// Evaluate returns the first effective fault decision for info.
+func (e *Engine) Evaluate(info *awsapi.RequestInfo) *Decision {
+	if info == nil {
+		return nil
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.disabled {
+		return nil
+	}
+
+	normalized := *info
+	normalized.Service = e.catalog.MustNormalize(normalized.Service)
+	now := e.clock()
+
+	for _, id := range e.order {
+		rule := e.rules[id]
+
+		decision := e.evaluateRule(&rule, &normalized, now)
+		if decision == nil {
+			continue
+		}
+
+		return decision
+	}
+
+	return nil
+}
+
+func (e *Engine) evaluateRule(rule *Rule, info *awsapi.RequestInfo, now time.Time) *Decision {
+	if !rule.Enabled || !matches(&rule.Match, info) {
+		return nil
+	}
+
+	if rule.Fault.Until != nil && now.After(*rule.Fault.Until) {
+		return nil
+	}
+
+	if !e.probabilityAllows(rule.Fault.Probability) {
+		return nil
+	}
+
+	switch rule.Fault.Type {
+	case FaultError:
+		errSpec := defaultErrorSpec(&rule.Fault)
+
+		return &Decision{RuleID: rule.ID, Error: &errSpec}
+	case FaultDelay:
+		return e.delayDecision(rule)
+	case FaultRateLimit:
+		return e.rateLimitDecision(rule, now)
+	default:
+		return nil
+	}
+}
+
+func (e *Engine) probabilityAllows(probability float64) bool {
+	return probability <= 0 || probability >= 1 || e.rng.Float64() <= probability
+}
+
+func (e *Engine) delayDecision(rule *Rule) *Decision {
+	delay := time.Duration(rule.Fault.FixedMs) * time.Millisecond
+	if rule.Fault.Latency != nil {
+		delay = rule.Fault.Latency.DurationAt(e.rng.Float64())
+	}
+
+	if delay <= 0 {
+		return nil
+	}
+
+	return &Decision{RuleID: rule.ID, Delay: delay}
+}
+
+func (e *Engine) rateLimitDecision(rule *Rule, now time.Time) *Decision {
+	bucket := e.buckets[rule.ID]
+	if bucket == nil && rule.Fault.Limit != nil {
+		bucket = newTokenBucket(rule.Fault.Limit.RPS, rule.Fault.Limit.Burst, now)
+		e.buckets[rule.ID] = bucket
+	}
+
+	if bucket == nil || bucket.allow(now) {
+		return nil
+	}
+
+	errSpec := defaultRateLimitErrorSpec(rule.Fault.OnLimit)
+
+	return &Decision{RuleID: rule.ID, Error: &errSpec}
+}
+
+func validateFault(fault *Fault) error {
+	switch fault.Type {
+	case FaultError:
+		return nil
+	case FaultDelay:
+		if fault.Latency != nil {
+			return fault.Latency.Validate()
+		}
+
+		return nil
+	case FaultRateLimit:
+		if fault.Limit == nil || fault.Limit.RPS <= 0 || fault.Limit.Burst <= 0 {
+			return errInvalidRateLimit
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("unsupported fault type %q", fault.Type)
+	}
+}
+
+func matches(match *Match, info *awsapi.RequestInfo) bool {
+	if match.Service != "" && !sameToken(match.Service, info.Service) {
+		return false
+	}
+
+	if match.Action != "" && !sameToken(match.Action, info.Action) {
+		return false
+	}
+
+	if match.Method != "" && !strings.EqualFold(match.Method, info.Method) {
+		return false
+	}
+
+	if match.Path != "" && match.Path != info.Path {
+		return false
+	}
+
+	if match.Pattern != "" && match.Pattern != info.Pattern {
+		return false
+	}
+
+	return true
+}
+
+func sameToken(a, b string) bool {
+	return compactToken(a) == compactToken(b)
+}
+
+func compactToken(s string) string {
+	s = strings.TrimSpace(strings.ToLower(s))
+	s = strings.ReplaceAll(s, "-", "")
+	s = strings.ReplaceAll(s, "_", "")
+	s = strings.ReplaceAll(s, ".", "")
+
+	return s
+}
+
+func newRand(seed int64) *rand.Rand {
+	//nolint:gosec // Chaos sampling must be reproducible when a seed is configured.
+	return rand.New(rand.NewPCG(uint64(seed), uint64(seed>>32)))
+}
+
+type tokenBucket struct {
+	rps    float64
+	burst  float64
+	tokens float64
+	last   time.Time
+}
+
+func newTokenBucket(rps float64, burst int, now time.Time) *tokenBucket {
+	return &tokenBucket{
+		rps:    rps,
+		burst:  float64(burst),
+		tokens: float64(burst),
+		last:   now,
+	}
+}
+
+func (b *tokenBucket) allow(now time.Time) bool {
+	elapsed := now.Sub(b.last).Seconds()
+	if elapsed > 0 {
+		b.tokens += elapsed * b.rps
+		if b.tokens > b.burst {
+			b.tokens = b.burst
+		}
+
+		b.last = now
+	}
+
+	if b.tokens < 1 {
+		return false
+	}
+
+	b.tokens--
+
+	return true
+}

--- a/internal/chaos/engine_test.go
+++ b/internal/chaos/engine_test.go
@@ -1,0 +1,101 @@
+package chaos
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/sivchari/kumo/internal/awsapi"
+	"github.com/sivchari/kumo/internal/servicecatalog"
+)
+
+func TestLatencyProfileSamplesPercentileAnchors(t *testing.T) {
+	profile := LatencyProfile{
+		P50Ms: 20,
+		P95Ms: 300,
+		P99Ms: 1500,
+		MaxMs: 3000,
+	}
+
+	tests := map[float64]time.Duration{
+		0.00: 0,
+		0.50: 20 * time.Millisecond,
+		0.95: 300 * time.Millisecond,
+		0.99: 1500 * time.Millisecond,
+		1.00: 3000 * time.Millisecond,
+	}
+
+	for q, want := range tests {
+		got := profile.DurationAt(q)
+		if got != want {
+			t.Fatalf("DurationAt(%v) = %v, want %v", q, got, want)
+		}
+	}
+}
+
+func TestEngineReturnsConfiguredErrorForMatchingServiceAlias(t *testing.T) {
+	engine := NewEngine(servicecatalog.NewDefault())
+	if err := engine.UpsertRule(&Rule{
+		ID:      "ddb-down",
+		Enabled: true,
+		Match: Match{
+			Service: "DynamoDB_20120810",
+			Action:  "PutItem",
+		},
+		Fault: Fault{
+			Type:    FaultError,
+			Status:  http.StatusServiceUnavailable,
+			Code:    "ServiceUnavailable",
+			Message: "DynamoDB is unavailable",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	decision := engine.Evaluate(&awsapi.RequestInfo{Service: "dynamodb", Action: "PutItem"})
+	if decision == nil {
+		t.Fatal("expected a chaos decision")
+	}
+
+	if decision.Error == nil || decision.Error.Status != http.StatusServiceUnavailable {
+		t.Fatalf("unexpected decision: %#v", decision)
+	}
+}
+
+func TestEngineRateLimitReturnsErrorAfterBurst(t *testing.T) {
+	engine := NewEngine(servicecatalog.NewDefault())
+	engine.SetClock(func() time.Time { return time.Unix(100, 0) })
+
+	if err := engine.UpsertRule(&Rule{
+		ID:      "s3-put-limit",
+		Enabled: true,
+		Match: Match{
+			Service: "s3",
+			Action:  "PutObject",
+		},
+		Fault: Fault{
+			Type: FaultRateLimit,
+			Limit: &RateLimit{
+				RPS:   1,
+				Burst: 1,
+			},
+			OnLimit: &FaultErrorSpec{
+				Status:  http.StatusTooManyRequests,
+				Code:    "SlowDown",
+				Message: "Please reduce your request rate.",
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	first := engine.Evaluate(&awsapi.RequestInfo{Service: "s3", Action: "PutObject"})
+	if first != nil {
+		t.Fatalf("first request should be allowed, got %#v", first)
+	}
+
+	second := engine.Evaluate(&awsapi.RequestInfo{Service: "s3", Action: "PutObject"})
+	if second == nil || second.Error == nil || second.Error.Code != "SlowDown" {
+		t.Fatalf("expected SlowDown decision, got %#v", second)
+	}
+}

--- a/internal/chaos/types.go
+++ b/internal/chaos/types.go
@@ -1,0 +1,168 @@
+// Package chaos injects AWS-aware failures and latency into emulated API requests.
+package chaos
+
+import (
+	"math"
+	"net/http"
+	"time"
+)
+
+const (
+	// FaultError returns an AWS-shaped error response.
+	FaultError = "error"
+	// FaultDelay injects latency before the real handler runs.
+	FaultDelay = "delay"
+	// FaultRateLimit applies a token-bucket limit and returns OnLimit when exceeded.
+	FaultRateLimit = "rate_limit"
+)
+
+// Config is the JSON document accepted by future file-based chaos profiles.
+type Config struct {
+	Seed  int64  `json:"seed,omitempty"`
+	Rules []Rule `json:"rules"`
+}
+
+// Rule describes one fault-injection rule.
+type Rule struct {
+	ID      string `json:"id"`
+	Enabled bool   `json:"enabled"`
+	Match   Match  `json:"match"`
+	Fault   Fault  `json:"fault"`
+}
+
+// Match selects emulated AWS requests.
+type Match struct {
+	Service string `json:"service,omitempty"`
+	Action  string `json:"action,omitempty"`
+	Method  string `json:"method,omitempty"`
+	Path    string `json:"path,omitempty"`
+	Pattern string `json:"pattern,omitempty"`
+}
+
+// Fault describes the behavior to inject when a rule matches.
+type Fault struct {
+	Type        string          `json:"type"`
+	Probability float64         `json:"probability,omitempty"`
+	Status      int             `json:"status,omitempty"`
+	Code        string          `json:"code,omitempty"`
+	Message     string          `json:"message,omitempty"`
+	FixedMs     int             `json:"fixedMs,omitempty"`
+	Latency     *LatencyProfile `json:"latency,omitempty"`
+	Limit       *RateLimit      `json:"limit,omitempty"`
+	OnLimit     *FaultErrorSpec `json:"onLimit,omitempty"`
+	Until       *time.Time      `json:"until,omitempty"`
+}
+
+// LatencyProfile describes a target injected-latency distribution.
+type LatencyProfile struct {
+	P50Ms int `json:"p50Ms,omitempty"`
+	P95Ms int `json:"p95Ms,omitempty"`
+	P99Ms int `json:"p99Ms,omitempty"`
+	MaxMs int `json:"maxMs,omitempty"`
+}
+
+// DurationAt returns the injected delay for quantile q in [0, 1].
+func (p LatencyProfile) DurationAt(q float64) time.Duration {
+	switch {
+	case q <= 0:
+		return 0
+	case q <= 0.50:
+		return lerpDuration(0, p.P50Ms, q/0.50)
+	case q <= 0.95:
+		return lerpDuration(p.P50Ms, p.P95Ms, (q-0.50)/0.45)
+	case q <= 0.99:
+		return lerpDuration(p.P95Ms, p.P99Ms, (q-0.95)/0.04)
+	case q >= 1:
+		return time.Duration(p.MaxMs) * time.Millisecond
+	default:
+		return lerpDuration(p.P99Ms, p.MaxMs, (q-0.99)/0.01)
+	}
+}
+
+// Validate checks that the profile anchors are monotonic.
+func (p LatencyProfile) Validate() error {
+	if p.P50Ms < 0 || p.P95Ms < 0 || p.P99Ms < 0 || p.MaxMs < 0 {
+		return errInvalidLatencyProfile
+	}
+
+	if p.P50Ms > p.P95Ms || p.P95Ms > p.P99Ms || p.P99Ms > p.MaxMs {
+		return errInvalidLatencyProfile
+	}
+
+	return nil
+}
+
+// RateLimit configures a token bucket.
+type RateLimit struct {
+	RPS   float64 `json:"rps"`
+	Burst int     `json:"burst"`
+}
+
+// FaultErrorSpec is the AWS-shaped error returned by an injected fault.
+type FaultErrorSpec struct {
+	Status            int    `json:"status,omitempty"`
+	Code              string `json:"code,omitempty"`
+	Message           string `json:"message,omitempty"`
+	RetryAfterSeconds int    `json:"retryAfterSeconds,omitempty"`
+}
+
+// Decision is an effective fault selected for one request.
+type Decision struct {
+	RuleID string
+	Delay  time.Duration
+	Error  *FaultErrorSpec
+}
+
+func defaultErrorSpec(f *Fault) FaultErrorSpec {
+	status := f.Status
+	if status == 0 {
+		status = http.StatusServiceUnavailable
+	}
+
+	code := f.Code
+	if code == "" {
+		code = "ServiceUnavailable"
+	}
+
+	message := f.Message
+	if message == "" {
+		message = "Service is temporarily unavailable"
+	}
+
+	return FaultErrorSpec{
+		Status:  status,
+		Code:    code,
+		Message: message,
+	}
+}
+
+func defaultRateLimitErrorSpec(spec *FaultErrorSpec) FaultErrorSpec {
+	if spec == nil {
+		return FaultErrorSpec{
+			Status:  http.StatusTooManyRequests,
+			Code:    "ThrottlingException",
+			Message: "Rate exceeded",
+		}
+	}
+
+	out := *spec
+	if out.Status == 0 {
+		out.Status = http.StatusTooManyRequests
+	}
+
+	if out.Code == "" {
+		out.Code = "ThrottlingException"
+	}
+
+	if out.Message == "" {
+		out.Message = "Rate exceeded"
+	}
+
+	return out
+}
+
+func lerpDuration(fromMs, toMs int, t float64) time.Duration {
+	ms := float64(fromMs) + (float64(toMs-fromMs) * t)
+
+	return time.Duration(math.Round(ms)) * time.Millisecond
+}

--- a/internal/server/chaos_billing_test.go
+++ b/internal/server/chaos_billing_test.go
@@ -1,0 +1,236 @@
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sivchari/kumo/internal/awsapi"
+	"github.com/sivchari/kumo/internal/billing"
+	"github.com/sivchari/kumo/internal/chaos"
+	"github.com/sivchari/kumo/internal/servicecatalog"
+)
+
+func TestRouterAppliesChaosAndRecordsBillingForS3Route(t *testing.T) {
+	catalog := servicecatalog.NewDefault()
+	engine := chaos.NewEngine(catalog)
+	meter := billing.NewMeter()
+	router := NewRouter(slog.New(slog.NewTextHandler(ioDiscard{}, nil)))
+	router.SetCatalog(catalog)
+	router.SetChaosEngine(engine)
+	router.SetBillingMeter(meter)
+
+	if err := engine.UpsertRule(&chaos.Rule{
+		ID:      "s3-put-down",
+		Enabled: true,
+		Match: chaos.Match{
+			Service: "s3",
+			Action:  "PutObject",
+		},
+		Fault: chaos.Fault{
+			Type:    chaos.FaultError,
+			Status:  http.StatusServiceUnavailable,
+			Code:    "ServiceUnavailable",
+			Message: "S3 is unavailable",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+
+	router.HandleWithService("PUT", "/{bucket}/{key...}", "s3", func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPut, "/bucket/key", strings.NewReader("payload"))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if called {
+		t.Fatal("handler should not be called when chaos error is applied")
+	}
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+
+	if got := meter.Usage().Quantity("s3", "PutObject", "requests.put_object"); got != 1 {
+		t.Fatalf("metered requests.put_object = %v, want 1", got)
+	}
+}
+
+func TestKumoChaosControlEndpoints(t *testing.T) {
+	router := newControlTestRouter()
+
+	ruleBody := `{
+		"id": "ddb-down",
+		"enabled": true,
+		"match": {"service": "DynamoDB_20120810", "action": "PutItem"},
+		"fault": {"type": "error", "status": 503, "code": "ServiceUnavailable"}
+	}`
+	req := httptest.NewRequest(http.MethodPut, "/kumo/chaos/rules/ddb-down", strings.NewReader(ruleBody))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put chaos rule status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/kumo/chaos/services", http.NoBody)
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("services status = %d", rec.Code)
+	}
+
+	var services struct {
+		Services []servicecatalog.Identity `json:"services"`
+	}
+
+	if err := json.Unmarshal(rec.Body.Bytes(), &services); err != nil {
+		t.Fatal(err)
+	}
+
+	foundEventBridge := false
+
+	for _, svc := range services.Services {
+		if svc.Canonical == "eventbridge" {
+			foundEventBridge = true
+		}
+	}
+
+	if !foundEventBridge {
+		t.Fatal("eventbridge should be listed as a canonical chaos service")
+	}
+}
+
+func TestKumoBillingControlEndpoints(t *testing.T) {
+	router := newControlTestRouter()
+
+	rateCard := `{
+		"currency": "USD",
+		"rates": [{"service":"s3","dimension":"requests.put_object","unit":"1000_requests","price":0.005}]
+	}`
+	req := httptest.NewRequest(http.MethodPut, "/kumo/billing/rate-card", strings.NewReader(rateCard))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put rate-card status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func newControlTestRouter() *Router {
+	catalog := servicecatalog.NewDefault()
+	engine := chaos.NewEngine(catalog)
+	meter := billing.NewMeter()
+	router := NewRouter(slog.New(slog.NewTextHandler(ioDiscard{}, nil)))
+	router.SetCatalog(catalog)
+	router.SetChaosEngine(engine)
+	router.SetBillingMeter(meter)
+	registerControlRoutes(router, catalog, engine, meter)
+
+	return router
+}
+
+func TestRouterAppliesChaosAndBillingToJSONProtocolRequest(t *testing.T) {
+	catalog := servicecatalog.NewDefault()
+	engine := chaos.NewEngine(catalog)
+	meter := billing.NewMeter(catalog)
+	router := NewRouter(slog.New(slog.NewTextHandler(ioDiscard{}, nil)))
+	router.SetCatalog(catalog)
+	router.SetChaosEngine(engine)
+	router.SetBillingMeter(meter)
+	router.RegisterJSONPrefix("AmazonSQS", "sqs")
+
+	err := engine.UpsertRule(&chaos.Rule{
+		ID:      "sqs-send-throttle",
+		Enabled: true,
+		Match: chaos.Match{
+			Service: "AmazonSQS",
+			Action:  "send_message",
+		},
+		Fault: chaos.Fault{
+			Type: chaos.FaultRateLimit,
+			Limit: &chaos.RateLimit{
+				RPS:   1,
+				Burst: 1,
+			},
+			OnLimit: &chaos.FaultErrorSpec{
+				Status: http.StatusTooManyRequests,
+				Code:   "ThrottlingException",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router.HandleFunc("POST", "/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+		req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+		req.Header.Set("X-Amz-Target", "AmazonSQS.SendMessage")
+
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		if i == 0 && rec.Code != http.StatusOK {
+			t.Fatalf("first status = %d, want %d", rec.Code, http.StatusOK)
+		}
+
+		if i == 1 && rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("second status = %d, want %d", rec.Code, http.StatusTooManyRequests)
+		}
+	}
+
+	if got := meter.Usage().Quantity("sqs", "SendMessage", "requests.send_message"); got != 2 {
+		t.Fatalf("metered requests.send_message = %v, want 2", got)
+	}
+}
+
+func TestBillingRateCardNormalizesServiceAliases(t *testing.T) {
+	catalog := servicecatalog.NewDefault()
+	meter := billing.NewMeter(catalog)
+	meter.SetRateCard(billing.RateCard{
+		Currency: "USD",
+		Rates: []billing.Rate{
+			{
+				Service:   "events",
+				Dimension: "requests.put_events",
+				Unit:      billing.UnitRequest,
+				Price:     0.01,
+			},
+		},
+	})
+
+	meter.Record(&billing.RequestUsage{
+		Info: awsapi.RequestInfo{
+			Service: "eventbridge",
+			Action:  "PutEvents",
+		},
+		Status: 200,
+	})
+
+	cost := meter.Cost()
+	if cost.Total != 0.01 {
+		t.Fatalf("cost = %v, want 0.01", cost.Total)
+	}
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) {
+	return len(p), nil
+}

--- a/internal/server/chaos_error.go
+++ b/internal/server/chaos_error.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/chaos"
+)
+
+func writeChaosError(w http.ResponseWriter, info *requestInfo, spec chaos.FaultErrorSpec) {
+	if spec.RetryAfterSeconds > 0 {
+		w.Header().Set("Retry-After", strconv.Itoa(spec.RetryAfterSeconds))
+	}
+
+	switch {
+	case info.Protocol == "cbor":
+		WriteCBORError(w, spec.Code, spec.Message, spec.Status)
+	case info.Service == "s3":
+		writeChaosXMLError(w, spec)
+	default:
+		writeChaosJSONError(w, spec)
+	}
+}
+
+func writeChaosJSONError(w http.ResponseWriter, spec chaos.FaultErrorSpec) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(spec.Status)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"__type":  spec.Code,
+		"message": spec.Message,
+	})
+}
+
+func writeChaosXMLError(w http.ResponseWriter, spec chaos.FaultErrorSpec) {
+	errResp := struct {
+		XMLName   xml.Name `xml:"Error"`
+		Code      string   `xml:"Code"`
+		Message   string   `xml:"Message"`
+		RequestID string   `xml:"RequestId"`
+	}{
+		Code:      spec.Code,
+		Message:   spec.Message,
+		RequestID: uuid.New().String(),
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(spec.Status)
+	_, _ = io.WriteString(w, xml.Header)
+	_ = xml.NewEncoder(w).Encode(errResp)
+}

--- a/internal/server/control_routes.go
+++ b/internal/server/control_routes.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/sivchari/kumo/internal/billing"
+	"github.com/sivchari/kumo/internal/chaos"
+	"github.com/sivchari/kumo/internal/servicecatalog"
+)
+
+func registerControlRoutes(
+	router *Router,
+	catalog *servicecatalog.Catalog,
+	engine *chaos.Engine,
+	meter *billing.Meter,
+) {
+	registerChaosControlRoutes(router, catalog, engine)
+	registerBillingControlRoutes(router, meter)
+}
+
+func registerChaosControlRoutes(
+	router *Router,
+	catalog *servicecatalog.Catalog,
+	engine *chaos.Engine,
+) {
+	router.HandleFunc("GET", "/kumo/chaos/services", func(w http.ResponseWriter, _ *http.Request) {
+		writeControlJSON(w, http.StatusOK, map[string]any{"services": catalog.Services()})
+	})
+
+	router.HandleFunc("GET", "/kumo/chaos/rules", func(w http.ResponseWriter, _ *http.Request) {
+		writeControlJSON(w, http.StatusOK, map[string]any{"rules": engine.Rules()})
+	})
+
+	router.HandleFunc("PUT", "/kumo/chaos/rules/{id}", func(w http.ResponseWriter, r *http.Request) {
+		var rule chaos.Rule
+		if err := json.NewDecoder(r.Body).Decode(&rule); err != nil {
+			writeControlError(w, http.StatusBadRequest, "invalid chaos rule JSON")
+
+			return
+		}
+
+		if pathID := r.PathValue("id"); pathID != "" {
+			rule.ID = pathID
+		}
+
+		if err := engine.UpsertRule(&rule); err != nil {
+			writeControlError(w, http.StatusBadRequest, err.Error())
+
+			return
+		}
+
+		rule.Match.Service = catalog.MustNormalize(rule.Match.Service)
+		writeControlJSON(w, http.StatusOK, rule)
+	})
+
+	router.HandleFunc("DELETE", "/kumo/chaos/rules/{id}", func(w http.ResponseWriter, r *http.Request) {
+		engine.DeleteRule(r.PathValue("id"))
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	router.HandleFunc("POST", "/kumo/chaos/reset", func(w http.ResponseWriter, _ *http.Request) {
+		engine.Reset()
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func registerBillingControlRoutes(router *Router, meter *billing.Meter) {
+	router.HandleFunc("GET", "/kumo/billing/usage", func(w http.ResponseWriter, _ *http.Request) {
+		writeControlJSON(w, http.StatusOK, meter.Usage())
+	})
+
+	router.HandleFunc("POST", "/kumo/billing/reset", func(w http.ResponseWriter, _ *http.Request) {
+		meter.Reset()
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	router.HandleFunc("GET", "/kumo/billing/rate-card", func(w http.ResponseWriter, _ *http.Request) {
+		writeControlJSON(w, http.StatusOK, meter.RateCard())
+	})
+
+	router.HandleFunc("PUT", "/kumo/billing/rate-card", func(w http.ResponseWriter, r *http.Request) {
+		var card billing.RateCard
+		if err := json.NewDecoder(r.Body).Decode(&card); err != nil {
+			writeControlError(w, http.StatusBadRequest, "invalid rate card JSON")
+
+			return
+		}
+
+		meter.SetRateCard(card)
+		writeControlJSON(w, http.StatusOK, meter.RateCard())
+	})
+
+	router.HandleFunc("GET", "/kumo/billing/cost", func(w http.ResponseWriter, _ *http.Request) {
+		writeControlJSON(w, http.StatusOK, meter.Cost())
+	})
+}
+
+func writeControlJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeControlError(w http.ResponseWriter, status int, message string) {
+	writeControlJSON(w, status, map[string]string{"message": message})
+}

--- a/internal/server/request_info.go
+++ b/internal/server/request_info.go
@@ -1,0 +1,269 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/sivchari/kumo/internal/awsapi"
+)
+
+type requestInfo struct {
+	awsapi.RequestInfo
+	isControl bool
+}
+
+func (r *Router) requestInfo(routeService, method, pattern string, req *http.Request) requestInfo {
+	info := requestInfo{
+		RequestInfo: awsapi.RequestInfo{
+			Service: r.catalog.MustNormalize(routeService),
+			Method:  method,
+			Path:    req.URL.Path,
+			Pattern: pattern,
+		},
+		isControl: isControlPath(req.URL.Path),
+	}
+
+	if info.isControl {
+		info.Service = "kumo"
+		info.Protocol = "control"
+
+		return info
+	}
+
+	info.Protocol = "rest"
+
+	if target := req.Header.Get("X-Amz-Target"); target != "" {
+		r.applyJSONInfo(&info, target)
+
+		return info
+	}
+
+	if isQueryProtocolRequest(req) {
+		r.applyQueryInfo(&info, req)
+
+		return info
+	}
+
+	if serviceName, operation, ok := parseCBORPath(req.URL.Path); ok {
+		r.applyCBORInfo(&info, serviceName, operation)
+
+		return info
+	}
+
+	info.Action = inferRESTAction(info.Service, method, pattern, req)
+	info.Resource = inferResource(info.Service, req)
+
+	return info
+}
+
+func (r *Router) applyJSONInfo(info *requestInfo, target string) {
+	parts := strings.SplitN(target, ".", 2)
+	if len(parts) != 2 {
+		return
+	}
+
+	info.Protocol = "json"
+	info.Action = parts[1]
+
+	service, ok := r.jsonPrefixes[parts[0]]
+	if ok {
+		info.Service = service
+
+		return
+	}
+
+	info.Service = r.catalog.MustNormalize(parts[0])
+}
+
+func (r *Router) applyQueryInfo(info *requestInfo, req *http.Request) {
+	info.Protocol = "query"
+	info.Action = peekFormValue(req, "Action")
+
+	svcID := parseServiceFromUserAgent(req.Header.Get("User-Agent"))
+	if svcID != "" {
+		info.Service = r.catalog.MustNormalize(svcID)
+	}
+}
+
+func (r *Router) applyCBORInfo(info *requestInfo, serviceName, operation string) {
+	info.Protocol = "cbor"
+	info.Action = operation
+
+	service, ok := r.cborNames[serviceName]
+	if ok {
+		info.Service = service
+
+		return
+	}
+
+	info.Service = r.catalog.MustNormalize(serviceName)
+}
+
+func isControlPath(path string) bool {
+	return path == "/health" || path == "/kumo" || strings.HasPrefix(path, "/kumo/")
+}
+
+func isQueryProtocolRequest(req *http.Request) bool {
+	mediaType, _, _ := mime.ParseMediaType(req.Header.Get("Content-Type"))
+
+	return mediaType == "application/x-www-form-urlencoded"
+}
+
+func peekFormValue(req *http.Request, key string) string {
+	if value := req.URL.Query().Get(key); value != "" {
+		return value
+	}
+
+	if req.Body == nil {
+		return ""
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return ""
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		return ""
+	}
+
+	return values.Get(key)
+}
+
+func parseCBORPath(path string) (string, string, bool) {
+	if !strings.HasPrefix(path, "/service/") {
+		return "", "", false
+	}
+
+	remaining := strings.TrimPrefix(path, "/service/")
+	parts := strings.Split(remaining, "/operation/")
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+
+	return parts[0], parts[1], true
+}
+
+func inferRESTAction(serviceName, method, pattern string, req *http.Request) string {
+	if serviceName != "s3" {
+		return ""
+	}
+
+	q := req.URL.Query()
+
+	switch pattern {
+	case "/":
+		if method == http.MethodGet {
+			return "ListBuckets"
+		}
+	case "/{bucket}":
+		return inferS3BucketAction(method, q)
+	case "/{bucket}/{key...}":
+		return inferS3ObjectAction(method, q, req.Header)
+	}
+
+	return ""
+}
+
+func inferS3BucketAction(method string, q url.Values) string {
+	switch method {
+	case http.MethodPut:
+		return inferS3BucketPutAction(q)
+	case http.MethodGet:
+		return inferS3BucketGetAction(q)
+	case http.MethodDelete:
+		return "DeleteBucket"
+	case http.MethodHead:
+		return "HeadBucket"
+	case http.MethodPost:
+		if q.Has("delete") {
+			return "DeleteObjects"
+		}
+	}
+
+	return ""
+}
+
+func inferS3BucketPutAction(q url.Values) string {
+	switch {
+	case q.Has("versioning"):
+		return "PutBucketVersioning"
+	case q.Has("cors"):
+		return "PutBucketCors"
+	case q.Has("encryption"):
+		return "PutBucketEncryption"
+	default:
+		return "CreateBucket"
+	}
+}
+
+func inferS3BucketGetAction(q url.Values) string {
+	switch {
+	case q.Has("versioning"):
+		return "GetBucketVersioning"
+	case q.Has("cors"):
+		return "GetBucketCors"
+	case q.Has("encryption"):
+		return "GetBucketEncryption"
+	case q.Has("uploads"):
+		return "ListMultipartUploads"
+	default:
+		return "ListObjects"
+	}
+}
+
+func inferS3ObjectAction(method string, q url.Values, header http.Header) string {
+	switch method {
+	case http.MethodPut:
+		switch {
+		case q.Has("uploadId") && q.Has("partNumber"):
+			return "UploadPart"
+		case header.Get("x-amz-copy-source") != "":
+			return "CopyObject"
+		default:
+			return "PutObject"
+		}
+	case http.MethodGet:
+		return "GetObject"
+	case http.MethodHead:
+		return "HeadObject"
+	case http.MethodDelete:
+		return "DeleteObject"
+	case http.MethodPost:
+		switch {
+		case q.Has("uploads"):
+			return "CreateMultipartUpload"
+		case q.Has("uploadId"):
+			return "CompleteMultipartUpload"
+		}
+	}
+
+	return ""
+}
+
+func inferResource(serviceName string, req *http.Request) string {
+	if serviceName != "s3" {
+		return ""
+	}
+
+	bucket := req.PathValue("bucket")
+	key := req.PathValue("key")
+
+	if bucket == "" {
+		return ""
+	}
+
+	if key == "" {
+		return bucket
+	}
+
+	return bucket + "/" + key
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -10,12 +11,17 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/billing"
+	"github.com/sivchari/kumo/internal/chaos"
+	"github.com/sivchari/kumo/internal/servicecatalog"
 )
 
 // Route represents a registered HTTP route.
 type Route struct {
 	Method  string
 	Pattern string
+	Service string
 	Handler http.HandlerFunc
 }
 
@@ -25,6 +31,11 @@ type Router struct {
 	routes        []Route
 	prefixRouters map[string]*http.ServeMux // Separate routers for services with prefixes
 	logger        *slog.Logger
+	catalog       *servicecatalog.Catalog
+	chaosEngine   *chaos.Engine
+	billingMeter  *billing.Meter
+	jsonPrefixes  map[string]string
+	cborNames     map[string]string
 }
 
 // NewRouter creates a new router.
@@ -34,6 +45,9 @@ func NewRouter(logger *slog.Logger) *Router {
 		routes:        make([]Route, 0),
 		prefixRouters: make(map[string]*http.ServeMux),
 		logger:        logger,
+		catalog:       servicecatalog.NewDefault(),
+		jsonPrefixes:  make(map[string]string),
+		cborNames:     make(map[string]string),
 	}
 
 	return r
@@ -41,9 +55,15 @@ func NewRouter(logger *slog.Logger) *Router {
 
 // Handle registers a handler for the given method and pattern.
 func (r *Router) Handle(method, pattern string, handler http.HandlerFunc) {
+	r.HandleWithService(method, pattern, "", handler)
+}
+
+// HandleWithService registers a handler annotated with the owning service.
+func (r *Router) HandleWithService(method, pattern, serviceName string, handler http.HandlerFunc) {
 	r.routes = append(r.routes, Route{
 		Method:  method,
 		Pattern: pattern,
+		Service: serviceName,
 		Handler: handler,
 	})
 
@@ -57,7 +77,7 @@ func (r *Router) Handle(method, pattern string, handler http.HandlerFunc) {
 		}
 
 		fullPattern := method + " " + pattern
-		r.prefixRouters[prefix].HandleFunc(fullPattern, r.wrapHandler(method, pattern, handler))
+		r.prefixRouters[prefix].HandleFunc(fullPattern, r.wrapHandler(method, pattern, serviceName, handler))
 		r.logger.Debug("registered prefixed route", "method", method, "pattern", pattern, "prefix", prefix)
 
 		return
@@ -65,7 +85,7 @@ func (r *Router) Handle(method, pattern string, handler http.HandlerFunc) {
 
 	// Use Go 1.22+ method pattern
 	fullPattern := method + " " + pattern
-	r.mux.HandleFunc(fullPattern, r.wrapHandler(method, pattern, handler))
+	r.mux.HandleFunc(fullPattern, r.wrapHandler(method, pattern, serviceName, handler))
 	r.logger.Debug("registered route", "method", method, "pattern", pattern)
 }
 
@@ -111,11 +131,39 @@ func (r *Router) HandleFunc(method, pattern string, handler http.HandlerFunc) {
 	r.Handle(method, pattern, handler)
 }
 
+// SetCatalog sets the service catalog used for request normalization.
+func (r *Router) SetCatalog(catalog *servicecatalog.Catalog) {
+	if catalog != nil {
+		r.catalog = catalog
+	}
+}
+
+// SetChaosEngine sets the chaos engine used by the router.
+func (r *Router) SetChaosEngine(engine *chaos.Engine) {
+	r.chaosEngine = engine
+}
+
+// SetBillingMeter sets the billing meter used by the router.
+func (r *Router) SetBillingMeter(meter *billing.Meter) {
+	r.billingMeter = meter
+}
+
+// RegisterJSONPrefix maps an AWS JSON X-Amz-Target prefix to a canonical service.
+func (r *Router) RegisterJSONPrefix(prefix, serviceName string) {
+	r.jsonPrefixes[prefix] = r.catalog.MustNormalize(serviceName)
+}
+
+// RegisterCBORServiceName maps a Smithy RPC v2 CBOR service name to a canonical service.
+func (r *Router) RegisterCBORServiceName(serviceName, canonical string) {
+	r.cborNames[serviceName] = r.catalog.MustNormalize(canonical)
+}
+
 // wrapHandler wraps a handler with logging and request ID injection.
-func (r *Router) wrapHandler(method, pattern string, handler http.HandlerFunc) http.HandlerFunc {
+func (r *Router) wrapHandler(method, pattern, serviceName string, handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 		requestID := uuid.New().String()
+		info := r.requestInfo(serviceName, method, pattern, req)
 
 		// Add AWS-style headers
 		w.Header().Set("x-amz-request-id", requestID)
@@ -135,39 +183,97 @@ func (r *Router) wrapHandler(method, pattern string, handler http.HandlerFunc) h
 		// Wrap response writer to capture status code
 		wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 
+		// Apply AWS-aware chaos before the real handler runs.
+		if decision := r.evaluateChaos(&info); decision != nil {
+			if decision.Delay > 0 {
+				timer := time.NewTimer(decision.Delay)
+				select {
+				case <-timer.C:
+				case <-req.Context().Done():
+					timer.Stop()
+				}
+			}
+
+			if decision.Error != nil {
+				writeChaosError(wrapped, &info, *decision.Error)
+				r.recordBilling(&info, req, wrapped)
+				r.logRequest(method, pattern, req, wrapped, start, requestID)
+
+				return
+			}
+		}
+
 		// Call the actual handler
 		handler(wrapped, req)
 
-		// Build log attributes.
-		attrs := []any{
-			"method", method,
-			"path", req.URL.Path,
-			"pattern", pattern,
-			"status", wrapped.statusCode,
-			"duration", time.Since(start),
-			"request_id", requestID,
-		}
-
-		// Extract service and action from protocol headers.
-		if target := req.Header.Get("X-Amz-Target"); target != "" {
-			attrs = append(attrs, "target", target)
-		}
-
-		if action := req.URL.Query().Get("Action"); action != "" {
-			attrs = append(attrs, "action", action)
-		}
-
-		if ua := req.Header.Get("User-Agent"); ua != "" {
-			attrs = append(attrs, "ua", ua)
-		}
-
-		r.logger.Info("request", attrs...)
+		r.recordBilling(&info, req, wrapped)
+		r.logRequest(method, pattern, req, wrapped, start, requestID)
 
 		// Log request body at debug level.
 		if requestBody != "" {
 			r.logger.Debug("request body", "request_id", requestID, "body", requestBody)
 		}
 	}
+}
+
+func (r *Router) evaluateChaos(info *requestInfo) *chaos.Decision {
+	if r.chaosEngine == nil || info.isControl {
+		return nil
+	}
+
+	return r.chaosEngine.Evaluate(&info.RequestInfo)
+}
+
+func (r *Router) recordBilling(info *requestInfo, req *http.Request, wrapped *responseWriter) {
+	if r.billingMeter == nil || info.isControl {
+		return
+	}
+
+	requestBytes := req.ContentLength
+	if requestBytes < 0 {
+		requestBytes = 0
+	}
+
+	r.billingMeter.Record(&billing.RequestUsage{
+		Info:          info.RequestInfo,
+		RequestBytes:  requestBytes,
+		ResponseBytes: wrapped.bytesWritten,
+		Status:        wrapped.statusCode,
+	})
+}
+
+func (r *Router) logRequest(
+	method string,
+	pattern string,
+	req *http.Request,
+	wrapped *responseWriter,
+	start time.Time,
+	requestID string,
+) {
+	// Build log attributes.
+	attrs := []any{
+		"method", method,
+		"path", req.URL.Path,
+		"pattern", pattern,
+		"status", wrapped.statusCode,
+		"duration", time.Since(start),
+		"request_id", requestID,
+	}
+
+	// Extract service and action from protocol headers.
+	if target := req.Header.Get("X-Amz-Target"); target != "" {
+		attrs = append(attrs, "target", target)
+	}
+
+	if action := req.URL.Query().Get("Action"); action != "" {
+		attrs = append(attrs, "action", action)
+	}
+
+	if ua := req.Header.Get("User-Agent"); ua != "" {
+		attrs = append(attrs, "ua", ua)
+	}
+
+	r.logger.Info("request", attrs...)
 }
 
 // ServeHTTP implements http.Handler.
@@ -292,11 +398,24 @@ func extractBucketFromHost(host string) string {
 // responseWriter wraps http.ResponseWriter to capture the status code.
 type responseWriter struct {
 	http.ResponseWriter
-	statusCode int
+	statusCode   int
+	bytesWritten int64
 }
 
 // WriteHeader captures the status code.
 func (w *responseWriter) WriteHeader(code int) {
 	w.statusCode = code
 	w.ResponseWriter.WriteHeader(code)
+}
+
+// Write captures the response body size.
+func (w *responseWriter) Write(p []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(p)
+	w.bytesWritten += int64(n)
+
+	if err != nil {
+		return n, fmt.Errorf("write response: %w", err)
+	}
+
+	return n, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,8 +17,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sivchari/kumo/internal/billing"
+	"github.com/sivchari/kumo/internal/chaos"
 	"github.com/sivchari/kumo/internal/initdir"
 	"github.com/sivchari/kumo/internal/service"
+	"github.com/sivchari/kumo/internal/servicecatalog"
 )
 
 // Config holds the server configuration.
@@ -78,6 +81,9 @@ type Server struct {
 	jsonDispatcher  *JSONProtocolDispatcher
 	queryDispatcher *QueryProtocolDispatcher
 	cborDispatcher  *CBORProtocolDispatcher
+	catalog         *servicecatalog.Catalog
+	chaosEngine     *chaos.Engine
+	billingMeter    *billing.Meter
 	logger          *slog.Logger
 	server          *http.Server
 }
@@ -90,7 +96,14 @@ func New(config Config) *Server {
 	}))
 
 	registry := service.NewRegistry()
+	catalog := servicecatalog.NewDefault()
+	chaosEngine := chaos.NewEngine(catalog)
+	billingMeter := billing.NewMeter(catalog)
 	router := NewRouter(logger)
+	router.SetCatalog(catalog)
+	router.SetChaosEngine(chaosEngine)
+	router.SetBillingMeter(billingMeter)
+
 	jsonDispatcher := NewJSONProtocolDispatcher()
 	queryDispatcher := NewQueryProtocolDispatcher()
 	cborDispatcher := NewCBORProtocolDispatcher()
@@ -102,8 +115,13 @@ func New(config Config) *Server {
 		jsonDispatcher:  jsonDispatcher,
 		queryDispatcher: queryDispatcher,
 		cborDispatcher:  cborDispatcher,
+		catalog:         catalog,
+		chaosEngine:     chaosEngine,
+		billingMeter:    billingMeter,
 		logger:          logger,
 	}
+
+	registerControlRoutes(router, catalog, chaosEngine, billingMeter)
 
 	// Auto-register services from global registry
 	for _, svc := range service.Services() {
@@ -161,11 +179,12 @@ func (s *Server) Router() *Router {
 // RegisterService registers a service with the server.
 func (s *Server) RegisterService(svc service.Service) {
 	s.registry.Register(svc)
-	svc.RegisterRoutes(s.router)
+	svc.RegisterRoutes(serviceRouter{router: s.router, serviceName: svc.Name()})
 
 	// Check if service implements JSON protocol.
 	if jsonSvc, ok := svc.(service.JSONProtocolService); ok {
 		s.jsonDispatcher.Register(jsonSvc.TargetPrefix(), jsonSvc.DispatchAction)
+		s.router.RegisterJSONPrefix(jsonSvc.TargetPrefix(), svc.Name())
 		s.logger.Debug("registered JSON protocol service", "name", svc.Name(), "prefix", jsonSvc.TargetPrefix())
 	}
 
@@ -188,6 +207,7 @@ func (s *Server) RegisterService(svc service.Service) {
 	// Check if service implements CBOR protocol.
 	if cborSvc, ok := svc.(service.CBORProtocolService); ok {
 		s.cborDispatcher.Register(cborSvc.ServiceName(), cborSvc.DispatchCBORAction)
+		s.router.RegisterCBORServiceName(cborSvc.ServiceName(), svc.Name())
 		s.logger.Debug("registered CBOR protocol service", "name", svc.Name(), "serviceName", cborSvc.ServiceName())
 	}
 

--- a/internal/server/service_router.go
+++ b/internal/server/service_router.go
@@ -1,0 +1,16 @@
+package server
+
+import "net/http"
+
+type serviceRouter struct {
+	router      *Router
+	serviceName string
+}
+
+func (r serviceRouter) Handle(method, pattern string, handler http.HandlerFunc) {
+	r.router.HandleWithService(method, pattern, r.serviceName, handler)
+}
+
+func (r serviceRouter) HandleFunc(method, pattern string, handler http.HandlerFunc) {
+	r.Handle(method, pattern, handler)
+}

--- a/internal/servicecatalog/catalog.go
+++ b/internal/servicecatalog/catalog.go
@@ -1,0 +1,201 @@
+// Package servicecatalog normalizes AWS, SDK, and kumo-internal service names.
+package servicecatalog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Identity describes one AWS service name as exposed to kumo control APIs.
+type Identity struct {
+	Canonical string   `json:"name"`
+	KumoName  string   `json:"kumoName,omitempty"`
+	Aliases   []string `json:"aliases,omitempty"`
+	Protocols []string `json:"protocols,omitempty"`
+}
+
+// Catalog normalizes AWS SDK, AWS protocol, and kumo-internal service names.
+type Catalog struct {
+	byCanonical map[string]Identity
+	byAlias     map[string]string
+}
+
+// New creates an empty catalog.
+func New() *Catalog {
+	return &Catalog{
+		byCanonical: make(map[string]Identity),
+		byAlias:     make(map[string]string),
+	}
+}
+
+// NewDefault returns the catalog used by kumo control-plane features.
+func NewDefault() *Catalog {
+	c := New()
+
+	for _, identity := range defaultIdentities() {
+		if err := c.Register(&identity); err != nil {
+			panic(err)
+		}
+	}
+
+	return c
+}
+
+// Register adds a service identity and all aliases.
+func (c *Catalog) Register(identity *Identity) error {
+	identity.Canonical = canonicalKey(identity.Canonical)
+	if identity.Canonical == "" {
+		return fmt.Errorf("canonical service name is required")
+	}
+
+	if identity.KumoName == "" {
+		identity.KumoName = identity.Canonical
+	}
+
+	aliases := make([]string, 0, 2+len(identity.Aliases))
+	aliases = append(aliases, identity.Canonical, identity.KumoName)
+	aliases = append(aliases, identity.Aliases...)
+	identity.Aliases = uniqueStrings(identity.Aliases)
+	identity.Protocols = uniqueStrings(identity.Protocols)
+
+	if existing, ok := c.byCanonical[identity.Canonical]; ok {
+		return fmt.Errorf("service %q is already registered as %q", identity.Canonical, existing.Canonical)
+	}
+
+	for _, alias := range aliases {
+		key := canonicalKey(alias)
+		if key == "" {
+			continue
+		}
+
+		if owner, ok := c.byAlias[key]; ok && owner != identity.Canonical {
+			return fmt.Errorf("service alias %q is already registered for %q", alias, owner)
+		}
+	}
+
+	c.byCanonical[identity.Canonical] = *identity
+
+	for _, alias := range aliases {
+		key := canonicalKey(alias)
+		if key != "" {
+			c.byAlias[key] = identity.Canonical
+		}
+	}
+
+	return nil
+}
+
+// Normalize returns the canonical service name for name.
+func (c *Catalog) Normalize(name string) (string, bool) {
+	canonical, ok := c.byAlias[canonicalKey(name)]
+
+	return canonical, ok
+}
+
+// MustNormalize returns the canonical service name or the normalized input when unknown.
+func (c *Catalog) MustNormalize(name string) string {
+	if canonical, ok := c.Normalize(name); ok {
+		return canonical
+	}
+
+	return canonicalKey(name)
+}
+
+// Services returns all registered services sorted by canonical name.
+func (c *Catalog) Services() []Identity {
+	out := make([]Identity, 0, len(c.byCanonical))
+	for _, identity := range c.byCanonical {
+		out = append(out, identity)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Canonical < out[j].Canonical
+	})
+
+	return out
+}
+
+func canonicalKey(s string) string {
+	s = strings.TrimSpace(strings.ToLower(s))
+	s = strings.ReplaceAll(s, "-", "")
+	s = strings.ReplaceAll(s, "_", "")
+	s = strings.ReplaceAll(s, " ", "")
+
+	return s
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+
+		seen[key] = struct{}{}
+
+		out = append(out, value)
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+func defaultIdentities() []Identity {
+	return []Identity{
+		{Canonical: "acm", KumoName: "acm", Aliases: []string{"CertificateManager"}, Protocols: []string{"json"}},
+		{Canonical: "amp", KumoName: "amp", Aliases: []string{"aps"}},
+		{Canonical: "athena", KumoName: "athena", Aliases: []string{"AmazonAthena"}, Protocols: []string{"json"}},
+		{Canonical: "cloudformation", KumoName: "cloudformation", Aliases: []string{"CloudFormation"}, Protocols: []string{"query"}},
+		{Canonical: "cloudtrail", KumoName: "cloudtrail", Aliases: []string{"CloudTrail_20131101"}, Protocols: []string{"json"}},
+		{Canonical: "cloudwatch", KumoName: "monitoring", Aliases: []string{"GraniteServiceVersion20100801"}, Protocols: []string{"cbor"}},
+		{Canonical: "cloudwatchlogs", KumoName: "logs", Aliases: []string{"Logs_20140328"}, Protocols: []string{"json"}},
+		{Canonical: "codeguruprofiler", KumoName: "codeguru-profiler", Aliases: []string{"codeguru-profiler"}},
+		{Canonical: "codegurureviewer", KumoName: "codeguru-reviewer", Aliases: []string{"codeguru-reviewer"}},
+		{Canonical: "cognitoidentityprovider", KumoName: "cognito-idp", Aliases: []string{"cognito", "cognito-idp", "AWSCognitoIdentityProviderService"}, Protocols: []string{"json"}},
+		{Canonical: "configservice", KumoName: "configservice", Aliases: []string{"StarlingDoveService"}, Protocols: []string{"json"}},
+		{Canonical: "costexplorer", KumoName: "ce", Aliases: []string{"ce", "AWSInsightsIndexService"}, Protocols: []string{"json"}},
+		{Canonical: "directoryservice", KumoName: "ds", Aliases: []string{"ds", "DirectoryService_20150416"}, Protocols: []string{"json"}},
+		{Canonical: "docdb", KumoName: "docdb", Aliases: []string{"documentdb"}, Protocols: []string{"query"}},
+		{Canonical: "dynamodb", KumoName: "dynamodb", Aliases: []string{"DynamoDB_20120810"}, Protocols: []string{"json"}},
+		{Canonical: "ec2", KumoName: "ec2", Aliases: []string{"AmazonEC2"}, Protocols: []string{"query"}},
+		{Canonical: "ecr", KumoName: "ecr", Aliases: []string{"AmazonEC2ContainerRegistry_V20150921"}, Protocols: []string{"json"}},
+		{Canonical: "ecs", KumoName: "ecs", Aliases: []string{"AmazonEC2ContainerServiceV20141113"}, Protocols: []string{"json"}},
+		{Canonical: "elasticache", KumoName: "elasticache", Aliases: []string{"AmazonElastiCacheV9"}, Protocols: []string{"query"}},
+		{Canonical: "elasticbeanstalk", KumoName: "elasticbeanstalk", Aliases: []string{"ElasticBeanstalk"}, Protocols: []string{"query"}},
+		{Canonical: "elasticloadbalancingv2", KumoName: "elasticloadbalancingv2", Aliases: []string{"elbv2", "ElasticLoadBalancing"}, Protocols: []string{"query"}},
+		{Canonical: "eventbridge", KumoName: "events", Aliases: []string{"events", "cloudwatch-events", "AWSEvents"}, Protocols: []string{"json"}},
+		{Canonical: "firehose", KumoName: "firehose", Aliases: []string{"Firehose_20150804"}, Protocols: []string{"json"}},
+		{Canonical: "forecast", KumoName: "forecast", Aliases: []string{"AmazonForecast"}, Protocols: []string{"json"}},
+		{Canonical: "gamelift", KumoName: "gamelift", Aliases: []string{"GameLift"}, Protocols: []string{"json"}},
+		{Canonical: "globalaccelerator", KumoName: "globalaccelerator", Aliases: []string{"GlobalAccelerator_V20180706"}, Protocols: []string{"json"}},
+		{Canonical: "glue", KumoName: "glue", Aliases: []string{"AWSGlue"}, Protocols: []string{"json"}},
+		{Canonical: "kinesis", KumoName: "kinesis", Aliases: []string{"Kinesis_20131202"}, Protocols: []string{"json"}},
+		{Canonical: "kms", KumoName: "kms", Aliases: []string{"TrentService"}, Protocols: []string{"json"}},
+		{Canonical: "memorydb", KumoName: "memorydb", Aliases: []string{"AmazonMemoryDB"}, Protocols: []string{"json"}},
+		{Canonical: "neptune", KumoName: "neptune", Aliases: []string{"AmazonNeptuneDataService"}, Protocols: []string{"query"}},
+		{Canonical: "organizations", KumoName: "organizations", Aliases: []string{"AWSOrganizationsV20161128"}, Protocols: []string{"json"}},
+		{Canonical: "pinpointsmsvoicev2", KumoName: "pinpointsmsvoicev2", Aliases: []string{"PinpointSMSVoiceV2"}, Protocols: []string{"json"}},
+		{Canonical: "rds", KumoName: "rds", Aliases: []string{"rds"}, Protocols: []string{"query"}},
+		{Canonical: "redshift", KumoName: "redshift", Aliases: []string{"RedshiftServiceVersion20121201"}, Protocols: []string{"query"}},
+		{Canonical: "rekognition", KumoName: "rekognition", Aliases: []string{"RekognitionService"}, Protocols: []string{"json"}},
+		{Canonical: "route53resolver", KumoName: "route53resolver", Aliases: []string{"Route53Resolver"}, Protocols: []string{"json"}},
+		{Canonical: "s3", KumoName: "s3", Protocols: []string{"rest"}},
+		{Canonical: "sagemaker", KumoName: "sagemaker", Aliases: []string{"SageMaker"}, Protocols: []string{"json"}},
+		{Canonical: "secretsmanager", KumoName: "secretsmanager", Protocols: []string{"json"}},
+		{Canonical: "servicequotas", KumoName: "service-quotas", Aliases: []string{"service-quotas", "ServiceQuotasV20190624"}, Protocols: []string{"json"}},
+		{Canonical: "sfn", KumoName: "states", Aliases: []string{"states", "stepfunctions", "step-functions", "AWSStepFunctions"}, Protocols: []string{"json"}},
+		{Canonical: "sns", KumoName: "sns", Aliases: []string{"AmazonSimpleNotificationService"}, Protocols: []string{"query"}},
+		{Canonical: "sqs", KumoName: "sqs", Aliases: []string{"AmazonSQS"}, Protocols: []string{"json"}},
+		{Canonical: "ssm", KumoName: "ssm", Aliases: []string{"AmazonSSM"}, Protocols: []string{"json"}},
+		{Canonical: "sts", KumoName: "sts", Aliases: []string{"AWSSecurityTokenServiceV20110615"}, Protocols: []string{"query"}},
+	}
+}

--- a/internal/servicecatalog/catalog_test.go
+++ b/internal/servicecatalog/catalog_test.go
@@ -1,0 +1,56 @@
+package servicecatalog
+
+import "testing"
+
+func TestDefaultCatalogNormalizesAWSAndKumoServiceNames(t *testing.T) {
+	catalog := NewDefault()
+
+	tests := map[string]string{
+		"eventbridge":                   "eventbridge",
+		"events":                        "eventbridge",
+		"cloudwatch-events":             "eventbridge",
+		"sfn":                           "sfn",
+		"states":                        "sfn",
+		"step_functions":                "sfn",
+		"cloudwatch":                    "cloudwatch",
+		"monitoring":                    "cloudwatch",
+		"cloudwatchlogs":                "cloudwatchlogs",
+		"logs":                          "cloudwatchlogs",
+		"elasticloadbalancingv2":        "elasticloadbalancingv2",
+		"elbv2":                         "elasticloadbalancingv2",
+		"cognitoidentityprovider":       "cognitoidentityprovider",
+		"cognito-idp":                   "cognitoidentityprovider",
+		"directoryservice":              "directoryservice",
+		"ds":                            "directoryservice",
+		"costexplorer":                  "costexplorer",
+		"ce":                            "costexplorer",
+		"codeguru-profiler":             "codeguruprofiler",
+		"codeguruprofiler":              "codeguruprofiler",
+		"AmazonSQS":                     "sqs",
+		"DynamoDB_20120810":             "dynamodb",
+		"GraniteServiceVersion20100801": "cloudwatch",
+	}
+
+	for input, want := range tests {
+		got, ok := catalog.Normalize(input)
+		if !ok {
+			t.Fatalf("Normalize(%q) returned !ok", input)
+		}
+
+		if got != want {
+			t.Fatalf("Normalize(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestCatalogRejectsAliasCollisions(t *testing.T) {
+	catalog := New()
+	if err := catalog.Register(&Identity{Canonical: "s3", KumoName: "s3"}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := catalog.Register(&Identity{Canonical: "sqs", Aliases: []string{"s3"}})
+	if err == nil {
+		t.Fatal("expected alias collision error")
+	}
+}


### PR DESCRIPTION
## Superseded

This combined draft is closed because the scope mixed latency emulation, chaos-style runtime controls, and billing/cost metering.

The work has been split into focused PRs:

- #667: config-driven latency emulator loaded from `KUMO_LATENCY_CONFIG`, with no runtime control endpoints
- #668: billing and cost metering APIs under `/kumo/billing/*`

The latency proposal is now #664. The billing/cost metering proposal is #666.
