### PR TITLE
fix(kinesis): validate record key inputs

### DIFF
--- a/internal/service/kinesis/storage.go
+++ b/internal/service/kinesis/storage.go
@@ -30,6 +30,7 @@ const (
 	defaultRetentionHours   = 24
 	maxRecordsPerGet        = 10000
 	shardIteratorExpiration = 5 * time.Minute
+	maxHashKeyString        = "340282366920938463463374607431768211455"
 )
 
 // Storage defines the Kinesis storage interface.
@@ -381,10 +382,16 @@ func (s *MemoryStorage) PutRecord(_ context.Context, streamName string, data []b
 		return "", "", &ServiceError{Code: errResourceNotFound, Message: "Stream not found"}
 	}
 
+	if !isValidPartitionKey(partitionKey) {
+		return "", "", &ServiceError{Code: errInvalidArgument, Message: "Invalid PartitionKey"}
+	}
+
 	// Determine shard based on hash key.
 	hashKey := explicitHashKey
 	if hashKey == "" {
 		hashKey = computeHashKey(partitionKey)
+	} else if !isValidExplicitHashKey(hashKey) {
+		return "", "", &ServiceError{Code: errInvalidArgument, Message: "Invalid ExplicitHashKey"}
 	}
 
 	shardID := s.findShardForHashKey(sd, hashKey)
@@ -418,35 +425,7 @@ func (s *MemoryStorage) PutRecords(_ context.Context, streamName string, records
 	results := make([]PutRecordsResultEntry, len(records))
 
 	for i, entry := range records {
-		hashKey := entry.ExplicitHashKey
-		if hashKey == "" {
-			hashKey = computeHashKey(entry.PartitionKey)
-		}
-
-		shardID := s.findShardForHashKey(sd, hashKey)
-		if shardID == "" {
-			results[i] = PutRecordsResultEntry{
-				ErrorCode:    errInvalidArgument,
-				ErrorMessage: "Could not determine shard for partition key",
-			}
-
-			continue
-		}
-
-		seqNum := s.nextSequenceNumber()
-		record := &Record{
-			Data:                        entry.Data,
-			PartitionKey:                entry.PartitionKey,
-			SequenceNumber:              seqNum,
-			ApproximateArrivalTimestamp: time.Now(),
-		}
-
-		sd.Shards[shardID].Records = append(sd.Shards[shardID].Records, record)
-
-		results[i] = PutRecordsResultEntry{
-			ShardID:        shardID,
-			SequenceNumber: seqNum,
-		}
+		results[i] = s.putRecordsEntry(sd, entry)
 	}
 
 	var failedCount int32
@@ -458,6 +437,43 @@ func (s *MemoryStorage) PutRecords(_ context.Context, streamName string, records
 	}
 
 	return results, failedCount, nil
+}
+
+func (s *MemoryStorage) putRecordsEntry(sd *StreamData, entry PutRecordsRequestEntry) PutRecordsResultEntry {
+	if !isValidPartitionKey(entry.PartitionKey) {
+		return newPutRecordsFailure("Invalid PartitionKey")
+	}
+
+	hashKey := entry.ExplicitHashKey
+	if hashKey == "" {
+		hashKey = computeHashKey(entry.PartitionKey)
+	} else if !isValidExplicitHashKey(hashKey) {
+		return newPutRecordsFailure("Invalid ExplicitHashKey")
+	}
+
+	shardID := s.findShardForHashKey(sd, hashKey)
+	if shardID == "" {
+		return newPutRecordsFailure("Could not determine shard for partition key")
+	}
+
+	seqNum := s.nextSequenceNumber()
+	record := &Record{
+		Data:                        entry.Data,
+		PartitionKey:                entry.PartitionKey,
+		SequenceNumber:              seqNum,
+		ApproximateArrivalTimestamp: time.Now(),
+	}
+
+	sd.Shards[shardID].Records = append(sd.Shards[shardID].Records, record)
+
+	return PutRecordsResultEntry{
+		ShardID:        shardID,
+		SequenceNumber: seqNum,
+	}
+}
+
+func newPutRecordsFailure(message string) PutRecordsResultEntry {
+	return PutRecordsResultEntry{ErrorCode: errInvalidArgument, ErrorMessage: message}
 }
 
 // GetShardIterator gets a shard iterator.
@@ -607,9 +623,31 @@ func computeHashKey(partitionKey string) string {
 	return hashInt.String()
 }
 
