### PR TITLE
feat(s3): deliver ObjectCreated notifications to SQS queues

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -112,6 +112,7 @@ func New(config Config) *Server {
 
 	// Cross-service wiring (must happen after all services are registered).
 	wireSNStoSQS(registry)
+	wireS3toSQS(registry)
 
 	// Register unified protocol dispatcher for POST /
 	hasJSONServices := len(jsonDispatcher.handlers) > 0

--- a/internal/server/sns_sqs_wiring.go
+++ b/internal/server/sns_sqs_wiring.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sivchari/kumo/internal/service"
+	"github.com/sivchari/kumo/internal/service/s3"
 	"github.com/sivchari/kumo/internal/service/sns"
 	"github.com/sivchari/kumo/internal/service/sqs"
 )
@@ -94,6 +95,83 @@ func (p *snsToSQSPublisher) endpointToQueueURL(endpoint string) string {
 	parts := strings.Split(endpoint, ":")
 	if len(parts) < 6 {
 		return endpoint
+	}
+
+	account := parts[4]
+	name := parts[5]
+
+	return p.baseURL + "/" + account + "/" + name
+}
+
+// wireS3toSQS connects the S3 service to the SQS service so that
+// S3 bucket notification configurations with QueueConfigurations
+// actually deliver event messages into the target SQS queue.
+//
+// Without this wiring, PutObject silently ignores QueueConfiguration
+// entries because s3.Service.sqsPublisher is nil. The pattern mirrors
+// wireSNStoSQS.
+func wireS3toSQS(registry *service.Registry) {
+	s3Svc, ok := registry.Get("s3")
+	if !ok {
+		return
+	}
+
+	sqsSvc, ok := registry.Get("sqs")
+	if !ok {
+		return
+	}
+
+	s3Typed, ok := s3Svc.(*s3.Service)
+	if !ok {
+		return
+	}
+
+	sqsTyped, ok := sqsSvc.(*sqs.Service)
+	if !ok {
+		return
+	}
+
+	s3Typed.SetSQSPublisher(&s3ToSQSPublisher{
+		storage: sqsTyped.Storage(),
+		baseURL: sqsTyped.BaseURL(),
+	})
+}
+
+// s3ToSQSPublisher adapts the SQS storage layer to the S3
+// SQSPublisher interface. It accepts an SQS ARN in the queueARN
+// argument, translates it to the queue URL the SQS storage layer
+// keys queues by, and sends the message.
+type s3ToSQSPublisher struct {
+	storage sqs.Storage
+	baseURL string
+}
+
+// PublishToSQS delivers an S3 event notification message to an SQS
+// queue identified by its ARN. The message body is the full JSON
+// event notification envelope (Records[]).
+func (p *s3ToSQSPublisher) PublishToSQS(ctx context.Context, queueARN, body string) error {
+	queueURL := p.arnToQueueURL(queueARN)
+
+	_, err := p.storage.SendMessage(ctx, queueURL, body, 0, nil, "", "")
+	if err != nil {
+		return err //nolint:wrapcheck // adapter is a thin pass-through
+	}
+
+	return nil
+}
+
+// arnToQueueURL converts an SQS ARN to the queue URL that the storage
+// layer keys queues by. If the input is already a URL it is returned
+// unchanged.
+func (p *s3ToSQSPublisher) arnToQueueURL(arn string) string {
+	if !strings.HasPrefix(arn, "arn:") {
+		return arn
+	}
+
+	// arn:aws:sqs:<region>:<account>:<name> -> <baseURL>/<account>/<name>
+	parts := strings.Split(arn, ":")
+	if len(parts) < 6 {
+		return arn
 	}
 
 	account := parts[4]

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -759,6 +759,9 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 
 	// Emit EventBridge notification if enabled.
 	go s.emitObjectCreatedEvent(context.Background(), bucket, key, obj.Size, obj.ETag)
+
+	// Deliver S3 event notification to configured SQS queues.
+	go s.emitSQSNotifications(context.Background(), bucket, key, "s3:ObjectCreated:Put", obj.Size, obj.ETag)
 }
 
 // CopyObject handles PUT /{bucket}/{key} with X-Amz-Copy-Source header.
