### PR TITLE
chore: add lefthook for pre-commit and pre-push hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,22 @@
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      glob: "*.go"
+      run: make lint
+    test:
+      glob: "*.go"
+      run: make test
+
+pre-push:
+  parallel: true
+  commands:
+    lint:
+      glob: "*.go"
+      run: make lint
+    test:
+      glob: "*.go"
+      run: make test
+    test-integration:
+      glob: "*.go"
+      run: make test-integration


### PR DESCRIPTION
## Summary
- Add `lefthook.yml` to run `make lint` and `make test` on pre-commit
- Add `make lint`, `make test`, and `make test-integration` on pre-push

## Test plan
- [x] `lefthook install` activates hooks correctly
- [x] `git push` triggers pre-push hooks (verified: skipped cleanly with no .go changes)