### PR TITLE
Reject empty S3 multipart completion

### DIFF
--- a/internal/service/s3/blob_test.go
+++ b/internal/service/s3/blob_test.go
@@ -114,6 +114,8 @@ func TestMemoryStorage_VersionedBodiesRoundTrip(t *testing.T) {
 }
 
 func TestMemoryStorage_LegacyInlineBodyMigrates(t *testing.T) {
+	const legacyBody = "hello"
+
 	ctx := context.Background()
 	dir := t.TempDir()
 
@@ -132,8 +134,8 @@ func TestMemoryStorage_LegacyInlineBodyMigrates(t *testing.T) {
 		t.Fatalf("get object from legacy snapshot: %v", err)
 	}
 
-	if got := string(obj.Body); got != "hello" {
-		t.Fatalf("legacy body = %q, want %q", got, "hello")
+	if got := string(obj.Body); got != legacyBody {
+		t.Fatalf("legacy body = %q, want %q", got, legacyBody)
 	}
 
 	// On the next save the inline body is migrated to a blob.
@@ -141,7 +143,7 @@ func TestMemoryStorage_LegacyInlineBodyMigrates(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
-	if _, err := os.Stat(blobPath(dir, bodyRefOf([]byte("hello")))); err != nil {
+	if _, err := os.Stat(blobPath(dir, bodyRefOf([]byte(legacyBody)))); err != nil {
 		t.Errorf("body not migrated to blob: %v", err)
 	}
 }

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -2525,7 +2525,9 @@ func handleMultipartError(w http.ResponseWriter, r *http.Request, err error) {
 	var multipartErr *MultipartError
 	if errors.As(err, &multipartErr) {
 		status := http.StatusNotFound
-		if multipartErr.Code == "InvalidPart" || multipartErr.Code == "InvalidPartOrder" || multipartErr.Code == "InvalidArgument" {
+
+		switch multipartErr.Code {
+		case "InvalidPart", "InvalidPartOrder", "InvalidArgument", "MalformedXML":
 			status = http.StatusBadRequest
 		}
 

--- a/internal/service/s3/multipart_test.go
+++ b/internal/service/s3/multipart_test.go
@@ -1,0 +1,88 @@
+package s3
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCompleteMultipartUploadRejectsEmptyPartList(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	ctx := context.Background()
+
+	if err := store.CreateBucket(ctx, "mpu-test"); err != nil {
+		t.Fatal(err)
+	}
+
+	upload, err := store.CreateMultipartUpload(ctx, "mpu-test", "object", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	part, err := store.UploadPart(ctx, "mpu-test", "object", upload.UploadID, 1, strings.NewReader("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.CompleteMultipartUpload(ctx, "mpu-test", "object", upload.UploadID, nil)
+	if err == nil {
+		t.Fatal("expected empty part list to be rejected")
+	}
+
+	var multipartErr *MultipartError
+	if !errors.As(err, &multipartErr) || multipartErr.Code != "MalformedXML" {
+		t.Fatalf("expected MalformedXML, got %v", err)
+	}
+
+	obj, err := store.CompleteMultipartUpload(ctx, "mpu-test", "object", upload.UploadID, []PartRequest{
+		{PartNumber: 1, ETag: part.ETag},
+	})
+	if err != nil {
+		t.Fatalf("multipart upload should remain available after rejected empty completion: %v", err)
+	}
+
+	if string(obj.Body) != "hello" {
+		t.Fatalf("body = %q, want %q", string(obj.Body), "hello")
+	}
+}
+
+func TestCompleteMultipartUploadEmptyPartsHandlerReturnsMalformedXML(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "http://localhost:4566")
+	ctx := context.Background()
+
+	if err := store.CreateBucket(ctx, "mpu-handler-test"); err != nil {
+		t.Fatal(err)
+	}
+
+	upload, err := store.CreateMultipartUpload(ctx, "mpu-handler-test", "object", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/mpu-handler-test/object?uploadId="+upload.UploadID,
+		strings.NewReader(`<CompleteMultipartUpload></CompleteMultipartUpload>`),
+	)
+	req.SetPathValue("bucket", "mpu-handler-test")
+	req.SetPathValue("key", "object")
+
+	w := httptest.NewRecorder()
+	svc.CompleteMultipartUpload(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	if !strings.Contains(w.Body.String(), "<Code>MalformedXML</Code>") {
+		t.Fatalf("expected MalformedXML response, got %s", w.Body.String())
+	}
+}

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -1224,6 +1224,10 @@ func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, 
 // assembleMultipartBody validates the part list (ascending order, no
 // duplicates, ETag match) and concatenates the part bodies in order.
 func assembleMultipartBody(upload *MultipartUpload, parts []PartRequest, uploadID string) ([]byte, error) {
+	if len(parts) == 0 {
+		return nil, &MultipartError{Code: "MalformedXML", Message: "CompleteMultipartUpload requires at least one part", UploadID: uploadID}
+	}
+
 	var combinedBody []byte
 
 	previousPartNumber := 0


### PR DESCRIPTION
## Summary
- reject `CompleteMultipartUpload` requests with an empty part list
- preserve the in-progress multipart upload after the invalid completion attempt
- add regression coverage for the empty part list case

Fixes #672.
Related to #669.

## Test
- `go test ./internal/service/s3 -run TestCompleteMultipartUploadRejectsEmptyPartList -count=1`
- `go test ./internal/service/s3 -count=1`
- `make lint`
- `git diff --check`