### PR TITLE
feat(dynamodbstreams): add DynamoDB Streams service with cross-service event emission

### DIFF
--- a/cmd/kumo/main.go
+++ b/cmd/kumo/main.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/sivchari/kumo/internal/service/documentdb"
 	_ "github.com/sivchari/kumo/internal/service/ds"
 	_ "github.com/sivchari/kumo/internal/service/dynamodb"
+	_ "github.com/sivchari/kumo/internal/service/dynamodbstreams"
 	_ "github.com/sivchari/kumo/internal/service/ebs"
 	_ "github.com/sivchari/kumo/internal/service/ec2"
 	_ "github.com/sivchari/kumo/internal/service/ecr"

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/sivchari/kumo/internal/storage"
+	"github.com/sivchari/kumo/internal/streams"
 )
 
 const (
@@ -58,11 +59,12 @@ var (
 
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
-	mu      sync.RWMutex          `json:"-"`
-	Tables  map[string]*tableData `json:"tables"`
-	baseURL string
-	dataDir string
-	stopTTL chan struct{}
+	mu          sync.RWMutex          `json:"-"`
+	Tables      map[string]*tableData `json:"tables"`
+	baseURL     string
+	dataDir     string
+	stopTTL     chan struct{}
+	streamStore *streams.Store
 }
 
 type tableData struct {
@@ -73,9 +75,10 @@ type tableData struct {
 // NewMemoryStorage creates a new in-memory DynamoDB storage.
 func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
 	s := &MemoryStorage{
-		Tables:  make(map[string]*tableData),
-		baseURL: baseURL,
-		stopTTL: make(chan struct{}),
+		Tables:      make(map[string]*tableData),
+		baseURL:     baseURL,
+		stopTTL:     make(chan struct{}),
+		streamStore: streams.Global,
 	}
 	for _, o := range opts {
 		o(s)
@@ -192,6 +195,8 @@ func (m *MemoryStorage) Close() error {
 }
 
 // CreateTable creates a new table.
+//
+//nolint:funlen // Table creation with stream setup.
 func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) (*Table, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -228,6 +233,25 @@ func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) 
 		table.StreamEnabled = true
 		table.StreamViewType = req.StreamSpecification.StreamViewType
 		table.LatestStreamArn = fmt.Sprintf("%s/stream/%s", table.TableARN, time.Now().Format("2006-01-02T15:04:05.000"))
+
+		// Register the stream in the shared event store so DynamoDB Streams can read it.
+		keySchema := make([]streams.KeySchemaElement, len(req.KeySchema))
+		for i, ks := range req.KeySchema {
+			keySchema[i] = streams.KeySchemaElement{
+				AttributeName: ks.AttributeName,
+				KeyType:       ks.KeyType,
+			}
+		}
+
+		m.streamStore.RegisterStream(&streams.StreamInfo{
+			StreamARN:      table.LatestStreamArn,
+			TableName:      table.Name,
+			StreamViewType: table.StreamViewType,
+			StreamLabel:    time.Now().Format("2006-01-02T15:04:05.000"),
+			StreamStatus:   "ENABLED",
+			KeySchema:      keySchema,
+			CreationTime:   time.Now(),
+		})
 	}
 
 	m.Tables[req.TableName] = &tableData{
@@ -364,6 +388,16 @@ func (m *MemoryStorage) PutItem(_ context.Context, tableName string, item Item, 
 
 	td.Items[key] = m.copyItem(item)
 
+	// Emit stream event if streams are enabled for this table.
+	if td.Table.StreamEnabled && td.Table.LatestStreamArn != "" {
+		eventName := streams.OperationTypeInsert
+		if existingItem != nil {
+			eventName = streams.OperationTypeModify
+		}
+
+		m.emitStreamEvent(td.Table, eventName, m.extractKey(td.Table, item), existingItem, item)
+	}
+
 	return oldItem, nil
 }
 
@@ -430,12 +464,19 @@ func (m *MemoryStorage) DeleteItem(_ context.Context, tableName string, key Item
 		}
 
 		delete(td.Items, keyStr)
+
+		// Emit stream event if streams are enabled for this table.
+		if td.Table.StreamEnabled && td.Table.LatestStreamArn != "" {
+			m.emitStreamEvent(td.Table, streams.OperationTypeRemove, key, existingItem, nil)
+		}
 	}
 
 	return oldItem, nil
 }
 
 // UpdateItem updates an item in a table.
+//
+//nolint:funlen // Item update with expression evaluation.
 func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item, updateExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, returnValues string, cond ConditionInput) (Item, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -483,6 +524,16 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 	}
 
 	td.Items[keyStr] = item