+func isValidPartitionKey(partitionKey string) bool {
+	return partitionKey != "" && len(partitionKey) <= 256
+}
+
+func isValidExplicitHashKey(hashKey string) bool {
+	for _, r := range hashKey {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	hashKeyBig := new(big.Int)
+	if _, ok := hashKeyBig.SetString(hashKey, 10); !ok {
+		return false
+	}
+
+	maxHashKey := new(big.Int)
+	maxHashKey.SetString(maxHashKeyString, 10)
+
+	return hashKeyBig.Cmp(maxHashKey) <= 0
+}
+
 func calculateHashKeyRanges(shardCount int32) []HashKeyRange {
 	maxHashKey := new(big.Int)
-	maxHashKey.SetString("340282366920938463463374607431768211455", 10) // 2^128 - 1
+	maxHashKey.SetString(maxHashKeyString, 10) // 2^128 - 1
 
 	ranges := make([]HashKeyRange, shardCount)
 	shardSize := new(big.Int).Div(maxHashKey, big.NewInt(int64(shardCount)))

--- a/internal/service/kinesis/storage_test.go
+++ b/internal/service/kinesis/storage_test.go
@@ -1,0 +1,105 @@
+package kinesis
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPutRecordRejectsInvalidExplicitHashKey(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	createKinesisTestStream(t, store)
+
+	_, _, err := store.PutRecord(t.Context(), "test-stream", []byte("data"), "pk", "not-a-number")
+	expectKinesisErrorCode(t, err, errInvalidArgument)
+}
+
+func TestPutRecordRejectsEmptyPartitionKey(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	createKinesisTestStream(t, store)
+
+	_, _, err := store.PutRecord(t.Context(), "test-stream", []byte("data"), "", "")
+	expectKinesisErrorCode(t, err, errInvalidArgument)
+}
+
+func TestPutRecordsRejectsInvalidExplicitHashKeyEntry(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	createKinesisTestStream(t, store)
+
+	results, failed, err := store.PutRecords(t.Context(), "test-stream", []PutRecordsRequestEntry{
+		{Data: []byte("bad"), PartitionKey: "pk", ExplicitHashKey: "not-a-number"},
+		{Data: []byte("good"), PartitionKey: "pk"},
+	})
+	if err != nil {
+		t.Fatalf("PutRecords: %v", err)
+	}
+
+	if failed != 1 {
+		t.Fatalf("failed count = %d, want 1", failed)
+	}
+
+	if results[0].ErrorCode != errInvalidArgument {
+		t.Fatalf("first result error = %q, want %q", results[0].ErrorCode, errInvalidArgument)
+	}
+
+	if results[1].ShardID == "" || results[1].SequenceNumber == "" {
+		t.Fatalf("second result should succeed: %#v", results[1])
+	}
+}
+
+func TestPutRecordsRejectsEmptyPartitionKeyEntry(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	createKinesisTestStream(t, store)
+
+	results, failed, err := store.PutRecords(t.Context(), "test-stream", []PutRecordsRequestEntry{
+		{Data: []byte("bad"), PartitionKey: ""},
+		{Data: []byte("good"), PartitionKey: "pk"},
+	})
+	if err != nil {
+		t.Fatalf("PutRecords: %v", err)
+	}
+
+	if failed != 1 {
+		t.Fatalf("failed count = %d, want 1", failed)
+	}
+
+	if results[0].ErrorCode != errInvalidArgument {
+		t.Fatalf("first result error = %q, want %q", results[0].ErrorCode, errInvalidArgument)
+	}
+
+	if results[1].ShardID == "" || results[1].SequenceNumber == "" {
+		t.Fatalf("second result should succeed: %#v", results[1])
+	}
+}
+
+func createKinesisTestStream(t *testing.T, store *MemoryStorage) {
+	t.Helper()
+
+	shardCount := int32(2)
+	if err := store.CreateStream(t.Context(), &CreateStreamRequest{
+		StreamName: "test-stream",
+		ShardCount: &shardCount,
+	}); err != nil {
+		t.Fatalf("CreateStream: %v", err)
+	}
+}
+
+func expectKinesisErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+
+	var serviceErr *ServiceError
+	if !errors.As(err, &serviceErr) {
+		t.Fatalf("got err %v, want ServiceError code %s", err, code)
+	}
+
+	if serviceErr.Code != code {
+		t.Fatalf("got ServiceError code %s, want %s", serviceErr.Code, code)
+	}
+}


### PR DESCRIPTION
## Summary
- reject non-numeric ExplicitHashKey values for PutRecord
- reject empty PartitionKey values for PutRecord
- return entry-level InvalidArgumentException for invalid ExplicitHashKey / PartitionKey values in PutRecords
- share the Kinesis max hash key constant with range calculation
- add storage-level regression tests for both paths

Fixes #684.
Refs #669.

## Tests
- go test ./internal/service/kinesis -count=1
- make lint
- git diff --check