### PR TITLE
fix(s3): honor copy source version id

### DIFF
--- a/internal/service/s3/copyobject_version_test.go
+++ b/internal/service/s3/copyobject_version_test.go
@@ -1,0 +1,109 @@
+package s3
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCopyObjectCopiesSpecifiedSourceVersion(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	v1, v2 := setupVersionedSourceObject(t, store)
+
+	req := httptest.NewRequest(http.MethodPut, "/dst/copied.txt", http.NoBody)
+	req.SetPathValue("bucket", "dst")
+	req.SetPathValue("key", "copied.txt")
+	req.Header.Set("X-Amz-Copy-Source", "/src/source.txt?versionId="+v1)
+
+	w := httptest.NewRecorder()
+	svc.CopyObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	if got := w.Header().Get("x-amz-copy-source-version-id"); got != v1 {
+		t.Fatalf("copy source version header: got %q, want %q", got, v1)
+	}
+
+	dstObj, err := store.GetObject(ctx, "dst", "copied.txt")
+	if err != nil {
+		t.Fatalf("GetObject dst: %v", err)
+	}
+
+	if string(dstObj.Body) != "old" {
+		t.Fatalf("copied body: got %q from latest %s, want old from %s", dstObj.Body, v2, v1)
+	}
+}
+
+func TestUploadPartCopyCopiesSpecifiedSourceVersion(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	v1, v2 := setupVersionedSourceObject(t, store)
+
+	upload, err := store.CreateMultipartUpload(ctx, "dst", "joined.txt")
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/dst/joined.txt?partNumber=1&uploadId="+upload.UploadID, http.NoBody)
+	req.SetPathValue("bucket", "dst")
+	req.SetPathValue("key", "joined.txt")
+	req.Header.Set("X-Amz-Copy-Source", "/src/source.txt?versionId="+v1)
+
+	w := httptest.NewRecorder()
+	svc.UploadPartCopy(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("UploadPartCopy status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	part, ok := upload.Parts[1]
+	if !ok {
+		t.Fatal("copied part was not stored")
+	}
+
+	if string(part.Body) != "old" {
+		t.Fatalf("copied part body: got %q from latest %s, want old from %s", part.Body, v2, v1)
+	}
+}
+
+func setupVersionedSourceObject(t *testing.T, store *MemoryStorage) (string, string) {
+	t.Helper()
+
+	ctx := context.Background()
+	if err := store.CreateBucket(ctx, "src"); err != nil {
+		t.Fatalf("CreateBucket src: %v", err)
+	}
+
+	if err := store.CreateBucket(ctx, "dst"); err != nil {
+		t.Fatalf("CreateBucket dst: %v", err)
+	}
+
+	if err := store.PutBucketVersioning(ctx, "src", VersioningEnabled); err != nil {
+		t.Fatalf("PutBucketVersioning: %v", err)
+	}
+
+	first, err := store.PutObject(ctx, "src", "source.txt", strings.NewReader("old"), nil)
+	if err != nil {
+		t.Fatalf("PutObject first: %v", err)
+	}
+
+	second, err := store.PutObject(ctx, "src", "source.txt", strings.NewReader("new"), nil)
+	if err != nil {
+		t.Fatalf("PutObject second: %v", err)
+	}
+
+	return first.VersionID, second.VersionID
+}

--- a/internal/service/s3/copysource_test.go
+++ b/internal/service/s3/copysource_test.go
@@ -9,29 +9,32 @@ func TestParseCopySource(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name       string
-		source     string
-		wantBucket string
-		wantKey    string
+		name        string
+		source      string
+		wantBucket  string
+		wantKey     string
+		wantVersion string
 	}{
-		{"plain", "bucket/key.txt", "bucket", "key.txt"},
-		{"leading slash", "/bucket/key.txt", "bucket", "key.txt"},
-		{"encoded separator", "bucket%2Fkey.txt", "bucket", "key.txt"},
-		{"encoded subpath", "bucket/path%2Fto%2Fkey.txt", "bucket", "path/to/key.txt"},
-		{"fully encoded with leading slash", "%2Fbucket%2Fkey.txt", "bucket", "key.txt"},
-		{"plus preserved", "bucket/file+name.txt", "bucket", "file+name.txt"},
-		{"no separator", "bucket", "", ""},
-		{"empty", "", "", ""},
+		{"plain", "bucket/key.txt", "bucket", "key.txt", ""},
+		{"leading slash", "/bucket/key.txt", "bucket", "key.txt", ""},
+		{"encoded separator", "bucket%2Fkey.txt", "bucket", "key.txt", ""},
+		{"encoded subpath", "bucket/path%2Fto%2Fkey.txt", "bucket", "path/to/key.txt", ""},
+		{"fully encoded with leading slash", "%2Fbucket%2Fkey.txt", "bucket", "key.txt", ""},
+		{"plus preserved", "bucket/file+name.txt", "bucket", "file+name.txt", ""},
+		{"version id", "bucket/key.txt?versionId=v1", "bucket", "key.txt", "v1"},
+		{"encoded version id", "bucket%2Fkey.txt%3FversionId%3Dv1", "bucket", "key.txt", "v1"},
+		{"no separator", "bucket", "", "", ""},
+		{"empty", "", "", "", ""},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotBucket, gotKey := parseCopySource(tc.source)
-			if gotBucket != tc.wantBucket || gotKey != tc.wantKey {
-				t.Errorf("parseCopySource(%q) = (%q, %q), want (%q, %q)",
-					tc.source, gotBucket, gotKey, tc.wantBucket, tc.wantKey)
+			gotBucket, gotKey, gotVersion := parseCopySource(tc.source)
+			if gotBucket != tc.wantBucket || gotKey != tc.wantKey || gotVersion != tc.wantVersion {
+				t.Errorf("parseCopySource(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tc.source, gotBucket, gotKey, gotVersion, tc.wantBucket, tc.wantKey, tc.wantVersion)
 			}
 		})
 	}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -769,7 +769,7 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 	dstKey := r.PathValue("key")
 
 	copySource := r.Header.Get("X-Amz-Copy-Source")
-	srcBucket, srcKey := parseCopySource(copySource)
+	srcBucket, srcKey, srcVersionID := parseCopySource(copySource)
 
 	if srcBucket == "" || srcKey == "" {
 		writeS3Error(w, r, "InvalidArgument", "Invalid copy source", http.StatusBadRequest)
@@ -777,7 +777,16 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	srcObj, err := s.storage.GetObject(r.Context(), srcBucket, srcKey)
+	var srcObj *Object
+
+	var err error
+
+	if srcVersionID != "" {
+		srcObj, err = s.storage.GetObjectVersion(r.Context(), srcBucket, srcKey, srcVersionID)
+	} else {
+		srcObj, err = s.storage.GetObject(r.Context(), srcBucket, srcKey)
+	}
+
 	if err != nil {
 		handleGetObjectError(w, r, err)
 
@@ -809,6 +818,10 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 		LastModified: dstObj.LastModified.Format(timeFormatISO),
 	}
 
+	if srcVersionID != "" {
+		w.Header().Set("x-amz-copy-source-version-id", srcVersionID)
+	}
+
 	writeXMLResponse(w, result)
 
 	go s.emitObjectCreatedEvent(context.Background(), dstBucket, dstKey, dstObj.Size, dstObj.ETag)
@@ -816,7 +829,7 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 
 // parseCopySource parses the X-Amz-Copy-Source header value.
 // Format: /bucket/key or bucket/key (URL-encoded).
-func parseCopySource(source string) (bucket, key string) {
+func parseCopySource(source string) (bucket, key, versionID string) {
 	// AWS accepts both plain ("bucket/key") and URL-encoded
 	// ("bucket%2Fkey") forms. Decode first so a single split handles
 	// both. PathUnescape (not QueryUnescape) preserves '+' which is a
@@ -827,12 +840,18 @@ func parseCopySource(source string) (bucket, key string) {
 
 	source = strings.TrimPrefix(source, "/")
 
-	idx := strings.IndexByte(source, '/')
+	sourcePath, rawQuery, _ := strings.Cut(source, "?")
+
+	idx := strings.IndexByte(sourcePath, '/')
 	if idx < 0 {
-		return "", ""
+		return "", "", ""
 	}
 
-	return source[:idx], source[idx+1:]
+	if values, err := url.ParseQuery(rawQuery); err == nil {
+		versionID = values.Get("versionId")
+	}
+
+	return sourcePath[:idx], sourcePath[idx+1:], versionID
 }
 
 // GetObject handles GET /{bucket}/{key...} - download an object.
@@ -2001,7 +2020,7 @@ func (s *Service) UploadPartCopy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	srcBucket, srcKey := parseCopySource(r.Header.Get("X-Amz-Copy-Source"))
+	srcBucket, srcKey, srcVersionID := parseCopySource(r.Header.Get("X-Amz-Copy-Source"))
 	if srcBucket == "" || srcKey == "" {
 		writeS3Error(w, r, "InvalidArgument", "Invalid copy source", http.StatusBadRequest)
 
@@ -2015,7 +2034,7 @@ func (s *Service) UploadPartCopy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	part, err := s.storage.UploadPartCopy(r.Context(), dstBucket, dstKey, uploadID, partNumber, srcBucket, srcKey, copyRange)
+	part, err := s.storage.UploadPartCopy(r.Context(), dstBucket, dstKey, uploadID, partNumber, srcBucket, srcKey, srcVersionID, copyRange)
 	if err != nil {
 		handleMultipartError(w, r, err)
 
@@ -2027,6 +2046,11 @@ func (s *Service) UploadPartCopy(w http.ResponseWriter, r *http.Request) {
 		LastModified: part.LastModified.UTC().Format(timeFormatISO),
 		ETag:         part.ETag,
 	}
+
+	if srcVersionID != "" {
+		w.Header().Set("x-amz-copy-source-version-id", srcVersionID)
+	}
+
 	writeXMLResponse(w, result)
 }
 

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -51,7 +51,7 @@ type Storage interface {
 	AbortMultipartUpload(ctx context.Context, bucket, key, uploadID string) error
 	ListMultipartUploads(ctx context.Context, bucket, prefix string, maxUploads int) ([]*MultipartUpload, error)
 	ListParts(ctx context.Context, bucket, key, uploadID string, maxParts int) ([]*Part, error)
-	UploadPartCopy(ctx context.Context, dstBucket, dstKey, uploadID string, partNumber int, srcBucket, srcKey string, copyRange *CopyRange) (*Part, error)
+	UploadPartCopy(ctx context.Context, dstBucket, dstKey, uploadID string, partNumber int, srcBucket, srcKey, srcVersionID string, copyRange *CopyRange) (*Part, error)
 
 	// Object tagging
 	PutObjectTagging(ctx context.Context, bucket, key string, tags map[string]string) error
@@ -923,18 +923,13 @@ func (s *MemoryStorage) UploadPart(_ context.Context, bucket, key, uploadID stri
 // UploadPartCopy copies bytes from an existing object into a part of an
 // in-progress multipart upload. RFC-equivalent: AWS S3 UploadPartCopy.
 // `copyRange` may be nil to copy the entire source object.
-func (s *MemoryStorage) UploadPartCopy(_ context.Context, dstBucket, dstKey, uploadID string, partNumber int, srcBucket, srcKey string, copyRange *CopyRange) (*Part, error) {
+func (s *MemoryStorage) UploadPartCopy(_ context.Context, dstBucket, dstKey, uploadID string, partNumber int, srcBucket, srcKey, srcVersionID string, copyRange *CopyRange) (*Part, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	srcB, exists := s.Buckets[srcBucket]
-	if !exists {
-		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: srcBucket}
-	}
-
-	srcObj, exists := srcB.Objects[srcKey]
-	if !exists {
-		return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: srcKey}
+	srcObj, err := s.objectForCopySourceLocked(srcBucket, srcKey, srcVersionID)
+	if err != nil {
+		return nil, err
 	}
 
 	dstB, exists := s.Buckets[dstBucket]
@@ -971,6 +966,36 @@ func (s *MemoryStorage) UploadPartCopy(_ context.Context, dstBucket, dstKey, upl
 	upload.Parts[partNumber] = part
 
 	return part, nil
+}
+
+func (s *MemoryStorage) objectForCopySourceLocked(bucket, key, versionID string) (*Object, error) {
+	srcB, exists := s.Buckets[bucket]
+	if !exists {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if versionID == "" {
+		srcObj, exists := srcB.Objects[key]
+		if !exists || srcObj.IsDeleteMarker {
+			return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
+		}
+
+		return srcObj, nil
+	}
+
+	for _, obj := range srcB.Versions[key] {
+		if obj.VersionID != versionID {
+			continue
+		}
+
+		if obj.IsDeleteMarker {
+			return nil, &ObjectError{Code: "MethodNotAllowed", Message: "The specified method is not allowed against this resource.", Key: key}
+		}
+
+		return obj, nil
+	}
+
+	return nil, &ObjectError{Code: "NoSuchVersion", Message: "The specified version does not exist.", Key: key}
 }
 
 // CompleteMultipartUpload completes a multipart upload by assembling parts.

--- a/internal/service/s3/uploadpartcopy_test.go
+++ b/internal/service/s3/uploadpartcopy_test.go
@@ -198,12 +198,12 @@ func TestUploadPartCopy_RoundTripsThroughComplete(t *testing.T) {
 		t.Fatalf("CreateMultipartUpload: %v", err)
 	}
 
-	p1, err := store.UploadPartCopy(ctx, "dst", "joined", upload.UploadID, 1, "src", "blob", &CopyRange{Start: 0, End: 4})
+	p1, err := store.UploadPartCopy(ctx, "dst", "joined", upload.UploadID, 1, "src", "blob", "", &CopyRange{Start: 0, End: 4})
 	if err != nil {
 		t.Fatalf("UploadPartCopy 1: %v", err)
 	}
 
-	p2, err := store.UploadPartCopy(ctx, "dst", "joined", upload.UploadID, 2, "src", "blob", &CopyRange{Start: 5, End: 9})
+	p2, err := store.UploadPartCopy(ctx, "dst", "joined", upload.UploadID, 2, "src", "blob", "", &CopyRange{Start: 5, End: 9})
 	if err != nil {
 		t.Fatalf("UploadPartCopy 2: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Fixes #692
- Related to #669
- parse versionId from x-amz-copy-source
- make CopyObject read the requested source object version
- make UploadPartCopy copy bytes from the requested source object version
- return x-amz-copy-source-version-id when a versioned source was used

## Tests
- go test ./internal/service/s3 -run TestParseCopySource|TestCopyObjectCopiesSpecifiedSourceVersion|TestUploadPartCopyCopiesSpecifiedSourceVersion -count=1
- go test ./internal/service/s3 -count=1
- go test ./... -count=1
- make lint
- git diff --check