### PR TITLE
fix(dynamodb): apply projection expressions to reads

### DIFF
--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -226,6 +226,8 @@ func (s *Service) GetItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	item = projectItemForExpression(item, req.ProjectionExpression, req.ExpressionAttributeNames)
+
 	writeJSONResponse(w, GetItemResponse{
 		Item: item,
 	})
@@ -388,6 +390,8 @@ func (s *Service) Query(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	items = projectItemsForExpression(items, req.ProjectionExpression, req.ExpressionAttributeNames)
+
 	writeJSONResponse(w, QueryResponse{
 		Items:            items,
 		Count:            len(items),
@@ -432,6 +436,8 @@ func (s *Service) Scan(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
+
+	items = projectItemsForExpression(items, req.ProjectionExpression, req.ExpressionAttributeNames)
 
 	writeJSONResponse(w, ScanResponse{
 		Items:            items,
@@ -714,7 +720,16 @@ func (s *Service) TransactGetItems(w http.ResponseWriter, r *http.Request) {
 	}
 
 	responses := make([]TransactGetItemResponse, len(items))
+
 	for i, item := range items {
+		if req.TransactItems[i].Get != nil {
+			item = projectItemForExpression(
+				item,
+				req.TransactItems[i].Get.ProjectionExpression,
+				req.TransactItems[i].Get.ExpressionAttributeNames,
+			)
+		}
+
 		responses[i] = TransactGetItemResponse{Item: item}
 	}
 
@@ -831,6 +846,16 @@ func (s *Service) BatchGetItem(w http.ResponseWriter, r *http.Request) {
 		writeDynamoDBError(w, "InternalServerError", "Internal server error", http.StatusInternalServerError)
 
 		return
+	}
+
+	for tableName, keysAndAttributes := range req.RequestItems {
+		if items, ok := responses[tableName]; ok {
+			responses[tableName] = projectItemsForExpression(
+				items,
+				keysAndAttributes.ProjectionExpression,
+				keysAndAttributes.ExpressionAttributeNames,
+			)
+		}
 	}
 
 	writeJSONResponse(w, BatchGetItemResponse{Responses: responses})

--- a/internal/service/dynamodb/projection.go
+++ b/internal/service/dynamodb/projection.go
@@ -1,0 +1,71 @@
+package dynamodb
+
+import "strings"
+
+func projectItemsForExpression(items []Item, projectionExpression string, exprNames map[string]string) []Item {
+	if strings.TrimSpace(projectionExpression) == "" {
+		return items
+	}
+
+	projected := make([]Item, len(items))
+	for i, item := range items {
+		projected[i] = projectItemForExpression(item, projectionExpression, exprNames)
+	}
+
+	return projected
+}
+
+func projectItemForExpression(item Item, projectionExpression string, exprNames map[string]string) Item {
+	if item == nil || strings.TrimSpace(projectionExpression) == "" {
+		return item
+	}
+
+	names := projectionAttributeNames(projectionExpression, exprNames)
+	projected := make(Item, len(names))
+	seen := make(map[string]struct{}, len(names))
+
+	for _, name := range names {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+
+		seen[name] = struct{}{}
+
+		if value, ok := item[name]; ok {
+			projected[name] = value
+		}
+	}
+
+	return projected
+}
+
+func projectionAttributeNames(projectionExpression string, exprNames map[string]string) []string {
+	tokens := strings.Split(projectionExpression, ",")
+	names := make([]string, 0, len(tokens))
+
+	for _, token := range tokens {
+		name := resolveProjectionToken(strings.TrimSpace(token), exprNames)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+
+	return names
+}
+
+func resolveProjectionToken(token string, exprNames map[string]string) string {
+	if token == "" {
+		return ""
+	}
+
+	if name, ok := exprNames[token]; ok {
+		return strings.TrimSpace(name)
+	}
+
+	resolved := token
+	for placeholder, name := range exprNames {
+		resolved = strings.ReplaceAll(resolved, placeholder, name)
+	}
+
+	return strings.TrimSpace(resolved)
+}

--- a/internal/service/dynamodb/projection_expression_test.go
+++ b/internal/service/dynamodb/projection_expression_test.go
@@ -1,0 +1,197 @@
+package dynamodb
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+//nolint:funlen // Exercises all DynamoDB read APIs that accept ProjectionExpression.
+func TestReadAPIsApplyProjectionExpression(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage("http://localhost:4566")
+	svc := New(store)
+
+	if _, err := store.CreateTable(t.Context(), &CreateTableRequest{
+		TableName: "projection-test",
+		KeySchema: []KeySchemaElement{
+			{AttributeName: "pk", KeyType: "HASH"},
+			{AttributeName: "sk", KeyType: "RANGE"},
+		},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "pk", AttributeType: "S"},
+			{AttributeName: "sk", AttributeType: "S"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	for _, item := range []Item{
+		{
+			"pk":     {S: ptr("tenant-a")},
+			"sk":     {S: ptr("001")},
+			"name":   {S: ptr("first")},
+			"status": {S: ptr("active")},
+			"secret": {S: ptr("hidden")},
+		},
+		{
+			"pk":     {S: ptr("tenant-a")},
+			"sk":     {S: ptr("002")},
+			"name":   {S: ptr("second")},
+			"status": {S: ptr("active")},
+			"secret": {S: ptr("hidden")},
+		},
+	} {
+		if _, err := store.PutItem(t.Context(), "projection-test", item, false, ConditionInput{}); err != nil {
+			t.Fatalf("PutItem: %v", err)
+		}
+	}
+
+	t.Run("GetItem", func(t *testing.T) {
+		t.Parallel()
+
+		req := `{
+			"TableName":"projection-test",
+			"Key":{"pk":{"S":"tenant-a"},"sk":{"S":"001"}},
+			"ProjectionExpression":"#n, status",
+			"ExpressionAttributeNames":{"#n":"name"}
+		}`
+
+		var resp GetItemResponse
+
+		dispatchDynamoDBForProjectionTest(t, svc, "GetItem", req, &resp)
+
+		assertProjectedItem(t, resp.Item, "name", "status")
+	})
+
+	t.Run("Query", func(t *testing.T) {
+		t.Parallel()
+
+		req := `{
+			"TableName":"projection-test",
+			"KeyConditionExpression":"pk = :pk",
+			"ProjectionExpression":"#n, status",
+			"ExpressionAttributeNames":{"#n":"name"},
+			"ExpressionAttributeValues":{":pk":{"S":"tenant-a"}}
+		}`
+
+		var resp QueryResponse
+
+		dispatchDynamoDBForProjectionTest(t, svc, "Query", req, &resp)
+
+		if got, want := len(resp.Items), 2; got != want {
+			t.Fatalf("Items length: got %d, want %d", got, want)
+		}
+
+		for _, item := range resp.Items {
+			assertProjectedItem(t, item, "name", "status")
+		}
+	})
+
+	t.Run("Scan", func(t *testing.T) {
+		t.Parallel()
+
+		req := `{
+			"TableName":"projection-test",
+			"ProjectionExpression":"#n, status",
+			"ExpressionAttributeNames":{"#n":"name"}
+		}`
+
+		var resp ScanResponse
+
+		dispatchDynamoDBForProjectionTest(t, svc, "Scan", req, &resp)
+
+		if got, want := len(resp.Items), 2; got != want {
+			t.Fatalf("Items length: got %d, want %d", got, want)
+		}
+
+		for _, item := range resp.Items {
+			assertProjectedItem(t, item, "name", "status")
+		}
+	})
+
+	t.Run("BatchGetItem", func(t *testing.T) {
+		t.Parallel()
+
+		req := `{
+			"RequestItems":{
+				"projection-test":{
+					"Keys":[{"pk":{"S":"tenant-a"},"sk":{"S":"001"}}],
+					"ProjectionExpression":"#n, status",
+					"ExpressionAttributeNames":{"#n":"name"}
+				}
+			}
+		}`
+
+		var resp BatchGetItemResponse
+
+		dispatchDynamoDBForProjectionTest(t, svc, "BatchGetItem", req, &resp)
+
+		items := resp.Responses["projection-test"]
+		if got, want := len(items), 1; got != want {
+			t.Fatalf("Items length: got %d, want %d", got, want)
+		}
+
+		assertProjectedItem(t, items[0], "name", "status")
+	})
+
+	t.Run("TransactGetItems", func(t *testing.T) {
+		t.Parallel()
+
+		req := `{
+			"TransactItems":[{
+				"Get":{
+					"TableName":"projection-test",
+					"Key":{"pk":{"S":"tenant-a"},"sk":{"S":"001"}},
+					"ProjectionExpression":"#n, status",
+					"ExpressionAttributeNames":{"#n":"name"}
+				}
+			}]
+		}`
+
+		var resp TransactGetItemsResponse
+
+		dispatchDynamoDBForProjectionTest(t, svc, "TransactGetItems", req, &resp)
+
+		if got, want := len(resp.Responses), 1; got != want {
+			t.Fatalf("Responses length: got %d, want %d", got, want)
+		}
+
+		assertProjectedItem(t, resp.Responses[0].Item, "name", "status")
+	})
+}
+
+func dispatchDynamoDBForProjectionTest(t *testing.T, svc *Service, action, body string, out any) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810."+action)
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("%s status: got %d, body=%s", action, w.Code, w.Body.String())
+	}
+
+	if err := json.Unmarshal(w.Body.Bytes(), out); err != nil {
+		t.Fatalf("%s decode: %v; body=%s", action, err, w.Body.String())
+	}
+}
+
+func assertProjectedItem(t *testing.T, item Item, names ...string) {
+	t.Helper()
+
+	if len(item) != len(names) {
+		t.Fatalf("projected item = %v, want only %v", item, names)
+	}
+
+	for _, name := range names {
+		if _, ok := item[name]; !ok {
+			t.Fatalf("projected item = %v, missing %q", item, name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Apply `ProjectionExpression` to DynamoDB `GetItem`, `Query`, `Scan`, `BatchGetItem`, and `TransactGetItems` responses.
- Support expression attribute name aliases for top-level projected attributes.
- Add regression coverage for all read APIs that accept projection expressions.

Closes #698.
Related to #669.

## Tests
- `go test ./internal/service/dynamodb -run TestReadAPIsApplyProjectionExpression -count=1`
- `go test ./internal/service/dynamodb -count=1`
- `go test ./... -count=1`
- `make lint`
- `git diff --check`