### PR TITLE
feat(eventbridge): implement InputTransformer for event targets

### DIFF
--- a/internal/service/eventbridge/handlers.go
+++ b/internal/service/eventbridge/handlers.go
@@ -342,6 +342,13 @@ func (s *Service) ListTargetsByRule(w http.ResponseWriter, r *http.Request) {
 			InputPath:      target.InputPath,
 			HTTPParameters: target.HTTPParameters,
 		}
+
+		if target.InputTransformer != nil {
+			outputs[i].InputTransformer = &InputTransformerOutput{
+				InputPathsMap: target.InputTransformer.InputPathsMap,
+				InputTemplate: target.InputTransformer.InputTemplate,
+			}
+		}
 	}
 
 	resp := &ListTargetsByRuleResponse{

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -465,6 +465,13 @@ func (s *MemoryStorage) PutTargets(_ context.Context, eventBusName, ruleName str
 			HTTPParameters: t.HTTPParameters,
 		}
 
+		if t.InputTransformer != nil {
+			target.InputTransformer = &InputTransformer{
+				InputPathsMap: t.InputTransformer.InputPathsMap,
+				InputTemplate: t.InputTransformer.InputTemplate,
+			}
+		}
+
 		// Find and update existing target or add new one.
 		found := false
 		existingTargets := s.Targets[targetKey][ruleName]
@@ -654,6 +661,13 @@ func (s *MemoryStorage) buildEventPayload(eventID, eventBusName string, target *
 		return nil
 	}
 
+	// Apply InputTransformer if set on the target.
+	if target.InputTransformer != nil {
+		if transformed := applyInputTransformer(body, target.InputTransformer); transformed != nil {
+			return transformed
+		}
+	}
+
 	// Apply InputPath if set on the target.
 	if target.InputPath != "" {
 		if resolved := resolveInputPath(body, target.InputPath); resolved != nil {
@@ -697,6 +711,75 @@ func resolveInputPath(payload []byte, inputPath string) []byte {
 	}
 
 	return result
+}
+
+// applyInputTransformer applies an InputTransformer to an event payload.
+// It extracts values from the event JSON using InputPathsMap (simple JSONPath expressions),
+// then replaces <key> placeholders in InputTemplate with the extracted values.
+func applyInputTransformer(payload []byte, transformer *InputTransformer) []byte {
+	var event map[string]any
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return nil
+	}
+
+	// Extract values using InputPathsMap.
+	values := make(map[string]any, len(transformer.InputPathsMap))
+	for key, path := range transformer.InputPathsMap {
+		values[key] = extractJSONPath(event, path)
+	}
+
+	// Replace <key> placeholders in the template.
+	result := transformer.InputTemplate
+
+	for key, val := range values {
+		placeholder := "<" + key + ">"
+
+		var replacement string
+
+		switch v := val.(type) {
+		case nil:
+			replacement = "null"
+		case string:
+			// Strings are quoted in the output.
+			quoted, _ := json.Marshal(v)
+			replacement = string(quoted)
+		default:
+			// Objects, arrays, numbers, booleans are serialized as raw JSON.
+			raw, _ := json.Marshal(v)
+			replacement = string(raw)
+		}
+
+		result = strings.ReplaceAll(result, placeholder, replacement)
+	}
+
+	return []byte(result)
+}
+
+// extractJSONPath extracts a value from a nested map using a simple JSONPath expression.
+// Supports paths like "$.detail.marker", "$.source".
+func extractJSONPath(obj map[string]any, path string) any {
+	path = strings.TrimPrefix(path, "$.")
+	if path == "" || path == "$" {
+		return obj
+	}
+
+	parts := strings.Split(path, ".")
+
+	var current any = obj
+
+	for _, part := range parts {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil
+		}
+
+		current, ok = m[part]
+		if !ok {
+			return nil
+		}
+	}
+
+	return current
 }
 
 // deliverToHTTP sends an event to an API Destination's HTTP endpoint.

--- a/internal/service/eventbridge/storage_test.go
+++ b/internal/service/eventbridge/storage_test.go
@@ -1,6 +1,8 @@
 package eventbridge
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 )
 
