### PR TITLE
fix(s3): fix fuzz test build failure for parseCopySource

### DIFF
--- a/internal/service/s3/fuzz_test.go
+++ b/internal/service/s3/fuzz_test.go
@@ -36,7 +36,7 @@ func FuzzParseCopySourceAndRangeNoPanic(f *testing.F) {
 	f.Add("single-segment", "items=0-99")
 
 	f.Fuzz(func(t *testing.T, source, copyRange string) {
-		_, _ = parseCopySource(source)
+		_, _, _ = parseCopySource(source)
 
 		rng, err := parseCopySourceRange(copyRange)
 		if err != nil || rng == nil {


### PR DESCRIPTION
## Summary

- `parseCopySource` was changed to return 3 values (bucket, key, versionID) but `fuzz_test.go` still captured only 2, causing a build failure on main

## Test plan

- [x] `go test ./internal/service/s3/...` passes