### PR TITLE
Fix DynamoDB key attribute updates

### DIFF
--- a/internal/service/dynamodb/condition_test.go
+++ b/internal/service/dynamodb/condition_test.go
@@ -10,6 +10,8 @@ import (
 
 func ptr[T any](v T) *T { return &v }
 
+const errCodeValidation = "ValidationException"
+
 //nolint:cyclop,funlen // Test function exercises multiple storage operations sequentially.
 func TestConditionThroughStorage(t *testing.T) {
 	t.Parallel()
@@ -878,8 +880,6 @@ func TestFilterExpressionFailsClosed(t *testing.T) {
 		t.Fatalf("expected 2 of 3 items to match IN filter, got %d of %d", len(items), scanned)
 	}
 
-	const errCodeValidation = "ValidationException"
-
 	// An unparseable filter is a ValidationException, not match-all.
 	items, _, scanned, err = s.Scan(ctx, "filter-test", "complete garbage !!!",
 		nil, nil, 0, nil, nil, nil)
@@ -912,8 +912,6 @@ func TestFilterExpressionFailsClosed(t *testing.T) {
 // ValidationException rather than a silent empty result.
 func TestExpressionValidationEdgeCases(t *testing.T) {
 	t.Parallel()
-
-	const errCodeValidation = "ValidationException"
 
 	s := NewMemoryStorage("http://localhost:4566")
 	ctx := context.Background()

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -885,9 +885,9 @@ func convertAttributeUpdates(req *UpdateItemRequest) {
 			req.ExpressionAttributeValues[valueKey] = update.Value
 
 			setParts = append(setParts, nameKey+" = "+valueKey)
-		case "DELETE":
+		case updateActionDel:
 			removeParts = append(removeParts, nameKey)
-		case "ADD":
+		case updateActionAdd:
 			req.ExpressionAttributeValues[valueKey] = update.Value
 
 			addParts = append(addParts, nameKey+" "+valueKey)
@@ -899,15 +899,15 @@ func convertAttributeUpdates(req *UpdateItemRequest) {
 	var parts []string
 
 	if len(setParts) > 0 {
-		parts = append(parts, "SET "+strings.Join(setParts, ", "))
+		parts = append(parts, updateActionSet+" "+strings.Join(setParts, ", "))
 	}
 
 	if len(removeParts) > 0 {
-		parts = append(parts, "REMOVE "+strings.Join(removeParts, ", "))
+		parts = append(parts, updateActionRem+" "+strings.Join(removeParts, ", "))
 	}
 
 	if len(addParts) > 0 {
-		parts = append(parts, "ADD "+strings.Join(addParts, ", "))
+		parts = append(parts, updateActionAdd+" "+strings.Join(addParts, ", "))
 	}
 
 	req.UpdateExpression = strings.Join(parts, " ")

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -21,6 +21,10 @@ import (
 const (
 	defaultRegion    = "us-east-1"
 	defaultAccountID = "000000000000"
+	updateActionAdd  = "ADD"
+	updateActionDel  = "DELETE"
+	updateActionRem  = "REMOVE"
+	updateActionSet  = "SET"
 )
 
 // Storage defines the interface for DynamoDB storage operations.
@@ -569,7 +573,12 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 
 	// Parse and apply update expression.
 	if updateExpr != "" {
-		item = m.applyUpdateExpression(item, updateExpr, exprNames, exprValues)
+		updated, err := m.applyValidatedUpdateExpression(td.Table, item, updateExpr, exprNames, exprValues)
+		if err != nil {
+			return nil, err
+		}
+
+		item = updated
 	}
 
 	td.Items[keyStr] = item
@@ -1298,18 +1307,94 @@ func (m *MemoryStorage) applyUpdateExpression(item Item, updateExpr string, expr
 
 	for _, clause := range clauses {
 		switch clause.action {
-		case "SET":
+		case updateActionSet:
 			item = applySetClause(item, clause.body, exprValues)
-		case "ADD":
+		case updateActionAdd:
 			item = applyAddClause(item, clause.body, exprValues)
-		case "DELETE":
+		case updateActionDel:
 			item = applyDeleteClause(item, clause.body, exprValues)
-		case "REMOVE":
+		case updateActionRem:
 			item = applyRemoveClause(item, clause.body)
 		}
 	}
 
 	return item
+}
+
+func (m *MemoryStorage) applyValidatedUpdateExpression(table *Table, item Item, updateExpr string, exprNames map[string]string, exprValues map[string]AttributeValue) (Item, error) {
+	if err := validateUpdateExpressionDoesNotTouchKeys(updateExpr, exprNames, table.KeySchema); err != nil {
+		return nil, err
+	}
+
+	return m.applyUpdateExpression(item, updateExpr, exprNames, exprValues), nil
+}
+
+func validateUpdateExpressionDoesNotTouchKeys(updateExpr string, exprNames map[string]string, keySchema []KeySchemaElement) error {
+	keyNames := make(map[string]struct{}, len(keySchema))
+	for _, key := range keySchema {
+		keyNames[key.AttributeName] = struct{}{}
+	}
+
+	if len(keyNames) == 0 {
+		return nil
+	}
+
+	expr := resolveNames(updateExpr, exprNames)
+	for _, clause := range parseUpdateClauses(expr) {
+		for _, path := range updatedAttributePaths(clause) {
+			attrName := topLevelAttribute(path)
+			if _, ok := keyNames[attrName]; ok {
+				return &TableError{
+					Code:    "ValidationException",
+					Message: "One or more parameter values were invalid: Cannot update key attribute " + attrName,
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func updatedAttributePaths(clause updateClause) []string {
+	switch clause.action {
+	case updateActionSet:
+		assignments := splitAssignments(clause.body)
+		paths := make([]string, 0, len(assignments))
+
+		for _, assignment := range assignments {
+			parts := strings.SplitN(strings.TrimSpace(assignment), "=", 2)
+			if len(parts) == 2 {
+				paths = append(paths, parts[0])
+			}
+		}
+
+		return paths
+	case updateActionAdd, updateActionDel:
+		actions := strings.Split(clause.body, ",")
+		paths := make([]string, 0, len(actions))
+
+		for _, action := range actions {
+			fields := strings.Fields(strings.TrimSpace(action))
+			if len(fields) > 0 {
+				paths = append(paths, fields[0])
+			}
+		}
+
+		return paths
+	case updateActionRem:
+		return strings.Split(clause.body, ",")
+	default:
+		return nil
+	}
+}
+
+func topLevelAttribute(path string) string {
+	path = strings.TrimSpace(path)
+	if idx := strings.IndexAny(path, ".["); idx >= 0 {
+		return strings.TrimSpace(path[:idx])
+	}
+
+	return path
 }
 
 type updateClause struct {
@@ -1319,7 +1404,7 @@ type updateClause struct {
 
 // parseUpdateClauses splits an update expression into individual clauses.
 func parseUpdateClauses(expr string) []updateClause {
-	keywords := []string{"SET", "ADD", "DELETE", "REMOVE"}
+	keywords := []string{updateActionSet, updateActionAdd, updateActionDel, updateActionRem}
 	upper := asciiUpper(expr)
 
 	type pos struct {

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -1906,60 +1906,84 @@ func (m *MemoryStorage) validateTransactWriteItem(twi TransactWriteItem) (*Cance
 
 	switch {
 	case twi.Put != nil:
-		td, exists := m.Tables[twi.Put.TableName]
-		if !exists {
-			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.Put.TableName)}
-		}
-
-		if err := validateItemKey(td.Table, twi.Put.Item); err != nil {
-			return nil, err
-		}
-
-		return m.checkTransactCondition(twi.Put.TableName, twi.Put.Item, ConditionInput{
-			Expression: twi.Put.ConditionExpression, ExprNames: twi.Put.ExpressionAttributeNames, ExprValues: twi.Put.ExpressionAttributeValues,
-		})
+		return m.validateTransactPut(twi.Put)
 	case twi.Delete != nil:
-		td, exists := m.Tables[twi.Delete.TableName]
-		if !exists {
-			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.Delete.TableName)}
-		}
-
-		if err := validateKey(td.Table, twi.Delete.Key); err != nil {
-			return nil, err
-		}
-
-		return m.checkTransactCondition(twi.Delete.TableName, twi.Delete.Key, ConditionInput{
-			Expression: twi.Delete.ConditionExpression, ExprNames: twi.Delete.ExpressionAttributeNames, ExprValues: twi.Delete.ExpressionAttributeValues,
-		})
+		return m.validateTransactDelete(twi.Delete)
 	case twi.Update != nil:
-		td, exists := m.Tables[twi.Update.TableName]
-		if !exists {
-			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.Update.TableName)}
-		}
-
-		if err := validateKey(td.Table, twi.Update.Key); err != nil {
-			return nil, err
-		}
-
-		return m.checkTransactCondition(twi.Update.TableName, twi.Update.Key, ConditionInput{
-			Expression: twi.Update.ConditionExpression, ExprNames: twi.Update.ExpressionAttributeNames, ExprValues: twi.Update.ExpressionAttributeValues,
-		})
+		return m.validateTransactUpdate(twi.Update)
 	case twi.ConditionCheck != nil:
-		td, exists := m.Tables[twi.ConditionCheck.TableName]
-		if !exists {
-			return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", twi.ConditionCheck.TableName)}
-		}
-
-		if err := validateKey(td.Table, twi.ConditionCheck.Key); err != nil {
-			return nil, err
-		}
-
-		return m.checkTransactCondition(twi.ConditionCheck.TableName, twi.ConditionCheck.Key, ConditionInput{
-			Expression: twi.ConditionCheck.ConditionExpression, ExprNames: twi.ConditionCheck.ExpressionAttributeNames, ExprValues: twi.ConditionCheck.ExpressionAttributeValues,
-		})
+		return m.validateTransactConditionCheck(twi.ConditionCheck)
 	}
 
 	return nil, newValidationException("TransactItems member must contain exactly one action")
+}
+
+// validateTransactPut validates a Put action's item key and condition.
+func (m *MemoryStorage) validateTransactPut(put *TransactPut) (*CancellationReason, error) {
+	td, exists := m.Tables[put.TableName]
+	if !exists {
+		return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", put.TableName)}
+	}
+
+	if err := validateItemKey(td.Table, put.Item); err != nil {
+		return nil, err
+	}
+
+	return m.checkTransactCondition(put.TableName, put.Item, ConditionInput{
+		Expression: put.ConditionExpression, ExprNames: put.ExpressionAttributeNames, ExprValues: put.ExpressionAttributeValues,
+	})
+}
+
+// validateTransactDelete validates a Delete action's key and condition.
+func (m *MemoryStorage) validateTransactDelete(del *TransactDelete) (*CancellationReason, error) {
+	td, exists := m.Tables[del.TableName]
+	if !exists {
+		return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", del.TableName)}
+	}
+
+	if err := validateKey(td.Table, del.Key); err != nil {
+		return nil, err
+	}
+
+	return m.checkTransactCondition(del.TableName, del.Key, ConditionInput{
+		Expression: del.ConditionExpression, ExprNames: del.ExpressionAttributeNames, ExprValues: del.ExpressionAttributeValues,
+	})
+}
+
+// validateTransactUpdate validates an Update action's key, update expression, and condition.
+func (m *MemoryStorage) validateTransactUpdate(upd *TransactUpdate) (*CancellationReason, error) {
+	td, exists := m.Tables[upd.TableName]
+	if !exists {
+		return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", upd.TableName)}
+	}
+
+	if err := validateKey(td.Table, upd.Key); err != nil {
+		return nil, err
+	}
+
+	if err := validateUpdateExpressionDoesNotTouchKeys(upd.UpdateExpression, upd.ExpressionAttributeNames, td.Table.KeySchema); err != nil {
+		return nil, err
+	}
+
+	return m.checkTransactCondition(upd.TableName, upd.Key, ConditionInput{
+		Expression: upd.ConditionExpression, ExprNames: upd.ExpressionAttributeNames, ExprValues: upd.ExpressionAttributeValues,
+	})
+}
+
+// validateTransactConditionCheck validates a ConditionCheck action's key and condition.
+func (m *MemoryStorage) validateTransactConditionCheck(cc *TransactConditionCheck) (*CancellationReason, error) {
+	td, exists := m.Tables[cc.TableName]
+	if !exists {
+		return nil, &TableError{Code: "ResourceNotFoundException", Message: fmt.Sprintf("Table: %s not found", cc.TableName)}
+	}
+
+	if err := validateKey(td.Table, cc.Key); err != nil {
+		return nil, err
+	}
+
+	return m.checkTransactCondition(cc.TableName, cc.Key, ConditionInput{
+		Expression: cc.ConditionExpression, ExprNames: cc.ExpressionAttributeNames, ExprValues: cc.ExpressionAttributeValues,
+	})
 }
 
 // checkTransactCondition checks a condition against the existing item in a table.

--- a/internal/service/dynamodb/storage_update_key_test.go
+++ b/internal/service/dynamodb/storage_update_key_test.go
@@ -1,0 +1,94 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestUpdateItemRejectsKeyAttributeUpdates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		expr       string
+		exprNames  map[string]string
+		exprValues map[string]AttributeValue
+	}{
+		{
+			name: "remove hash key",
+			expr: "REMOVE pk",
+		},
+		{
+			name:       "set range key through expression attribute name",
+			expr:       "SET #sk = :new",
+			exprNames:  map[string]string{"#sk": "sk"},
+			exprValues: map[string]AttributeValue{":new": {S: ptr("changed")}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newKeyUpdateTestStorage(t)
+			key := Item{"pk": {S: ptr("seed")}, "sk": {S: ptr("sort")}}
+
+			_, err := store.UpdateItem(context.Background(), "key-update-test", key, tt.expr, tt.exprNames, tt.exprValues, ReturnValuesAllNew, ConditionInput{})
+			if err == nil {
+				t.Fatal("expected UpdateItem to reject key attribute update")
+			}
+
+			var tableErr *TableError
+			if !errors.As(err, &tableErr) || tableErr.Code != "ValidationException" {
+				t.Fatalf("expected ValidationException, got %v", err)
+			}
+
+			item, err := store.GetItem(context.Background(), "key-update-test", key)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if item["pk"].S == nil || *item["pk"].S != "seed" {
+				t.Fatalf("hash key was mutated: %#v", item["pk"])
+			}
+
+			if item["sk"].S == nil || *item["sk"].S != "sort" {
+				t.Fatalf("range key was mutated: %#v", item["sk"])
+			}
+		})
+	}
+}
+
+func newKeyUpdateTestStorage(t *testing.T) *MemoryStorage {
+	t.Helper()
+
+	store := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := store.CreateTable(ctx, &CreateTableRequest{
+		TableName: "key-update-test",
+		KeySchema: []KeySchemaElement{
+			{AttributeName: "pk", KeyType: "HASH"},
+			{AttributeName: "sk", KeyType: "RANGE"},
+		},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "pk", AttributeType: "S"},
+			{AttributeName: "sk", AttributeType: "S"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.PutItem(ctx, "key-update-test", Item{
+		"pk":     {S: ptr("seed")},
+		"sk":     {S: ptr("sort")},
+		"status": {S: ptr("active")},
+	}, false, ConditionInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return store
+}

--- a/internal/service/dynamodb/storage_update_key_test.go
+++ b/internal/service/dynamodb/storage_update_key_test.go
@@ -40,7 +40,7 @@ func TestUpdateItemRejectsKeyAttributeUpdates(t *testing.T) {
 			}
 
 			var tableErr *TableError
-			if !errors.As(err, &tableErr) || tableErr.Code != "ValidationException" {
+			if !errors.As(err, &tableErr) || tableErr.Code != errCodeValidation {
 				t.Fatalf("expected ValidationException, got %v", err)
 			}
 
@@ -57,6 +57,38 @@ func TestUpdateItemRejectsKeyAttributeUpdates(t *testing.T) {
 				t.Fatalf("range key was mutated: %#v", item["sk"])
 			}
 		})
+	}
+}
+
+func TestTransactWriteItemsRejectsKeyAttributeUpdates(t *testing.T) {
+	t.Parallel()
+
+	store := newKeyUpdateTestStorage(t)
+	key := Item{"pk": {S: ptr("seed")}, "sk": {S: ptr("sort")}}
+
+	_, err := store.TransactWriteItems(context.Background(), []TransactWriteItem{{
+		Update: &TransactUpdate{
+			TableName:        "key-update-test",
+			Key:              key,
+			UpdateExpression: "REMOVE pk",
+		},
+	}})
+	if err == nil {
+		t.Fatal("expected TransactWriteItems to reject key attribute update")
+	}
+
+	var tableErr *TableError
+	if !errors.As(err, &tableErr) || tableErr.Code != errCodeValidation {
+		t.Fatalf("expected ValidationException, got %v", err)
+	}
+
+	item, err := store.GetItem(context.Background(), "key-update-test", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if item["pk"].S == nil || *item["pk"].S != "seed" {
+		t.Fatalf("hash key was mutated: %#v", item["pk"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject UpdateItem expressions that target table key attributes
- reject TransactWriteItems Update expressions that target table key attributes
- keep the existing item unchanged when such an update is rejected
- add regression coverage for hash/range key updates and transactional key updates

Fixes #670.
Related to #669.

## Test
- go test ./internal/service/dynamodb -run "Test(UpdateItemRejectsKeyAttributeUpdates|TransactWriteItemsRejectsKeyAttributeUpdates)" -count=1
- go test ./internal/service/dynamodb -count=1
- make lint
- git diff --check