### PR TITLE
Add fuzz coverage for S3 and DynamoDB edge cases

### DIFF
--- a/internal/service/dynamodb/condition.go
+++ b/internal/service/dynamodb/condition.go
@@ -245,6 +245,10 @@ func evalContains(av AttributeValue, operand AttributeValue) bool {
 	// List contains value.
 	if av.L != nil {
 		for _, elem := range av.L {
+			if elem == nil {
+				continue
+			}
+
 			if attributeValuesEqualStatic(*elem, operand) {
 				return true
 			}

--- a/internal/service/dynamodb/fuzz_test.go
+++ b/internal/service/dynamodb/fuzz_test.go
@@ -1,0 +1,69 @@
+package dynamodb
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func FuzzConditionExpressionNoPanic(f *testing.F) {
+	f.Add(`{"items":{"L":[null]}}`, `contains(items, :needle)`, `{":needle":{"S":"x"}}`)
+	f.Add(`{"pk":{"S":"1"},"count":{"N":"3"}}`, `count >= :min`, `{":min":{"N":"1"}}`)
+	f.Add(`{"meta":{"M":{"version":{"N":"1"}}}}`, `attribute_exists(meta.version)`, `{}`)
+	f.Add(`{"tags":{"SS":["a","b"]}}`, `contains(tags, :tag)`, `{":tag":{"S":"a"}}`)
+	f.Add(`{"name":{"S":"alice"}}`, `begins_with(name, :prefix)`, `{":prefix":{"S":"al"}}`)
+
+	f.Fuzz(func(t *testing.T, itemJSON, expression, valuesJSON string) {
+		if len(itemJSON) > 4096 || len(expression) > 512 || len(valuesJSON) > 4096 {
+			t.Skip()
+		}
+
+		var item Item
+		if err := json.Unmarshal([]byte(itemJSON), &item); err != nil {
+			return
+		}
+
+		values := make(map[string]AttributeValue)
+		if err := json.Unmarshal([]byte(valuesJSON), &values); err != nil {
+			return
+		}
+
+		_, _ = evaluateCondition(item, ConditionInput{
+			Expression: expression,
+			ExprNames: map[string]string{
+				"#items": "items",
+				"#name":  "name",
+			},
+			ExprValues: values,
+		})
+	})
+}
+
+func FuzzAttributeValueJSONRoundTrip(f *testing.F) {
+	f.Add(`{"S":"hello"}`)
+	f.Add(`{"N":"123.45"}`)
+	f.Add(`{"BOOL":true}`)
+	f.Add(`{"NULL":true}`)
+	f.Add(`{"L":[{"S":"x"},null,{"N":"1"}]}`)
+	f.Add(`{"M":{"nested":{"SS":["a","b"]}}}`)
+
+	f.Fuzz(func(t *testing.T, data string) {
+		if len(data) > 4096 {
+			t.Skip()
+		}
+
+		var first AttributeValue
+		if err := json.Unmarshal([]byte(data), &first); err != nil {
+			return
+		}
+
+		encoded, err := json.Marshal(first)
+		if err != nil {
+			t.Fatalf("marshal after unmarshal failed: %v", err)
+		}
+
+		var second AttributeValue
+		if err := json.Unmarshal(encoded, &second); err != nil {
+			t.Fatalf("unmarshal after marshal failed: %v encoded=%s", err, string(encoded))
+		}
+	})
+}

--- a/internal/service/s3/fuzz_test.go
+++ b/internal/service/s3/fuzz_test.go
@@ -1,0 +1,50 @@
+package s3
+
+import "testing"
+
+func FuzzParseByteRangeInvariants(f *testing.F) {
+	f.Add("bytes=0-99", int64(1000))
+	f.Add("bytes=-100", int64(1000))
+	f.Add("bytes=500-", int64(1000))
+	f.Add("bytes=200-100", int64(1000))
+	f.Add("items=0-99", int64(1000))
+	f.Add("bytes=-1", int64(0))
+
+	f.Fuzz(func(t *testing.T, header string, totalSize int64) {
+		start, end, ok := parseByteRange(header, totalSize)
+		if !ok {
+			return
+		}
+
+		if totalSize <= 0 {
+			t.Fatalf("parseByteRange(%q, %d) returned ok for non-positive content length: start=%d end=%d",
+				header, totalSize, start, end)
+		}
+
+		if start < 0 || end < start || end >= totalSize {
+			t.Fatalf("parseByteRange(%q, %d) = (%d, %d, true), violates byte-range bounds",
+				header, totalSize, start, end)
+		}
+	})
+}
+
+func FuzzParseCopySourceAndRangeNoPanic(f *testing.F) {
+	f.Add("/bucket/key", "")
+	f.Add("bucket%2Fkey", "bytes=0-99")
+	f.Add("bucket/key%2Fpart", "bytes= 0 - 99 ")
+	f.Add("%zz", "bytes=-99")
+	f.Add("single-segment", "items=0-99")
+
+	f.Fuzz(func(t *testing.T, source, copyRange string) {
+		_, _ = parseCopySource(source)
+
+		rng, err := parseCopySourceRange(copyRange)
+		if err != nil || rng == nil {
+			return
+		}
+
+		if rng.Start < 0 || rng.End < rng.Start {
+			t.Fatalf("parseCopySourceRange(%q) = %+v, violates closed range bounds", copyRange, rng)
+		}
+	})
+}

--- a/internal/service/s3/range.go
+++ b/internal/service/s3/range.go
@@ -22,6 +22,10 @@ import (
 // for a follow-up since the typical S3 consumer (multipart download)
 // only sends single-range requests.
 func parseByteRange(header string, totalSize int64) (start, end int64, ok bool) {
+	if totalSize <= 0 {
+		return 0, 0, false
+	}
+
 	startRaw, endRaw, valid := splitByteRangeSpec(header)
 	if !valid {
 		return 0, 0, false


### PR DESCRIPTION
## Summary

Adds targeted Go fuzz coverage for S3 and DynamoDB edge cases, then fixes the issues found by the new fuzz seeds.

## Bugs Found

- S3 byte range parsing accepted suffix ranges for zero-length objects. For example, `Range: bytes=-1` with a zero-length object produced an invalid successful range `(0, -1)`, which could lead to an invalid `206 Partial Content` response such as `Content-Range: bytes 0--1/0`.
- DynamoDB condition evaluation could panic when `contains()` was evaluated against a list attribute containing a JSON `null` element, because the list walker dereferenced a nil `*AttributeValue`.

## Fuzz Coverage Added

- `FuzzParseByteRangeInvariants`
  - checks S3 byte range parser bounds and zero-length object behavior
- `FuzzParseCopySourceAndRangeNoPanic`
  - exercises S3 copy source and upload-part-copy range parsing
- `FuzzConditionExpressionNoPanic`
  - exercises DynamoDB condition expressions against fuzzed item/value JSON
- `FuzzAttributeValueJSONRoundTrip`
  - exercises DynamoDB `AttributeValue` JSON unmarshal/marshal/unmarshal stability

## Validation

- `go test ./internal/service/s3 -run '^$' -fuzz=FuzzParseByteRangeInvariants -fuzztime=15s -parallel=4`
- `go test ./internal/service/s3 -run '^$' -fuzz=FuzzParseCopySourceAndRangeNoPanic -fuzztime=15s -parallel=4`
- `go test ./internal/service/dynamodb -run '^$' -fuzz=FuzzConditionExpressionNoPanic -fuzztime=15s -parallel=4`
- `go test ./internal/service/dynamodb -run '^$' -fuzz=FuzzAttributeValueJSONRoundTrip -fuzztime=15s -parallel=4`
- `go test ./internal/service/s3 ./internal/service/dynamodb -count=1 -v`
- `make test`
- `make lint`
- `git diff --check`
