### PR TITLE
ci(fuzz): add daily fuzzing CI workflow

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,18 @@
+name: Fuzz
+
+on:
+  schedule:
+    - cron: '0 18 * * *' # UTC 18:00 = JST 3:00
+  workflow_dispatch: {}
+
+jobs:
+  fuzz:
+    name: Fuzz tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Run fuzz tests
+        run: make test-fuzz

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-integration test-helm-e2e clean docker lint lint-fix fmt fmt-diff
+.PHONY: build run test test-fuzz test-integration test-helm-e2e clean docker lint lint-fix fmt fmt-diff
 
 BINARY_NAME=kumo
 VERSION?=$(shell grep 'const Version' version.go | cut -d'"' -f2)
@@ -24,6 +24,12 @@ test-cover:
 
 test-integration:
 	go test -C test -v -tags=integration ./integration/...
+
+test-fuzz:
+	go test -fuzz=FuzzParseByteRangeInvariants -fuzztime=60s ./internal/service/s3/...
+	go test -fuzz=FuzzParseCopySourceAndRangeNoPanic -fuzztime=60s ./internal/service/s3/...
+	go test -fuzz=FuzzConditionExpressionNoPanic -fuzztime=60s ./internal/service/dynamodb/...
+	go test -fuzz=FuzzAttributeValueJSONRoundTrip -fuzztime=60s ./internal/service/dynamodb/...
 
 test-helm-e2e:
 	bash test/e2e/helm-e2e.sh


### PR DESCRIPTION
## Summary
- Add daily scheduled GitHub Actions workflow for fuzz testing (UTC 18:00)
- Add test-fuzz Makefile target
- Fuzz tests remain in internal/ (unexported function access required)

## Test plan
- [x] go test -fuzz works locally
- [x] make lint passes