@@ -810,6 +813,7 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 	writeXMLResponse(w, result)
 
 	go s.emitObjectCreatedEvent(context.Background(), dstBucket, dstKey, dstObj.Size, dstObj.ETag)
+	go s.emitSQSNotifications(context.Background(), dstBucket, dstKey, "s3:ObjectCreated:Copy", dstObj.Size, dstObj.ETag)
 }
 
 // parseCopySource parses the X-Amz-Copy-Source header value.
@@ -2284,6 +2288,7 @@ func (s *Service) PutBucketNotificationConfiguration(w http.ResponseWriter, r *h
 
 	enabled := config.EventBridgeConfig != nil
 	s.storage.SetEventBridgeNotification(r.Context(), bucket, enabled)
+	s.storage.SetQueueConfigurations(r.Context(), bucket, config.QueueConfigurations)
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -8,13 +8,24 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/sivchari/kumo/internal/service"
 )
+
+// SQSPublisher is the interface the S3 service uses to deliver event
+// notification messages to SQS queues. The server wiring layer
+// provides a concrete implementation backed by the SQS storage.
+type SQSPublisher interface {
+	// PublishToSQS sends a single message to the SQS queue identified
+	// by queueARN. The body is the full JSON event notification.
+	PublishToSQS(ctx context.Context, queueARN, body string) error
+}
 
 const defaultBaseURL = "http://localhost:4566"
 
