### PR TITLE
feat(cloudwatch): notify SNS action targets on alarm state change

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -113,6 +113,7 @@ func New(config Config) *Server {
 	// Cross-service wiring (must happen after all services are registered).
 	wireSNStoSQS(registry)
 	wireS3toSQS(registry)
+	wireCloudWatchToSNS(registry)
 
 	// Register unified protocol dispatcher for POST /
 	hasJSONServices := len(jsonDispatcher.handlers) > 0

--- a/internal/server/sns_sqs_wiring.go
+++ b/internal/server/sns_sqs_wiring.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/sivchari/kumo/internal/service"
@@ -9,6 +10,14 @@ import (
 	"github.com/sivchari/kumo/internal/service/sns"
 	"github.com/sivchari/kumo/internal/service/sqs"
 )
+
+// alarmActionWirer is satisfied by cloudwatch.Service. Using a local
+// interface avoids importing the cloudwatch package directly, which
+// would create an import cycle. The SetSNSPublisher method accepts any
+// and internally asserts it to the cloudwatch.SNSPublisher interface.
+type alarmActionWirer interface {
+	SetSNSPublisher(publisher any)
+}
 
 // wireSNStoSQS connects the SNS service to the SQS service so SNS topic
 // subscriptions with protocol=sqs actually deliver messages into the
@@ -178,4 +187,57 @@ func (p *s3ToSQSPublisher) arnToQueueURL(arn string) string {
 	name := parts[5]
 
 	return p.baseURL + "/" + account + "/" + name
+}
+
+// wireCloudWatchToSNS connects the CloudWatch service to the SNS service
+// so that alarm actions (AlarmActions, OKActions) actually deliver
+// notification messages to the configured SNS topics when an alarm state
+// changes via SetAlarmState.
+//
+// Without this wiring, SetAlarmState only updates the alarm state in
+// memory and silently ignores the action target ARNs.
+//
+// We use a local interface (alarmActionWirer) rather than importing the
+// cloudwatch package directly, because cloudwatch already imports server
+// for CBOR helpers and a direct import would create a cycle.
+func wireCloudWatchToSNS(registry *service.Registry) {
+	cwSvc, ok := registry.Get("monitoring")
+	if !ok {
+		return
+	}
+
+	snsSvc, ok := registry.Get("sns")
+	if !ok {
+		return
+	}
+
+	cwWirer, ok := cwSvc.(alarmActionWirer)
+	if !ok {
+		return
+	}
+
+	snsTyped, ok := snsSvc.(*sns.Service)
+	if !ok {
+		return
+	}
+
+	cwWirer.SetSNSPublisher(&cloudWatchToSNSPublisher{
+		snsStorage: snsTyped.Storage(),
+	})
+}
+
+// cloudWatchToSNSPublisher adapts the SNS storage Publish method to the
+// CloudWatch SNSPublisher interface.
+type cloudWatchToSNSPublisher struct {
+	snsStorage sns.Storage
+}
+
+// Publish sends a CloudWatch alarm notification to an SNS topic.
+func (p *cloudWatchToSNSPublisher) Publish(ctx context.Context, topicARN, message, subject string) error {
+	_, err := p.snsStorage.Publish(ctx, topicARN, message, subject, "", "", nil)
+	if err != nil {
+		return fmt.Errorf("cloudwatch alarm action publish failed: %w", err)
+	}
+
+	return nil
 }

--- a/internal/service/cloudwatch/handlers.go
+++ b/internal/service/cloudwatch/handlers.go
@@ -242,6 +242,30 @@ func (s *Service) DescribeAlarms(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// SetAlarmState handles the SetAlarmState action via JSON protocol.
+func (s *Service) SetAlarmState(w http.ResponseWriter, r *http.Request) {
+	var req SetAlarmStateRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.AlarmName == "" {
+		writeCloudWatchError(w, errMissingParameter, "The parameter AlarmName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.SetAlarmState(r.Context(), req.AlarmName, req.StateValue, req.StateReason); err != nil {
+		handleCloudWatchError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, struct{}{})
+}
+
 // DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.
 func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 	target := r.Header.Get("X-Amz-Target")
@@ -262,6 +286,8 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 		s.DeleteAlarms(w, r)
 	case "DescribeAlarms":
 		s.DescribeAlarms(w, r)
+	case "SetAlarmState":
+		s.SetAlarmState(w, r)
 	case "ListTagsForResource":
 		s.ListTagsForResource(w, r)
 	case "TagResource":

--- a/internal/service/cloudwatch/service.go
+++ b/internal/service/cloudwatch/service.go
@@ -119,6 +119,24 @@ func (s *Service) DispatchCBORAction(w http.ResponseWriter, r *http.Request, ope
 	}
 }
 
+// Storage returns the CloudWatch storage.
+// This can be used to set up cross-service integration (e.g., CloudWatch alarm actions to SNS).
+func (s *Service) Storage() Storage {
+	return s.storage
+}
+
+// SetSNSPublisher installs the SNS publisher used to deliver alarm
+// action notifications. The argument must satisfy the SNSPublisher
+// interface (Publish method). Accepting any here avoids an import
+// cycle between server and cloudwatch.
+func (s *Service) SetSNSPublisher(publisher any) {
+	if p, ok := publisher.(SNSPublisher); ok {
+		if ms, ok := s.storage.(*MemoryStorage); ok {
+			ms.SetSNSPublisher(p)
+		}
+	}
+}
+
 // Close saves the storage state if persistence is enabled.
 func (s *Service) Close() error {
 	if c, ok := s.storage.(io.Closer); ok {

--- a/internal/service/cloudwatch/storage.go
+++ b/internal/service/cloudwatch/storage.go
@@ -16,6 +16,14 @@ import (
 // defaultAccountID is the default AWS account ID used in the emulator.
 const defaultAccountID = "000000000000"
 
+// defaultRegion is the default AWS region used in the emulator.
+const defaultRegion = "us-east-1"
+
+// SNSPublisher is an interface for publishing alarm action notifications to SNS topics.
+type SNSPublisher interface {
+	Publish(ctx context.Context, topicARN, message, subject string) error
+}
+
 // Storage defines the CloudWatch storage interface.
 type Storage interface {
 	PutMetricData(ctx context.Context, namespace string, metricData []MetricDatum) error
@@ -61,11 +69,12 @@ var (
 
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu      sync.RWMutex                `json:"-"`
-	Metrics map[MetricKey]*StoredMetric `json:"metrics"`
-	Alarms  map[string]*Alarm           `json:"alarms"`
-	baseURL string
-	dataDir string
+	mu           sync.RWMutex                `json:"-"`
+	Metrics      map[MetricKey]*StoredMetric `json:"metrics"`
+	Alarms       map[string]*Alarm           `json:"alarms"`
+	baseURL      string
+	dataDir      string
+	snsPublisher SNSPublisher `json:"-"`
 }
 
 // NewMemoryStorage creates a new in-memory CloudWatch storage.
@@ -170,6 +179,11 @@ func (s *MemoryStorage) Close() error {
 	}
 
 	return nil
+}
+
+// SetSNSPublisher sets the SNS publisher for alarm action notifications.
+func (s *MemoryStorage) SetSNSPublisher(publisher SNSPublisher) {
+	s.snsPublisher = publisher
 }
 
 // PutMetricData stores metric data.
@@ -440,24 +454,120 @@ func (s *MemoryStorage) DeleteAlarms(_ context.Context, alarmNames []string) err
 	return nil
 }
 
-// SetAlarmState sets the state of an alarm.
-func (s *MemoryStorage) SetAlarmState(_ context.Context, alarmName, stateValue, stateReason string) error {
+// SetAlarmState sets the state of an alarm and fires the corresponding
+// alarm actions (AlarmActions for ALARM, OKActions for OK) by publishing
+// a notification message to each SNS topic ARN listed in the action list.
+func (s *MemoryStorage) SetAlarmState(ctx context.Context, alarmName, stateValue, stateReason string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	alarm, exists := s.Alarms[alarmName]
 	if !exists {
+		s.mu.Unlock()
+
 		return &Error{
 			Code:    "ResourceNotFound",
 			Message: fmt.Sprintf("Alarm %s does not exist", alarmName),
 		}
 	}
 
+	previousState := alarm.StateValue
 	alarm.StateValue = stateValue
 	alarm.StateReason = stateReason
 	alarm.StateUpdatedAt = time.Now().UTC().Format(time.RFC3339)
 
+	// Determine which actions to fire based on the new state.
+	var actionARNs []string
+
+	if alarm.ActionsEnabled {
+		switch stateValue {
+		case "ALARM":
+			actionARNs = append(actionARNs, alarm.AlarmActions...)
+		case "OK":
+			actionARNs = append(actionARNs, alarm.OKActions...)
+		}
+	}
+
+	// Copy alarm fields needed for the notification while still holding
+	// the lock, then release before performing I/O.
+	notification := s.buildAlarmNotification(alarm, previousState)
+	s.mu.Unlock()
+
+	// Publish to each action target (SNS topic ARNs).
+	if s.snsPublisher != nil && len(actionARNs) > 0 {
+		body, err := json.Marshal(notification)
+		if err != nil {
+			return fmt.Errorf("SetAlarmState failed: %w", err)
+		}
+
+		subject := fmt.Sprintf("ALARM: %q in %s", alarmName, defaultRegion)
+
+		for _, arn := range actionARNs {
+			// Best-effort delivery: log but do not fail the SetAlarmState
+			// call if a publish fails (matches AWS behaviour where action
+			// delivery is asynchronous).
+			_ = s.snsPublisher.Publish(ctx, arn, string(body), subject)
+		}
+	}
+
 	return nil
+}
+
+// alarmNotification mirrors the JSON structure AWS CloudWatch sends to
+// SNS action targets when an alarm state changes.
+//
+//nolint:tagliatelle // AWS notification uses PascalCase JSON fields.
+type alarmNotification struct {
+	AlarmName        string                   `json:"AlarmName"`
+	AlarmDescription string                   `json:"AlarmDescription,omitempty"`
+	AWSAccountID     string                   `json:"AWSAccountId"`
+	NewStateValue    string                   `json:"NewStateValue"`
+	NewStateReason   string                   `json:"NewStateReason"`
+	OldStateValue    string                   `json:"OldStateValue"`
+	StateChangeTime  string                   `json:"StateChangeTime"`
+	Region           string                   `json:"Region"`
+	AlarmARN         string                   `json:"AlarmArn"`
+	Trigger          alarmNotificationTrigger `json:"Trigger"`
+}
+
+// alarmNotificationTrigger contains the metric details that triggered the
+// alarm.
+//
+//nolint:tagliatelle // AWS notification uses PascalCase JSON fields.
+type alarmNotificationTrigger struct {
+	MetricName         string      `json:"MetricName"`
+	Namespace          string      `json:"Namespace"`
+	Statistic          string      `json:"Statistic,omitempty"`
+	Dimensions         []Dimension `json:"Dimensions,omitempty"`
+	Period             int32       `json:"Period"`
+	EvaluationPeriods  int32       `json:"EvaluationPeriods"`
+	Threshold          float64     `json:"Threshold"`
+	ComparisonOperator string      `json:"ComparisonOperator"`
+}
+
+// buildAlarmNotification creates an alarm notification message from alarm
+// state. The caller must hold at least a read lock on s.mu.
+func (s *MemoryStorage) buildAlarmNotification(alarm *Alarm, previousState string) *alarmNotification {
+	return &alarmNotification{
+		AlarmName:        alarm.AlarmName,
+		AlarmDescription: alarm.AlarmDescription,
+		AWSAccountID:     defaultAccountID,
+		NewStateValue:    alarm.StateValue,
+		NewStateReason:   alarm.StateReason,
+		OldStateValue:    previousState,
+		StateChangeTime:  alarm.StateUpdatedAt,
+		Region:           defaultRegion,
+		AlarmARN:         alarm.AlarmARN,
+		Trigger: alarmNotificationTrigger{
+			MetricName:         alarm.MetricName,
+			Namespace:          alarm.Namespace,
+			Statistic:          alarm.Statistic,
+			Dimensions:         alarm.Dimensions,
+			Period:             alarm.Period,
+			EvaluationPeriods:  alarm.EvaluationPeriods,
+			Threshold:          alarm.Threshold,
+			ComparisonOperator: alarm.ComparisonOperator,
+		},
+	}
 }
 
 // DescribeAlarms returns information about alarms.


### PR DESCRIPTION
## Summary

- SetAlarmState publishes to AlarmActions/OKActions SNS topics
- Add cross-service wiring (CloudWatch -> SNS) with import cycle avoidance
- AWS-compatible alarm notification JSON format

Closes #711, Ref: #416