@@ -74,6 +76,183 @@ func TestResolveInputPath(t *testing.T) {
 
 			if string(got) != tt.want {
 				t.Errorf("resolveInputPath() = %s, want %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+//nolint:funlen // Table-driven test with comprehensive extractJSONPath coverage.
+func TestExtractJSONPath(t *testing.T) {
+	t.Parallel()
+
+	event := map[string]any{
+		"version":     "0",
+		"id":          "abc-123",
+		"source":      "my.app",
+		"detail-type": "OrderCreated",
+		"detail": map[string]any{
+			"marker": "test-marker-value",
+			"nested": map[string]any{
+				"key": "val",
+			},
+			"count": float64(42),
+		},
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want any
+	}{
+		{
+			name: "extract top-level string field",
+			path: "$.source",
+			want: "my.app",
+		},
+		{
+			name: "extract nested string field",
+			path: "$.detail.marker",
+			want: "test-marker-value",
+		},
+		{
+			name: "extract deeply nested field",
+			path: "$.detail.nested.key",
+			want: "val",
+		},
+		{
+			name: "extract nested object",
+			path: "$.detail.nested",
+			want: map[string]any{"key": "val"},
+		},
+		{
+			name: "extract numeric field",
+			path: "$.detail.count",
+			want: float64(42),
+		},
+		{
+			name: "non-existent field returns nil",
+			path: "$.nonexistent",
+			want: nil,
+		},
+		{
+			name: "non-existent nested path returns nil",
+			path: "$.detail.nonexistent.deep",
+			want: nil,
+		},
+		{
+			name: "empty path returns entire object",
+			path: "",
+			want: event,
+		},
+		{
+			name: "dollar only returns entire object",
+			path: "$",
+			want: event,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := extractJSONPath(event, tt.path)
+
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("extractJSONPath() = %v, want nil", got)
+				}
+
+				return
+			}
+
+			// For map comparison, marshal both to JSON.
+			if _, ok := tt.want.(map[string]any); ok {
+				gotJSON, _ := json.Marshal(got)
+				wantJSON, _ := json.Marshal(tt.want)
+
+				if !bytes.Equal(gotJSON, wantJSON) {
+					t.Errorf("extractJSONPath() = %s, want %s", gotJSON, wantJSON)
+				}
+
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("extractJSONPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+//nolint:funlen // Table-driven test with comprehensive InputTransformer coverage.
+func TestApplyInputTransformer(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"version":"0","id":"abc","source":"my.app","detail-type":"OrderCreated","detail":{"marker":"test-marker-123","nested":{"key":"val"}},"region":"us-east-1","account":"000000000000","time":"2026-01-01T00:00:00Z"}`)
+
+	tests := []struct {
+		name        string
+		transformer *InputTransformer
+		want        string
+	}{
+		{
+			name: "simple string replacement",
+			transformer: &InputTransformer{
+				InputPathsMap: map[string]string{
+					"marker": "$.detail.marker",
+				},
+				InputTemplate: `{"transformedMarker": <marker>, "source": "custom-bus"}`,
+			},
+			want: `{"transformedMarker": "test-marker-123", "source": "custom-bus"}`,
+		},
+		{
+			name: "multiple replacements",
+			transformer: &InputTransformer{
+				InputPathsMap: map[string]string{
+					"marker": "$.detail.marker",
+					"src":    "$.source",
+				},
+				InputTemplate: `{"marker": <marker>, "src": <src>}`,
+			},
+			want: `{"marker": "test-marker-123", "src": "my.app"}`,
+		},
+		{
+			name: "object replacement",
+			transformer: &InputTransformer{
+				InputPathsMap: map[string]string{
+					"nested": "$.detail.nested",
+				},
+				InputTemplate: `{"data": <nested>}`,
+			},
+			want: `{"data": {"key":"val"}}`,
+		},
+		{
+			name: "non-existent path yields null",
+			transformer: &InputTransformer{
+				InputPathsMap: map[string]string{
+					"missing": "$.nonexistent",
+				},
+				InputTemplate: `{"value": <missing>}`,
+			},
+			want: `{"value": null}`,
+		},
+		{
+			name: "empty InputPathsMap with no placeholders",
+			transformer: &InputTransformer{
+				InputPathsMap: nil,
+				InputTemplate: `{"static": "value"}`,
+			},
+			want: `{"static": "value"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := applyInputTransformer(payload, tt.transformer)
+			if string(got) != tt.want {
+				t.Errorf("applyInputTransformer() = %s, want %s", string(got), tt.want)
 			}
 		})
 	}

--- a/internal/service/eventbridge/types.go
+++ b/internal/service/eventbridge/types.go
@@ -49,14 +49,21 @@ type Rule struct {
 	LastModified       time.Time `json:"lastModified"`
 }
 
+// InputTransformer represents an input transformer for a target.
+type InputTransformer struct {
+	InputPathsMap map[string]string `json:"inputPathsMap,omitempty"`
+	InputTemplate string            `json:"inputTemplate"`
+}
+
 // Target represents a rule target.
 type Target struct {
-	ID             string          `json:"id"`
-	Arn            string          `json:"arn"`
-	RoleArn        string          `json:"roleArn,omitempty"`
-	Input          string          `json:"input,omitempty"`
-	InputPath      string          `json:"inputPath,omitempty"`
-	HTTPParameters *HTTPParameters `json:"httpParameters,omitempty"`
+	ID               string            `json:"id"`
+	Arn              string            `json:"arn"`
+	RoleArn          string            `json:"roleArn,omitempty"`
+	Input            string            `json:"input,omitempty"`
+	InputPath        string            `json:"inputPath,omitempty"`
+	InputTransformer *InputTransformer `json:"inputTransformer,omitempty"`
+	HTTPParameters   *HTTPParameters   `json:"httpParameters,omitempty"`
 }
 
 // EpochTime wraps time.Time to support JSON unmarshalling from both
@@ -237,14 +244,21 @@ type ListRulesResponse struct {
 	NextToken string       `json:"NextToken,omitempty"`
 }
 
+// InputTransformerInput represents an input transformer in API requests.
+type InputTransformerInput struct {
+	InputPathsMap map[string]string `json:"InputPathsMap,omitempty"`
+	InputTemplate string            `json:"InputTemplate"`
+}
+
 // TargetInput represents a target in API requests.
 type TargetInput struct {
-	ID             string          `json:"Id"`
-	Arn            string          `json:"Arn"`
-	RoleArn        string          `json:"RoleArn,omitempty"`
-	Input          string          `json:"Input,omitempty"`
-	InputPath      string          `json:"InputPath,omitempty"`
-	HTTPParameters *HTTPParameters `json:"HttpParameters,omitempty"`
+	ID               string                 `json:"Id"`
+	Arn              string                 `json:"Arn"`
+	RoleArn          string                 `json:"RoleArn,omitempty"`
+	Input            string                 `json:"Input,omitempty"`
+	InputPath        string                 `json:"InputPath,omitempty"`
+	InputTransformer *InputTransformerInput `json:"InputTransformer,omitempty"`
+	HTTPParameters   *HTTPParameters        `json:"HttpParameters,omitempty"`
 }
 
 // PutTargetsRequest is the request for PutTargets.
@@ -307,14 +321,21 @@ type ListTargetsByRuleRequest struct {
 	NextToken    string `json:"NextToken,omitempty"`
 }
 
+// InputTransformerOutput represents an input transformer in API responses.
+type InputTransformerOutput struct {
+	InputPathsMap map[string]string `json:"InputPathsMap,omitempty"`
+	InputTemplate string            `json:"InputTemplate,omitempty"`
+}
+
 // TargetOutput represents a target in API responses.
 type TargetOutput struct {
-	ID             string          `json:"Id,omitempty"`
-	Arn            string          `json:"Arn,omitempty"`
-	RoleArn        string          `json:"RoleArn,omitempty"`
-	Input          string          `json:"Input,omitempty"`
-	InputPath      string          `json:"InputPath,omitempty"`
-	HTTPParameters *HTTPParameters `json:"HttpParameters,omitempty"`
+	ID               string                  `json:"Id,omitempty"`
+	Arn              string                  `json:"Arn,omitempty"`
+	RoleArn          string                  `json:"RoleArn,omitempty"`
+	Input            string                  `json:"Input,omitempty"`
+	InputPath        string                  `json:"InputPath,omitempty"`
+	InputTransformer *InputTransformerOutput `json:"InputTransformer,omitempty"`
+	HTTPParameters   *HTTPParameters         `json:"HttpParameters,omitempty"`
 }
 
 // ListTargetsByRuleResponse is the response for ListTargetsByRule.

--- a/test/integration/eventbridge_test.go
+++ b/test/integration/eventbridge_test.go
@@ -619,6 +619,142 @@ func TestEventBridge_PutEvents_InputPath(t *testing.T) {
 	}
 }
 
+func TestEventBridge_PutEvents_InputTransformer(t *testing.T) {
+	ebClient := newEventBridgeClient(t)
+	sqsClient := newSQSClient(t)
+	ctx := t.Context()
+
+	queueName := "eb-inputtransformer-test"
+
+	// Create SQS queue.
+	_, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	busName := "transform-bus"
+
+	// Create custom event bus.
+	_, err = ebClient.CreateEventBus(ctx, &eventbridge.CreateEventBusInput{
+		Name: aws.String(busName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create rule on custom bus.
+	_, err = ebClient.PutRule(ctx, &eventbridge.PutRuleInput{
+		Name:         aws.String("transform-rule"),
+		EventBusName: aws.String(busName),
+		EventPattern: aws.String(`{"source": ["transform.service"], "detail-type": ["TransformEvent"]}`),
+		State:        types.RuleStateEnabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add SQS target with InputTransformer.
+	_, err = ebClient.PutTargets(ctx, &eventbridge.PutTargetsInput{
+		Rule:         aws.String("transform-rule"),
+		EventBusName: aws.String(busName),
+		Targets: []types.Target{
+			{
+				Id:  aws.String("transform-target"),
+				Arn: aws.String("arn:aws:sqs:us-east-1:000000000000:" + queueName),
+				InputTransformer: &types.InputTransformer{
+					InputPathsMap: map[string]string{
+						"marker": "$.detail.marker",
+					},
+					InputTemplate: aws.String(`{"transformedMarker": <marker>, "source": "custom-bus"}`),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		_, _ = ebClient.RemoveTargets(cleanupCtx, &eventbridge.RemoveTargetsInput{
+			EventBusName: aws.String(busName),
+			Ids:          []string{"transform-target"},
+			Rule:         aws.String("transform-rule"),
+		})
+		_, _ = ebClient.DeleteRule(cleanupCtx, &eventbridge.DeleteRuleInput{
+			EventBusName: aws.String(busName),
+			Name:         aws.String("transform-rule"),
+		})
+		_, _ = ebClient.DeleteEventBus(cleanupCtx, &eventbridge.DeleteEventBusInput{
+			Name: aws.String(busName),
+		})
+		_, _ = sqsClient.DeleteQueue(cleanupCtx, &sqs.DeleteQueueInput{
+			QueueUrl: aws.String("http://localhost:4566/000000000000/" + queueName),
+		})
+	})
+
+	// Put matching event.
+	marker := "test-marker-" + t.Name()
+
+	_, err = ebClient.PutEvents(ctx, &eventbridge.PutEventsInput{
+		Entries: []types.PutEventsRequestEntry{
+			{
+				EventBusName: aws.String(busName),
+				Source:       aws.String("transform.service"),
+				DetailType:   aws.String("TransformEvent"),
+				Detail:       aws.String(`{"marker":"` + marker + `"}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Receive message from SQS and verify transformation was applied.
+	var recvOutput *sqs.ReceiveMessageOutput
+
+	for range 10 {
+		recvOutput, err = sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:        aws.String("http://localhost:4566/000000000000/" + queueName),
+			WaitTimeSeconds: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(recvOutput.Messages) > 0 {
+			break
+		}
+	}
+
+	if len(recvOutput.Messages) == 0 {
+		t.Fatal("expected transformed event to be delivered to SQS queue, but no message received")
+	}
+
+	body := *recvOutput.Messages[0].Body
+
+	// Verify the message contains the transformed content.
+	var transformed map[string]any
+	if err := json.Unmarshal([]byte(body), &transformed); err != nil {
+		t.Fatalf("failed to parse SQS message body as JSON: %v (body: %s)", err, body)
+	}
+
+	if transformed["transformedMarker"] != marker {
+		t.Errorf("expected transformedMarker=%s, got %v", marker, transformed["transformedMarker"])
+	}
+
+	if transformed["source"] != "custom-bus" {
+		t.Errorf("expected source=custom-bus, got %v", transformed["source"])
+	}
+
+	// Verify envelope fields are NOT present (InputTransformer produces custom output).
+	if _, hasVersion := transformed["version"]; hasVersion {
+		t.Errorf("expected InputTransformer to replace envelope, but found 'version' in: %s", body)
+	}
+}
+
 func TestEventBridge_EventBusNotFound(t *testing.T) {
 	client := newEventBridgeClient(t)
 	ctx := t.Context()


### PR DESCRIPTION
## Summary

- Add `InputTransformer` type with `InputPathsMap` and `InputTemplate`
- Implement JSONPath extraction and template substitution
- Apply transformation during event delivery to SQS targets
- Add unit tests + integration test

Closes #652, Ref: #416