### PR TITLE
fix(s3): return bucket notification config

### DIFF
--- a/internal/service/s3/bucket_resources_test.go
+++ b/internal/service/s3/bucket_resources_test.go
@@ -181,6 +181,55 @@ func TestBucketLifecycle_PutGetDelete(t *testing.T) {
 	}
 }
 
+// --- BucketNotification ---------------------------------------------
+
+func TestBucketNotification_EventBridgeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage(), "")
+	ctx := context.Background()
+
+	store, ok := svc.storage.(*MemoryStorage)
+	if !ok {
+		t.Fatalf("storage is not *MemoryStorage")
+	}
+
+	_ = store.CreateBucket(ctx, "nb")
+
+	putReq := httptest.NewRequest(
+		http.MethodPut,
+		"/nb?notification",
+		strings.NewReader(`<NotificationConfiguration><EventBridgeConfiguration></EventBridgeConfiguration></NotificationConfiguration>`),
+	)
+	putReq.SetPathValue("bucket", "nb")
+
+	putW := httptest.NewRecorder()
+	svc.handleBucketPut(putW, putReq)
+
+	if putW.Code != http.StatusOK {
+		t.Fatalf("PUT status: got %d, want 200 (body=%s)", putW.Code, putW.Body.String())
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/nb?notification", http.NoBody)
+	getReq.SetPathValue("bucket", "nb")
+
+	getW := httptest.NewRecorder()
+	svc.handleBucketGet(getW, getReq)
+
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GET status: got %d, want 200 (body=%s)", getW.Code, getW.Body.String())
+	}
+
+	var got NotificationConfiguration
+	if err := xml.Unmarshal(getW.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, getW.Body.String())
+	}
+
+	if got.EventBridgeConfig == nil {
+		t.Fatalf("EventBridgeConfiguration was not returned: body=%s", getW.Body.String())
+	}
+}
+
 // --- Object Restore --------------------------------------------------
 
 func TestObjectRestore_FirstRequestReturns202(t *testing.T) {

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -133,6 +133,7 @@ var bucketGetSubresources = []struct {
 	{"website", (*Service).GetBucketWebsite},
 	{"lifecycle", (*Service).GetBucketLifecycleConfiguration},
 	{"cors", (*Service).GetBucketCors},
+	{"notification", (*Service).GetBucketNotificationConfiguration},
 }
 
 func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
@@ -2452,6 +2453,34 @@ func (s *Service) ListParts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeXMLResponse(w, result)
+}
+
+// GetBucketNotificationConfiguration handles GET /{bucket}?notification.
+func (s *Service) GetBucketNotificationConfiguration(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	exists, err := s.storage.BucketExists(r.Context(), bucket)
+	if err != nil {
+		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	if !exists {
+		writeS3Error(w, r, "NoSuchBucket", "The specified bucket does not exist", http.StatusNotFound)
+
+		return
+	}
+
+	resp := NotificationConfiguration{Xmlns: s3Namespace}
+	if s.storage.IsEventBridgeEnabled(r.Context(), bucket) {
+		resp.EventBridgeConfig = &EventBridgeConfig{}
+	}
+
+	resp.QueueConfigurations = s.storage.GetQueueConfigurations(r.Context(), bucket)
+	resp.LambdaFunctionConfigurations = s.storage.GetLambdaConfigurations(r.Context(), bucket)
+
+	writeXMLResponse(w, resp)
 }
 
 // PutBucketNotificationConfiguration handles PUT /{bucket}?notification.

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -441,6 +441,7 @@ type CopyRange struct {
 // NotificationConfiguration represents S3 bucket notification configuration.
 type NotificationConfiguration struct {
 	XMLName                      xml.Name                      `xml:"NotificationConfiguration"`
+	Xmlns                        string                        `xml:"xmlns,attr,omitempty"`
 	EventBridgeConfig            *EventBridgeConfig            `xml:"EventBridgeConfiguration,omitempty"`
 	QueueConfigurations          []QueueConfiguration          `xml:"QueueConfiguration,omitempty"`
 	LambdaFunctionConfigurations []LambdaFunctionConfiguration `xml:"CloudFunctionConfiguration,omitempty"`


### PR DESCRIPTION
## Summary
- Fixes #694
- Related to #669
- route GET /{bucket}?notification to a notification configuration handler
- return NotificationConfiguration XML instead of falling through to ListBucketResult
- include EventBridgeConfiguration when EventBridge notification is enabled
- return NoSuchBucket for missing buckets

## Tests
- go test ./internal/service/s3 -run TestBucketNotification_EventBridgeRoundTrip -count=1
- go test ./internal/service/s3 -count=1
- go test ./... -count=1
- make lint
- git diff --check