### PR TITLE
Fix DynamoDB UpdateExpression invalid UTF-8 panic

### DIFF
--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -998,7 +998,7 @@ type updateClause struct {
 // parseUpdateClauses splits an update expression into individual clauses.
 func parseUpdateClauses(expr string) []updateClause {
 	keywords := []string{"SET", "ADD", "DELETE", "REMOVE"}
-	upper := strings.ToUpper(expr)
+	upper := asciiUpper(expr)
 
 	type pos struct {
 		idx    int
@@ -1051,6 +1051,17 @@ func parseUpdateClauses(expr string) []updateClause {
 	}
 
 	return clauses
+}
+
+func asciiUpper(s string) string {
+	out := []byte(s)
+	for i, b := range out {
+		if b >= 'a' && b <= 'z' {
+			out[i] = b - ('a' - 'A')
+		}
+	}
+
+	return string(out)
 }
 
 // applySetClause handles SET attr = :val, SET attr = if_not_exists(attr, :val).

--- a/internal/service/dynamodb/storage_update_expression_test.go
+++ b/internal/service/dynamodb/storage_update_expression_test.go
@@ -1,0 +1,34 @@
+package dynamodb
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUpdateItemInvalidUTF8ExpressionDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := store.CreateTable(ctx, &CreateTableRequest{
+		TableName: "invalid-utf8-update-test",
+		KeySchema: []KeySchemaElement{
+			{AttributeName: "pk", KeyType: "HASH"},
+		},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "pk", AttributeType: "S"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("UpdateItem panicked for invalid UTF-8 update expression: %v", r)
+		}
+	}()
+
+	_, _ = store.UpdateItem(ctx, "invalid-utf8-update-test", Item{"pk": {S: ptr("seed")}}, "\x98 REMOVE", nil, nil, ReturnValuesAllNew, ConditionInput{})
+}


### PR DESCRIPTION
## Summary
- avoid byte-index drift in `parseUpdateClauses` by uppercasing ASCII bytes without changing length
- add regression coverage for an invalid UTF-8 update expression that previously panicked

Fixes #671.
Related to #669.

## Test
- `go test ./internal/service/dynamodb -run TestUpdateItemInvalidUTF8ExpressionDoesNotPanic -count=1`
- `go test ./internal/service/dynamodb -count=1`
- `make lint`
- `git diff --check`