### PR TITLE
fix(kinesis): validate CreateStream inputs

### DIFF
--- a/internal/service/kinesis/handlers.go
+++ b/internal/service/kinesis/handlers.go
@@ -448,6 +448,8 @@ func getErrorStatus(code string) int {
 		return http.StatusConflict
 	case errInvalidArgument:
 		return http.StatusBadRequest
+	case errValidation:
+		return http.StatusBadRequest
 	case errExpiredIterator:
 		return http.StatusBadRequest
 	default:

--- a/internal/service/kinesis/storage.go
+++ b/internal/service/kinesis/storage.go
@@ -23,6 +23,7 @@ const (
 	errResourceInUse    = "ResourceInUseException"
 	errInvalidArgument  = "InvalidArgumentException"
 	errExpiredIterator  = "ExpiredIteratorException"
+	errValidation       = "ValidationException"
 )
 
 // Default values.
@@ -31,8 +32,14 @@ const (
 	defaultShardCount       = 1
 	defaultRetentionHours   = 24
 	maxRecordsPerGet        = 10000
+	maxStreamNameLength     = 128
 	shardIteratorExpiration = 5 * time.Minute
 	maxHashKeyString        = "340282366920938463463374607431768211455"
+)
+
+const (
+	streamModeOnDemand    = "ON_DEMAND"
+	streamModeProvisioned = "PROVISIONED"
 )
 
 // Storage defines the Kinesis storage interface.
@@ -188,6 +195,18 @@ func (s *MemoryStorage) Close() error {
 
 // CreateStream creates a new stream.
 func (s *MemoryStorage) CreateStream(_ context.Context, req *CreateStreamRequest) error {
+	if !isValidStreamName(req.StreamName) {
+		return &ServiceError{Code: errValidation, Message: "Invalid stream name"}
+	}
+
+	if req.ShardCount != nil && *req.ShardCount < 1 {
+		return &ServiceError{Code: errValidation, Message: "Invalid shard count"}
+	}
+
+	if req.StreamModeDetails != nil && !isValidStreamMode(req.StreamModeDetails.StreamMode) {
+		return &ServiceError{Code: errValidation, Message: "Invalid stream mode"}
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -200,6 +219,14 @@ func (s *MemoryStorage) CreateStream(_ context.Context, req *CreateStreamRequest
 		shardCount = *req.ShardCount
 	}
 
+	s.Streams[req.StreamName] = s.newStreamData(req, shardCount)
+
+	s.saveLocked()
+
+	return nil
+}
+
+func (s *MemoryStorage) newStreamData(req *CreateStreamRequest, shardCount int32) *StreamData {
 	now := time.Now()
 	stream := &Stream{
 		StreamName:              req.StreamName,
@@ -214,10 +241,16 @@ func (s *MemoryStorage) CreateStream(_ context.Context, req *CreateStreamRequest
 	}
 
 	if stream.StreamModeDetails == nil {
-		stream.StreamModeDetails = &StreamModeDetails{StreamMode: "PROVISIONED"}
+		stream.StreamModeDetails = &StreamModeDetails{StreamMode: streamModeProvisioned}
 	}
 
-	// Create shards.
+	return &StreamData{
+		Stream: stream,
+		Shards: s.createShards(shardCount),
+	}
+}
+
+func (s *MemoryStorage) createShards(shardCount int32) map[string]*ShardData {
 	shards := make(map[string]*ShardData)
 	hashKeyRange := calculateHashKeyRanges(shardCount)
 
@@ -239,14 +272,31 @@ func (s *MemoryStorage) CreateStream(_ context.Context, req *CreateStreamRequest
 		}
 	}
 
-	s.Streams[req.StreamName] = &StreamData{
-		Stream: stream,
-		Shards: shards,
+	return shards
+}
+
+func isValidStreamName(name string) bool {
+	if name == "" || len(name) > maxStreamNameLength {
+		return false
 	}
 
-	s.saveLocked()
+	for i := range name {
+		c := name[i]
+		if (c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') ||
+			c == '_' || c == '.' || c == '-' {
+			continue
+		}
 
-	return nil
+		return false
+	}
+
+	return true
+}
+
+func isValidStreamMode(mode string) bool {
+	return mode == streamModeProvisioned || mode == streamModeOnDemand
 }
 
 // DeleteStream deletes a stream.

--- a/internal/service/kinesis/storage_test.go
+++ b/internal/service/kinesis/storage_test.go
@@ -2,6 +2,7 @@ package kinesis
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -76,6 +77,90 @@ func TestPutRecordsRejectsEmptyPartitionKeyEntry(t *testing.T) {
 
 	if results[1].ShardID == "" || results[1].SequenceNumber == "" {
 		t.Fatalf("second result should succeed: %#v", results[1])
+	}
+}
+
+func TestCreateStreamRejectsInvalidStreamNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		streamName string
+	}{
+		{name: "empty", streamName: ""},
+		{name: "too long", streamName: strings.Repeat("a", 129)},
+		{name: "slash delimiter", streamName: "tenant/stream"},
+		{name: "colon delimiter", streamName: "tenant:stream"},
+		{name: "space", streamName: "tenant stream"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := NewMemoryStorage()
+			shards := int32(1)
+
+			err := store.CreateStream(t.Context(), &CreateStreamRequest{
+				StreamName: tt.streamName,
+				ShardCount: &shards,
+			})
+			expectKinesisErrorCode(t, err, errValidation)
+
+			if _, exists := store.Streams[tt.streamName]; exists {
+				t.Fatalf("invalid stream %q was stored", tt.streamName)
+			}
+		})
+	}
+}
+
+func TestCreateStreamRejectsInvalidShardCount(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	shards := int32(0)
+
+	err := store.CreateStream(t.Context(), &CreateStreamRequest{
+		StreamName: "test-stream",
+		ShardCount: &shards,
+	})
+	expectKinesisErrorCode(t, err, errValidation)
+
+	if _, exists := store.Streams["test-stream"]; exists {
+		t.Fatal("stream with invalid shard count was stored")
+	}
+}
+
+func TestCreateStreamRejectsInvalidStreamMode(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	shards := int32(1)
+
+	err := store.CreateStream(t.Context(), &CreateStreamRequest{
+		StreamName:        "test-stream",
+		ShardCount:        &shards,
+		StreamModeDetails: &StreamModeDetails{StreamMode: "BROKEN"},
+	})
+	expectKinesisErrorCode(t, err, errValidation)
+
+	if _, exists := store.Streams["test-stream"]; exists {
+		t.Fatal("stream with invalid stream mode was stored")
+	}
+}
+
+func TestCreateStreamAllowsValidStreamNameCharacters(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	shards := int32(1)
+
+	err := store.CreateStream(t.Context(), &CreateStreamRequest{
+		StreamName: "test.stream_name-1",
+		ShardCount: &shards,
+	})
+	if err != nil {
+		t.Fatalf("CreateStream: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #686
- Related to #669
- reject invalid CreateStream StreamName values before storing streams
- reject supplied ShardCount values below 1
- reject unsupported StreamModeDetails.StreamMode values
- keep shard creation separated from request validation so invalid requests cannot persist malformed ARNs

## Tests
- go test ./internal/service/kinesis -count=1
- go test ./... -count=1
- make lint
- git diff --check