@@ -38,9 +49,10 @@ func init() {
 
 // Service implements the S3 service.
 type Service struct {
-	storage Storage
-	baseURL string
-	logger  *slog.Logger
+	storage      Storage
+	baseURL      string
+	logger       *slog.Logger
+	sqsPublisher SQSPublisher
 }
 
 // New creates a new S3 service.
@@ -97,6 +109,89 @@ func (s *Service) Close() error {
 	}
 
 	return nil
+}
+
+// SetSQSPublisher installs the adapter that delivers S3 event
+// notification messages to SQS queues. Called by the server wiring
+// layer after all services have been registered.
+func (s *Service) SetSQSPublisher(p SQSPublisher) {
+	s.sqsPublisher = p
+}
+
+// emitSQSNotifications delivers S3 event notification messages to
+// every SQS queue configured in the bucket's notification configuration
+// whose event filter matches the given eventName.
+func (s *Service) emitSQSNotifications(ctx context.Context, bucket, key, eventName string, size int64, etag string) {
+	if s.sqsPublisher == nil {
+		return
+	}
+
+	configs := s.storage.GetQueueConfigurations(ctx, bucket)
+	if len(configs) == 0 {
+		return
+	}
+
+	for _, cfg := range configs {
+		if !matchesEventFilter(cfg.Events, eventName) {
+			continue
+		}
+
+		record := EventNotification{
+			Records: []EventRecord{{
+				EventVersion: "2.1",
+				EventSource:  "aws:s3",
+				AWSRegion:    "us-east-1",
+				EventTime:    time.Now().UTC().Format(time.RFC3339),
+				EventName:    eventName,
+				UserIdentity: map[string]string{"principalId": "EXAMPLE"},
+				S3: EventRecordS3Detail{
+					SchemaVersion:   "1.0",
+					ConfigurationID: cfg.ID,
+					Bucket: EventRecordBucket{
+						Name: bucket,
+						Arn:  "arn:aws:s3:::" + bucket,
+					},
+					Object: EventRecordObject{
+						Key:  url.QueryEscape(key),
+						Size: size,
+						ETag: strings.Trim(etag, "\""),
+					},
+				},
+			}},
+		}
+
+		body, err := json.Marshal(record)
+		if err != nil {
+			s.logger.Error("failed to marshal S3 event notification", "error", err)
+
+			continue
+		}
+
+		if err := s.sqsPublisher.PublishToSQS(ctx, cfg.QueueArn, string(body)); err != nil {
+			s.logger.Error("failed to deliver S3 notification to SQS",
+				"bucket", bucket, "key", key, "queueArn", cfg.QueueArn, "error", err)
+		}
+	}
+}
+
+// matchesEventFilter checks whether an eventName (e.g. "s3:ObjectCreated:Put")
+// matches any of the configured event filter strings (e.g. "s3:ObjectCreated:*").
+func matchesEventFilter(filters []string, eventName string) bool {
+	for _, f := range filters {
+		if f == eventName {
+			return true
+		}
+
+		// Handle wildcard: "s3:ObjectCreated:*" matches "s3:ObjectCreated:Put"
+		if strings.HasSuffix(f, "*") {
+			prefix := strings.TrimSuffix(f, "*")
+			if strings.HasPrefix(eventName, prefix) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // emitObjectCreatedEvent sends an S3 Object Created event to EventBridge.

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -64,6 +64,8 @@ type Storage interface {
 	// Notification and CORS
 	SetEventBridgeNotification(ctx context.Context, bucket string, enabled bool)
 	IsEventBridgeEnabled(ctx context.Context, bucket string) bool
+	SetQueueConfigurations(ctx context.Context, bucket string, configs []QueueConfiguration)
+	GetQueueConfigurations(ctx context.Context, bucket string) []QueueConfiguration
 	SetCORSConfiguration(ctx context.Context, bucket string, rules []CORSRule)
 	GetCORSRules(ctx context.Context, bucket string) []CORSRule
 
@@ -118,23 +120,24 @@ type MemoryStorage struct {
 
 // MemoryBucket holds the data for a single S3 bucket.
 type MemoryBucket struct {
-	Name               string                      `json:"name"`
-	CreationDate       time.Time                   `json:"creationDate"`
-	Objects            map[string]*Object          `json:"objects"`                     // current/latest version per key
-	Versions           map[string][]*Object        `json:"versions"`                    // all versions per key (newest first)
-	VersioningStatus   string                      `json:"versioningStatus"`            // "", "Enabled", "Suspended"
-	VersionIDCounter   uint64                      `json:"versionIdcounter"`            // counter for generating version IDs
-	MultipartUploads   map[string]*MultipartUpload `json:"-"`                           // uploadID -> MultipartUpload
-	EventBridgeEnabled bool                        `json:"eventBridgeEnabled"`          // EventBridge notification
-	CORSRules          []CORSRule                  `json:"corsRules,omitempty"`         // CORS configuration
-	PublicAccessBlock  *PublicAccessBlockConfig    `json:"publicAccessBlock,omitempty"` // public access block configuration
-	Encryption         *ServerSideEncryptionConfig `json:"encryption,omitempty"`        // server-side encryption configuration
-	Policy             string                      `json:"policy,omitempty"`            // bucket policy JSON document (empty == not configured)
-	Logging            *BucketLoggingConfig        `json:"logging,omitempty"`           // server access logging target (nil == disabled)
-	ObjectACLs         map[string]*ObjectACL       `json:"objectAcls,omitempty"`        // per-object ACL (key -> ACL)
-	Website            *WebsiteConfiguration       `json:"website,omitempty"`           // static-site-hosting configuration
-	Lifecycle          *LifecycleConfiguration     `json:"lifecycle,omitempty"`         // expiration / transition rules
-	ObjectRestores     map[string]*RestoreState    `json:"objectRestores,omitempty"`    // per-object restore state (key -> state)
+	Name                string                      `json:"name"`
+	CreationDate        time.Time                   `json:"creationDate"`
+	Objects             map[string]*Object          `json:"objects"`                       // current/latest version per key
+	Versions            map[string][]*Object        `json:"versions"`                      // all versions per key (newest first)
+	VersioningStatus    string                      `json:"versioningStatus"`              // "", "Enabled", "Suspended"
+	VersionIDCounter    uint64                      `json:"versionIdcounter"`              // counter for generating version IDs
+	MultipartUploads    map[string]*MultipartUpload `json:"-"`                             // uploadID -> MultipartUpload
+	EventBridgeEnabled  bool                        `json:"eventBridgeEnabled"`            // EventBridge notification
+	QueueConfigurations []QueueConfiguration        `json:"queueConfigurations,omitempty"` // SQS queue notification destinations
+	CORSRules           []CORSRule                  `json:"corsRules,omitempty"`           // CORS configuration
+	PublicAccessBlock   *PublicAccessBlockConfig    `json:"publicAccessBlock,omitempty"`   // public access block configuration
+	Encryption          *ServerSideEncryptionConfig `json:"encryption,omitempty"`          // server-side encryption configuration
+	Policy              string                      `json:"policy,omitempty"`              // bucket policy JSON document (empty == not configured)
+	Logging             *BucketLoggingConfig        `json:"logging,omitempty"`             // server access logging target (nil == disabled)
+	ObjectACLs          map[string]*ObjectACL       `json:"objectAcls,omitempty"`          // per-object ACL (key -> ACL)
+	Website             *WebsiteConfiguration       `json:"website,omitempty"`             // static-site-hosting configuration
+	Lifecycle           *LifecycleConfiguration     `json:"lifecycle,omitempty"`           // expiration / transition rules
+	ObjectRestores      map[string]*RestoreState    `json:"objectRestores,omitempty"`      // per-object restore state (key -> state)
 }
 
 // BucketLoggingConfig stores the destination for server access logs.
@@ -1204,6 +1207,28 @@ func (s *MemoryStorage) IsEventBridgeEnabled(_ context.Context, bucket string) b
 	}
 
 	return false
+}
+
+// SetQueueConfigurations stores the SQS queue notification destinations for a bucket.
+func (s *MemoryStorage) SetQueueConfigurations(_ context.Context, bucket string, configs []QueueConfiguration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if b, exists := s.Buckets[bucket]; exists {
+		b.QueueConfigurations = configs
+	}
+}
+
+// GetQueueConfigurations returns the SQS queue notification destinations for a bucket.
+func (s *MemoryStorage) GetQueueConfigurations(_ context.Context, bucket string) []QueueConfiguration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if b, exists := s.Buckets[bucket]; exists {
+		return b.QueueConfigurations
+	}
+
+	return nil
 }
 
 // SetCORSConfiguration sets the CORS configuration for a bucket.

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -358,12 +358,60 @@ type CopyRange struct {
 
 // NotificationConfiguration represents S3 bucket notification configuration.
 type NotificationConfiguration struct {
-	XMLName           xml.Name           `xml:"NotificationConfiguration"`
-	EventBridgeConfig *EventBridgeConfig `xml:"EventBridgeConfiguration,omitempty"`
+	XMLName             xml.Name             `xml:"NotificationConfiguration"`
+	EventBridgeConfig   *EventBridgeConfig   `xml:"EventBridgeConfiguration,omitempty"`
+	QueueConfigurations []QueueConfiguration `xml:"QueueConfiguration,omitempty"`
 }
 
 // EventBridgeConfig represents EventBridge notification configuration.
 type EventBridgeConfig struct{}
+
+// QueueConfiguration represents an SQS queue destination in the bucket
+// notification configuration.
+type QueueConfiguration struct {
+	ID       string   `xml:"Id,omitempty"       json:"id,omitempty"`
+	QueueArn string   `xml:"Queue"              json:"queue"`
+	Events   []string `xml:"Event"              json:"events"`
+}
+
+// EventNotification is the top-level wrapper sent to SQS when an S3
+// event fires. AWS calls this the "event message structure".
+type EventNotification struct {
+	Records []EventRecord `json:"Records"` //nolint:tagliatelle // AWS S3 event format
+}
+
+// EventRecord represents a single record inside the Records array of
+// an S3 event notification message delivered to SQS.
+type EventRecord struct {
+	EventVersion string              `json:"eventVersion"`
+	EventSource  string              `json:"eventSource"`
+	AWSRegion    string              `json:"awsRegion"`
+	EventTime    string              `json:"eventTime"`
+	EventName    string              `json:"eventName"`
+	S3           EventRecordS3Detail `json:"s3"`
+	UserIdentity map[string]string   `json:"userIdentity"`
+}
+
+// EventRecordS3Detail holds the s3-specific portion of an event record.
+type EventRecordS3Detail struct {
+	SchemaVersion   string            `json:"s3SchemaVersion"`
+	ConfigurationID string            `json:"configurationId"`
+	Bucket          EventRecordBucket `json:"bucket"`
+	Object          EventRecordObject `json:"object"`
+}
+
+// EventRecordBucket describes the bucket in an S3 event record.
+type EventRecordBucket struct {
+	Name string `json:"name"`
+	Arn  string `json:"arn"`
+}
+
+// EventRecordObject describes the object in an S3 event record.
+type EventRecordObject struct {
+	Key  string `json:"key"`
+	Size int64  `json:"size"`
+	ETag string `json:"eTag"`
+}
 
 // CORSConfiguration represents S3 bucket CORS configuration (XML request body).
 type CORSConfiguration struct {

--- a/test/integration/s3_eventbridge_test.go
+++ b/test/integration/s3_eventbridge_test.go
@@ -4,9 +4,11 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -141,5 +143,164 @@ func TestS3_EventBridgeNotification(t *testing.T) {
 
 	if envelope["detail-type"] != "Object Created" {
 		t.Errorf("expected detail-type=Object Created, got %v", envelope["detail-type"])
+	}
+}
+
+// TestS3_NotificationToSQS verifies that PutObject delivers an S3
+// event notification to an SQS queue configured via
+// PutBucketNotificationConfiguration (QueueConfiguration). This is
+// the "classic" S3 -> SQS path (not via EventBridge).
+func TestS3_NotificationToSQS(t *testing.T) {
+	s3Client := newS3Client(t)
+	sqsClient := newSQSClient(t)
+	ctx := t.Context()
+
+	bucketName := "s3-notif-sqs-test"
+	queueName := "s3-notif-sqs-queue"
+
+	// 1. Create S3 bucket.
+	_, err := s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		_, _ = s3Client.DeleteObject(cleanupCtx, &s3.DeleteObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String("notif-test.txt"),
+		})
+		_, _ = s3Client.DeleteBucket(cleanupCtx, &s3.DeleteBucketInput{
+			Bucket: aws.String(bucketName),
+		})
+	})
+
+	// 2. Create SQS queue.
+	createQueueOutput, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queueURL := *createQueueOutput.QueueUrl
+
+	t.Cleanup(func() {
+		_, _ = sqsClient.DeleteQueue(context.Background(), &sqs.DeleteQueueInput{
+			QueueUrl: aws.String(queueURL),
+		})
+	})
+
+	// 3. Configure bucket notification with QueueConfiguration.
+	queueARN := "arn:aws:sqs:us-east-1:000000000000:" + queueName
+	notifXML := `<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
+		`<QueueConfiguration>` +
+		`<Id>sqs-notif</Id>` +
+		`<Queue>` + queueARN + `</Queue>` +
+		`<Event>s3:ObjectCreated:*</Event>` +
+		`</QueueConfiguration>` +
+		`</NotificationConfiguration>`
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		"http://localhost:4566/"+bucketName+"?notification",
+		bytes.NewReader([]byte(notifXML)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PutBucketNotificationConfiguration returned %d", resp.StatusCode)
+	}
+
+	// 4. Upload an object to trigger the notification.
+	putObjOutput, err := s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("notif-test.txt"),
+		Body:   bytes.NewReader([]byte("hello sqs notification")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("ETag", "VersionId", "ResultMetadata")).Assert(t.Name()+"_put_object", putObjOutput)
+
+	// Wait for async notification goroutine to complete.
+	time.Sleep(500 * time.Millisecond)
+
+	// 5. Receive message from SQS to confirm the event was delivered.
+	var recvOutput *sqs.ReceiveMessageOutput
+
+	for range 10 {
+		recvOutput, err = sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:        aws.String(queueURL),
+			WaitTimeSeconds: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(recvOutput.Messages) > 0 {
+			break
+		}
+	}
+
+	if len(recvOutput.Messages) == 0 {
+		t.Fatal("expected S3 event notification to be delivered to SQS queue, but no message received")
+	}
+
+	// 6. Verify the event payload matches the S3 event notification format.
+	msgBody := aws.ToString(recvOutput.Messages[0].Body)
+
+	var notification struct {
+		Records []struct {
+			EventSource string `json:"eventSource"`
+			EventName   string `json:"eventName"`
+			S3          struct {
+				Bucket struct {
+					Name string `json:"name"`
+				} `json:"bucket"`
+				Object struct {
+					Key string `json:"key"`
+				} `json:"object"`
+			} `json:"s3"`
+		} `json:"Records"`
+	}
+
+	if err := json.Unmarshal([]byte(msgBody), &notification); err != nil {
+		t.Fatalf("failed to parse SQS message body as S3 event notification: %v", err)
+	}
+
+	if len(notification.Records) == 0 {
+		t.Fatal("expected at least one record in the notification")
+	}
+
+	record := notification.Records[0]
+
+	if record.EventSource != "aws:s3" {
+		t.Errorf("expected eventSource=aws:s3, got %q", record.EventSource)
+	}
+
+	if record.EventName != "s3:ObjectCreated:Put" {
+		t.Errorf("expected eventName=s3:ObjectCreated:Put, got %q", record.EventName)
+	}
+
+	if record.S3.Bucket.Name != bucketName {
+		t.Errorf("expected bucket name=%q, got %q", bucketName, record.S3.Bucket.Name)
+	}
+
+	if !strings.Contains(record.S3.Object.Key, "notif-test.txt") {
+		t.Errorf("expected object key to contain notif-test.txt, got %q", record.S3.Object.Key)
 	}
 }

--- a/test/integration/testdata/s3_eventbridge_test_TestS3_NotificationToSQS_TestS3_NotificationToSQS_put_object.golden.go
+++ b/test/integration/testdata/s3_eventbridge_test_TestS3_NotificationToSQS_TestS3_NotificationToSQS_put_object.golden.go
@@ -1,0 +1,20 @@
+{
+  "BucketKeyEnabled": null,
+  "ChecksumCRC32": null,
+  "ChecksumCRC32C": null,
+  "ChecksumCRC64NVME": null,
+  "ChecksumSHA1": null,
+  "ChecksumSHA256": null,
+  "ChecksumType": "",
+  "ETag": "\"d11328bbd0b0d5147949db09f37bc9ff\"",
+  "Expiration": null,
+  "RequestCharged": "",
+  "SSECustomerAlgorithm": null,
+  "SSECustomerKeyMD5": null,
+  "SSEKMSEncryptionContext": null,
+  "SSEKMSKeyId": null,
+  "ServerSideEncryption": "",
+  "Size": null,
+  "VersionId": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Store QueueConfigurations from PutBucketNotificationConfiguration
- Emit S3 event notification JSON to matching SQS queues on PutObject/CopyObject
- Add cross-service wiring following SNS->SQS pattern
- Add integration test

Closes #648, Ref: #416