### PR TITLE
fix(sqs): accept numeric maxReceiveCount in RedrivePolicy and notify DLQ on redrive

### DIFF
--- a/internal/service/sqs/storage.go
+++ b/internal/service/sqs/storage.go
@@ -797,8 +797,8 @@ func applyQueueAttributes(q *Queue, attrs map[string]string) {
 
 // redrivePolicy is used for JSON unmarshaling of RedrivePolicy attribute.
 type redrivePolicy struct {
-	DeadLetterTargetArn string `json:"deadLetterTargetArn"`
-	MaxReceiveCount     string `json:"maxReceiveCount"`
+	DeadLetterTargetArn string      `json:"deadLetterTargetArn"`
+	MaxReceiveCount     json.Number `json:"maxReceiveCount"`
 }
 
 // requeueExpiredMessages moves inflight messages whose visibility timeout has
@@ -849,6 +849,12 @@ func (s *MemoryStorage) moveToDeadLetterQueue(dlqArn string, msg *Message) {
 
 			qd.Messages = append(qd.Messages, dlqMsg)
 
+			// Notify long-polling receivers on the DLQ.
+			select {
+			case qd.notify <- struct{}{}:
+			default:
+			}
+
 			return
 		}
 	}
@@ -861,5 +867,13 @@ func parseRedrivePolicy(q *Queue, val string) {
 	}
 
 	q.DeadLetterTargetArn = rp.DeadLetterTargetArn
-	_, _ = fmt.Sscanf(rp.MaxReceiveCount, "%d", &q.MaxReceiveCount)
+
+	if rp.MaxReceiveCount != "" {
+		n, err := rp.MaxReceiveCount.Int64()
+		if err != nil {
+			return
+		}
+
+		q.MaxReceiveCount = int(n)
+	}
 }


### PR DESCRIPTION
## Summary

- Change `redrivePolicy.MaxReceiveCount` from `string` to `json.Number` to handle both `"2"` and `2`
- Notify DLQ's long-poll channel when a message is moved to DLQ

Closes #709, Ref: #416