### PR TITLE
fix(messaging): validate SNS and SQS names

### DIFF
--- a/internal/awsname/messaging.go
+++ b/internal/awsname/messaging.go
@@ -1,0 +1,39 @@
+// Package awsname holds resource-name validators shared between AWS service
+// emulators (currently SNS topics, SQS queues — same character rules, different
+// length caps).
+package awsname
+
+import "strings"
+
+// IsValidMessagingResource returns true when name satisfies the character /
+// suffix rules AWS applies to SNS topic and SQS queue names:
+//
+//   - 1..maxLen characters
+//   - alphanumeric, underscore, hyphen
+//   - a single trailing ".fifo" is permitted (FIFO queue / topic), and the
+//     pre-suffix base must be non-empty; no other '.' is allowed
+func IsValidMessagingResource(name string, maxLen int) bool {
+	if name == "" || len(name) > maxLen {
+		return false
+	}
+
+	base := name
+	if strings.HasSuffix(name, ".fifo") {
+		base = strings.TrimSuffix(name, ".fifo")
+		if base == "" {
+			return false
+		}
+	} else if strings.Contains(name, ".") {
+		return false
+	}
+
+	for _, r := range base {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
+			continue
+		}
+
+		return false
+	}
+
+	return true
+}

--- a/internal/awsname/messaging_test.go
+++ b/internal/awsname/messaging_test.go
@@ -1,0 +1,38 @@
+package awsname
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsValidMessagingResource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   bool
+	}{
+		{name: "plain", input: "topic", maxLen: 256, want: true},
+		{name: "fifo", input: "topic.fifo", maxLen: 256, want: true},
+		{name: "alphanumeric and separators", input: "Topic_1-2", maxLen: 256, want: true},
+		{name: "empty", input: "", maxLen: 256, want: false},
+		{name: "only .fifo", input: ".fifo", maxLen: 256, want: false},
+		{name: "embedded dot", input: "to.pic", maxLen: 256, want: false},
+		{name: "invalid char", input: "topic/sub", maxLen: 256, want: false},
+		{name: "space", input: "topic name", maxLen: 256, want: false},
+		{name: "exactly maxLen", input: strings.Repeat("a", 80), maxLen: 80, want: true},
+		{name: "over maxLen", input: strings.Repeat("a", 81), maxLen: 80, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := IsValidMessagingResource(tt.input, tt.maxLen); got != tt.want {
+				t.Errorf("IsValidMessagingResource(%q, %d) = %v, want %v", tt.input, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/sivchari/kumo/internal/awsname"
 	"github.com/sivchari/kumo/internal/storage"
 )
 
@@ -550,33 +551,7 @@ func (m *MemoryStorage) ListSubscriptionsByTopic(_ context.Context, topicARN, ne
 }
 
 func isValidTopicName(name string) bool {
-	return isValidMessagingName(name, 256)
-}
-
-func isValidMessagingName(name string, maxLen int) bool {
-	if name == "" || len(name) > maxLen {
-		return false
-	}
-
-	base := name
-	if strings.HasSuffix(name, ".fifo") {
-		base = strings.TrimSuffix(name, ".fifo")
-		if base == "" {
-			return false
-		}
-	} else if strings.Contains(name, ".") {
-		return false
-	}
-
-	for _, r := range base {
-		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
-			continue
-		}
-
-		return false
-	}
-
-	return true
+	return awsname.IsValidMessagingResource(name, 256)
 }
 
 // buildTopicARN builds an ARN for a topic.

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -146,6 +146,13 @@ func (m *MemoryStorage) CreateTopic(_ context.Context, name string, attributes m
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if !isValidTopicName(name) {
+		return nil, &TopicError{
+			Code:    "InvalidParameter",
+			Message: "Topic name contains invalid characters",
+		}
+	}
+
 	arn := m.buildTopicARN(name)
 
 	// Return existing topic if it exists.
@@ -540,6 +547,36 @@ func (m *MemoryStorage) ListSubscriptionsByTopic(_ context.Context, topicARN, ne
 	}
 
 	return result, newNextToken, nil
+}
+
+func isValidTopicName(name string) bool {
+	return isValidMessagingName(name, 256)
+}
+
+func isValidMessagingName(name string, maxLen int) bool {
+	if name == "" || len(name) > maxLen {
+		return false
+	}
+
+	base := name
+	if strings.HasSuffix(name, ".fifo") {
+		base = strings.TrimSuffix(name, ".fifo")
+		if base == "" {
+			return false
+		}
+	} else if strings.Contains(name, ".") {
+		return false
+	}
+
+	for _, r := range base {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
+			continue
+		}
+
+		return false
+	}
+
+	return true
 }
 
 // buildTopicARN builds an ARN for a topic.

--- a/internal/service/sns/storage_test.go
+++ b/internal/service/sns/storage_test.go
@@ -1,0 +1,56 @@
+package sns
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCreateTopicRejectsDelimiterNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"bad:name",
+		"bad/name",
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			store := NewMemoryStorage("http://localhost:4566")
+
+			_, err := store.CreateTopic(t.Context(), name, nil)
+			expectTopicErrorCode(t, err, "InvalidParameter")
+		})
+	}
+}
+
+func TestCreateTopicAcceptsValidNames(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage("http://localhost:4566")
+
+	for _, name := range []string{"topic_name-1", "topic-name.fifo"} {
+		topic, err := store.CreateTopic(t.Context(), name, nil)
+		if err != nil {
+			t.Fatalf("CreateTopic(%q): %v", name, err)
+		}
+
+		if topic.Name != name {
+			t.Fatalf("CreateTopic(%q) name = %q", name, topic.Name)
+		}
+	}
+}
+
+func expectTopicErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+
+	var topicErr *TopicError
+	if !errors.As(err, &topicErr) {
+		t.Fatalf("got err %v, want TopicError code %s", err, code)
+	}
+
+	if topicErr.Code != code {
+		t.Fatalf("got TopicError code %s, want %s", topicErr.Code, code)
+	}
+}

