### PR TITLE
fix(awsquery): convert non-string attribute values in flattenAttributes

### DIFF
--- a/internal/server/awsquery.go
+++ b/internal/server/awsquery.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"sort"
@@ -297,7 +298,7 @@ func parseAttributeEntry(key string, value any, attrs map[string]string) {
 
 	strValue, ok := value.(string)
 	if !ok {
-		return
+		strValue = fmt.Sprint(value)
 	}
 
 	switch field {


### PR DESCRIPTION
## Summary

`parseAttributeEntry` silently dropped non-string attribute values. Since `parseFormValue` converts `"true"` to `bool` and numbers to `int64`, Subscribe Attributes like `RawMessageDelivery=true` were lost.

Use `fmt.Sprint` as fallback for non-string values.

This fixes 4 SNS test regressions (SNS publish to SQS, filter policy, FIFO, and IAM STS assume role).

Ref: #416