### PR TITLE
fix(sns): parse MessageAttributes from Query protocol and support RawMessageDelivery

### DIFF
--- a/internal/server/awsquery.go
+++ b/internal/server/awsquery.go
@@ -240,6 +240,9 @@ func formToJSON(form map[string][]string) []byte {
 	// Handle nested attributes (like Attributes.entry.N.key/value).
 	result = flattenAttributes(result)
 
+	// Handle MessageAttributes.entry.N.Name / Value.DataType / Value.StringValue.
+	result = flattenMessageAttributes(result)
+
 	jsonBytes, _ := json.Marshal(result)
 
 	return jsonBytes
@@ -328,6 +331,95 @@ func buildAttributesMap(attrs map[string]string, result map[string]any) {
 	if len(attrMap) > 0 {
 		result["Attributes"] = attrMap
 	}
+}
+
+// flattenMessageAttributes converts MessageAttributes.entry.N.* form keys
+// into a nested JSON map that matches the SNS PublishRequest wire shape:
+//
+//	MessageAttributes.entry.1.Name          = event_type
+//	MessageAttributes.entry.1.Value.DataType    = String
+//	MessageAttributes.entry.1.Value.StringValue = billing
+//
+// becomes:
+//
+//	{"MessageAttributes": {"event_type": {"DataType":"String","StringValue":"billing"}}}
+//
+//nolint:funlen // AWS Query form attribute parsing.
+func flattenMessageAttributes(data map[string]any) map[string]any {
+	const prefix = "MessageAttributes.entry."
+
+	// Collect per-index fields.
+	type entryFields struct {
+		name        string
+		dataType    string
+		stringValue string
+	}
+
+	entries := make(map[string]*entryFields) // keyed by index (e.g. "1")
+	result := make(map[string]any)
+
+	for key, value := range data {
+		if !strings.HasPrefix(key, prefix) {
+			result[key] = value
+
+			continue
+		}
+
+		rest := key[len(prefix):] // e.g. "1.Name", "1.Value.DataType"
+		dotIdx := strings.Index(rest, ".")
+
+		if dotIdx < 0 {
+			result[key] = value
+
+			continue
+		}
+
+		idx := rest[:dotIdx]
+		field := rest[dotIdx+1:]
+		strValue, _ := value.(string)
+
+		e, ok := entries[idx]
+		if !ok {
+			e = &entryFields{}
+			entries[idx] = e
+		}
+
+		switch field {
+		case "Name":
+			e.name = strValue
+		case "Value.DataType":
+			e.dataType = strValue
+		case "Value.StringValue":
+			e.stringValue = strValue
+		}
+	}
+
+	if len(entries) > 0 {
+		msgAttrs := make(map[string]map[string]string, len(entries))
+
+		for _, e := range entries {
+			if e.name == "" {
+				continue
+			}
+
+			attr := make(map[string]string)
+			if e.dataType != "" {
+				attr["DataType"] = e.dataType
+			}
+
+			if e.stringValue != "" {
+				attr["StringValue"] = e.stringValue
+			}
+
+			msgAttrs[e.name] = attr
+		}
+
+		if len(msgAttrs) > 0 {
+			result["MessageAttributes"] = msgAttrs
+		}
+	}
+
+	return result
 }
 
 // writeQueryError writes an AWS Query protocol error response.

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -575,6 +575,12 @@ func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, m
 	switch sub.Protocol {
 	case "sqs":
 		if m.SqsPublisher != nil {
+			// Build the message body based on RawMessageDelivery setting.
+			body := message
+			if !isRawMessageDelivery(sub) {
+				body = buildSNSNotificationEnvelope(sub.TopicARN, message, subject, messageID, attributes)
+			}
+
 			attrs := map[string]string{
 				"MessageId": messageID,
 			}
@@ -582,7 +588,7 @@ func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, m
 				attrs["Subject"] = subject
 			}
 
-			if err := m.SqsPublisher.PublishToSQS(ctx, sub.Endpoint, message, messageGroupID, messageDeduplicationID, attrs); err != nil {
+			if err := m.SqsPublisher.PublishToSQS(ctx, sub.Endpoint, body, messageGroupID, messageDeduplicationID, attrs); err != nil {
 				return fmt.Errorf("failed to publish to SQS: %w", err)
 			}
 
@@ -597,6 +603,55 @@ func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, m
 	}
 
 	return nil
+}
+
+// isRawMessageDelivery checks whether the subscription has RawMessageDelivery enabled.
+func isRawMessageDelivery(sub *Subscription) bool {
+	if sub.SubscriptionAttributes == nil {
+		return false
+	}
+
+	return sub.SubscriptionAttributes["RawMessageDelivery"] == "true"
+}
+
+// buildSNSNotificationEnvelope wraps a message in the SNS notification JSON
+// envelope that AWS sends to SQS when RawMessageDelivery is not enabled.
+func buildSNSNotificationEnvelope(topicARN, message, subject, messageID string, attributes map[string]MessageAttribute) string {
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	envelope := snsNotificationEnvelope{
+		Type:             "Notification",
+		MessageID:        messageID,
+		TopicArn:         topicARN,
+		Message:          message,
+		Timestamp:        now,
+		SignatureVersion: "1",
+		Signature:        "EXAMPLE",
+		SigningCertURL:   "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
+		UnsubscribeURL:   fmt.Sprintf("https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=%s", topicARN),
+	}
+
+	if subject != "" {
+		envelope.Subject = subject
+	}
+
+	if len(attributes) > 0 {
+		envelope.MessageAttributes = make(map[string]snsNotificationAttribute, len(attributes))
+		for k, v := range attributes {
+			envelope.MessageAttributes[k] = snsNotificationAttribute{
+				Type:  v.DataType,
+				Value: v.StringValue,
+			}
+		}
+	}
+
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		// Fallback to raw message if marshaling fails.
+		return message
+	}
+
+	return string(data)
 }
 
 // ListSubscriptions returns all subscriptions.