+
+	// Emit stream event if streams are enabled for this table.
+	if td.Table.StreamEnabled && td.Table.LatestStreamArn != "" {
+		eventName := streams.OperationTypeInsert
+		if itemExists {
+			eventName = streams.OperationTypeModify
+		}
+
+		m.emitStreamEvent(td.Table, eventName, key, oldItem, item)
+	}
 
 	// Return based on returnValues.
 	switch returnValues {
@@ -1677,4 +1728,130 @@ func (m *MemoryStorage) compareForSort(a, b *AttributeValue) bool {
 	}
 
 	return false
+}
+
+// emitStreamEvent publishes a stream record to the shared event store.
+// Must be called under m.mu lock since it reads table metadata.
+func (m *MemoryStorage) emitStreamEvent(table *Table, eventName streams.OperationType, keyItem, oldItem, newItem Item) {
+	record := &streams.StreamRecord{
+		EventID:        uuid.New().String(),
+		EventName:      eventName,
+		AwsRegion:      defaultRegion,
+		StreamViewType: table.StreamViewType,
+		TableName:      table.Name,
+		StreamARN:      table.LatestStreamArn,
+		Keys:           convertItemToStreamAttrs(keyItem),
+		SizeBytes:      100, // Approximate size.
+	}
+
+	// Include old/new images based on stream view type.
+	switch table.StreamViewType {
+	case "NEW_AND_OLD_IMAGES":
+		record.OldImage = convertItemToStreamAttrs(oldItem)
+		record.NewImage = convertItemToStreamAttrs(newItem)
+	case "NEW_IMAGE":
+		record.NewImage = convertItemToStreamAttrs(newItem)
+	case "OLD_IMAGE":
+		record.OldImage = convertItemToStreamAttrs(oldItem)
+	case "KEYS_ONLY":
+		// Only keys are included; already set above.
+	} //nolint:wsl // Intentional empty case with comment.
+
+	m.streamStore.PutRecord(record)
+}
+
+// convertItemToStreamAttrs converts DynamoDB Item to streams.AttributeValue map.
+//
+//nolint:gocritic // rangeValCopy: copy needed for value conversion.
+func convertItemToStreamAttrs(item Item) map[string]streams.AttributeValue {
+	if item == nil {
+		return nil
+	}
+
+	result := make(map[string]streams.AttributeValue, len(item))
+
+	for k, v := range item {
+		result[k] = convertAttrToStreamAttr(v)
+	}
+
+	return result
+}
+
+// convertAttrToStreamAttr converts a single DynamoDB AttributeValue to streams.AttributeValue.
+//
+//nolint:funlen,gocritic // hugeParam + exhaustive type switch for all DynamoDB attribute types.
+func convertAttrToStreamAttr(av AttributeValue) streams.AttributeValue {
+	result := streams.AttributeValue{}
+
+	if av.S != nil {
+		s := *av.S
+		result.S = &s
+	}
+
+	if av.N != nil {
+		n := *av.N
+		result.N = &n
+	}
+
+	if av.B != nil {
+		b := make([]byte, len(av.B))
+		copy(b, av.B)
+		result.B = b
+	}
+
+	if av.SS != nil {
+		ss := make([]string, len(av.SS))
+		copy(ss, av.SS)
+		result.SS = ss
+	}
+
+	if av.NS != nil {
+		ns := make([]string, len(av.NS))
+		copy(ns, av.NS)
+		result.NS = ns
+	}
+
+	if av.BS != nil {
+		bs := make([][]byte, len(av.BS))
+		for i, b := range av.BS {
+			bs[i] = make([]byte, len(b))
+			copy(bs[i], b)
+		}
+
+		result.BS = bs
+	}
+
+	if av.M != nil {
+		m := make(map[string]*streams.AttributeValue, len(av.M))
+
+		for k, v := range av.M {
+			converted := convertAttrToStreamAttr(*v)
+			m[k] = &converted
+		}
+
+		result.M = m
+	}
+
+	if av.L != nil {
+		l := make([]*streams.AttributeValue, len(av.L))
+
+		for i, v := range av.L {
+			converted := convertAttrToStreamAttr(*v)
+			l[i] = &converted
+		}
+
+		result.L = l
+	}
+
+	if av.NULL != nil {
+		n := *av.NULL
+		result.NULL = &n
+	}
+
+	if av.BOOL != nil {
+		b := *av.BOOL
+		result.BOOL = &b
+	}
+
+	return result
 }

