### PR TITLE
fix(range): reject suffix ranges on empty bodies

### DIFF
--- a/internal/service/cloudfront/cache/rules.go
+++ b/internal/service/cloudfront/cache/rules.go
@@ -586,7 +586,7 @@ func splitByteRangeSpec(header string) (string, string, bool) {
 // parseSuffixRange resolves `bytes=-N` (the last N bytes).
 func parseSuffixRange(endRaw string, totalSize int64) (int64, int64, bool) {
 	n, err := strconv.ParseInt(endRaw, 10, 64)
-	if err != nil || n <= 0 {
+	if err != nil || n <= 0 || totalSize <= 0 {
 		return 0, 0, false
 	}
 

--- a/internal/service/cloudfront/cache/rules_test.go
+++ b/internal/service/cloudfront/cache/rules_test.go
@@ -399,3 +399,11 @@ func TestParseRange(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRangeRejectsSuffixRangeForEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	if start, end, ok := ParseRange("bytes=-1", 0); ok {
+		t.Fatalf("got (%d, %d, true), want unsatisfiable", start, end)
+	}
+}

--- a/internal/service/s3/range.go
+++ b/internal/service/s3/range.go
@@ -64,7 +64,7 @@ func splitByteRangeSpec(header string) (string, string, bool) {
 // 100-byte object returns the whole object.
 func parseSuffixRange(endRaw string, totalSize int64) (int64, int64, bool) {
 	n, err := strconv.ParseInt(endRaw, 10, 64)
-	if err != nil || n <= 0 {
+	if err != nil || n <= 0 || totalSize <= 0 {
 		return 0, 0, false
 	}
 

--- a/internal/service/s3/range_test.go
+++ b/internal/service/s3/range_test.go
@@ -45,6 +45,14 @@ func TestParseByteRange(t *testing.T) {
 	}
 }
 
+func TestParseByteRangeRejectsSuffixRangeForEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	if start, end, ok := parseByteRange("bytes=-1", 0); ok {
+		t.Fatalf("got (%d, %d, true), want unsatisfiable", start, end)
+	}
+}
+
 // rangeCase pins one Range scenario for the HTTP-layer table test.
 type rangeCase struct {
 	name        string


### PR DESCRIPTION
## Summary
- reject suffix byte ranges when total size is zero in S3 range parsing
- apply the same empty-body suffix guard to CloudFront cache range parsing
- add parser regression tests for both services

Fixes #678.
Refs #669.

## Tests
- go test ./internal/service/s3 ./internal/service/cloudfront/cache -count=1
- make lint
- git diff --check