### PR TITLE
fix(s3): honor CopyObject tagging directive

### DIFF
--- a/internal/service/s3/copyobject_tagging_test.go
+++ b/internal/service/s3/copyobject_tagging_test.go
@@ -1,0 +1,115 @@
+package s3
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCopyObjectCopiesSourceTagsByDefault(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupCopyObjectTaggingFixture(t)
+	w := issueTaggedCopyObject(svc, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	tags, err := store.GetObjectTagging(context.Background(), "dst", "copied.txt")
+	if err != nil {
+		t.Fatalf("GetObjectTagging dst: %v", err)
+	}
+
+	if got := tags["color"]; got != "blue" {
+		t.Fatalf("tag color: got %q, want blue", got)
+	}
+}
+
+func TestCopyObjectReplacesTagsWhenDirectiveIsReplace(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupCopyObjectTaggingFixture(t)
+	w := issueTaggedCopyObject(svc, map[string]string{
+		"X-Amz-Tagging-Directive": "REPLACE",
+		"X-Amz-Tagging":           "color=red&env=prod",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	tags, err := store.GetObjectTagging(context.Background(), "dst", "copied.txt")
+	if err != nil {
+		t.Fatalf("GetObjectTagging dst: %v", err)
+	}
+
+	if got := tags["color"]; got != "red" {
+		t.Fatalf("tag color: got %q, want red", got)
+	}
+
+	if got := tags["env"]; got != "prod" {
+		t.Fatalf("tag env: got %q, want prod", got)
+	}
+}
+
+func TestCopyObjectRejectsInvalidTaggingDirective(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupCopyObjectTaggingFixture(t)
+	w := issueTaggedCopyObject(svc, map[string]string{
+		"X-Amz-Tagging-Directive": "BROKEN",
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	if _, err := store.GetObject(context.Background(), "dst", "copied.txt"); err == nil {
+		t.Fatal("destination object was stored for invalid tagging directive")
+	}
+}
+
+func setupCopyObjectTaggingFixture(t *testing.T) (*MemoryStorage, *Service) {
+	t.Helper()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	if err := store.CreateBucket(ctx, "src"); err != nil {
+		t.Fatalf("CreateBucket src: %v", err)
+	}
+
+	if err := store.CreateBucket(ctx, "dst"); err != nil {
+		t.Fatalf("CreateBucket dst: %v", err)
+	}
+
+	if _, err := store.PutObject(ctx, "src", "source.txt", strings.NewReader("copy me"), nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	if err := store.PutObjectTagging(ctx, "src", "source.txt", map[string]string{"color": "blue"}); err != nil {
+		t.Fatalf("PutObjectTagging: %v", err)
+	}
+
+	return store, svc
+}
+
+func issueTaggedCopyObject(svc *Service, headers map[string]string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut, "/dst/copied.txt", http.NoBody)
+	req.SetPathValue("bucket", "dst")
+	req.SetPathValue("key", "copied.txt")
+	req.Header.Set("X-Amz-Copy-Source", "/src/source.txt")
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	w := httptest.NewRecorder()
+	svc.CopyObject(w, req)
+
+	return w
+}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -27,6 +27,11 @@ const (
 	// to a const because the metadata-pass loop excludes it in three
 	// different handlers — goconst was flagging the literal.
 	contentTypeHeader = "Content-Type"
+
+	taggingDirectiveHeader  = "X-Amz-Tagging-Directive"
+	taggingDirectiveCopy    = "COPY"
+	taggingDirectiveReplace = "REPLACE"
+	taggingHeader           = "X-Amz-Tagging"
 )
 
 // applyCORSHeaders sets CORS response headers if the bucket has CORS configured and the request Origin matches.
@@ -820,6 +825,13 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	tags, err := s.copyObjectTags(r.Context(), r.Header, srcBucket, srcKey)
+	if err != nil {
+		writeS3Error(w, r, "InvalidArgument", err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
 	dstObj, err := s.storage.PutObject(r.Context(), dstBucket, dstKey, bytes.NewReader(srcObj.Body), srcObj.Metadata)
 	if err != nil {
 		var bucketErr *BucketError
@@ -829,6 +841,12 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	if err := s.storage.PutObjectTagging(r.Context(), dstBucket, dstKey, tags); err != nil {
 		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
 
 		return
@@ -867,6 +885,52 @@ func (s *Service) getCopySource(ctx context.Context, bucket, key, versionID stri
 	}
 
 	return obj, nil
+}
+
+func (s *Service) copyObjectTags(ctx context.Context, header http.Header, srcBucket, srcKey string) (map[string]string, error) {
+	switch strings.ToUpper(header.Get(taggingDirectiveHeader)) {
+	case "", taggingDirectiveCopy:
+		tags, err := s.storage.GetObjectTagging(ctx, srcBucket, srcKey)
+		if err != nil {
+			return nil, fmt.Errorf("get source object tagging: %w", err)
+		}
+
+		return cloneStringMap(tags), nil
+	case taggingDirectiveReplace:
+		return parseObjectTaggingHeader(header.Get(taggingHeader))
+	default:
+		return nil, errors.New("invalid tagging directive")
+	}
+}
+
+func parseObjectTaggingHeader(raw string) (map[string]string, error) {
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return nil, errors.New("invalid tagging")
+	}
+
+	tags := make(map[string]string, len(values))
+
+	for key, value := range values {
+		if len(value) == 0 {
+			tags[key] = ""
+
+			continue
+		}
+
+		tags[key] = value[0]
+	}
+
+	return tags, nil
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
 }
 
 // parseCopySource parses the X-Amz-Copy-Source header value.

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -801,6 +801,8 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 }
 
 // CopyObject handles PUT /{bucket}/{key} with X-Amz-Copy-Source header.
+//
+//nolint:funlen // CopyObject keeps source-resolution, preconditions, put, version header, and event emission in one place.
 func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 	dstBucket := r.PathValue("bucket")
 	dstKey := r.PathValue("key")

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -778,9 +778,9 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Store tags from x-amz-tagging header (URL-encoded query string format).
-	if taggingHeader := r.Header.Get("X-Amz-Tagging"); taggingHeader != "" {
-		tags := parseTaggingHeader(taggingHeader)
-		if len(tags) > 0 {
+	if header := r.Header.Get("X-Amz-Tagging"); header != "" {
+		tags, err := parseTaggingHeader(header)
+		if err == nil && len(tags) > 0 {
 			_ = s.storage.PutObjectTagging(r.Context(), bucket, key, tags)
 		}
 	}
@@ -897,31 +897,10 @@ func (s *Service) copyObjectTags(ctx context.Context, header http.Header, srcBuc
 
 		return cloneStringMap(tags), nil
 	case taggingDirectiveReplace:
-		return parseObjectTaggingHeader(header.Get(taggingHeader))
+		return parseTaggingHeader(header.Get(taggingHeader))
 	default:
 		return nil, errors.New("invalid tagging directive")
 	}
-}
-
-func parseObjectTaggingHeader(raw string) (map[string]string, error) {
-	values, err := url.ParseQuery(raw)
-	if err != nil {
-		return nil, errors.New("invalid tagging")
-	}
-
-	tags := make(map[string]string, len(values))
-
-	for key, value := range values {
-		if len(value) == 0 {
-			tags[key] = ""
-
-			continue
-		}
-
-		tags[key] = value[0]
-	}
-
-	return tags, nil
 }
 
 func cloneStringMap(src map[string]string) map[string]string {
@@ -2511,19 +2490,27 @@ func extractObjectMetadata(r *http.Request) map[string]string {
 
 // parseTaggingHeader parses the x-amz-tagging header value.
 // Format: URL-encoded query string, e.g. "key1=value1&key2=value2".
-func parseTaggingHeader(header string) map[string]string {
-	tags := make(map[string]string)
+// Percent-encoded keys / values are decoded via url.ParseQuery, so PutObject
+// and CopyObject (with REPLACE directive) treat tagging strings identically.
+func parseTaggingHeader(raw string) (map[string]string, error) {
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return nil, errors.New("invalid tagging")
+	}
 
-	for _, pair := range strings.Split(header, "&") {
-		k, v, ok := strings.Cut(pair, "=")
-		if !ok || k == "" {
+	tags := make(map[string]string, len(values))
+
+	for key, value := range values {
+		if len(value) == 0 {
+			tags[key] = ""
+
 			continue
 		}
 
-		tags[k] = v
+		tags[key] = value[0]
 	}
 
-	return tags
+	return tags, nil
 }
 
 // PutObjectTagging handles PUT /{bucket}/{key}?tagging.


### PR DESCRIPTION
## Summary
- Fixes #690
- Related to #669 and #689
- copy source object tags by default during CopyObject
- support x-amz-tagging-directive=REPLACE with tags from x-amz-tagging
- reject unsupported tagging directive values before storing the destination object

## Tests
- go test ./internal/service/s3 -run TestCopyObject.*Tags|TestCopyObjectRejectsInvalidTaggingDirective -count=1
- go test ./internal/service/s3 -count=1
- go test ./... -count=1
- make lint
- git diff --check