--- a/internal/service/dynamodbstreams/handlers.go
+++ b/internal/service/dynamodbstreams/handlers.go
@@ -1,0 +1,127 @@
+package dynamodbstreams
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.
+func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
+	target := r.Header.Get("X-Amz-Target")
+	action := strings.TrimPrefix(target, s.TargetPrefix()+".")
+
+	switch action {
+	case "DescribeStream":
+		s.DescribeStream(w, r)
+	case "GetShardIterator":
+		s.GetShardIterator(w, r)
+	case "GetRecords":
+		s.GetRecords(w, r)
+	default:
+		writeError(w, "UnknownOperationException", "The action "+action+" is not valid")
+	}
+}
+
+// DescribeStream handles the DescribeStream action.
+func (s *Service) DescribeStream(w http.ResponseWriter, r *http.Request) {
+	var req DescribeStreamRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "SerializationException", "Failed to parse request body")
+
+		return
+	}
+
+	if req.StreamArn == "" {
+		writeError(w, "ValidationException", "StreamArn is required")
+
+		return
+	}
+
+	desc, err := s.storage.DescribeStream(req.StreamArn, req.Limit, req.ExclusiveStartShardID)
+	if err != nil {
+		writeError(w, "ResourceNotFoundException", "Requested resource not found: "+req.StreamArn)
+
+		return
+	}
+
+	writeResponse(w, DescribeStreamResponse{
+		StreamDescription: *desc,
+	})
+}
+
+// GetShardIterator handles the GetShardIterator action.
+func (s *Service) GetShardIterator(w http.ResponseWriter, r *http.Request) {
+	var req GetShardIteratorRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "SerializationException", "Failed to parse request body")
+
+		return
+	}
+
+	if req.StreamArn == "" || req.ShardID == "" || req.ShardIteratorType == "" {
+		writeError(w, "ValidationException", "StreamArn, ShardId, and ShardIteratorType are required")
+
+		return
+	}
+
+	iterator, err := s.storage.GetShardIterator(req.StreamArn, req.ShardID, req.ShardIteratorType, req.SequenceNumber)
+	if err != nil {
+		writeError(w, "ResourceNotFoundException", "Requested resource not found")
+
+		return
+	}
+
+	writeResponse(w, GetShardIteratorResponse{
+		ShardIterator: iterator,
+	})
+}
+
+// GetRecords handles the GetRecords action.
+func (s *Service) GetRecords(w http.ResponseWriter, r *http.Request) {
+	var req GetRecordsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "SerializationException", "Failed to parse request body")
+
+		return
+	}
+
+	if req.ShardIterator == "" {
+		writeError(w, "ValidationException", "ShardIterator is required")
+
+		return
+	}
+
+	records, nextIterator, err := s.storage.GetRecords(req.ShardIterator, req.Limit)
+	if err != nil {
+		writeError(w, "ExpiredIteratorException", err.Error())
+
+		return
+	}
+
+	writeResponse(w, GetRecordsResponse{
+		Records:           records,
+		NextShardIterator: nextIterator,
+	})
+}
+
+// writeResponse writes a JSON response.
+func writeResponse(w http.ResponseWriter, resp any) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// writeError writes an error response.
+func writeError(w http.ResponseWriter, code, message string) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(&ErrorResponse{
+		Type:    code,
+		Message: message,
+	})
+}

