### PR TITLE
fix(dynamodb): partition parallel scan segments

### DIFF
--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -419,6 +419,8 @@ func (s *Service) Scan(w http.ResponseWriter, r *http.Request) {
 		req.ExpressionAttributeValues,
 		req.Limit,
 		req.ExclusiveStartKey,
+		req.Segment,
+		req.TotalSegments,
 	)
 	if err != nil {
 		var tErr *TableError

--- a/internal/service/dynamodb/parallel_scan_test.go
+++ b/internal/service/dynamodb/parallel_scan_test.go
@@ -1,0 +1,87 @@
+package dynamodb
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestScanPartitionsItemsAcrossSegments(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage("http://localhost:4566")
+	svc := New(store)
+
+	if _, err := store.CreateTable(t.Context(), &CreateTableRequest{
+		TableName: "parallel-scan-test",
+		KeySchema: []KeySchemaElement{
+			{AttributeName: "pk", KeyType: "HASH"},
+		},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "pk", AttributeType: "S"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	const itemCount = 50
+
+	for i := range itemCount {
+		item := Item{
+			"pk":    {S: ptr(fmt.Sprintf("item-%02d", i))},
+			"value": {S: ptr("payload")},
+		}
+
+		if _, err := store.PutItem(t.Context(), "parallel-scan-test", item, false, ConditionInput{}); err != nil {
+			t.Fatalf("PutItem: %v", err)
+		}
+	}
+
+	seen := make(map[string]struct{}, itemCount)
+
+	for segment := range 4 {
+		body := fmt.Sprintf(`{"TableName":"parallel-scan-test","Segment":%d,"TotalSegments":4}`, segment)
+
+		var resp ScanResponse
+
+		dispatchDynamoDBForParallelScanTest(t, svc, body, &resp)
+
+		for _, item := range resp.Items {
+			pk := item["pk"].S
+			if pk == nil {
+				t.Fatalf("item missing pk: %v", item)
+			}
+
+			if _, ok := seen[*pk]; ok {
+				t.Fatalf("item %q returned by more than one segment", *pk)
+			}
+
+			seen[*pk] = struct{}{}
+		}
+	}
+
+	if got, want := len(seen), itemCount; got != want {
+		t.Fatalf("parallel scan returned %d unique items, want %d", got, want)
+	}
+}
+
+func dispatchDynamoDBForParallelScanTest(t *testing.T, svc *Service, body string, out any) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.Scan")
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Scan status: got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	if err := json.Unmarshal(w.Body.Bytes(), out); err != nil {
+		t.Fatalf("Scan decode: %v; body=%s", err, w.Body.String())
+	}
+}

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"sort"
 	"strconv"
 	"strings"
@@ -31,7 +32,7 @@ type Storage interface {
 	DeleteItem(ctx context.Context, tableName string, key Item, returnOld bool, cond ConditionInput) (Item, error)
 	UpdateItem(ctx context.Context, tableName string, key Item, updateExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, returnValues string, cond ConditionInput) (Item, error)
 	Query(ctx context.Context, tableName, indexName string, keyCondExpr string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item, scanForward bool) ([]Item, Item, int, error)
-	Scan(ctx context.Context, tableName string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item) ([]Item, Item, int, error)
+	Scan(ctx context.Context, tableName string, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item, segment, totalSegments *int) ([]Item, Item, int, error)
 	TransactWriteItems(ctx context.Context, items []TransactWriteItem) ([]CancellationReason, error)
 	TransactGetItems(ctx context.Context, items []TransactGetItem) ([]Item, error)
 	BatchWriteItem(ctx context.Context, requestItems map[string][]WriteRequest) (map[string][]WriteRequest, error)
@@ -671,7 +672,7 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 // Scan scans items from a table.
 //
 //nolint:funlen // Scan requires pagination logic that exceeds line limit.
-func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item) ([]Item, Item, int, error) {
+func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int, exclusiveStartKey Item, segment, totalSegments *int) ([]Item, Item, int, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -683,12 +684,21 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 		}
 	}
 
+	if err := validateScanSegment(segment, totalSegments); err != nil {
+		return nil, nil, 0, err
+	}
+
 	// Collect all items.
 	var results []Item
 
 	scannedCount := 0
 
 	for _, item := range td.Items {
+		key := m.serializeKey(td.Table, item)
+		if !scanSegmentMatches(key, segment, totalSegments) {
+			continue
+		}
+
 		scannedCount++
 
 		// Apply filter expression.
@@ -748,6 +758,47 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 	}
 
 	return results, lastEvaluatedKey, scannedCount, nil
+}
+
+func validateScanSegment(segment, totalSegments *int) error {
+	if segment == nil && totalSegments == nil {
+		return nil
+	}
+
+	if segment == nil || totalSegments == nil {
+		return &TableError{
+			Code:    "ValidationException",
+			Message: "Segment and TotalSegments must be specified together",
+		}
+	}
+
+	if *totalSegments <= 0 {
+		return &TableError{
+			Code:    "ValidationException",
+			Message: "TotalSegments must be greater than zero",
+		}
+	}
+
+	if *segment < 0 || *segment >= *totalSegments {
+		return &TableError{
+			Code:    "ValidationException",
+			Message: "Segment must be greater than or equal to zero and less than TotalSegments",
+		}
+	}
+
+	return nil
+}
+
+func scanSegmentMatches(key string, segment, totalSegments *int) bool {
+	if segment == nil || totalSegments == nil {
+		return true
+	}
+
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+
+	//nolint:gosec // totalSegments is validated to be positive before this helper is called.
+	return int(h.Sum64()%uint64(*totalSegments)) == *segment
 }
 
 // serializeKey creates a string key from the primary key attributes.


### PR DESCRIPTION
## Summary
- Honor DynamoDB `Scan` requests with `Segment` and `TotalSegments`.
- Use a stable FNV-1a hash of the serialized primary key to assign each item to one segment.
- Add regression coverage that combines all segments without duplicates.

Closes #610.
Related to #669.

## Tests
- `go test ./internal/service/dynamodb -run TestScanPartitionsItemsAcrossSegments -count=1`
- `go test ./internal/service/dynamodb -count=1`
- `go test ./... -count=1`
- `make lint`
- `git diff --check`