### PR TITLE
feat(sfn): implement state machine execution engine

### DIFF
--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -1,0 +1,397 @@
+package sfn
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// stateMachineDefinition represents a parsed Step Functions state machine definition.
+//
+//nolint:tagliatelle // AWS Step Functions definition uses PascalCase
+type stateMachineDefinition struct {
+	Comment string                     `json:"Comment"`
+	StartAt string                     `json:"StartAt"`
+	States  map[string]stateDefinition `json:"States"`
+}
+
+// stateDefinition represents a single state in a state machine definition.
+//
+//nolint:tagliatelle // AWS Step Functions definition uses PascalCase
+type stateDefinition struct {
+	Type       string         `json:"Type"`
+	Resource   string         `json:"Resource"`
+	Parameters map[string]any `json:"Parameters"`
+	Next       string         `json:"Next"`
+	End        bool           `json:"End"`
+	Result     any            `json:"Result"`
+	ResultPath *string        `json:"ResultPath"`
+	InputPath  *string        `json:"InputPath"`
+	OutputPath *string        `json:"OutputPath"`
+	Comment    string         `json:"Comment"`
+}
+
+// executionEngine executes a state machine definition.
+type executionEngine struct {
+	baseURL string
+	client  *http.Client
+}
+
+// newExecutionEngine creates a new execution engine.
+func newExecutionEngine(baseURL string) *executionEngine {
+	return &executionEngine{
+		baseURL: baseURL,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// parseDefinition parses a state machine definition JSON string.
+func parseDefinition(definition string) (*stateMachineDefinition, error) {
+	var def stateMachineDefinition
+	if err := json.Unmarshal([]byte(definition), &def); err != nil {
+		return nil, fmt.Errorf("parse definition: %w", err)
+	}
+
+	if def.StartAt == "" {
+		return nil, fmt.Errorf("parse definition: StartAt is required")
+	}
+
+	if len(def.States) == 0 {
+		return nil, fmt.Errorf("parse definition: States is required")
+	}
+
+	return &def, nil
+}
+
+// execute runs the state machine and returns the output JSON string.
+func (e *executionEngine) execute(ctx context.Context, def *stateMachineDefinition, input string) (string, error) {
+	currentState := def.StartAt
+	currentInput := input
+
+	for {
+		state, ok := def.States[currentState]
+		if !ok {
+			return "", fmt.Errorf("state %q not found in definition", currentState)
+		}
+
+		output, err := e.executeState(ctx, currentState, &state, currentInput)
+		if err != nil {
+			return "", fmt.Errorf("execute state %q: %w", currentState, err)
+		}
+
+		if state.End {
+			return output, nil
+		}
+
+		if state.Next == "" {
+			return "", fmt.Errorf("state %q has no End or Next", currentState)
+		}
+
+		currentInput = output
+		currentState = state.Next
+	}
+}
+
+// executeState executes a single state and returns the output.
+func (e *executionEngine) executeState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
+	switch state.Type {
+	case "Pass":
+		return e.executePassState(state, input)
+	case "Task":
+		return e.executeTaskState(ctx, name, state, input)
+	default:
+		return "", fmt.Errorf("unsupported state type %q", state.Type)
+	}
+}
+
+// executePassState executes a Pass state.
+func (e *executionEngine) executePassState(state *stateDefinition, input string) (string, error) {
+	if state.Result != nil {
+		result, err := json.Marshal(state.Result)
+		if err != nil {
+			return "", fmt.Errorf("marshal pass result: %w", err)
+		}
+
+		return string(result), nil
+	}
+
+	return input, nil
+}
+
+// executeTaskState executes a Task state by calling the appropriate service.
+func (e *executionEngine) executeTaskState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
+	resource := state.Resource
+	if resource == "" {
+		return "", fmt.Errorf("task state %q has no Resource", name)
+	}
+
+	// Resolve parameters with JSONPath references from input.
+	params, err := resolveParameters(state.Parameters, input)
+	if err != nil {
+		return "", fmt.Errorf("resolve parameters for state %q: %w", name, err)
+	}
+
+	switch resource {
+	case "arn:aws:states:::sqs:sendMessage":
+		return e.executeSQSSendMessage(ctx, params)
+	case "arn:aws:states:::lambda:invoke":
+		return e.executeLambdaInvoke(ctx, params)
+	default:
+		return "", fmt.Errorf("unsupported task resource %q", resource)
+	}
+}
+
+// resolveParameters resolves parameter values, handling JSONPath references
+// (keys ending with ".$" whose values are JSONPath expressions like "$.field").
+//
+//nolint:nestif // JSONPath resolution requires nested type checks.
+func resolveParameters(params map[string]any, input string) (map[string]any, error) {
+	if params == nil {
+		return map[string]any{}, nil
+	}
+
+	var inputData map[string]any
+
+	resolved := make(map[string]any, len(params))
+
+	for key, value := range params {
+		if strings.HasSuffix(key, ".$") {
+			// This is a JSONPath reference.
+			actualKey := strings.TrimSuffix(key, ".$")
+
+			pathStr, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("jsonPath reference for key %q must be a string", key)
+			}
+
+			if inputData == nil {
+				if err := json.Unmarshal([]byte(input), &inputData); err != nil {
+					return nil, fmt.Errorf("parse input for JSONPath: %w", err)
+				}
+			}
+
+			resolvedValue, err := resolveJSONPath(inputData, pathStr)
+			if err != nil {
+				return nil, fmt.Errorf("resolve JSONPath %q for key %q: %w", pathStr, key, err)
+			}
+
+			resolved[actualKey] = resolvedValue
+		} else {
+			// Static value -- recurse into nested maps.
+			if subMap, ok := value.(map[string]any); ok {
+				subResolved, err := resolveParameters(subMap, input)
+				if err != nil {
+					return nil, err
+				}
+
+				resolved[key] = subResolved
+			} else {
+				resolved[key] = value
+			}
+		}
+	}
+
+	return resolved, nil
+}
+
+// resolveJSONPath resolves a simple JSONPath expression ("$" or "$.field") against the input data.
+// Only single-level field access is supported (e.g., "$.message"), plus "$" for the whole input.
+func resolveJSONPath(data map[string]any, path string) (any, error) {
+	if path == "$" {
+		return data, nil
+	}
+
+	if !strings.HasPrefix(path, "$.") {
+		return nil, fmt.Errorf("unsupported JSONPath %q: must start with $", path)
+	}
+
+	field := strings.TrimPrefix(path, "$.")
+
+	// Support nested field access like "$.a.b.c".
+	parts := strings.Split(field, ".")
+
+	var current any = data
+
+	for _, part := range parts {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("jsonPath %q: cannot access field %q on non-object", path, part)
+		}
+
+		val, exists := m[part]
+		if !exists {
+			return nil, fmt.Errorf("jsonPath %q: field %q not found", path, part)
+		}
+
+		current = val
+	}
+
+	return current, nil
+}
+
+// executeSQSSendMessage sends a message to SQS via HTTP.
+func (e *executionEngine) executeSQSSendMessage(ctx context.Context, params map[string]any) (string, error) {
+	queueURL, _ := params["QueueUrl"].(string)
+	if queueURL == "" {
+		return "", fmt.Errorf("sqs sendMessage: QueueUrl is required")
+	}
+
+	messageBody, err := formatMessageBody(params["MessageBody"])
+	if err != nil {
+		return "", fmt.Errorf("sqs sendMessage: %w", err)
+	}
+
+	// Build SQS SendMessage request payload (JSON protocol).
+	sqsReq := map[string]any{
+		"QueueUrl":    queueURL,
+		"MessageBody": messageBody,
+	}
+
+	body, err := json.Marshal(sqsReq)
+	if err != nil {
+		return "", fmt.Errorf("sqs sendMessage: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("sqs sendMessage: create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", "AmazonSQS.SendMessage")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sqs sendMessage: send request: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("sqs sendMessage: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("sqs sendMessage: unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	slog.Debug("SFN executor: SQS sendMessage succeeded", "queueUrl", queueURL)
+
+	return string(respBody), nil
+}
+
+// formatMessageBody converts a message body value to a string suitable for SQS.
+func formatMessageBody(v any) (string, error) {
+	if v == nil {
+		return "", fmt.Errorf("messageBody is required")
+	}
+
+	switch val := v.(type) {
+	case string:
+		return val, nil
+	default:
+		encoded, err := json.Marshal(val)
+		if err != nil {
+			return "", fmt.Errorf("marshal MessageBody: %w", err)
+		}
+
+		return string(encoded), nil
+	}
+}
+
+// executeLambdaInvoke invokes a Lambda function via HTTP.
+//
+//nolint:funlen // Straightforward HTTP call with error handling.
+func (e *executionEngine) executeLambdaInvoke(ctx context.Context, params map[string]any) (string, error) {
+	functionName, _ := params["FunctionName"].(string)
+	if functionName == "" {
+		return "", fmt.Errorf("lambda invoke: FunctionName is required")
+	}
+
+	// Extract just the function name from ARN if provided.
+	functionName = extractLambdaFunctionName(functionName)
+
+	var payload []byte
+
+	if p, ok := params["Payload"]; ok {
+		var err error
+
+		payload, err = json.Marshal(p)
+		if err != nil {
+			return "", fmt.Errorf("lambda invoke: marshal payload: %w", err)
+		}
+	} else {
+		payload = []byte("{}")
+	}
+
+	invokeURL := fmt.Sprintf("%s/lambda/2015-03-31/functions/%s/invocations", e.baseURL, functionName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, invokeURL, bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("lambda invoke: create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("lambda invoke: send request: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("lambda invoke: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("lambda invoke: unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	slog.Debug("SFN executor: Lambda invoke succeeded", "function", functionName)
+
+	// Wrap Lambda response in the Step Functions format.
+	lambdaResult := map[string]any{
+		"StatusCode": resp.StatusCode,
+	}
+
+	// Try to parse the response body as JSON for the Payload field.
+	var payloadValue any
+	if err := json.Unmarshal(respBody, &payloadValue); err == nil {
+		lambdaResult["Payload"] = payloadValue
+	} else {
+		lambdaResult["Payload"] = string(respBody)
+	}
+
+	result, err := json.Marshal(lambdaResult)
+	if err != nil {
+		return "", fmt.Errorf("lambda invoke: marshal result: %w", err)
+	}
+
+	return string(result), nil
+}
+
+// extractLambdaFunctionName extracts the function name from an ARN or returns the input as-is.
+func extractLambdaFunctionName(nameOrARN string) string {
+	if !strings.HasPrefix(nameOrARN, "arn:") {
+		return nameOrARN
+	}
+
+	// arn:aws:lambda:<region>:<account>:function:<name>
+	parts := strings.Split(nameOrARN, ":")
+	if len(parts) >= 7 {
+		return parts[6]
+	}
+
+	return nameOrARN
+}

--- a/internal/service/sfn/service.go
+++ b/internal/service/sfn/service.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sivchari/kumo/internal/service"
 )
 
+const defaultBaseURL = "http://localhost:4566"
+
 // Service is the Step Functions service.
 type Service struct {
 	storage Storage
@@ -48,6 +50,8 @@ func init() {
 	if dir := os.Getenv("KUMO_DATA_DIR"); dir != "" {
 		opts = append(opts, WithDataDir(dir))
 	}
+
+	opts = append(opts, WithBaseURL(defaultBaseURL))
 
 	service.Register(New(NewMemoryStorage(opts...)))
 }

--- a/internal/service/sfn/storage.go
+++ b/internal/service/sfn/storage.go
@@ -54,6 +54,13 @@ func WithDataDir(dir string) Option {
 	}
 }
 
+// WithBaseURL sets the base URL for cross-service HTTP calls (SQS, Lambda).
+func WithBaseURL(url string) Option {
+	return func(s *MemoryStorage) {
+		s.baseURL = url
+	}
+}
+
 // Compile-time interface checks.
 var (
 	_ json.Marshaler   = (*MemoryStorage)(nil)
@@ -69,6 +76,8 @@ type MemoryStorage struct {
 	accountID     string
 	EventCounter  int64 `json:"eventCounter"`
 	dataDir       string
+	baseURL       string
+	engine        *executionEngine
 }
 
 // ExecutionData holds execution information and its history.
@@ -89,10 +98,13 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 		Executions:    make(map[string]*ExecutionData),
 		region:        region,
 		accountID:     "000000000000",
+		baseURL:       defaultBaseURL,
 	}
 	for _, o := range opts {
 		o(s)
 	}
+
+	s.engine = newExecutionEngine(s.baseURL)
 
 	if s.dataDir != "" {
 		_ = storage.Load(s.dataDir, "states", s)
@@ -264,16 +276,88 @@ func (s *MemoryStorage) StartExecution(_ context.Context, stateMachineArn, name,
 
 	now := time.Now()
 	exec := s.createExecution(executionArn, stateMachineArn, execName, input, traceHeader, now)
-	history := s.createExecutionHistory(sm.RoleArn, input, now)
 
-	exec.Status = ExecutionStatusSucceeded
-	exec.StopDate = &now
-	exec.Output = input
-	exec.OutputDetails = &CloudWatchEventsExecutionDataDetails{Included: true}
+	startID := atomic.AddInt64(&s.EventCounter, 1)
+	history := []*HistoryEvent{
+		{
+			Timestamp: now, Type: HistoryEventTypeExecutionStarted, ID: startID, PreviousEventID: 0,
+			ExecutionStartedEventDetails: &ExecutionStartedEventDetails{
+				Input: input, InputDetails: &CloudWatchEventsExecutionDataDetails{Included: true}, RoleArn: sm.RoleArn,
+			},
+		},
+	}
 
-	s.Executions[executionArn] = &ExecutionData{Execution: exec, History: history}
+	ed := &ExecutionData{Execution: exec, History: history}
+	s.Executions[executionArn] = ed
+
+	// Parse the definition and run the state machine asynchronously.
+	definition := sm.Definition
+
+	go s.runExecution(ed, definition, input, startID)
 
 	return exec, nil
+}
+
+// runExecution executes the state machine in a background goroutine.
+func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string, lastEventID int64) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	def, err := parseDefinition(definition)
+	if err != nil {
+		s.failExecution(ed, lastEventID, "States.Runtime", fmt.Sprintf("Failed to parse definition: %v", err))
+
+		return
+	}
+
+	output, err := s.engine.execute(ctx, def, input)
+	if err != nil {
+		s.failExecution(ed, lastEventID, "States.TaskFailed", err.Error())
+
+		return
+	}
+
+	s.succeedExecution(ed, lastEventID, output)
+}
+
+// succeedExecution marks an execution as SUCCEEDED.
+func (s *MemoryStorage) succeedExecution(ed *ExecutionData, lastEventID int64, output string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	ed.Execution.Status = ExecutionStatusSucceeded
+	ed.Execution.StopDate = &now
+	ed.Execution.Output = output
+	ed.Execution.OutputDetails = &CloudWatchEventsExecutionDataDetails{Included: true}
+
+	eventID := atomic.AddInt64(&s.EventCounter, 1)
+	ed.History = append(ed.History, &HistoryEvent{
+		Timestamp: now, Type: HistoryEventTypeExecutionSucceeded, ID: eventID, PreviousEventID: lastEventID,
+		ExecutionSucceededEventDetails: &ExecutionSucceededEventDetails{
+			Output: output, OutputDetails: &CloudWatchEventsExecutionDataDetails{Included: true},
+		},
+	})
+}
+
+// failExecution marks an execution as FAILED.
+func (s *MemoryStorage) failExecution(ed *ExecutionData, lastEventID int64, errorCode, cause string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	ed.Execution.Status = ExecutionStatusFailed
+	ed.Execution.StopDate = &now
+	ed.Execution.Error = errorCode
+	ed.Execution.Cause = cause
+
+	eventID := atomic.AddInt64(&s.EventCounter, 1)
+	ed.History = append(ed.History, &HistoryEvent{
+		Timestamp: now, Type: HistoryEventTypeExecutionFailed, ID: eventID, PreviousEventID: lastEventID,
+		ExecutionFailedEventDetails: &ExecutionFailedEventDetails{
+			Error: errorCode, Cause: cause,
+		},
+	})
 }
 
 // createExecution creates a new execution object.
@@ -287,27 +371,6 @@ func (s *MemoryStorage) createExecution(arn, smArn, name, input, traceHeader str
 		Input:           input,
 		InputDetails:    &CloudWatchEventsExecutionDataDetails{Included: true},
 		TraceHeader:     traceHeader,
-	}
-}
-
-// createExecutionHistory creates execution history events for a pass-through execution.
-func (s *MemoryStorage) createExecutionHistory(roleArn, input string, now time.Time) []*HistoryEvent {
-	startID := atomic.AddInt64(&s.EventCounter, 1)
-	endID := atomic.AddInt64(&s.EventCounter, 1)
-
-	return []*HistoryEvent{
-		{
-			Timestamp: now, Type: HistoryEventTypeExecutionStarted, ID: startID, PreviousEventID: 0,
-			ExecutionStartedEventDetails: &ExecutionStartedEventDetails{
-				Input: input, InputDetails: &CloudWatchEventsExecutionDataDetails{Included: true}, RoleArn: roleArn,
-			},
-		},
-		{
-			Timestamp: now, Type: HistoryEventTypeExecutionSucceeded, ID: endID, PreviousEventID: startID,
-			ExecutionSucceededEventDetails: &ExecutionSucceededEventDetails{
-				Output: input, OutputDetails: &CloudWatchEventsExecutionDataDetails{Included: true},
-			},
-		},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Parse state machine definitions and execute states (Task, Pass)
- Support SQS sendMessage and Lambda invoke via HTTP calls to localhost
- Resolve JSONPath references in Parameters (`.$` suffix)
- Handle End/Next state transitions
- Async execution: StartExecution returns RUNNING, goroutine runs the machine
- 5-minute timeout to prevent goroutine leaks

Closes #653, Ref: #416