### PR TITLE
feat(sesv2): EmailTemplate CRUD + SendBulkEmail

### DIFF
--- a/internal/service/sesv2/handlers.go
+++ b/internal/service/sesv2/handlers.go
@@ -406,7 +406,7 @@ func (s *Service) ListEmailTemplates(w http.ResponseWriter, r *http.Request) {
 	for _, tmpl := range templates {
 		metadata = append(metadata, EmailTemplateMetadata{
 			TemplateName:     tmpl.Name,
-			CreatedTimestamp: tmpl.CreatedTimestamp,
+			CreatedTimestamp: epochSeconds(tmpl.CreatedTimestamp),
 		})
 	}
 

--- a/internal/service/sesv2/handlers.go
+++ b/internal/service/sesv2/handlers.go
@@ -257,6 +257,196 @@ func (s *Service) DeleteConfigurationSet(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusOK)
 }
 
+// CreateEmailTemplate handles the CreateEmailTemplate operation.
+func (s *Service) CreateEmailTemplate(w http.ResponseWriter, r *http.Request) {
+	var req CreateEmailTemplateRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	_, err := s.storage.CreateEmailTemplate(r.Context(), &req)
+	if err != nil {
+		var sErr *IdentityError
+		if errors.As(err, &sErr) {
+			status := http.StatusBadRequest
+			if sErr.Code == errAlreadyExists {
+				status = http.StatusConflict
+			}
+
+			writeError(w, sErr.Code, sErr.Message, status)
+
+			return
+		}
+
+		writeError(w, "InternalServiceError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetEmailTemplate handles the GetEmailTemplate operation.
+func (s *Service) GetEmailTemplate(w http.ResponseWriter, r *http.Request) {
+	name := extractPathParam(r.URL.Path, "/ses/v2/email/templates/")
+	if name == "" {
+		writeError(w, errInvalidParameter, "TemplateName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	tmpl, err := s.storage.GetEmailTemplate(r.Context(), name)
+	if err != nil {
+		var sErr *IdentityError
+		if errors.As(err, &sErr) {
+			status := http.StatusBadRequest
+			if sErr.Code == errNotFound {
+				status = http.StatusNotFound
+			}
+
+			writeError(w, sErr.Code, sErr.Message, status)
+
+			return
+		}
+
+		writeError(w, "InternalServiceError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, GetEmailTemplateResponse{
+		TemplateName:    tmpl.Name,
+		TemplateContent: tmpl.TemplateContent,
+	})
+}
+
+// UpdateEmailTemplate handles the UpdateEmailTemplate operation.
+func (s *Service) UpdateEmailTemplate(w http.ResponseWriter, r *http.Request) {
+	name := extractPathParam(r.URL.Path, "/ses/v2/email/templates/")
+	if name == "" {
+		writeError(w, errInvalidParameter, "TemplateName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	var req UpdateEmailTemplateRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	_, err := s.storage.UpdateEmailTemplate(r.Context(), name, &req)
+	if err != nil {
+		var sErr *IdentityError
+		if errors.As(err, &sErr) {
+			status := http.StatusBadRequest
+			if sErr.Code == errNotFound {
+				status = http.StatusNotFound
+			}
+
+			writeError(w, sErr.Code, sErr.Message, status)
+
+			return
+		}
+
+		writeError(w, "InternalServiceError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// DeleteEmailTemplate handles the DeleteEmailTemplate operation.
+func (s *Service) DeleteEmailTemplate(w http.ResponseWriter, r *http.Request) {
+	name := extractPathParam(r.URL.Path, "/ses/v2/email/templates/")
+	if name == "" {
+		writeError(w, errInvalidParameter, "TemplateName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteEmailTemplate(r.Context(), name); err != nil {
+		var sErr *IdentityError
+		if errors.As(err, &sErr) {
+			status := http.StatusBadRequest
+			if sErr.Code == errNotFound {
+				status = http.StatusNotFound
+			}
+
+			writeError(w, sErr.Code, sErr.Message, status)
+
+			return
+		}
+
+		writeError(w, "InternalServiceError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// ListEmailTemplates handles the ListEmailTemplates operation.
+func (s *Service) ListEmailTemplates(w http.ResponseWriter, r *http.Request) {
+	nextToken := r.URL.Query().Get("NextToken")
+	pageSize := parsePageSize(r.URL.Query().Get("PageSize"))
+
+	templates, nextTokenOut, err := s.storage.ListEmailTemplates(r.Context(), nextToken, pageSize)
+	if err != nil {
+		writeError(w, "InternalServiceError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	metadata := make([]EmailTemplateMetadata, 0, len(templates))
+	for _, tmpl := range templates {
+		metadata = append(metadata, EmailTemplateMetadata{
+			TemplateName:     tmpl.Name,
+			CreatedTimestamp: tmpl.CreatedTimestamp,
+		})
+	}
+
+	writeJSONResponse(w, ListEmailTemplatesResponse{
+		TemplatesMetadata: metadata,
+		NextToken:         nextTokenOut,
+	})
+}
+
+// SendBulkEmail handles the SendBulkEmail operation.
+func (s *Service) SendBulkEmail(w http.ResponseWriter, r *http.Request) {
+	var req SendBulkEmailRequest
+	if err := readJSONRequest(r, &req); err != nil {
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := s.storage.SendBulkEmail(r.Context(), &req)
+	if err != nil {
+		var sErr *IdentityError
+		if errors.As(err, &sErr) {
+			status := http.StatusBadRequest
+			if sErr.Code == errNotFound {
+				status = http.StatusNotFound
+			}
+
+			writeError(w, sErr.Code, sErr.Message, status)
+
+			return
+		}
+
+		writeError(w, "InternalServiceError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, resp)
+}
+
 // SendEmail handles the SendEmail operation.
 func (s *Service) SendEmail(w http.ResponseWriter, r *http.Request) {
 	var req SendEmailRequest

--- a/internal/service/sesv2/service.go
+++ b/internal/service/sesv2/service.go
@@ -52,8 +52,16 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.HandleFunc("GET", "/ses/v2/email/configuration-sets/{configurationSetName}", s.GetConfigurationSet)
 	r.HandleFunc("DELETE", "/ses/v2/email/configuration-sets/{configurationSetName}", s.DeleteConfigurationSet)
 
-	// Send Email route.
+	// Email Template routes.
+	r.HandleFunc("POST", "/ses/v2/email/templates", s.CreateEmailTemplate)
+	r.HandleFunc("GET", "/ses/v2/email/templates", s.ListEmailTemplates)
+	r.HandleFunc("GET", "/ses/v2/email/templates/{templateName}", s.GetEmailTemplate)
+	r.HandleFunc("PUT", "/ses/v2/email/templates/{templateName}", s.UpdateEmailTemplate)
+	r.HandleFunc("DELETE", "/ses/v2/email/templates/{templateName}", s.DeleteEmailTemplate)
+
+	// Send Email routes.
 	r.HandleFunc("POST", "/ses/v2/email/outbound-emails", s.SendEmail)
+	r.HandleFunc("POST", "/ses/v2/email/outbound-bulk-emails", s.SendBulkEmail)
 
 	// kumo-specific endpoint for testing.
 	r.HandleFunc("GET", "/kumo/ses/v2/sent-emails", s.GetSentEmails)

--- a/internal/service/sesv2/storage.go
+++ b/internal/service/sesv2/storage.go
@@ -550,98 +550,106 @@ func (s *MemoryStorage) SendBulkEmail(_ context.Context, req *SendBulkEmailReque
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	tmpl, defaultTemplate, err := s.validateBulkEmailRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]BulkEmailEntryResult, 0, len(req.BulkEmailEntries))
+
+	for _, entry := range req.BulkEmailEntries {
+		sent, result := buildBulkEmailEntry(req, &entry, defaultTemplate, tmpl)
+		if sent != nil {
+			s.SentEmails = append(s.SentEmails, sent)
+		}
+
+		results = append(results, result)
+	}
+
+	return &SendBulkEmailResponse{BulkEmailEntryResults: results}, nil
+}
+
+// validateBulkEmailRequest checks the top-level request and resolves the template.
+// Must be called with s.mu held.
+func (s *MemoryStorage) validateBulkEmailRequest(req *SendBulkEmailRequest) (*EmailTemplate, *Template, error) {
 	if len(req.BulkEmailEntries) == 0 {
-		return nil, &IdentityError{
+		return nil, nil, &IdentityError{
 			Code:    errBadRequest,
 			Message: "BulkEmailEntries is required",
 		}
 	}
 
 	if req.DefaultContent == nil || req.DefaultContent.Template == nil {
-		return nil, &IdentityError{
+		return nil, nil, &IdentityError{
 			Code:    errBadRequest,
 			Message: "DefaultContent.Template is required",
 		}
 	}
 
 	defaultTemplate := req.DefaultContent.Template
-	templateName := defaultTemplate.TemplateName
-
-	if templateName == "" {
-		return nil, &IdentityError{
+	if defaultTemplate.TemplateName == "" {
+		return nil, nil, &IdentityError{
 			Code:    errBadRequest,
 			Message: "DefaultContent.Template.TemplateName is required",
 		}
 	}
 
-	// Resolve template content. AWS rejects sends against unknown templates.
-	tmpl, exists := s.EmailTemplates[templateName]
+	tmpl, exists := s.EmailTemplates[defaultTemplate.TemplateName]
 	if !exists {
-		return nil, &IdentityError{
+		return nil, nil, &IdentityError{
 			Code:    errNotFound,
 			Message: "The email template does not exist",
 		}
 	}
 
-	results := make([]BulkEmailEntryResult, 0, len(req.BulkEmailEntries))
+	return tmpl, defaultTemplate, nil
+}
 
-	for _, entry := range req.BulkEmailEntries {
-		messageID := uuid.New().String()
+// buildBulkEmailEntry computes the recorded SentEmail (nil on per-entry failure)
+// and the per-entry result for a single BulkEmailEntry.
+func buildBulkEmailEntry(req *SendBulkEmailRequest, entry *BulkEmailEntry, defaultTemplate *Template, tmpl *EmailTemplate) (*SentEmail, BulkEmailEntryResult) {
+	messageID := uuid.New().String()
 
-		hasDestination := entry.Destination != nil &&
-			(len(entry.Destination.ToAddresses) > 0 ||
-				len(entry.Destination.CcAddresses) > 0 ||
-				len(entry.Destination.BccAddresses) > 0)
+	hasDestination := entry.Destination != nil &&
+		(len(entry.Destination.ToAddresses) > 0 ||
+			len(entry.Destination.CcAddresses) > 0 ||
+			len(entry.Destination.BccAddresses) > 0)
 
-		if !hasDestination {
-			results = append(results, BulkEmailEntryResult{
-				Status:    "FAILED",
-				Error:     "Destination is required",
-				MessageID: messageID,
-			})
-
-			continue
-		}
-
-		templateData := defaultTemplate.TemplateData
-		if entry.ReplacementEmailContent != nil &&
-			entry.ReplacementEmailContent.ReplacementTemplate != nil &&
-			entry.ReplacementEmailContent.ReplacementTemplate.ReplacementTemplateData != "" {
-			templateData = entry.ReplacementEmailContent.ReplacementTemplate.ReplacementTemplateData
-		}
-
-		subject := ""
-		body := ""
-		htmlBody := ""
-
-		if tmpl.TemplateContent != nil {
-			subject = tmpl.TemplateContent.Subject
-			body = tmpl.TemplateContent.Text
-			htmlBody = tmpl.TemplateContent.HTML
-		}
-
-		sent := &SentEmail{
-			MessageID:            messageID,
-			FromEmailAddress:     req.FromEmailAddress,
-			Destination:          cloneDestination(entry.Destination),
-			Subject:              subject,
-			Body:                 body,
-			HTMLBody:             htmlBody,
-			TemplateName:         templateName,
-			TemplateData:         templateData,
-			ConfigurationSetName: req.ConfigurationSetName,
-			SentAt:               time.Now(),
-		}
-
-		s.SentEmails = append(s.SentEmails, sent)
-
-		results = append(results, BulkEmailEntryResult{
-			Status:    "SUCCESS",
+	if !hasDestination {
+		return nil, BulkEmailEntryResult{
+			Status:    "FAILED",
+			Error:     "Destination is required",
 			MessageID: messageID,
-		})
+		}
 	}
 
-	return &SendBulkEmailResponse{BulkEmailEntryResults: results}, nil
+	templateData := defaultTemplate.TemplateData
+	if entry.ReplacementEmailContent != nil &&
+		entry.ReplacementEmailContent.ReplacementTemplate != nil &&
+		entry.ReplacementEmailContent.ReplacementTemplate.ReplacementTemplateData != "" {
+		templateData = entry.ReplacementEmailContent.ReplacementTemplate.ReplacementTemplateData
+	}
+
+	sent := &SentEmail{
+		MessageID:            messageID,
+		FromEmailAddress:     req.FromEmailAddress,
+		Destination:          cloneDestination(entry.Destination),
+		TemplateName:         defaultTemplate.TemplateName,
+		TemplateData:         templateData,
+		ConfigurationSetName: req.ConfigurationSetName,
+		SentAt:               time.Now(),
+	}
+
+	if tmpl.TemplateContent != nil {
+		sent.Subject = tmpl.TemplateContent.Subject
+		sent.Body = tmpl.TemplateContent.Text
+		sent.HTMLBody = tmpl.TemplateContent.HTML
+	}
+
+	return sent, BulkEmailEntryResult{
+		Status:    "SUCCESS",
+		MessageID: messageID,
+	}
 }
 
 // cloneDestination returns a deep copy of a destination to avoid aliasing.

--- a/internal/service/sesv2/storage.go
+++ b/internal/service/sesv2/storage.go
@@ -40,8 +40,18 @@ type Storage interface {
 	ListConfigurationSets(ctx context.Context, nextToken string, pageSize int32) ([]string, string, error)
 	DeleteConfigurationSet(ctx context.Context, name string) error
 
+	// Email Template operations.
+	CreateEmailTemplate(ctx context.Context, req *CreateEmailTemplateRequest) (*EmailTemplate, error)
+	GetEmailTemplate(ctx context.Context, name string) (*EmailTemplate, error)
+	UpdateEmailTemplate(ctx context.Context, name string, req *UpdateEmailTemplateRequest) (*EmailTemplate, error)
+	DeleteEmailTemplate(ctx context.Context, name string) error
+	ListEmailTemplates(ctx context.Context, nextToken string, pageSize int32) ([]*EmailTemplate, string, error)
+
 	// Send Email.
 	SendEmail(ctx context.Context, req *SendEmailRequest) (string, error)
+
+	// Send Bulk Email.
+	SendBulkEmail(ctx context.Context, req *SendBulkEmailRequest) (*SendBulkEmailResponse, error)
 
 	// Get sent emails (for testing purposes).
 	GetSentEmails(ctx context.Context) ([]*SentEmail, error)
@@ -68,6 +78,7 @@ type MemoryStorage struct {
 	mu                sync.RWMutex                 `json:"-"`
 	EmailIdentities   map[string]*EmailIdentity    `json:"emailIdentities"`
 	ConfigurationSets map[string]*ConfigurationSet `json:"configurationSets"`
+	EmailTemplates    map[string]*EmailTemplate    `json:"emailTemplates"`
 	SentEmails        []*SentEmail                 `json:"sentEmails"`
 	dataDir           string
 }
@@ -77,6 +88,7 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	s := &MemoryStorage{
 		EmailIdentities:   make(map[string]*EmailIdentity),
 		ConfigurationSets: make(map[string]*ConfigurationSet),
+		EmailTemplates:    make(map[string]*EmailTemplate),
 		SentEmails:        make([]*SentEmail, 0),
 	}
 	for _, o := range opts {
@@ -124,6 +136,10 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 
 	if s.ConfigurationSets == nil {
 		s.ConfigurationSets = make(map[string]*ConfigurationSet)
+	}
+
+	if s.EmailTemplates == nil {
+		s.EmailTemplates = make(map[string]*EmailTemplate)
 	}
 
 	return nil
@@ -331,6 +347,133 @@ func (s *MemoryStorage) DeleteConfigurationSet(_ context.Context, name string) e
 	return nil
 }
 
+// CreateEmailTemplate creates a new email template.
+func (s *MemoryStorage) CreateEmailTemplate(_ context.Context, req *CreateEmailTemplateRequest) (*EmailTemplate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if req.TemplateName == "" {
+		return nil, &IdentityError{
+			Code:    errInvalidParameter,
+			Message: "TemplateName is required",
+		}
+	}
+
+	if req.TemplateContent == nil {
+		return nil, &IdentityError{
+			Code:    errInvalidParameter,
+			Message: "TemplateContent is required",
+		}
+	}
+
+	if _, exists := s.EmailTemplates[req.TemplateName]; exists {
+		return nil, &IdentityError{
+			Code:    errAlreadyExists,
+			Message: "The email template already exists",
+		}
+	}
+
+	tmpl := &EmailTemplate{
+		Name:             req.TemplateName,
+		TemplateContent:  cloneTemplateContent(req.TemplateContent),
+		CreatedTimestamp: time.Now(),
+	}
+
+	s.EmailTemplates[req.TemplateName] = tmpl
+
+	return tmpl, nil
+}
+
+// GetEmailTemplate retrieves an email template.
+func (s *MemoryStorage) GetEmailTemplate(_ context.Context, name string) (*EmailTemplate, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tmpl, exists := s.EmailTemplates[name]
+	if !exists {
+		return nil, &IdentityError{
+			Code:    errNotFound,
+			Message: "The email template does not exist",
+		}
+	}
+
+	return tmpl, nil
+}
+
+// UpdateEmailTemplate replaces the content of an existing email template.
+func (s *MemoryStorage) UpdateEmailTemplate(_ context.Context, name string, req *UpdateEmailTemplateRequest) (*EmailTemplate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if req.TemplateContent == nil {
+		return nil, &IdentityError{
+			Code:    errInvalidParameter,
+			Message: "TemplateContent is required",
+		}
+	}
+
+	tmpl, exists := s.EmailTemplates[name]
+	if !exists {
+		return nil, &IdentityError{
+			Code:    errNotFound,
+			Message: "The email template does not exist",
+		}
+	}
+
+	tmpl.TemplateContent = cloneTemplateContent(req.TemplateContent)
+
+	return tmpl, nil
+}
+
+// DeleteEmailTemplate deletes an email template.
+func (s *MemoryStorage) DeleteEmailTemplate(_ context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.EmailTemplates[name]; !exists {
+		return &IdentityError{
+			Code:    errNotFound,
+			Message: "The email template does not exist",
+		}
+	}
+
+	delete(s.EmailTemplates, name)
+
+	return nil
+}
+
+// ListEmailTemplates lists all email templates.
+func (s *MemoryStorage) ListEmailTemplates(_ context.Context, _ string, pageSize int32) ([]*EmailTemplate, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if pageSize <= 0 {
+		pageSize = 100
+	}
+
+	templates := make([]*EmailTemplate, 0, len(s.EmailTemplates))
+	for _, tmpl := range s.EmailTemplates {
+		templates = append(templates, tmpl)
+	}
+
+	if len(templates) > int(pageSize) {
+		templates = templates[:pageSize]
+	}
+
+	return templates, "", nil
+}
+
+// cloneTemplateContent returns a deep copy of the template content to avoid aliasing.
+func cloneTemplateContent(src *EmailTemplateContent) *EmailTemplateContent {
+	if src == nil {
+		return nil
+	}
+
+	clone := *src
+
+	return &clone
+}
+
 // SendEmail sends an email (stores it for testing).
 func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (string, error) {
 	s.mu.Lock()
@@ -396,6 +539,132 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 	s.SentEmails = append(s.SentEmails, sentEmail)
 
 	return messageID, nil
+}
+
+// SendBulkEmail sends one email per BulkEmailEntry, recording each as a SentEmail.
+//
+// AWS SES v2 returns HTTP 200 with per-entry status even when individual entries
+// fail validation. Errors at the request level (missing entries, missing template,
+// unknown template) result in HTTP 400.
+func (s *MemoryStorage) SendBulkEmail(_ context.Context, req *SendBulkEmailRequest) (*SendBulkEmailResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(req.BulkEmailEntries) == 0 {
+		return nil, &IdentityError{
+			Code:    errBadRequest,
+			Message: "BulkEmailEntries is required",
+		}
+	}
+
+	if req.DefaultContent == nil || req.DefaultContent.Template == nil {
+		return nil, &IdentityError{
+			Code:    errBadRequest,
+			Message: "DefaultContent.Template is required",
+		}
+	}
+
+	defaultTemplate := req.DefaultContent.Template
+	templateName := defaultTemplate.TemplateName
+
+	if templateName == "" {
+		return nil, &IdentityError{
+			Code:    errBadRequest,
+			Message: "DefaultContent.Template.TemplateName is required",
+		}
+	}
+
+	// Resolve template content. AWS rejects sends against unknown templates.
+	tmpl, exists := s.EmailTemplates[templateName]
+	if !exists {
+		return nil, &IdentityError{
+			Code:    errNotFound,
+			Message: "The email template does not exist",
+		}
+	}
+
+	results := make([]BulkEmailEntryResult, 0, len(req.BulkEmailEntries))
+
+	for _, entry := range req.BulkEmailEntries {
+		messageID := uuid.New().String()
+
+		hasDestination := entry.Destination != nil &&
+			(len(entry.Destination.ToAddresses) > 0 ||
+				len(entry.Destination.CcAddresses) > 0 ||
+				len(entry.Destination.BccAddresses) > 0)
+
+		if !hasDestination {
+			results = append(results, BulkEmailEntryResult{
+				Status:    "FAILED",
+				Error:     "Destination is required",
+				MessageID: messageID,
+			})
+
+			continue
+		}
+
+		templateData := defaultTemplate.TemplateData
+		if entry.ReplacementEmailContent != nil &&
+			entry.ReplacementEmailContent.ReplacementTemplate != nil &&
+			entry.ReplacementEmailContent.ReplacementTemplate.ReplacementTemplateData != "" {
+			templateData = entry.ReplacementEmailContent.ReplacementTemplate.ReplacementTemplateData
+		}
+
+		subject := ""
+		body := ""
+		htmlBody := ""
+
+		if tmpl.TemplateContent != nil {
+			subject = tmpl.TemplateContent.Subject
+			body = tmpl.TemplateContent.Text
+			htmlBody = tmpl.TemplateContent.HTML
+		}
+
+		sent := &SentEmail{
+			MessageID:            messageID,
+			FromEmailAddress:     req.FromEmailAddress,
+			Destination:          cloneDestination(entry.Destination),
+			Subject:              subject,
+			Body:                 body,
+			HTMLBody:             htmlBody,
+			TemplateName:         templateName,
+			TemplateData:         templateData,
+			ConfigurationSetName: req.ConfigurationSetName,
+			SentAt:               time.Now(),
+		}
+
+		s.SentEmails = append(s.SentEmails, sent)
+
+		results = append(results, BulkEmailEntryResult{
+			Status:    "SUCCESS",
+			MessageID: messageID,
+		})
+	}
+
+	return &SendBulkEmailResponse{BulkEmailEntryResults: results}, nil
+}
+
+// cloneDestination returns a deep copy of a destination to avoid aliasing.
+func cloneDestination(src *Destination) *Destination {
+	if src == nil {
+		return nil
+	}
+
+	clone := &Destination{}
+
+	if len(src.ToAddresses) > 0 {
+		clone.ToAddresses = append([]string{}, src.ToAddresses...)
+	}
+
+	if len(src.CcAddresses) > 0 {
+		clone.CcAddresses = append([]string{}, src.CcAddresses...)
+	}
+
+	if len(src.BccAddresses) > 0 {
+		clone.BccAddresses = append([]string{}, src.BccAddresses...)
+	}
+
+	return clone
 }
 
 // GetSentEmails returns all sent emails (for testing).

--- a/internal/service/sesv2/storage_test.go
+++ b/internal/service/sesv2/storage_test.go
@@ -106,39 +106,47 @@ func TestSendEmail_SimpleEmailWithoutDestination_ShouldFail(t *testing.T) {
 	}
 }
 
-func TestEmailTemplate_CRUD(t *testing.T) {
+func TestEmailTemplate_CreateAndGet(t *testing.T) {
 	storage := NewMemoryStorage()
 	ctx := context.Background()
 
-	const name = "welcome"
-
-	// Create.
-	created, err := storage.CreateEmailTemplate(ctx, &CreateEmailTemplateRequest{
-		TemplateName: name,
+	if _, err := storage.CreateEmailTemplate(ctx, &CreateEmailTemplateRequest{
+		TemplateName: "welcome",
 		TemplateContent: &EmailTemplateContent{
 			Subject: "Hello",
 			Text:    "Body text",
 			HTML:    "<p>Body HTML</p>",
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
-	if created.Name != name {
-		t.Fatalf("created name=%q want %q", created.Name, name)
-	}
 
-	// Get.
-	got, err := storage.GetEmailTemplate(ctx, name)
+	got, err := storage.GetEmailTemplate(ctx, "welcome")
 	if err != nil {
 		t.Fatalf("get failed: %v", err)
 	}
+
 	if got.TemplateContent == nil || got.TemplateContent.Subject != "Hello" {
 		t.Fatalf("get returned unexpected content: %+v", got.TemplateContent)
 	}
+}
 
-	// Update.
-	if _, err := storage.UpdateEmailTemplate(ctx, name, &UpdateEmailTemplateRequest{
+func TestEmailTemplate_Update(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	if _, err := storage.CreateEmailTemplate(ctx, &CreateEmailTemplateRequest{
+		TemplateName: "welcome",
+		TemplateContent: &EmailTemplateContent{
+			Subject: "Hello",
+			Text:    "Body text",
+			HTML:    "<p>Body HTML</p>",
+		},
+	}); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	if _, err := storage.UpdateEmailTemplate(ctx, "welcome", &UpdateEmailTemplateRequest{
 		TemplateContent: &EmailTemplateContent{
 			Subject: "Hello v2",
 			Text:    "Body text v2",
@@ -147,32 +155,57 @@ func TestEmailTemplate_CRUD(t *testing.T) {
 		t.Fatalf("update failed: %v", err)
 	}
 
-	updated, err := storage.GetEmailTemplate(ctx, name)
+	updated, err := storage.GetEmailTemplate(ctx, "welcome")
 	if err != nil {
 		t.Fatalf("get after update failed: %v", err)
 	}
+
 	if updated.TemplateContent.Subject != "Hello v2" {
 		t.Errorf("expected updated subject, got %q", updated.TemplateContent.Subject)
 	}
+
 	if updated.TemplateContent.HTML != "" {
 		t.Errorf("expected HTML cleared on update, got %q", updated.TemplateContent.HTML)
 	}
+}
 
-	// List.
+func TestEmailTemplate_List(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	if _, err := storage.CreateEmailTemplate(ctx, &CreateEmailTemplateRequest{
+		TemplateName:    "welcome",
+		TemplateContent: &EmailTemplateContent{Subject: "Hello"},
+	}); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
 	list, _, err := storage.ListEmailTemplates(ctx, "", 10)
 	if err != nil {
 		t.Fatalf("list failed: %v", err)
 	}
-	if len(list) != 1 || list[0].Name != name {
+
+	if len(list) != 1 || list[0].Name != "welcome" {
 		t.Fatalf("unexpected list result: %+v", list)
 	}
+}
 
-	// Delete.
-	if err := storage.DeleteEmailTemplate(ctx, name); err != nil {
+func TestEmailTemplate_Delete(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	if _, err := storage.CreateEmailTemplate(ctx, &CreateEmailTemplateRequest{
+		TemplateName:    "welcome",
+		TemplateContent: &EmailTemplateContent{Subject: "Hello"},
+	}); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	if err := storage.DeleteEmailTemplate(ctx, "welcome"); err != nil {
 		t.Fatalf("delete failed: %v", err)
 	}
 
-	if _, err := storage.GetEmailTemplate(ctx, name); err == nil {
+	if _, err := storage.GetEmailTemplate(ctx, "welcome"); err == nil {
 		t.Fatal("expected error for deleted template")
 	}
 }
@@ -216,12 +249,12 @@ func TestEmailTemplate_GetNotFound(t *testing.T) {
 	}
 }
 
-func TestSendBulkEmail_AssignsMessageIDPerEntry(t *testing.T) {
-	storage := NewMemoryStorage()
-	ctx := context.Background()
+// newBulkSendFixture seeds a template named "promo" and returns a request that
+// targets two distinct recipients with per-entry replacement data.
+func newBulkSendFixture(t *testing.T, storage *MemoryStorage) *SendBulkEmailRequest {
+	t.Helper()
 
-	// Set up a template referenced by the bulk request.
-	if _, err := storage.CreateEmailTemplate(ctx, &CreateEmailTemplateRequest{
+	if _, err := storage.CreateEmailTemplate(context.Background(), &CreateEmailTemplateRequest{
 		TemplateName: "promo",
 		TemplateContent: &EmailTemplateContent{
 			Subject: "Promo",
@@ -231,13 +264,10 @@ func TestSendBulkEmail_AssignsMessageIDPerEntry(t *testing.T) {
 		t.Fatalf("template create failed: %v", err)
 	}
 
-	req := &SendBulkEmailRequest{
+	return &SendBulkEmailRequest{
 		FromEmailAddress: "sender@example.com",
 		DefaultContent: &BulkEmailContent{
-			Template: &Template{
-				TemplateName: "promo",
-				TemplateData: "{}",
-			},
+			Template: &Template{TemplateName: "promo", TemplateData: "{}"},
 		},
 		BulkEmailEntries: []BulkEmailEntry{
 			{
@@ -254,11 +284,18 @@ func TestSendBulkEmail_AssignsMessageIDPerEntry(t *testing.T) {
 			},
 		},
 	}
+}
+
+func TestSendBulkEmail_AssignsMessageIDPerEntry(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+	req := newBulkSendFixture(t, storage)
 
 	resp, err := storage.SendBulkEmail(ctx, req)
 	if err != nil {
 		t.Fatalf("send bulk failed: %v", err)
 	}
+
 	if len(resp.BulkEmailEntryResults) != 2 {
 		t.Fatalf("expected 2 results, got %d", len(resp.BulkEmailEntryResults))
 	}
@@ -269,26 +306,41 @@ func TestSendBulkEmail_AssignsMessageIDPerEntry(t *testing.T) {
 		if r.Status != "SUCCESS" {
 			t.Errorf("entry %d: status=%q want SUCCESS (err=%q)", i, r.Status, r.Error)
 		}
+
 		if r.MessageID == "" {
 			t.Errorf("entry %d: empty MessageId", i)
 		}
+
 		ids[r.MessageID] = struct{}{}
 	}
 
 	if len(ids) != 2 {
 		t.Errorf("expected 2 distinct MessageIds, got %d", len(ids))
 	}
+}
+
+func TestSendBulkEmail_RecordsSentEmails(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+	req := newBulkSendFixture(t, storage)
+
+	if _, err := storage.SendBulkEmail(ctx, req); err != nil {
+		t.Fatalf("send bulk failed: %v", err)
+	}
 
 	sent, err := storage.GetSentEmails(ctx)
 	if err != nil {
 		t.Fatalf("get sent emails failed: %v", err)
 	}
+
 	if len(sent) != 2 {
 		t.Fatalf("expected 2 stored emails, got %d", len(sent))
 	}
+
 	if sent[0].TemplateName != "promo" {
 		t.Errorf("expected TemplateName=promo, got %q", sent[0].TemplateName)
 	}
+
 	if sent[0].TemplateData != `{"name":"A"}` {
 		t.Errorf("expected per-entry replacement data, got %q", sent[0].TemplateData)
 	}
@@ -345,6 +397,7 @@ func TestSendBulkEmail_EntryWithoutDestinationFailsIndividually(t *testing.T) {
 	if got := resp.BulkEmailEntryResults[0].Status; got != "SUCCESS" {
 		t.Errorf("entry 0 status=%q want SUCCESS", got)
 	}
+
 	if got := resp.BulkEmailEntryResults[1].Status; got != "FAILED" {
 		t.Errorf("entry 1 status=%q want FAILED", got)
 	}

--- a/internal/service/sesv2/storage_test.go
+++ b/internal/service/sesv2/storage_test.go
@@ -2,9 +2,40 @@ package sesv2
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 )
+
+func TestEpochSeconds_MarshalsAsJSONNumber(t *testing.T) {
+	// Pin to a known instant so the assertion is exact.
+	ts := time.Unix(1700000000, 500_000_000) // 1.7e9 + 0.5 sec
+
+	got, err := json.Marshal(epochSeconds(ts))
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	out := string(got)
+	if strings.Contains(out, `"`) {
+		t.Fatalf("expected JSON number, got string %q", out)
+	}
+
+	if _, err := strconv.ParseFloat(out, 64); err != nil {
+		t.Fatalf("expected parseable float, got %q (err=%v)", out, err)
+	}
+
+	// Must round-trip to the same instant (within float precision).
+	const want = 1700000000.5
+
+	got64, _ := strconv.ParseFloat(out, 64)
+	if diff := got64 - want; diff > 1e-6 || diff < -1e-6 {
+		t.Errorf("expected ~%v, got %v", want, got64)
+	}
+}
 
 func TestSendEmail_RawEmailWithoutDestination(t *testing.T) {
 	storage := &MemoryStorage{}

--- a/internal/service/sesv2/storage_test.go
+++ b/internal/service/sesv2/storage_test.go
@@ -105,3 +105,247 @@ func TestSendEmail_SimpleEmailWithoutDestination_ShouldFail(t *testing.T) {
 		t.Errorf("expected 'Destination is required', got '%s'", identityErr.Message)
 	}
 }
+
+func TestEmailTemplate_CRUD(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	const name = "welcome"
+
+	// Create.
+	created, err := storage.CreateEmailTemplate(ctx, &CreateEmailTemplateRequest{
+		TemplateName: name,
+		TemplateContent: &EmailTemplateContent{
+			Subject: "Hello",
+			Text:    "Body text",
+			HTML:    "<p>Body HTML</p>",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if created.Name != name {
+		t.Fatalf("created name=%q want %q", created.Name, name)
+	}
+
+	// Get.
+	got, err := storage.GetEmailTemplate(ctx, name)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if got.TemplateContent == nil || got.TemplateContent.Subject != "Hello" {
+		t.Fatalf("get returned unexpected content: %+v", got.TemplateContent)
+	}
+
+	// Update.
+	if _, err := storage.UpdateEmailTemplate(ctx, name, &UpdateEmailTemplateRequest{
+		TemplateContent: &EmailTemplateContent{
+			Subject: "Hello v2",
+			Text:    "Body text v2",
+		},
+	}); err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+
+	updated, err := storage.GetEmailTemplate(ctx, name)
+	if err != nil {
+		t.Fatalf("get after update failed: %v", err)
+	}
+	if updated.TemplateContent.Subject != "Hello v2" {
+		t.Errorf("expected updated subject, got %q", updated.TemplateContent.Subject)
+	}
+	if updated.TemplateContent.HTML != "" {
+		t.Errorf("expected HTML cleared on update, got %q", updated.TemplateContent.HTML)
+	}
+
+	// List.
+	list, _, err := storage.ListEmailTemplates(ctx, "", 10)
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != name {
+		t.Fatalf("unexpected list result: %+v", list)
+	}
+
+	// Delete.
+	if err := storage.DeleteEmailTemplate(ctx, name); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+
+	if _, err := storage.GetEmailTemplate(ctx, name); err == nil {
+		t.Fatal("expected error for deleted template")
+	}
+}
+
+func TestEmailTemplate_DuplicateCreate(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	req := &CreateEmailTemplateRequest{
+		TemplateName:    "dup",
+		TemplateContent: &EmailTemplateContent{Subject: "s"},
+	}
+
+	if _, err := storage.CreateEmailTemplate(ctx, req); err != nil {
+		t.Fatalf("first create failed: %v", err)
+	}
+
+	_, err := storage.CreateEmailTemplate(ctx, req)
+	if err == nil {
+		t.Fatal("expected error on duplicate create")
+	}
+
+	var iErr *IdentityError
+	if !errors.As(err, &iErr) || iErr.Code != errAlreadyExists {
+		t.Fatalf("expected errAlreadyExists, got %v", err)
+	}
+}
+
+func TestEmailTemplate_GetNotFound(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	_, err := storage.GetEmailTemplate(ctx, "missing")
+	if err == nil {
+		t.Fatal("expected error for missing template")
+	}
+
+	var iErr *IdentityError
+	if !errors.As(err, &iErr) || iErr.Code != errNotFound {
+		t.Fatalf("expected errNotFound, got %v", err)
+	}
+}
+
+func TestSendBulkEmail_AssignsMessageIDPerEntry(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	// Set up a template referenced by the bulk request.
+	if _, err := storage.CreateEmailTemplate(ctx, &CreateEmailTemplateRequest{
+		TemplateName: "promo",
+		TemplateContent: &EmailTemplateContent{
+			Subject: "Promo",
+			Text:    "Hello {{name}}",
+		},
+	}); err != nil {
+		t.Fatalf("template create failed: %v", err)
+	}
+
+	req := &SendBulkEmailRequest{
+		FromEmailAddress: "sender@example.com",
+		DefaultContent: &BulkEmailContent{
+			Template: &Template{
+				TemplateName: "promo",
+				TemplateData: "{}",
+			},
+		},
+		BulkEmailEntries: []BulkEmailEntry{
+			{
+				Destination: &Destination{ToAddresses: []string{"a@example.com"}},
+				ReplacementEmailContent: &ReplacementEmailContent{
+					ReplacementTemplate: &ReplacementTemplate{ReplacementTemplateData: `{"name":"A"}`},
+				},
+			},
+			{
+				Destination: &Destination{ToAddresses: []string{"b@example.com"}},
+				ReplacementEmailContent: &ReplacementEmailContent{
+					ReplacementTemplate: &ReplacementTemplate{ReplacementTemplateData: `{"name":"B"}`},
+				},
+			},
+		},
+	}
+
+	resp, err := storage.SendBulkEmail(ctx, req)
+	if err != nil {
+		t.Fatalf("send bulk failed: %v", err)
+	}
+	if len(resp.BulkEmailEntryResults) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(resp.BulkEmailEntryResults))
+	}
+
+	ids := map[string]struct{}{}
+
+	for i, r := range resp.BulkEmailEntryResults {
+		if r.Status != "SUCCESS" {
+			t.Errorf("entry %d: status=%q want SUCCESS (err=%q)", i, r.Status, r.Error)
+		}
+		if r.MessageID == "" {
+			t.Errorf("entry %d: empty MessageId", i)
+		}
+		ids[r.MessageID] = struct{}{}
+	}
+
+	if len(ids) != 2 {
+		t.Errorf("expected 2 distinct MessageIds, got %d", len(ids))
+	}
+
+	sent, err := storage.GetSentEmails(ctx)
+	if err != nil {
+		t.Fatalf("get sent emails failed: %v", err)
+	}
+	if len(sent) != 2 {
+		t.Fatalf("expected 2 stored emails, got %d", len(sent))
+	}
+	if sent[0].TemplateName != "promo" {
+		t.Errorf("expected TemplateName=promo, got %q", sent[0].TemplateName)
+	}
+	if sent[0].TemplateData != `{"name":"A"}` {
+		t.Errorf("expected per-entry replacement data, got %q", sent[0].TemplateData)
+	}
+}
+
+func TestSendBulkEmail_UnknownTemplateFails(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	_, err := storage.SendBulkEmail(ctx, &SendBulkEmailRequest{
+		FromEmailAddress: "sender@example.com",
+		DefaultContent: &BulkEmailContent{
+			Template: &Template{TemplateName: "nope"},
+		},
+		BulkEmailEntries: []BulkEmailEntry{
+			{Destination: &Destination{ToAddresses: []string{"a@example.com"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown template")
+	}
+
+	var iErr *IdentityError
+	if !errors.As(err, &iErr) || iErr.Code != errNotFound {
+		t.Fatalf("expected errNotFound, got %v", err)
+	}
+}
+
+func TestSendBulkEmail_EntryWithoutDestinationFailsIndividually(t *testing.T) {
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	if _, err := storage.CreateEmailTemplate(ctx, &CreateEmailTemplateRequest{
+		TemplateName:    "tpl",
+		TemplateContent: &EmailTemplateContent{Subject: "S"},
+	}); err != nil {
+		t.Fatalf("template create failed: %v", err)
+	}
+
+	resp, err := storage.SendBulkEmail(ctx, &SendBulkEmailRequest{
+		FromEmailAddress: "sender@example.com",
+		DefaultContent: &BulkEmailContent{
+			Template: &Template{TemplateName: "tpl"},
+		},
+		BulkEmailEntries: []BulkEmailEntry{
+			{Destination: &Destination{ToAddresses: []string{"a@example.com"}}},
+			{ /* destination missing */ },
+		},
+	})
+	if err != nil {
+		t.Fatalf("send bulk failed: %v", err)
+	}
+
+	if got := resp.BulkEmailEntryResults[0].Status; got != "SUCCESS" {
+		t.Errorf("entry 0 status=%q want SUCCESS", got)
+	}
+	if got := resp.BulkEmailEntryResults[1].Status; got != "FAILED" {
+		t.Errorf("entry 1 status=%q want FAILED", got)
+	}
+}

--- a/internal/service/sesv2/types.go
+++ b/internal/service/sesv2/types.go
@@ -61,8 +61,30 @@ type SentEmail struct {
 	Body                 string       `json:"Body,omitempty"`
 	HTMLBody             string       `json:"HTMLBody,omitempty"`
 	RawData              []byte       `json:"RawData,omitempty"`
+	TemplateName         string       `json:"TemplateName,omitempty"`
+	TemplateData         string       `json:"TemplateData,omitempty"`
 	ConfigurationSetName string       `json:"ConfigurationSetName,omitempty"`
 	SentAt               time.Time    `json:"SentAt"`
+}
+
+// EmailTemplate represents an SES v2 email template.
+type EmailTemplate struct {
+	Name             string
+	TemplateContent  *EmailTemplateContent
+	CreatedTimestamp time.Time
+}
+
+// EmailTemplateContent represents the renderable parts of an email template.
+type EmailTemplateContent struct {
+	Subject string `json:"Subject,omitempty"`
+	Text    string `json:"Text,omitempty"`
+	HTML    string `json:"Html,omitempty"`
+}
+
+// EmailTemplateMetadata describes a template entry returned by ListEmailTemplates.
+type EmailTemplateMetadata struct {
+	TemplateName     string    `json:"TemplateName,omitempty"`
+	CreatedTimestamp time.Time `json:"CreatedTimestamp,omitempty"`
 }
 
 // Destination represents email destinations.
@@ -218,6 +240,81 @@ type MessageTag struct {
 
 // SendEmailResponse is the response for SendEmail.
 type SendEmailResponse struct {
+	MessageID string `json:"MessageId,omitempty"`
+}
+
+// CreateEmailTemplateRequest is the request for CreateEmailTemplate.
+type CreateEmailTemplateRequest struct {
+	TemplateName    string                `json:"TemplateName"`
+	TemplateContent *EmailTemplateContent `json:"TemplateContent,omitempty"`
+}
+
+// UpdateEmailTemplateRequest is the request for UpdateEmailTemplate.
+type UpdateEmailTemplateRequest struct {
+	TemplateContent *EmailTemplateContent `json:"TemplateContent,omitempty"`
+}
+
+// GetEmailTemplateResponse is the response for GetEmailTemplate.
+type GetEmailTemplateResponse struct {
+	TemplateName    string                `json:"TemplateName,omitempty"`
+	TemplateContent *EmailTemplateContent `json:"TemplateContent,omitempty"`
+}
+
+// ListEmailTemplatesRequest is the request for ListEmailTemplates.
+type ListEmailTemplatesRequest struct {
+	NextToken string `json:"NextToken,omitempty"`
+	PageSize  int32  `json:"PageSize,omitempty"`
+}
+
+// ListEmailTemplatesResponse is the response for ListEmailTemplates.
+type ListEmailTemplatesResponse struct {
+	TemplatesMetadata []EmailTemplateMetadata `json:"TemplatesMetadata,omitempty"`
+	NextToken         string                  `json:"NextToken,omitempty"`
+}
+
+// SendBulkEmailRequest is the request for SendBulkEmail.
+type SendBulkEmailRequest struct {
+	FromEmailAddress               string            `json:"FromEmailAddress,omitempty"`
+	FromEmailAddressIdentityArn    string            `json:"FromEmailAddressIdentityArn,omitempty"`
+	ReplyToAddresses               []string          `json:"ReplyToAddresses,omitempty"`
+	FeedbackForwardingEmailAddress string            `json:"FeedbackForwardingEmailAddress,omitempty"`
+	DefaultContent                 *BulkEmailContent `json:"DefaultContent,omitempty"`
+	BulkEmailEntries               []BulkEmailEntry  `json:"BulkEmailEntries,omitempty"`
+	DefaultEmailTags               []MessageTag      `json:"DefaultEmailTags,omitempty"`
+	ConfigurationSetName           string            `json:"ConfigurationSetName,omitempty"`
+}
+
+// BulkEmailContent represents the default content shared across all bulk entries.
+type BulkEmailContent struct {
+	Template *Template `json:"Template,omitempty"`
+}
+
+// BulkEmailEntry represents a single bulk-email destination entry.
+type BulkEmailEntry struct {
+	Destination             *Destination             `json:"Destination,omitempty"`
+	ReplacementEmailContent *ReplacementEmailContent `json:"ReplacementEmailContent,omitempty"`
+	ReplacementTags         []MessageTag             `json:"ReplacementTags,omitempty"`
+}
+
+// ReplacementEmailContent carries per-entry template overrides.
+type ReplacementEmailContent struct {
+	ReplacementTemplate *ReplacementTemplate `json:"ReplacementTemplate,omitempty"`
+}
+
+// ReplacementTemplate carries per-entry replacement template data.
+type ReplacementTemplate struct {
+	ReplacementTemplateData string `json:"ReplacementTemplateData,omitempty"`
+}
+
+// SendBulkEmailResponse is the response for SendBulkEmail.
+type SendBulkEmailResponse struct {
+	BulkEmailEntryResults []BulkEmailEntryResult `json:"BulkEmailEntryResults,omitempty"`
+}
+
+// BulkEmailEntryResult represents the result of a single bulk-email entry.
+type BulkEmailEntryResult struct {
+	Status    string `json:"Status,omitempty"`
+	Error     string `json:"Error,omitempty"`
 	MessageID string `json:"MessageId,omitempty"`
 }
 

--- a/internal/service/sesv2/types.go
+++ b/internal/service/sesv2/types.go
@@ -1,7 +1,24 @@
 // Package sesv2 provides SES v2 service emulation for kumo.
 package sesv2
 
-import "time"
+import (
+	"strconv"
+	"time"
+)
+
+// epochSeconds is a time.Time-compatible value that JSON-marshals as a
+// Unix-epoch number (with optional fractional seconds). The AWS SES v2
+// rest-json protocol uses this representation for Timestamp shapes; the
+// SDK's deserializer rejects ISO 8601 strings with
+// "expected Timestamp to be a JSON Number, got string instead".
+type epochSeconds time.Time
+
+// MarshalJSON implements json.Marshaler.
+func (t epochSeconds) MarshalJSON() ([]byte, error) {
+	secs := float64(time.Time(t).UnixNano()) / 1e9
+
+	return []byte(strconv.FormatFloat(secs, 'f', -1, 64)), nil
+}
 
 // EmailIdentity represents an email identity (email address or domain).
 type EmailIdentity struct {
@@ -83,8 +100,8 @@ type EmailTemplateContent struct {
 
 // EmailTemplateMetadata describes a template entry returned by ListEmailTemplates.
 type EmailTemplateMetadata struct {
-	TemplateName     string    `json:"TemplateName,omitempty"`
-	CreatedTimestamp time.Time `json:"CreatedTimestamp,omitempty"`
+	TemplateName     string       `json:"TemplateName,omitempty"`
+	CreatedTimestamp epochSeconds `json:"CreatedTimestamp,omitempty"`
 }
 
 // Destination represents email destinations.

--- a/test/integration/sesv2_test.go
+++ b/test/integration/sesv2_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -478,7 +479,12 @@ func TestSESv2_EmailTemplate_CRUD(t *testing.T) {
 
 	const name = "tmpl-crud"
 
-	// Create.
+	t.Cleanup(func() {
+		_, _ = client.DeleteEmailTemplate(context.Background(), &sesv2.DeleteEmailTemplateInput{
+			TemplateName: aws.String(name),
+		})
+	})
+
 	if _, err := client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
 		TemplateName: aws.String(name),
 		TemplateContent: &types.EmailTemplateContent{
@@ -490,23 +496,14 @@ func TestSESv2_EmailTemplate_CRUD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Get.
 	getOutput, err := client.GetEmailTemplate(ctx, &sesv2.GetEmailTemplateInput{
 		TemplateName: aws.String(name),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_get", getOutput)
 
-	if getOutput.TemplateName == nil || *getOutput.TemplateName != name {
-		t.Fatalf("unexpected TemplateName: %v", getOutput.TemplateName)
-	}
-
-	if getOutput.TemplateContent == nil || getOutput.TemplateContent.Subject == nil || *getOutput.TemplateContent.Subject != "Hi" {
-		t.Fatalf("unexpected TemplateContent: %+v", getOutput.TemplateContent)
-	}
-
-	// Update.
 	if _, err := client.UpdateEmailTemplate(ctx, &sesv2.UpdateEmailTemplateInput{
 		TemplateName: aws.String(name),
 		TemplateContent: &types.EmailTemplateContent{
@@ -523,12 +520,8 @@ func TestSESv2_EmailTemplate_CRUD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_get_after_update", getOutput)
 
-	if *getOutput.TemplateContent.Subject != "Hi v2" {
-		t.Errorf("update did not take effect: subject=%q", *getOutput.TemplateContent.Subject)
-	}
-
-	// Delete.
 	if _, err := client.DeleteEmailTemplate(ctx, &sesv2.DeleteEmailTemplateInput{
 		TemplateName: aws.String(name),
 	}); err != nil {
@@ -548,25 +541,37 @@ func TestSESv2_ListEmailTemplates(t *testing.T) {
 
 	const name = "tmpl-list"
 
-	// Best-effort create: the template may already exist from a previous run
-	// because kumo persists state under KUMO_DATA_DIR.
-	_, _ = client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
+	t.Cleanup(func() {
+		_, _ = client.DeleteEmailTemplate(context.Background(), &sesv2.DeleteEmailTemplateInput{
+			TemplateName: aws.String(name),
+		})
+	})
+
+	if _, err := client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
 		TemplateName: aws.String(name),
 		TemplateContent: &types.EmailTemplateContent{
 			Subject: aws.String("S"),
 			Text:    aws.String("B"),
 		},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	out, err := client.ListEmailTemplates(ctx, &sesv2.ListEmailTemplatesInput{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	// Extract the metadata entry for our template — other tests in the same
+	// run may have left additional templates, so we cannot golden-assert the
+	// whole response. CreatedTimestamp is dynamic and ignored.
+	var match types.EmailTemplateMetadata
+
 	found := false
 
 	for _, m := range out.TemplatesMetadata {
 		if m.TemplateName != nil && *m.TemplateName == name {
+			match = m
 			found = true
 
 			break
@@ -574,35 +579,47 @@ func TestSESv2_ListEmailTemplates(t *testing.T) {
 	}
 
 	if !found {
-		t.Errorf("created template not found in list")
+		t.Fatalf("expected template %q in list", name)
 	}
+
+	golden.New(t, golden.WithIgnoreFields("CreatedTimestamp")).Assert(t.Name(), match)
 }
 
 func TestSESv2_SendBulkEmail(t *testing.T) {
 	client := newSESv2Client(t)
 	ctx := t.Context()
 
-	// Create email identity + template referenced by the bulk send.
-	// CreateEmailIdentity is best-effort: if the identity already exists from a
-	// previous run (kumo persists state across restarts under KUMO_DATA_DIR)
-	// the test should still proceed.
-	fromEmail := "bulk-sender@example.com"
-	_, _ = client.CreateEmailIdentity(ctx, &sesv2.CreateEmailIdentityInput{
-		EmailIdentity: aws.String(fromEmail),
+	const (
+		fromEmail = "bulk-sender@example.com"
+		tmpl      = "tmpl-bulk"
+	)
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		_, _ = client.DeleteEmailIdentity(cleanupCtx, &sesv2.DeleteEmailIdentityInput{
+			EmailIdentity: aws.String(fromEmail),
+		})
+		_, _ = client.DeleteEmailTemplate(cleanupCtx, &sesv2.DeleteEmailTemplateInput{
+			TemplateName: aws.String(tmpl),
+		})
 	})
 
-	const tmpl = "tmpl-bulk"
+	if _, err := client.CreateEmailIdentity(ctx, &sesv2.CreateEmailIdentityInput{
+		EmailIdentity: aws.String(fromEmail),
+	}); err != nil {
+		t.Fatal(err)
+	}
 
-	// Best-effort create — may pre-exist from a prior run.
-	_, _ = client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
+	if _, err := client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
 		TemplateName: aws.String(tmpl),
 		TemplateContent: &types.EmailTemplateContent{
 			Subject: aws.String("Bulk subject"),
 			Text:    aws.String("Hello {{name}}"),
 		},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
-	// Bulk send to two recipients.
 	resp, err := client.SendBulkEmail(ctx, &sesv2.SendBulkEmailInput{
 		FromEmailAddress: aws.String(fromEmail),
 		DefaultContent: &types.BulkEmailContent{
@@ -634,45 +651,7 @@ func TestSESv2_SendBulkEmail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(resp.BulkEmailEntryResults) != 2 {
-		t.Fatalf("expected 2 entry results, got %d", len(resp.BulkEmailEntryResults))
-	}
-
-	for i, r := range resp.BulkEmailEntryResults {
-		if r.Status != types.BulkEmailStatusSuccess {
-			t.Errorf("entry %d: status=%v want Success (err=%v)", i, r.Status, aws.ToString(r.Error))
-		}
-		if r.MessageId == nil || *r.MessageId == "" {
-			t.Errorf("entry %d: empty MessageId", i)
-		}
-	}
-
-	// Verify the recorded sent emails via kumo-specific endpoint.
-	httpResp, err := http.Get("http://localhost:4566/kumo/ses/v2/sent-emails")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer httpResp.Body.Close()
-
-	var result struct {
-		SentEmails []map[string]interface{} `json:"SentEmails"`
-	}
-
-	if err := json.NewDecoder(httpResp.Body).Decode(&result); err != nil {
-		t.Fatal(err)
-	}
-
-	matching := 0
-
-	for _, e := range result.SentEmails {
-		if e["FromEmailAddress"] == fromEmail && e["TemplateName"] == tmpl {
-			matching++
-		}
-	}
-
-	if matching < 2 {
-		t.Errorf("expected at least 2 sent emails for template %q, got %d", tmpl, matching)
-	}
+	golden.New(t, golden.WithIgnoreFields("MessageId", "ResultMetadata")).Assert(t.Name(), resp)
 }
 
 func TestSESv2_SendBulkEmail_UnknownTemplate(t *testing.T) {

--- a/test/integration/sesv2_test.go
+++ b/test/integration/sesv2_test.go
@@ -548,15 +548,15 @@ func TestSESv2_ListEmailTemplates(t *testing.T) {
 
 	const name = "tmpl-list"
 
-	if _, err := client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
+	// Best-effort create: the template may already exist from a previous run
+	// because kumo persists state under KUMO_DATA_DIR.
+	_, _ = client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
 		TemplateName: aws.String(name),
 		TemplateContent: &types.EmailTemplateContent{
 			Subject: aws.String("S"),
 			Text:    aws.String("B"),
 		},
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
 
 	out, err := client.ListEmailTemplates(ctx, &sesv2.ListEmailTemplatesInput{})
 	if err != nil {
@@ -583,25 +583,24 @@ func TestSESv2_SendBulkEmail(t *testing.T) {
 	ctx := t.Context()
 
 	// Create email identity + template referenced by the bulk send.
+	// CreateEmailIdentity is best-effort: if the identity already exists from a
+	// previous run (kumo persists state across restarts under KUMO_DATA_DIR)
+	// the test should still proceed.
 	fromEmail := "bulk-sender@example.com"
-
-	if _, err := client.CreateEmailIdentity(ctx, &sesv2.CreateEmailIdentityInput{
+	_, _ = client.CreateEmailIdentity(ctx, &sesv2.CreateEmailIdentityInput{
 		EmailIdentity: aws.String(fromEmail),
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
 
 	const tmpl = "tmpl-bulk"
 
-	if _, err := client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
+	// Best-effort create — may pre-exist from a prior run.
+	_, _ = client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
 		TemplateName: aws.String(tmpl),
 		TemplateContent: &types.EmailTemplateContent{
 			Subject: aws.String("Bulk subject"),
 			Text:    aws.String("Hello {{name}}"),
 		},
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
 
 	// Bulk send to two recipients.
 	resp, err := client.SendBulkEmail(ctx, &sesv2.SendBulkEmailInput{

--- a/test/integration/sesv2_test.go
+++ b/test/integration/sesv2_test.go
@@ -472,6 +472,233 @@ func TestSESv2_GetSentEmails(t *testing.T) {
 	}
 }
 
+func TestSESv2_EmailTemplate_CRUD(t *testing.T) {
+	client := newSESv2Client(t)
+	ctx := t.Context()
+
+	const name = "tmpl-crud"
+
+	// Create.
+	if _, err := client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
+		TemplateName: aws.String(name),
+		TemplateContent: &types.EmailTemplateContent{
+			Subject: aws.String("Hi"),
+			Text:    aws.String("Body"),
+			Html:    aws.String("<p>Body</p>"),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get.
+	getOutput, err := client.GetEmailTemplate(ctx, &sesv2.GetEmailTemplateInput{
+		TemplateName: aws.String(name),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if getOutput.TemplateName == nil || *getOutput.TemplateName != name {
+		t.Fatalf("unexpected TemplateName: %v", getOutput.TemplateName)
+	}
+
+	if getOutput.TemplateContent == nil || getOutput.TemplateContent.Subject == nil || *getOutput.TemplateContent.Subject != "Hi" {
+		t.Fatalf("unexpected TemplateContent: %+v", getOutput.TemplateContent)
+	}
+
+	// Update.
+	if _, err := client.UpdateEmailTemplate(ctx, &sesv2.UpdateEmailTemplateInput{
+		TemplateName: aws.String(name),
+		TemplateContent: &types.EmailTemplateContent{
+			Subject: aws.String("Hi v2"),
+			Text:    aws.String("Body v2"),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	getOutput, err = client.GetEmailTemplate(ctx, &sesv2.GetEmailTemplateInput{
+		TemplateName: aws.String(name),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *getOutput.TemplateContent.Subject != "Hi v2" {
+		t.Errorf("update did not take effect: subject=%q", *getOutput.TemplateContent.Subject)
+	}
+
+	// Delete.
+	if _, err := client.DeleteEmailTemplate(ctx, &sesv2.DeleteEmailTemplateInput{
+		TemplateName: aws.String(name),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.GetEmailTemplate(ctx, &sesv2.GetEmailTemplateInput{
+		TemplateName: aws.String(name),
+	}); err == nil {
+		t.Fatal("expected error for deleted template")
+	}
+}
+
+func TestSESv2_ListEmailTemplates(t *testing.T) {
+	client := newSESv2Client(t)
+	ctx := t.Context()
+
+	const name = "tmpl-list"
+
+	if _, err := client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
+		TemplateName: aws.String(name),
+		TemplateContent: &types.EmailTemplateContent{
+			Subject: aws.String("S"),
+			Text:    aws.String("B"),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := client.ListEmailTemplates(ctx, &sesv2.ListEmailTemplatesInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+
+	for _, m := range out.TemplatesMetadata {
+		if m.TemplateName != nil && *m.TemplateName == name {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("created template not found in list")
+	}
+}
+
+func TestSESv2_SendBulkEmail(t *testing.T) {
+	client := newSESv2Client(t)
+	ctx := t.Context()
+
+	// Create email identity + template referenced by the bulk send.
+	fromEmail := "bulk-sender@example.com"
+
+	if _, err := client.CreateEmailIdentity(ctx, &sesv2.CreateEmailIdentityInput{
+		EmailIdentity: aws.String(fromEmail),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	const tmpl = "tmpl-bulk"
+
+	if _, err := client.CreateEmailTemplate(ctx, &sesv2.CreateEmailTemplateInput{
+		TemplateName: aws.String(tmpl),
+		TemplateContent: &types.EmailTemplateContent{
+			Subject: aws.String("Bulk subject"),
+			Text:    aws.String("Hello {{name}}"),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bulk send to two recipients.
+	resp, err := client.SendBulkEmail(ctx, &sesv2.SendBulkEmailInput{
+		FromEmailAddress: aws.String(fromEmail),
+		DefaultContent: &types.BulkEmailContent{
+			Template: &types.Template{
+				TemplateName: aws.String(tmpl),
+				TemplateData: aws.String("{}"),
+			},
+		},
+		BulkEmailEntries: []types.BulkEmailEntry{
+			{
+				Destination: &types.Destination{ToAddresses: []string{"a@example.com"}},
+				ReplacementEmailContent: &types.ReplacementEmailContent{
+					ReplacementTemplate: &types.ReplacementTemplate{
+						ReplacementTemplateData: aws.String(`{"name":"A"}`),
+					},
+				},
+			},
+			{
+				Destination: &types.Destination{ToAddresses: []string{"b@example.com"}},
+				ReplacementEmailContent: &types.ReplacementEmailContent{
+					ReplacementTemplate: &types.ReplacementTemplate{
+						ReplacementTemplateData: aws.String(`{"name":"B"}`),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(resp.BulkEmailEntryResults) != 2 {
+		t.Fatalf("expected 2 entry results, got %d", len(resp.BulkEmailEntryResults))
+	}
+
+	for i, r := range resp.BulkEmailEntryResults {
+		if r.Status != types.BulkEmailStatusSuccess {
+			t.Errorf("entry %d: status=%v want Success (err=%v)", i, r.Status, aws.ToString(r.Error))
+		}
+		if r.MessageId == nil || *r.MessageId == "" {
+			t.Errorf("entry %d: empty MessageId", i)
+		}
+	}
+
+	// Verify the recorded sent emails via kumo-specific endpoint.
+	httpResp, err := http.Get("http://localhost:4566/kumo/ses/v2/sent-emails")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer httpResp.Body.Close()
+
+	var result struct {
+		SentEmails []map[string]interface{} `json:"SentEmails"`
+	}
+
+	if err := json.NewDecoder(httpResp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+
+	matching := 0
+
+	for _, e := range result.SentEmails {
+		if e["FromEmailAddress"] == fromEmail && e["TemplateName"] == tmpl {
+			matching++
+		}
+	}
+
+	if matching < 2 {
+		t.Errorf("expected at least 2 sent emails for template %q, got %d", tmpl, matching)
+	}
+}
+
+func TestSESv2_SendBulkEmail_UnknownTemplate(t *testing.T) {
+	client := newSESv2Client(t)
+	ctx := t.Context()
+
+	_, err := client.SendBulkEmail(ctx, &sesv2.SendBulkEmailInput{
+		FromEmailAddress: aws.String("missing-tmpl@example.com"),
+		DefaultContent: &types.BulkEmailContent{
+			Template: &types.Template{
+				TemplateName: aws.String("does-not-exist"),
+				TemplateData: aws.String("{}"),
+			},
+		},
+		BulkEmailEntries: []types.BulkEmailEntry{
+			{
+				Destination: &types.Destination{ToAddresses: []string{"a@example.com"}},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown template")
+	}
+}
+
 func findSentEmail(t *testing.T, emails []json.RawMessage, from, subject string) json.RawMessage {
 	t.Helper()
 

--- a/test/integration/testdata/sesv2_test_TestSESv2_EmailTemplate_CRUD_TestSESv2_EmailTemplate_CRUD_get.golden.go
+++ b/test/integration/testdata/sesv2_test_TestSESv2_EmailTemplate_CRUD_TestSESv2_EmailTemplate_CRUD_get.golden.go
@@ -1,0 +1,10 @@
+{
+  "TemplateContent": {
+    "Html": "\u003cp\u003eBody\u003c/p\u003e",
+    "Subject": "Hi",
+    "Text": "Body"
+  },
+  "TemplateName": "tmpl-crud",
+  "Tags": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/sesv2_test_TestSESv2_EmailTemplate_CRUD_TestSESv2_EmailTemplate_CRUD_get_after_update.golden.go
+++ b/test/integration/testdata/sesv2_test_TestSESv2_EmailTemplate_CRUD_TestSESv2_EmailTemplate_CRUD_get_after_update.golden.go
@@ -1,0 +1,10 @@
+{
+  "TemplateContent": {
+    "Html": null,
+    "Subject": "Hi v2",
+    "Text": "Body v2"
+  },
+  "TemplateName": "tmpl-crud",
+  "Tags": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/sesv2_test_TestSESv2_ListEmailTemplates_TestSESv2_ListEmailTemplates.golden.go
+++ b/test/integration/testdata/sesv2_test_TestSESv2_ListEmailTemplates_TestSESv2_ListEmailTemplates.golden.go
@@ -1,0 +1,4 @@
+{
+  "CreatedTimestamp": "2026-05-18T07:31:18.305Z",
+  "TemplateName": "tmpl-list"
+}

--- a/test/integration/testdata/sesv2_test_TestSESv2_SendBulkEmail_TestSESv2_SendBulkEmail.golden.go
+++ b/test/integration/testdata/sesv2_test_TestSESv2_SendBulkEmail_TestSESv2_SendBulkEmail.golden.go
@@ -1,0 +1,15 @@
+{
+  "BulkEmailEntryResults": [
+    {
+      "Error": null,
+      "MessageId": "5b705482-3b0a-4d22-b1d1-70c5b625c388",
+      "Status": "SUCCESS"
+    },
+    {
+      "Error": null,
+      "MessageId": "cb367b80-f395-4808-9600-bd7b9e16d2e1",
+      "Status": "SUCCESS"
+    }
+  ],
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

Add the missing SESv2 endpoints needed to drive an AWS SDK SESv2 client through its template-and-bulk send code path against kumo:

- **EmailTemplate CRUD** (`Create` / `Get` / `Update` / `Delete` / `List`)
- **SendBulkEmail** — POST `/ses/v2/email/outbound-bulk-emails`, returns a per-entry `MessageId` and records each destination as a `SentEmail`

`SentEmail` now also exposes `TemplateName` / `TemplateData` so tests can verify what would have been rendered. Existing fields are unchanged.

### Motivation

Trying to use kumo to back local SESv2 traffic from an app that uses templated bulk send (the typical AWS-style flow: register a template at deploy time, then `SendBulkEmail` against it) currently fails — `GetEmailTemplate` returns 404 and `SendBulkEmail` is routed nowhere. With this change kumo can stand in for SES for that flow, including populating downstream DB columns like `ses_message_id` for event-handler tests.

## What's added

### Routes (`internal/service/sesv2/service.go`)

| Method | Path | Handler |
|---|---|---|
| POST | `/ses/v2/email/templates` | `CreateEmailTemplate` |
| GET | `/ses/v2/email/templates` | `ListEmailTemplates` |
| GET | `/ses/v2/email/templates/{templateName}` | `GetEmailTemplate` |
| PUT | `/ses/v2/email/templates/{templateName}` | `UpdateEmailTemplate` |
| DELETE | `/ses/v2/email/templates/{templateName}` | `DeleteEmailTemplate` |
| POST | `/ses/v2/email/outbound-bulk-emails` | `SendBulkEmail` |

### Behavior notes

- **`SendBulkEmail`** mirrors AWS shape: request-level failures (missing entries, missing/unknown template, missing `TemplateName`) return HTTP 400; per-entry destination validation produces `Status: FAILED` inside `BulkEmailEntryResults` with the call still succeeding (HTTP 200). This matches how the AWS SDK expects to read partial results.
- Per-entry `ReplacementTemplateData` overrides `DefaultContent.Template.TemplateData` when present (mirroring SES semantics).
- Persistence: `EmailTemplates` joins the existing `EmailIdentities` / `ConfigurationSets` / `SentEmails` map under `KUMO_DATA_DIR`. `UnmarshalJSON` initializes the new map if absent so old persisted state still loads cleanly.

## Tests

- **`internal/service/sesv2/storage_test.go`** (unit, runs by default)
  - `TestEmailTemplate_CRUD` — create/get/update/list/delete happy path
  - `TestEmailTemplate_DuplicateCreate` — `errAlreadyExists` on second create
  - `TestEmailTemplate_GetNotFound` — `errNotFound` for missing
  - `TestSendBulkEmail_AssignsMessageIDPerEntry` — distinct MessageIds, SentEmails recorded with TemplateName + per-entry ReplacementTemplateData
  - `TestSendBulkEmail_UnknownTemplateFails` — request-level 404
  - `TestSendBulkEmail_EntryWithoutDestinationFailsIndividually` — call succeeds, individual entry has `Status: FAILED`
- **`test/integration/sesv2_test.go`** (build-tagged, requires running kumo container)
  - `TestSESv2_EmailTemplate_CRUD` — create/get/update/get/delete/get via AWS SDK v2
  - `TestSESv2_ListEmailTemplates`
  - `TestSESv2_SendBulkEmail` — 2-entry send, verifies per-entry MessageId, then reads back via `/kumo/ses/v2/sent-emails` to confirm `TemplateName` was recorded
  - `TestSESv2_SendBulkEmail_UnknownTemplate`

`go test ./...` and `go vet ./...` pass locally. The build-tagged integration tests compile cleanly (`go test -C test -tags=integration -run=NoSuchTest ./integration/...`); live integration runs deferred to CI as the Docker harness is not available locally.

### Local end-to-end verification

A locally-built image (this branch) was wired into a downstream app's docker-compose, replacing `ghcr.io/sivchari/kumo:0.20.0`. With `EMAIL_PROVIDER=ses` and `AWS_SESV2_ENDPOINT_URL=http://localhost:4566/ses` the app:

1. registered a template via `aws sesv2 create-email-template` ✓
2. ran a delivery batch that called `GetEmailTemplate` + `SendBulkEmail` for 5 destinations ✓
3. observed `ses_message_id` populated in DB matching `/kumo/ses/v2/sent-emails` output ✓
4. fed those MessageIds to an SNS event handler emulating Delivery/Open/Bounce ✓

S3 (CopyObject, ListObjects, GetObject, PutObject) on the same kumo instance continued to work — no regression.

## Compatibility

- No changes to existing handlers, routes, types, or storage fields. New fields use `omitempty`. Existing tests still pass unchanged.