--- a/internal/service/dynamodbstreams/service.go
+++ b/internal/service/dynamodbstreams/service.go
@@ -1,0 +1,58 @@
+package dynamodbstreams
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/sivchari/kumo/internal/service"
+	"github.com/sivchari/kumo/internal/streams"
+)
+
+// Compile-time check that Service implements io.Closer.
+var _ io.Closer = (*Service)(nil)
+
+func init() {
+	service.Register(New(NewMemoryStorage(streams.Global)))
+}
+
+// Service implements the DynamoDB Streams service.
+type Service struct {
+	storage Storage
+}
+
+// New creates a new DynamoDB Streams service.
+func New(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// Name returns the service name.
+func (s *Service) Name() string {
+	return "dynamodbstreams"
+}
+
+// RegisterRoutes registers routes for the service.
+// DynamoDB Streams uses AWS JSON 1.0 protocol, so no direct routes are registered.
+func (s *Service) RegisterRoutes(_ service.Router) {
+	// No routes to register - uses JSON protocol dispatcher.
+}
+
+// TargetPrefix returns the X-Amz-Target header prefix for DynamoDB Streams.
+func (s *Service) TargetPrefix() string {
+	return "DynamoDBStreams_20120810"
+}
+
+// JSONProtocol is a marker method that indicates DynamoDB Streams uses AWS JSON 1.0 protocol.
+func (s *Service) JSONProtocol() {}
+
+// Close releases resources held by the service.
+func (s *Service) Close() error {
+	if c, ok := s.storage.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			return fmt.Errorf("failed to close storage: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/dynamodbstreams/storage.go
+++ b/internal/service/dynamodbstreams/storage.go
@@ -1,0 +1,275 @@
+package dynamodbstreams
+
+import (
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sivchari/kumo/internal/streams"
+)
+
+const (
+	defaultMaxRecords       = 1000
+	shardIteratorExpiration = 5 * time.Minute
+)
+
+// Storage defines the DynamoDB Streams storage interface.
+type Storage interface {
+	DescribeStream(streamARN string, limit int32, exclusiveStartShardID string) (*StreamDescription, error)
+	GetShardIterator(streamARN, shardID, iteratorType, sequenceNumber string) (string, error)
+	GetRecords(shardIterator string, limit int32) ([]RecordOutput, *string, error)
+}
+
+// Option is a configuration option for MemoryStorage.
+type Option func(*MemoryStorage)
+
+// shardIteratorData holds shard iterator state.
+type shardIteratorData struct {
+	streamARN string
+	shardID   string
+	position  int
+	expiresAt time.Time
+}
+
+// MemoryStorage implements Storage backed by the shared streams.Store.
+type MemoryStorage struct {
+	mu             sync.Mutex
+	store          *streams.Store
+	shardIterators map[string]*shardIteratorData
+}
+
+// NewMemoryStorage creates a new MemoryStorage.
+func NewMemoryStorage(store *streams.Store, _ ...Option) *MemoryStorage {
+	return &MemoryStorage{
+		store:          store,
+		shardIterators: make(map[string]*shardIteratorData),
+	}
+}
+
+// DescribeStream returns stream metadata from the shared store.
+func (m *MemoryStorage) DescribeStream(streamARN string, _ int32, _ string) (*StreamDescription, error) {
+	info, shards, err := m.store.DescribeStream(streamARN)
+	if err != nil {
+		return nil, fmt.Errorf("describe-stream failed: %w", err)
+	}
+
+	outShards := make([]Shard, len(shards))
+	for i, sh := range shards {
+		outShards[i] = Shard{
+			ShardID:       sh.ShardID,
+			ParentShardID: sh.ParentShardID,
+			SequenceNumberRange: SequenceNumberRange{
+				StartingSequenceNumber: sh.SequenceNumberRangeStart,
+			},
+		}
+	}
+
+	keySchema := make([]KeySchema, len(info.KeySchema))
+	for i, ks := range info.KeySchema {
+		keySchema[i] = KeySchema{
+			AttributeName: ks.AttributeName,
+			KeyType:       ks.KeyType,
+		}
+	}
+
+	return &StreamDescription{
+		StreamArn:               info.StreamARN,
+		StreamLabel:             info.StreamLabel,
+		StreamStatus:            info.StreamStatus,
+		StreamViewType:          info.StreamViewType,
+		TableName:               info.TableName,
+		KeySchema:               keySchema,
+		Shards:                  outShards,
+		CreationRequestDateTime: float64(info.CreationTime.Unix()),
+	}, nil
+}
+
+// GetShardIterator creates a shard iterator for reading stream records.
+func (m *MemoryStorage) GetShardIterator(streamARN, shardID, iteratorType, _ string) (string, error) {
+	// Verify the stream and shard exist.
+	_, shards, err := m.store.DescribeStream(streamARN)
+	if err != nil {
+		return "", fmt.Errorf("get-shard-iterator failed: %w", err)
+	}
+
+	found := false
+
+	for _, sh := range shards {
+		if sh.ShardID == shardID {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		return "", fmt.Errorf("shard not found: %s", shardID)
+	}
+
+	var position int
+
+	switch iteratorType {
+	case "TRIM_HORIZON":
+		position = 0
+	case "LATEST":
+		position = m.store.ShardRecordCount(streamARN, shardID)
+	default:
+		position = 0
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	iteratorID := fmt.Sprintf("%s:%s:%d:%d", streamARN, shardID, position, time.Now().UnixNano())
+	encoded := base64.StdEncoding.EncodeToString([]byte(iteratorID))
+
+	m.shardIterators[encoded] = &shardIteratorData{
+		streamARN: streamARN,
+		shardID:   shardID,
+		position:  position,
+		expiresAt: time.Now().Add(shardIteratorExpiration),
+	}
+
+	return encoded, nil
+}
+
+// GetRecords reads stream records starting from the position encoded in the shard iterator.
+func (m *MemoryStorage) GetRecords(shardIterator string, limit int32) ([]RecordOutput, *string, error) {
+	m.mu.Lock()
+
+	iterData, exists := m.shardIterators[shardIterator]
+	if !exists {
+		m.mu.Unlock()
+
+		return nil, nil, fmt.Errorf("invalid shard iterator")
+	}
+
+	if time.Now().After(iterData.expiresAt) {
+		delete(m.shardIterators, shardIterator)
+		m.mu.Unlock()
+
+		return nil, nil, fmt.Errorf("expired shard iterator")
+	}
+
+	// Copy iterator data so we can release the lock.
+	streamARN := iterData.streamARN
+	shardID := iterData.shardID
+	position := iterData.position
+
+	m.mu.Unlock()
+
+	if limit <= 0 || limit > int32(defaultMaxRecords) {
+		limit = int32(defaultMaxRecords)
+	}
+
+	records, nextPos, err := m.store.GetRecords(streamARN, shardID, position, int(limit))
+	if err != nil {
+		return nil, nil, fmt.Errorf("get-records failed: %w", err)
+	}
+
+	// Convert stream records to output format.
+	outputs := make([]RecordOutput, len(records))
+	for i, rec := range records {
+		outputs[i] = convertStreamRecord(rec)
+	}
+
+	// Create next iterator.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.shardIterators, shardIterator)
+
+	nextIteratorID := fmt.Sprintf("%s:%s:%d:%d", streamARN, shardID, nextPos, time.Now().UnixNano())
+	nextEncoded := base64.StdEncoding.EncodeToString([]byte(nextIteratorID))
+
+	m.shardIterators[nextEncoded] = &shardIteratorData{
+		streamARN: streamARN,
+		shardID:   shardID,
+		position:  nextPos,
+		expiresAt: time.Now().Add(shardIteratorExpiration),
+	}
+
+	return outputs, &nextEncoded, nil
+}
+
+// convertStreamRecord converts an internal StreamRecord to the output format.
+func convertStreamRecord(rec *streams.StreamRecord) RecordOutput {
+	return RecordOutput{
+		EventID:      rec.EventID,
+		EventName:    string(rec.EventName),
+		EventVersion: rec.EventVersion,
+		EventSource:  rec.EventSource,
+		AwsRegion:    rec.AwsRegion,
+		Dynamodb: &StreamRecordOutput{
+			ApproximateCreationDateTime: float64(rec.CreatedAt.Unix()),
+			Keys:                        convertAttributes(rec.Keys),
+			NewImage:                    convertAttributes(rec.NewImage),
+			OldImage:                    convertAttributes(rec.OldImage),
+			SequenceNumber:              rec.SequenceNumber,
+			SizeBytes:                   rec.SizeBytes,
+			StreamViewType:              rec.StreamViewType,
+		},
+	}
+}
+
+// convertAttributes converts streams.AttributeValue map to AttributeOutput map.
+//
+//nolint:gocritic // rangeValCopy: copy needed for recursive conversion.
+func convertAttributes(attrs map[string]streams.AttributeValue) map[string]AttributeOutput {
+	if len(attrs) == 0 {
+		return nil
+	}
+
+	result := make(map[string]AttributeOutput, len(attrs))
+
+	for k, v := range attrs {
+		result[k] = convertSingleAttribute(v)
+	}
+
+	return result
+}
+
+// convertSingleAttribute converts a single streams.AttributeValue to AttributeOutput.
+//
+//nolint:gocritic // hugeParam: value needed for recursive conversion.
+func convertSingleAttribute(av streams.AttributeValue) AttributeOutput {
+	out := make(AttributeOutput)
+
+	switch {
+	case av.S != nil:
+		out["S"] = *av.S
+	case av.N != nil:
+		out["N"] = *av.N
+	case av.B != nil:
+		out["B"] = av.B
+	case av.SS != nil:
+		out["SS"] = av.SS
+	case av.NS != nil:
+		out["NS"] = av.NS
+	case av.BS != nil:
+		out["BS"] = av.BS
+	case av.M != nil:
+		m := make(map[string]AttributeOutput, len(av.M))
+
+		for k, v := range av.M {
+			m[k] = convertSingleAttribute(*v)
+		}
+
+		out["M"] = m
+	case av.L != nil:
+		l := make([]AttributeOutput, len(av.L))
+
+		for i, v := range av.L {
+			l[i] = convertSingleAttribute(*v)
+		}
+
+		out["L"] = l
+	case av.NULL != nil:
+		out["NULL"] = *av.NULL
+	case av.BOOL != nil:
+		out["BOOL"] = *av.BOOL
+	}
+
+	return out
+}

--- a/internal/service/dynamodbstreams/types.go
+++ b/internal/service/dynamodbstreams/types.go
@@ -1,0 +1,126 @@
+// Package dynamodbstreams provides a mock implementation of AWS DynamoDB Streams.
+package dynamodbstreams
+
+// DescribeStreamRequest is the request for DescribeStream.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type DescribeStreamRequest struct {
+	StreamArn             string `json:"StreamArn"`
+	Limit                 int32  `json:"Limit,omitempty"`
+	ExclusiveStartShardID string `json:"ExclusiveStartShardId,omitempty"`
+}
+
+// DescribeStreamResponse is the response for DescribeStream.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type DescribeStreamResponse struct {
+	StreamDescription StreamDescription `json:"StreamDescription"`
+}
+
+// StreamDescription contains stream details.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type StreamDescription struct {
+	StreamArn               string      `json:"StreamArn"`
+	StreamLabel             string      `json:"StreamLabel"`
+	StreamStatus            string      `json:"StreamStatus"`
+	StreamViewType          string      `json:"StreamViewType"`
+	TableName               string      `json:"TableName"`
+	KeySchema               []KeySchema `json:"KeySchema"`
+	Shards                  []Shard     `json:"Shards"`
+	CreationRequestDateTime float64     `json:"CreationRequestDateTime"`
+	LastEvaluatedShardID    string      `json:"LastEvaluatedShardId,omitempty"`
+}
+
+// KeySchema represents a key schema element.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type KeySchema struct {
+	AttributeName string `json:"AttributeName"`
+	KeyType       string `json:"KeyType"`
+}
+
+// Shard represents a shard in a DynamoDB stream.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type Shard struct {
+	ShardID             string              `json:"ShardId"`
+	ParentShardID       string              `json:"ParentShardId,omitempty"`
+	SequenceNumberRange SequenceNumberRange `json:"SequenceNumberRange"`
+}
+
+// SequenceNumberRange represents the range of sequence numbers for a shard.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type SequenceNumberRange struct {
+	StartingSequenceNumber string  `json:"StartingSequenceNumber"`
+	EndingSequenceNumber   *string `json:"EndingSequenceNumber,omitempty"`
+}
+
+// GetShardIteratorRequest is the request for GetShardIterator.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type GetShardIteratorRequest struct {
+	StreamArn         string `json:"StreamArn"`
+	ShardID           string `json:"ShardId"`
+	ShardIteratorType string `json:"ShardIteratorType"`
+	SequenceNumber    string `json:"SequenceNumber,omitempty"`
+}
+
+// GetShardIteratorResponse is the response for GetShardIterator.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type GetShardIteratorResponse struct {
+	ShardIterator string `json:"ShardIterator,omitempty"`
+}
+
+// GetRecordsRequest is the request for GetRecords.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type GetRecordsRequest struct {
+	ShardIterator string `json:"ShardIterator"`
+	Limit         int32  `json:"Limit,omitempty"`
+}
+
+// GetRecordsResponse is the response for GetRecords.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type GetRecordsResponse struct {
+	Records           []RecordOutput `json:"Records"`
+	NextShardIterator *string        `json:"NextShardIterator,omitempty"`
+}
+
+// RecordOutput is the output representation of a stream record.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type RecordOutput struct {
+	EventID      string              `json:"eventID"`
+	EventName    string              `json:"eventName"`
+	EventVersion string              `json:"eventVersion"`
+	EventSource  string              `json:"eventSource"`
+	AwsRegion    string              `json:"awsRegion"`
+	Dynamodb     *StreamRecordOutput `json:"dynamodb"`
+}
+
+// StreamRecordOutput represents the DynamoDB-specific portion of a stream record.
+//
+//nolint:tagliatelle // AWS JSON protocol uses PascalCase field names.
+type StreamRecordOutput struct {
+	ApproximateCreationDateTime float64                    `json:"ApproximateCreationDateTime"`
+	Keys                        map[string]AttributeOutput `json:"Keys"`
+	NewImage                    map[string]AttributeOutput `json:"NewImage,omitempty"`
+	OldImage                    map[string]AttributeOutput `json:"OldImage,omitempty"`
+	SequenceNumber              string                     `json:"SequenceNumber"`
+	SizeBytes                   int64                      `json:"SizeBytes"`
+	StreamViewType              string                     `json:"StreamViewType"`
+}
+
+// AttributeOutput is the JSON representation of a DynamoDB attribute value.
+// It wraps the streams.AttributeValue for JSON serialization.
+type AttributeOutput map[string]any
+
+// ErrorResponse represents an error response.
+type ErrorResponse struct {
+	Type    string `json:"__type"` //nolint:tagliatelle // AWS error format
+	Message string `json:"message"`
+}