--- a/internal/service/sns/types.go
+++ b/internal/service/sns/types.go
@@ -422,3 +422,26 @@ type setTopicAttributesRequest struct {
 type getTopicAttributesRequest struct {
 	TopicArn string `json:"TopicArn"`
 }
+
+// snsNotificationEnvelope is the JSON envelope AWS wraps around messages
+// delivered to SQS when RawMessageDelivery is not enabled.
+type snsNotificationEnvelope struct {
+	Type              string                              `json:"Type"`
+	MessageID         string                              `json:"MessageId"`
+	TopicArn          string                              `json:"TopicArn"`
+	Subject           string                              `json:"Subject,omitempty"`
+	Message           string                              `json:"Message"`
+	Timestamp         string                              `json:"Timestamp"`
+	SignatureVersion  string                              `json:"SignatureVersion"`
+	Signature         string                              `json:"Signature"`
+	SigningCertURL    string                              `json:"SigningCertURL"`
+	UnsubscribeURL    string                              `json:"UnsubscribeURL"`
+	MessageAttributes map[string]snsNotificationAttribute `json:"MessageAttributes,omitempty"`
+}
+
+// snsNotificationAttribute represents a single message attribute in the
+// SNS notification JSON envelope.
+type snsNotificationAttribute struct {
+	Type  string `json:"Type"`
+	Value string `json:"Value"`
+}


### PR DESCRIPTION
## Summary

- Add `flattenMessageAttributes` to `formToJSON` to parse `MessageAttributes.entry.N.*` from Query protocol form data
- Check `RawMessageDelivery` subscription attribute before delivery: raw sends body directly, non-raw wraps in SNS notification JSON envelope
- Add `snsNotificationEnvelope` type for SNS JSON wrapper

Root cause: MessageAttributes were silently dropped during Query-to-JSON conversion, so FilterPolicy matching always failed.

Closes #710, Ref: #416