--- a/internal/service/sqs/storage.go
+++ b/internal/service/sqs/storage.go
@@ -218,6 +218,13 @@ func (s *MemoryStorage) CreateQueue(_ context.Context, name string, attributes, 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if !isValidQueueName(name) {
+		return nil, &QueueError{
+			Code:    "InvalidParameterValue",
+			Message: "Queue name contains invalid characters",
+		}
+	}
+
 	queueURL := fmt.Sprintf("%s/000000000000/%s", s.baseURL, name)
 
 	if qd, exists := s.Queues[queueURL]; exists {
@@ -267,6 +274,32 @@ func (s *MemoryStorage) CreateQueue(_ context.Context, name string, attributes, 
 	s.Queues[queueURL] = qd
 
 	return queue, nil
+}
+
+func isValidQueueName(name string) bool {
+	if name == "" || len(name) > 80 {
+		return false
+	}
+
+	base := name
+	if strings.HasSuffix(name, ".fifo") {
+		base = strings.TrimSuffix(name, ".fifo")
+		if base == "" {
+			return false
+		}
+	} else if strings.Contains(name, ".") {
+		return false
+	}
+
+	for _, r := range base {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
+			continue
+		}
+
+		return false
+	}
+
+	return true
 }
 
 // DeleteQueue deletes a queue.

--- a/internal/service/sqs/storage.go
+++ b/internal/service/sqs/storage.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/sivchari/kumo/internal/awsname"
 	"github.com/sivchari/kumo/internal/storage"
 )
 
@@ -277,29 +278,7 @@ func (s *MemoryStorage) CreateQueue(_ context.Context, name string, attributes, 
 }
 
 func isValidQueueName(name string) bool {
-	if name == "" || len(name) > 80 {
-		return false
-	}
-
-	base := name
-	if strings.HasSuffix(name, ".fifo") {
-		base = strings.TrimSuffix(name, ".fifo")
-		if base == "" {
-			return false
-		}
-	} else if strings.Contains(name, ".") {
-		return false
-	}
-
-	for _, r := range base {
-		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
-			continue
-		}
-
-		return false
-	}
-
-	return true
+	return awsname.IsValidMessagingResource(name, 80)
 }
 
 // DeleteQueue deletes a queue.

--- a/internal/service/sqs/storage_test.go
+++ b/internal/service/sqs/storage_test.go
@@ -1,8 +1,55 @@
 package sqs
 
 import (
+	"errors"
 	"testing"
 )
+
+func TestMemoryStorage_CreateQueueRejectsDelimiterNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"bad/name",
+		"bad:name",
+		"bad%2Fname",
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			s := NewMemoryStorage("http://localhost:4566")
+
+			_, err := s.CreateQueue(t.Context(), name, nil, nil)
+			expectQueueErrorCode(t, err, "InvalidParameterValue")
+		})
+	}
+}
+
+func TestMemoryStorage_CreateQueueAcceptsValidNames(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+
+	tests := []struct {
+		name  string
+		attrs map[string]string
+	}{
+		{name: "queue_name-1"},
+		{name: "queue-name.fifo", attrs: map[string]string{"FifoQueue": "true"}},
+	}
+
+	for _, tt := range tests {
+		queue, err := s.CreateQueue(t.Context(), tt.name, tt.attrs, nil)
+		if err != nil {
+			t.Fatalf("CreateQueue(%q): %v", tt.name, err)
+		}
+
+		if queue.Name != tt.name {
+			t.Fatalf("CreateQueue(%q) name = %q", tt.name, queue.Name)
+		}
+	}
+}
 
 func TestMemoryStorage_ResolveQueueData_HostnameMismatch(t *testing.T) {
 	t.Parallel()
@@ -137,6 +184,19 @@ func TestMemoryStorage_TagsLifecycle(t *testing.T) {
 
 	if len(tags) != 1 || tags["key2"] != tagValue2 {
 		t.Fatalf("unexpected tags after untag: %#v", tags)
+	}
+}
+
+func expectQueueErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+
+	var queueErr *QueueError
+	if !errors.As(err, &queueErr) {
+		t.Fatalf("got err %v, want QueueError code %s", err, code)
+	}
+
+	if queueErr.Code != code {
+		t.Fatalf("got QueueError code %s, want %s", queueErr.Code, code)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject SNS topic names that contain ARN/path delimiter characters or unsupported dots
- reject SQS queue names that contain URL/ARN delimiter characters or unsupported dots
- keep valid standard and FIFO-style names accepted
- add storage-level regression tests for the delimiter cases

Fixes #682.
Refs #669.

## Tests
- go test ./internal/service/sns ./internal/service/sqs -count=1
- make lint
- git diff --check