--- a/internal/streams/store.go
+++ b/internal/streams/store.go
@@ -1,0 +1,232 @@
+// Package streams provides a shared event store for DynamoDB Streams.
+// Both the dynamodb service (producer) and the dynamodbstreams service
+// (consumer) reference this package to avoid circular imports.
+package streams
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// OperationType represents the type of DynamoDB stream event.
+type OperationType string
+
+// Operation type constants.
+const (
+	OperationTypeInsert OperationType = "INSERT"
+	OperationTypeModify OperationType = "MODIFY"
+	OperationTypeRemove OperationType = "REMOVE"
+)
+
+// AttributeValue mirrors DynamoDB's AttributeValue for stream records.
+// We use a simplified representation to avoid importing the dynamodb package.
+//
+//nolint:tagliatelle // AWS DynamoDB uses PascalCase attribute type fields.
+type AttributeValue struct {
+	S    *string                    `json:"S,omitempty"`
+	N    *string                    `json:"N,omitempty"`
+	B    []byte                     `json:"B,omitempty"`
+	SS   []string                   `json:"SS,omitempty"`
+	NS   []string                   `json:"NS,omitempty"`
+	BS   [][]byte                   `json:"BS,omitempty"`
+	M    map[string]*AttributeValue `json:"M,omitempty"`
+	L    []*AttributeValue          `json:"L,omitempty"`
+	NULL *bool                      `json:"NULL,omitempty"`
+	BOOL *bool                      `json:"BOOL,omitempty"`
+}
+
+// StreamRecord represents a single change event in a DynamoDB stream.
+type StreamRecord struct {
+	EventID        string
+	EventName      OperationType
+	EventVersion   string
+	EventSource    string
+	AwsRegion      string
+	StreamViewType string
+	TableName      string
+	StreamARN      string
+	Keys           map[string]AttributeValue
+	NewImage       map[string]AttributeValue
+	OldImage       map[string]AttributeValue
+	SequenceNumber string
+	CreatedAt      time.Time
+	SizeBytes      int64
+}
+
+// StreamInfo holds metadata about a stream.
+type StreamInfo struct {
+	StreamARN      string
+	TableName      string
+	StreamViewType string
+	StreamLabel    string
+	StreamStatus   string
+	KeySchema      []KeySchemaElement
+	CreationTime   time.Time
+}
+
+// KeySchemaElement represents a key schema element.
+type KeySchemaElement struct {
+	AttributeName string
+	KeyType       string // HASH or RANGE
+}
+
+// ShardInfo holds metadata about a shard within a stream.
+type ShardInfo struct {
+	ShardID                  string
+	ParentShardID            string
+	SequenceNumberRangeStart string
+}
+
+// Store is a global, concurrency-safe store for DynamoDB stream events.
+// DynamoDB storage writes events here; DynamoDB Streams reads them.
+type Store struct {
+	mu              sync.RWMutex
+	streams         map[string]*streamData // keyed by streamARN
+	sequenceCounter uint64
+}
+
+type streamData struct {
+	info   StreamInfo
+	shards []*shardData
+}
+
+type shardData struct {
+	info    ShardInfo
+	records []*StreamRecord
+}
+
+// Global is the default global Store instance shared between
+// the dynamodb and dynamodbstreams services.
+var Global = NewStore()
+
+// NewStore creates a new Store.
+func NewStore() *Store {
+	return &Store{
+		streams: make(map[string]*streamData),
+	}
+}
+
+// RegisterStream registers a stream for a table. Called when a DynamoDB table
+// with StreamSpecification is created.
+func (s *Store) RegisterStream(info *StreamInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.streams[info.StreamARN]; exists {
+		return
+	}
+
+	seq := s.nextSequenceNumber()
+	sd := &streamData{
+		info: *info,
+		shards: []*shardData{
+			{
+				info: ShardInfo{
+					ShardID:                  "shardId-000000000000",
+					SequenceNumberRangeStart: seq,
+				},
+				records: make([]*StreamRecord, 0),
+			},
+		},
+	}
+
+	s.streams[info.StreamARN] = sd
+}
+
+// PutRecord adds a stream record. Called by DynamoDB storage on item mutations.
+func (s *Store) PutRecord(record *StreamRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sd, exists := s.streams[record.StreamARN]
+	if !exists {
+		return
+	}
+
+	record.SequenceNumber = s.nextSequenceNumber()
+	record.CreatedAt = time.Now()
+	record.EventVersion = "1.1"
+	record.EventSource = "aws:dynamodb"
+
+	// Append to the last (active) shard.
+	activeShard := sd.shards[len(sd.shards)-1]
+	activeShard.records = append(activeShard.records, record)
+}
+
+// DescribeStream returns stream info and shard list for the given ARN.
+func (s *Store) DescribeStream(streamARN string) (*StreamInfo, []ShardInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sd, exists := s.streams[streamARN]
+	if !exists {
+		return nil, nil, fmt.Errorf("stream not found: %s", streamARN)
+	}
+
+	shards := make([]ShardInfo, len(sd.shards))
+	for i, sh := range sd.shards {
+		shards[i] = sh.info
+	}
+
+	return &sd.info, shards, nil
+}
+
+// GetRecords returns records from a given shard starting at the specified position.
+func (s *Store) GetRecords(streamARN, shardID string, position, limit int) ([]*StreamRecord, int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sd, exists := s.streams[streamARN]
+	if !exists {
+		return nil, 0, fmt.Errorf("stream not found: %s", streamARN)
+	}
+
+	for _, sh := range sd.shards {
+		if sh.info.ShardID != shardID {
+			continue
+		}
+
+		if position >= len(sh.records) {
+			return nil, position, nil
+		}
+
+		end := position + limit
+		if end > len(sh.records) {
+			end = len(sh.records)
+		}
+
+		result := make([]*StreamRecord, end-position)
+		copy(result, sh.records[position:end])
+
+		return result, end, nil
+	}
+
+	return nil, 0, fmt.Errorf("shard not found: %s", shardID)
+}
+
+// ShardRecordCount returns the number of records in a shard (used for iterator positioning).
+func (s *Store) ShardRecordCount(streamARN, shardID string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sd, exists := s.streams[streamARN]
+	if !exists {
+		return 0
+	}
+
+	for _, sh := range sd.shards {
+		if sh.info.ShardID == shardID {
+			return len(sh.records)
+		}
+	}
+
+	return 0
+}
+
+func (s *Store) nextSequenceNumber() string {
+	seq := atomic.AddUint64(&s.sequenceCounter, 1)
+
+	return fmt.Sprintf("%021d", seq)
+}


### PR DESCRIPTION
## Summary

- New `dynamodbstreams` service with JSON protocol (TargetPrefix: DynamoDBStreams_20120810)
- Implement DescribeStream, GetShardIterator, GetRecords
- Shared `internal/streams` package for cross-service event communication
- DynamoDB PutItem/UpdateItem/DeleteItem emit INSERT/MODIFY/REMOVE stream events
- Shard iterator with base64 encoding and 5-minute expiry

Closes #322, Ref: #416