### PR TITLE
fix(s3): reject unordered multipart completion

### DIFF
--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -2325,7 +2325,7 @@ func handleMultipartError(w http.ResponseWriter, r *http.Request, err error) {
 	var multipartErr *MultipartError
 	if errors.As(err, &multipartErr) {
 		status := http.StatusNotFound
-		if multipartErr.Code == "InvalidPart" || multipartErr.Code == "InvalidArgument" {
+		if multipartErr.Code == "InvalidPart" || multipartErr.Code == "InvalidPartOrder" || multipartErr.Code == "InvalidArgument" {
 			status = http.StatusBadRequest
 		}
 

--- a/internal/service/s3/multipart_order_test.go
+++ b/internal/service/s3/multipart_order_test.go
@@ -1,0 +1,81 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestCompleteMultipartUploadRejectsInvalidPartOrder(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	ctx := context.Background()
+	parts := createMultipartOrderTestParts(t, store)
+
+	_, err := store.CompleteMultipartUpload(ctx, "mpu-order-test", "object", parts.uploadID, []PartRequest{
+		{PartNumber: 2, ETag: parts.part2.ETag},
+		{PartNumber: 1, ETag: parts.part1.ETag},
+	})
+	expectMultipartCode(t, err, "InvalidPartOrder")
+}
+
+func TestCompleteMultipartUploadRejectsDuplicatePartNumbers(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	ctx := context.Background()
+	parts := createMultipartOrderTestParts(t, store)
+
+	_, err := store.CompleteMultipartUpload(ctx, "mpu-order-test", "object", parts.uploadID, []PartRequest{
+		{PartNumber: 1, ETag: parts.part1.ETag},
+		{PartNumber: 1, ETag: parts.part1.ETag},
+	})
+	expectMultipartCode(t, err, "InvalidPartOrder")
+}
+
+type multipartOrderTestParts struct {
+	uploadID string
+	part1    *Part
+	part2    *Part
+}
+
+func createMultipartOrderTestParts(t *testing.T, store *MemoryStorage) multipartOrderTestParts {
+	t.Helper()
+
+	ctx := context.Background()
+	if err := store.CreateBucket(ctx, "mpu-order-test"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	upload, err := store.CreateMultipartUpload(ctx, "mpu-order-test", "object")
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	part1, err := store.UploadPart(ctx, "mpu-order-test", "object", upload.UploadID, 1, bytes.NewReader([]byte("hello ")))
+	if err != nil {
+		t.Fatalf("UploadPart 1: %v", err)
+	}
+
+	part2, err := store.UploadPart(ctx, "mpu-order-test", "object", upload.UploadID, 2, bytes.NewReader([]byte("world")))
+	if err != nil {
+		t.Fatalf("UploadPart 2: %v", err)
+	}
+
+	return multipartOrderTestParts{uploadID: upload.UploadID, part1: part1, part2: part2}
+}
+
+func expectMultipartCode(t *testing.T, err error, code string) {
+	t.Helper()
+
+	var multipartErr *MultipartError
+	if !errors.As(err, &multipartErr) {
+		t.Fatalf("got err %v, want MultipartError code %s", err, code)
+	}
+
+	if multipartErr.Code != code {
+		t.Fatalf("got MultipartError code %s, want %s", multipartErr.Code, code)
+	}
+}

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -995,7 +995,15 @@ func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, 
 	// Validate and assemble parts
 	var combinedBody []byte
 
+	previousPartNumber := 0
+
 	for _, pr := range parts {
+		if pr.PartNumber <= previousPartNumber {
+			return nil, &MultipartError{Code: "InvalidPartOrder", Message: "The list of parts was not in ascending order. Parts must be ordered by part number.", UploadID: uploadID}
+		}
+
+		previousPartNumber = pr.PartNumber
+
 		part, ok := upload.Parts[pr.PartNumber]
 		if !ok {
 			return nil, &MultipartError{Code: "InvalidPart", Message: "One or more of the specified parts could not be found", UploadID: uploadID}


### PR DESCRIPTION
## Summary
- validate CompleteMultipartUpload parts are strictly ascending by PartNumber
- reject duplicate part numbers as InvalidPartOrder
- map InvalidPartOrder multipart errors to HTTP 400

Fixes #677.
Refs #669.

## Tests
- go test ./internal/service/s3 -count=1
- make lint
- git diff --check