### PR TITLE
fix(s3): honor CopyObject metadata directive

### DIFF
--- a/internal/service/s3/copyobject_test.go
+++ b/internal/service/s3/copyobject_test.go
@@ -1,0 +1,123 @@
+package s3
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCopyObjectReplacesMetadataWhenDirectiveIsReplace(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupCopyObjectMetadataFixture(t)
+	w := issueCopyObject(svc, map[string]string{
+		"X-Amz-Metadata-Directive": "REPLACE",
+		"X-Amz-Meta-Color":         "red",
+		"Content-Type":             "application/json",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	dstObj, err := store.GetObject(context.Background(), "dst", "copied.txt")
+	if err != nil {
+		t.Fatalf("GetObject dst: %v", err)
+	}
+
+	if got := dstObj.Metadata["color"]; got != "red" {
+		t.Fatalf("metadata color: got %q, want red", got)
+	}
+
+	if got := dstObj.Metadata["Content-Type"]; got != "application/json" {
+		t.Fatalf("metadata Content-Type: got %q, want application/json", got)
+	}
+}
+
+func TestCopyObjectCopiesSourceMetadataByDefault(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupCopyObjectMetadataFixture(t)
+	w := issueCopyObject(svc, map[string]string{
+		"X-Amz-Meta-Color": "red",
+		"Content-Type":     "application/json",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	dstObj, err := store.GetObject(context.Background(), "dst", "copied.txt")
+	if err != nil {
+		t.Fatalf("GetObject dst: %v", err)
+	}
+
+	if got := dstObj.Metadata["color"]; got != "blue" {
+		t.Fatalf("metadata color: got %q, want blue", got)
+	}
+
+	if got := dstObj.Metadata["Content-Type"]; got != "text/plain" {
+		t.Fatalf("metadata Content-Type: got %q, want text/plain", got)
+	}
+}
+
+func TestCopyObjectRejectsInvalidMetadataDirective(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupCopyObjectMetadataFixture(t)
+	w := issueCopyObject(svc, map[string]string{
+		"X-Amz-Metadata-Directive": "BROKEN",
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	if _, err := store.GetObject(context.Background(), "dst", "copied.txt"); err == nil {
+		t.Fatal("destination object was stored for invalid metadata directive")
+	}
+}
+
+func setupCopyObjectMetadataFixture(t *testing.T) (*MemoryStorage, *Service) {
+	t.Helper()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	if err := store.CreateBucket(ctx, "src"); err != nil {
+		t.Fatalf("CreateBucket src: %v", err)
+	}
+
+	if err := store.CreateBucket(ctx, "dst"); err != nil {
+		t.Fatalf("CreateBucket dst: %v", err)
+	}
+
+	_, err := store.PutObject(ctx, "src", "source.txt", strings.NewReader("copy me"), map[string]string{
+		"color":        "blue",
+		"Content-Type": "text/plain",
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	return store, svc
+}
+
+func issueCopyObject(svc *Service, headers map[string]string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut, "/dst/copied.txt", http.NoBody)
+	req.SetPathValue("bucket", "dst")
+	req.SetPathValue("key", "copied.txt")
+	req.Header.Set("X-Amz-Copy-Source", "/src/source.txt")
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	w := httptest.NewRecorder()
+	svc.CopyObject(w, req)
+
+	return w
+}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -32,6 +32,10 @@ const (
 	taggingDirectiveCopy    = "COPY"
 	taggingDirectiveReplace = "REPLACE"
 	taggingHeader           = "X-Amz-Tagging"
+
+	metadataDirectiveHeader  = "X-Amz-Metadata-Directive"
+	metadataDirectiveCopy    = "COPY"
+	metadataDirectiveReplace = "REPLACE"
 )
 
 // applyCORSHeaders sets CORS response headers if the bucket has CORS configured and the request Origin matches.
@@ -761,9 +765,7 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	metadata := extractObjectMetadata(r)
-
-	obj, err := s.storage.PutObject(r.Context(), bucket, key, r.Body, metadata)
+	obj, err := s.storage.PutObject(r.Context(), bucket, key, r.Body, extractObjectMetadata(r.Header))
 	if err != nil {
 		var bucketErr *BucketError
 		if errors.As(err, &bucketErr) {
@@ -827,6 +829,13 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	metadata, err := copyObjectMetadata(r.Header, srcObj.Metadata)
+	if err != nil {
+		writeS3Error(w, r, "InvalidArgument", err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
 	tags, err := s.copyObjectTags(r.Context(), r.Header, srcBucket, srcKey)
 	if err != nil {
 		writeS3Error(w, r, "InvalidArgument", err.Error(), http.StatusBadRequest)
@@ -834,7 +843,7 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dstObj, err := s.storage.PutObject(r.Context(), dstBucket, dstKey, bytes.NewReader(srcObj.Body), srcObj.Metadata)
+	dstObj, err := s.storage.PutObject(r.Context(), dstBucket, dstKey, bytes.NewReader(srcObj.Body), metadata)
 	if err != nil {
 		var bucketErr *BucketError
 		if errors.As(err, &bucketErr) {
@@ -887,6 +896,44 @@ func (s *Service) getCopySource(ctx context.Context, bucket, key, versionID stri
 	}
 
 	return obj, nil
+}
+
+func extractObjectMetadata(header http.Header) map[string]string {
+	metadata := make(map[string]string)
+	if ct := header.Get(contentTypeHeader); ct != "" {
+		metadata[contentTypeHeader] = ct
+	}
+
+	for name, values := range header {
+		if len(values) == 0 {
+			continue
+		}
+
+		if metaKey, found := strings.CutPrefix(strings.ToLower(name), "x-amz-meta-"); found {
+			metadata[metaKey] = values[0]
+		}
+	}
+
+	if sse := header.Get("X-Amz-Server-Side-Encryption"); sse != "" {
+		metadata["x-amz-server-side-encryption"] = sse
+	}
+
+	if sseKey := header.Get("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id"); sseKey != "" {
+		metadata["x-amz-server-side-encryption-aws-kms-key-id"] = sseKey
+	}
+
+	return metadata
+}
+
+func copyObjectMetadata(header http.Header, src map[string]string) (map[string]string, error) {
+	switch strings.ToUpper(header.Get(metadataDirectiveHeader)) {
+	case "", metadataDirectiveCopy:
+		return cloneStringMap(src), nil
+	case metadataDirectiveReplace:
+		return extractObjectMetadata(header), nil
+	default:
+		return nil, errors.New("invalid metadata directive")
+	}
 }
 
 func (s *Service) copyObjectTags(ctx context.Context, header http.Header, srcBucket, srcKey string) (map[string]string, error) {
@@ -2463,31 +2510,6 @@ func handleMultipartError(w http.ResponseWriter, r *http.Request, err error) {
 	}
 
 	writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
-}
-
-// extractObjectMetadata builds the metadata map from request headers.
-func extractObjectMetadata(r *http.Request) map[string]string {
-	metadata := make(map[string]string)
-
-	if ct := r.Header.Get("Content-Type"); ct != "" {
-		metadata["Content-Type"] = ct
-	}
-
-	for name, values := range r.Header {
-		if metaKey, found := strings.CutPrefix(strings.ToLower(name), "x-amz-meta-"); found {
-			metadata[metaKey] = values[0]
-		}
-	}
-
-	if sse := r.Header.Get("X-Amz-Server-Side-Encryption"); sse != "" {
-		metadata["x-amz-server-side-encryption"] = sse
-	}
-
-	if sseKey := r.Header.Get("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id"); sseKey != "" {
-		metadata["x-amz-server-side-encryption-aws-kms-key-id"] = sseKey
-	}
-
-	return metadata
 }
 
 // parseTaggingHeader parses the x-amz-tagging header value.


### PR DESCRIPTION
## Summary
- Fixes #688
- Related to #669
- honor x-amz-metadata-directive on CopyObject
- keep COPY as the default by cloning source metadata
- support REPLACE by extracting Content-Type and x-amz-meta-* headers from the copy request
- reject unsupported metadata directive values before storing the destination object

## Tests
- go test ./internal/service/s3 -run TestCopyObject.*Metadata -count=1
- go test ./internal/service/s3 -count=1
- go test ./... -count=1
- make lint
- git diff --check