### PR TITLE
refactor: eliminate hardcoded magic strings across services

### DIFF
--- a/internal/service/amplify/storage.go
+++ b/internal/service/amplify/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -66,14 +67,21 @@ type MemoryStorage struct {
 	mu       sync.RWMutex                  `json:"-"`
 	Apps     map[string]*App               `json:"apps"`
 	Branches map[string]map[string]*Branch `json:"branches"` // appID -> branchName -> Branch
+	region   string
 	dataDir  string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Apps:     make(map[string]*App),
 		Branches: make(map[string]map[string]*Branch),
+		region:   region,
 	}
 	for _, o := range opts {
 		o(s)
@@ -152,7 +160,7 @@ func (m *MemoryStorage) CreateApp(_ context.Context, input *CreateAppInput) (*Ap
 	}
 
 	app := &App{
-		AppArn:                fmt.Sprintf("arn:aws:amplify:%s:%s:apps/%s", defaultRegion, defaultAccountID, appID),
+		AppArn:                fmt.Sprintf("arn:aws:amplify:%s:%s:apps/%s", m.region, defaultAccountID, appID),
 		AppID:                 appID,
 		CreateTime:            now,
 		DefaultDomain:         fmt.Sprintf("%s.amplifyapp.com", appID),
@@ -289,7 +297,7 @@ func (m *MemoryStorage) CreateBranch(_ context.Context, appID string, input *Cre
 
 	branch := &Branch{
 		ActiveJobID:              "",
-		BranchArn:                fmt.Sprintf("arn:aws:amplify:%s:%s:apps/%s/branches/%s", defaultRegion, defaultAccountID, appID, input.BranchName),
+		BranchArn:                fmt.Sprintf("arn:aws:amplify:%s:%s:apps/%s/branches/%s", m.region, defaultAccountID, appID, input.BranchName),
 		BranchName:               input.BranchName,
 		CreateTime:               now,
 		CustomDomains:            []string{},

--- a/internal/service/appmesh/storage.go
+++ b/internal/service/appmesh/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -79,17 +80,24 @@ type MemoryStorage struct {
 	VirtualServices map[string]map[string]*VirtualServiceData   `json:"virtualServices"` // meshName -> virtualServiceName -> data
 	VirtualRouters  map[string]map[string]*VirtualRouterData    `json:"virtualRouters"`  // meshName -> virtualRouterName -> data
 	Routes          map[string]map[string]map[string]*RouteData `json:"routes"`          // meshName -> virtualRouterName -> routeName -> data
+	region          string
 	dataDir         string
 }
 
 // NewMemoryStorage creates a new MemoryStorage instance.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Meshes:          make(map[string]*MeshData),
 		VirtualNodes:    make(map[string]map[string]*VirtualNodeData),
 		VirtualServices: make(map[string]map[string]*VirtualServiceData),
 		VirtualRouters:  make(map[string]map[string]*VirtualRouterData),
 		Routes:          make(map[string]map[string]map[string]*RouteData),
+		region:          region,
 	}
 	for _, o := range opts {
 		o(s)
@@ -182,7 +190,7 @@ func (m *MemoryStorage) CreateMesh(_ context.Context, req *CreateMeshInput) (*Me
 
 	now := time.Now()
 	uid := uuid.New().String()
-	arn := fmt.Sprintf("arn:aws:appmesh:%s:%s:mesh/%s", defaultRegion, defaultAccountID, req.MeshName)
+	arn := fmt.Sprintf("arn:aws:appmesh:%s:%s:mesh/%s", m.region, defaultAccountID, req.MeshName)
 
 	mesh := &MeshData{
 		MeshName: req.MeshName,
@@ -347,7 +355,7 @@ func (m *MemoryStorage) CreateVirtualNode(_ context.Context, req *CreateVirtualN
 	now := time.Now()
 	uid := uuid.New().String()
 	arn := fmt.Sprintf("arn:aws:appmesh:%s:%s:mesh/%s/virtualNode/%s",
-		defaultRegion, defaultAccountID, req.MeshName, req.VirtualNodeName)
+		m.region, defaultAccountID, req.MeshName, req.VirtualNodeName)
 
 	node := &VirtualNodeData{
 		MeshName:        req.MeshName,
@@ -512,7 +520,7 @@ func (m *MemoryStorage) CreateVirtualService(_ context.Context, req *CreateVirtu
 	now := time.Now()
 	uid := uuid.New().String()
 	arn := fmt.Sprintf("arn:aws:appmesh:%s:%s:mesh/%s/virtualService/%s",
-		defaultRegion, defaultAccountID, req.MeshName, req.VirtualServiceName)
+		m.region, defaultAccountID, req.MeshName, req.VirtualServiceName)
 
 	service := &VirtualServiceData{
 		MeshName:           req.MeshName,
@@ -677,7 +685,7 @@ func (m *MemoryStorage) CreateVirtualRouter(_ context.Context, req *CreateVirtua
 	now := time.Now()
 	uid := uuid.New().String()
 	arn := fmt.Sprintf("arn:aws:appmesh:%s:%s:mesh/%s/virtualRouter/%s",
-		defaultRegion, defaultAccountID, req.MeshName, req.VirtualRouterName)
+		m.region, defaultAccountID, req.MeshName, req.VirtualRouterName)
 
 	router := &VirtualRouterData{
 		MeshName:          req.MeshName,
@@ -859,7 +867,7 @@ func (m *MemoryStorage) CreateRoute(_ context.Context, req *CreateRouteInput) (*
 	now := time.Now()
 	uid := uuid.New().String()
 	arn := fmt.Sprintf("arn:aws:appmesh:%s:%s:mesh/%s/virtualRouter/%s/route/%s",
-		defaultRegion, defaultAccountID, req.MeshName, req.VirtualRouterName, req.RouteName)
+		m.region, defaultAccountID, req.MeshName, req.VirtualRouterName, req.RouteName)
 
 	route := &RouteData{
 		MeshName:          req.MeshName,

--- a/internal/service/cloudtrail/storage.go
+++ b/internal/service/cloudtrail/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -62,9 +63,14 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Trails:    make(map[string]*Trail),
-		region:    defaultRegion,
+		region:    region,
 		accountID: defaultAccountID,
 	}
 	for _, o := range opts {

--- a/internal/service/cloudwatch/storage.go
+++ b/internal/service/cloudwatch/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -77,17 +78,24 @@ type MemoryStorage struct {
 	Alarms       map[string]*Alarm           `json:"alarms"`
 	Tags         map[string][]Tag            `json:"tags"`
 	baseURL      string
+	region       string
 	dataDir      string
 	snsPublisher SNSPublisher `json:"-"`
 }
 
 // NewMemoryStorage creates a new in-memory CloudWatch storage.
 func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Metrics: make(map[MetricKey]*StoredMetric),
 		Alarms:  make(map[string]*Alarm),
 		Tags:    make(map[string][]Tag),
 		baseURL: baseURL,
+		region:  region,
 	}
 	for _, o := range opts {
 		o(s)
@@ -512,7 +520,7 @@ func (s *MemoryStorage) SetAlarmState(ctx context.Context, alarmName, stateValue
 			return fmt.Errorf("SetAlarmState failed: %w", err)
 		}
 
-		subject := fmt.Sprintf("ALARM: %q in %s", alarmName, defaultRegion)
+		subject := fmt.Sprintf("ALARM: %q in %s", alarmName, s.region)
 
 		for _, arn := range actionARNs {
 			// Best-effort delivery: log but do not fail the SetAlarmState
@@ -568,7 +576,7 @@ func (s *MemoryStorage) buildAlarmNotification(alarm *Alarm, previousState strin
 		NewStateReason:   alarm.StateReason,
 		OldStateValue:    previousState,
 		StateChangeTime:  alarm.StateUpdatedAt,
-		Region:           defaultRegion,
+		Region:           s.region,
 		AlarmARN:         alarm.AlarmARN,
 		Trigger: alarmNotificationTrigger{
 			MetricName:         alarm.MetricName,

--- a/internal/service/cloudwatchlogs/storage.go
+++ b/internal/service/cloudwatchlogs/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -70,14 +71,21 @@ type MemoryStorage struct {
 	mu        sync.RWMutex             `json:"-"`
 	LogGroups map[string]*LogGroupData `json:"logGroups"`
 	baseURL   string
+	region    string
 	dataDir   string
 }
 
 // NewMemoryStorage creates a new in-memory CloudWatch Logs storage.
 func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		LogGroups: make(map[string]*LogGroupData),
 		baseURL:   baseURL,
+		region:    region,
 	}
 	for _, o := range opts {
 		o(s)
@@ -720,13 +728,13 @@ func findLogStreamStartIndex(streams []LogStreamResponse, nextToken string) int 
 // buildLogGroupARN builds an ARN for a log group.
 func (m *MemoryStorage) buildLogGroupARN(name string) string {
 	return fmt.Sprintf("arn:aws:logs:%s:%s:log-group:%s",
-		defaultRegion, defaultAccountID, name)
+		m.region, defaultAccountID, name)
 }
 
 // buildLogStreamARN builds an ARN for a log stream.
 func (m *MemoryStorage) buildLogStreamARN(groupName, streamName string) string {
 	return fmt.Sprintf("arn:aws:logs:%s:%s:log-group:%s:log-stream:%s",
-		defaultRegion, defaultAccountID, groupName, streamName)
+		m.region, defaultAccountID, groupName, streamName)
 }
 
 // filterEventsByTime filters events by time range.

--- a/internal/service/codeconnections/storage.go
+++ b/internal/service/codeconnections/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -11,6 +12,9 @@ import (
 
 	"github.com/sivchari/kumo/internal/storage"
 )
+
+// Default values.
+const defaultRegion = "us-east-1"
 
 // Error codes for CodeConnections.
 const (
@@ -75,12 +79,17 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Connections:     make(map[string]*Connection),
 		Hosts:           make(map[string]*Host),
 		RepositoryLinks: make(map[string]*RepositoryLink),
 		accountID:       "000000000000",
-		region:          "us-east-1",
+		region:          region,
 	}
 	for _, o := range opts {
 		o(s)

--- a/internal/service/cognito/storage.go
+++ b/internal/service/cognito/storage.go
@@ -25,6 +25,9 @@ const (
 	errInvalidParameter       = "InvalidParameterException"
 )
 
+// Default values.
+const defaultMfaConfiguration = "OFF"
+
 // Storage defines the Cognito storage interface.
 type Storage interface {
 	// User Pool operations.
@@ -691,7 +694,7 @@ func (s *MemoryStorage) GetUserPoolMfaConfig(_ context.Context, userPoolID strin
 
 	cfg, ok := s.MfaConfigs[userPoolID]
 	if !ok {
-		return &MfaConfig{MfaConfiguration: "OFF"}, nil
+		return &MfaConfig{MfaConfiguration: defaultMfaConfiguration}, nil
 	}
 
 	return cfg, nil

--- a/internal/service/configservice/storage.go
+++ b/internal/service/configservice/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -71,11 +72,16 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Recorders:        make(map[string]*ConfigurationRecorder),
 		RecorderStatuses: make(map[string]*ConfigurationRecorderStatus),
 		Rules:            make(map[string]*ConfigRule),
-		region:           defaultRegion,
+		region:           region,
 		accountID:        defaultAccountID,
 	}
 	for _, o := range opts {

--- a/internal/service/dlm/storage.go
+++ b/internal/service/dlm/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -62,9 +63,14 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Policies:  make(map[string]*LifecyclePolicy),
-		region:    defaultRegion,
+		region:    region,
 		accountID: defaultAccountID,
 	}
 	for _, o := range opts {

--- a/internal/service/documentdb/storage.go
+++ b/internal/service/documentdb/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -52,14 +53,21 @@ type MemoryStorage struct {
 	mu        sync.RWMutex           `json:"-"`
 	Clusters  map[string]*DBCluster  `json:"clusters"`
 	Instances map[string]*DBInstance `json:"instances"`
+	region    string
 	dataDir   string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Clusters:  make(map[string]*DBCluster),
 		Instances: make(map[string]*DBInstance),
+		region:    region,
 	}
 	for _, o := range opts {
 		o(s)
@@ -158,8 +166,8 @@ func (m *MemoryStorage) CreateDBCluster(_ context.Context, input *CreateDBCluste
 		EngineVersion:       engineVersion,
 		Status:              DBClusterStatusAvailable,
 		MasterUsername:      input.MasterUsername,
-		Endpoint:            fmt.Sprintf("%s.cluster-%s.%s.docdb.amazonaws.com", input.DBClusterIdentifier, generateID(), defaultRegion),
-		ReaderEndpoint:      fmt.Sprintf("%s.cluster-ro-%s.%s.docdb.amazonaws.com", input.DBClusterIdentifier, generateID(), defaultRegion),
+		Endpoint:            fmt.Sprintf("%s.cluster-%s.%s.docdb.amazonaws.com", input.DBClusterIdentifier, generateID(), m.region),
+		ReaderEndpoint:      fmt.Sprintf("%s.cluster-ro-%s.%s.docdb.amazonaws.com", input.DBClusterIdentifier, generateID(), m.region),
 		Port:                port,
 		ClusterCreateTime:   time.Now(),
 		DeletionProtection:  input.DeletionProtection,
@@ -273,7 +281,7 @@ func (m *MemoryStorage) CreateDBInstance(_ context.Context, input *CreateDBInsta
 		InstanceCreateTime:   time.Now(),
 		Tags:                 input.Tags,
 		Endpoint: &Endpoint{
-			Address: fmt.Sprintf("%s.%s.%s.docdb.amazonaws.com", input.DBInstanceIdentifier, generateID(), defaultRegion),
+			Address: fmt.Sprintf("%s.%s.%s.docdb.amazonaws.com", input.DBInstanceIdentifier, generateID(), m.region),
 			Port:    defaultDocDBPort,
 		},
 	}
@@ -358,11 +366,11 @@ func (m *MemoryStorage) DescribeDBInstances(_ context.Context, identifier string
 // Helper functions.
 
 func (m *MemoryStorage) dbClusterArn(identifier string) string {
-	return fmt.Sprintf("arn:aws:docdb:%s:%s:cluster:%s", defaultRegion, defaultAccountID, identifier)
+	return fmt.Sprintf("arn:aws:docdb:%s:%s:cluster:%s", m.region, defaultAccountID, identifier)
 }
 
 func (m *MemoryStorage) dbInstanceArn(identifier string) string {
-	return fmt.Sprintf("arn:aws:docdb:%s:%s:db:%s", defaultRegion, defaultAccountID, identifier)
+	return fmt.Sprintf("arn:aws:docdb:%s:%s:db:%s", m.region, defaultAccountID, identifier)
 }
 
 func generateID() string {

--- a/internal/service/ds/storage.go
+++ b/internal/service/ds/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -12,6 +13,9 @@ import (
 
 	"github.com/sivchari/kumo/internal/storage"
 )
+
+// Default values.
+const defaultRegion = "us-east-1"
 
 // Storage defines the Directory Service storage interface.
 type Storage interface {
@@ -51,10 +55,15 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Directories: make(map[string]*Directory),
 		Snapshots:   make(map[string]*Snapshot),
-		region:      "us-east-1",
+		region:      region,
 		accountID:   "123456789012",
 	}
 	for _, o := range opts {

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -68,6 +69,7 @@ type MemoryStorage struct {
 	Tables      map[string]*tableData `json:"tables"`
 	Tags        map[string][]Tag      `json:"tags,omitempty"`
 	baseURL     string
+	region      string
 	dataDir     string
 	stopTTL     chan struct{}
 	streamStore *streams.Store
@@ -80,10 +82,16 @@ type tableData struct {
 
 // NewMemoryStorage creates a new in-memory DynamoDB storage.
 func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Tables:      make(map[string]*tableData),
 		Tags:        make(map[string][]Tag),
 		baseURL:     baseURL,
+		region:      region,
 		stopTTL:     make(chan struct{}),
 		streamStore: streams.Global,
 	}
@@ -235,7 +243,7 @@ func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) 
 		TableStatus:            "ACTIVE",
 		ItemCount:              0,
 		TableSizeBytes:         0,
-		TableARN:               fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", defaultRegion, defaultAccountID, req.TableName),
+		TableARN:               fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", m.region, defaultAccountID, req.TableName),
 		BillingMode:            billingMode,
 		DeletionProtection:     req.DeletionProtectionEnabled,
 	}
@@ -1808,7 +1816,7 @@ func (m *MemoryStorage) emitStreamEvent(table *Table, eventName streams.Operatio
 	record := &streams.StreamRecord{
 		EventID:        uuid.New().String(),
 		EventName:      eventName,
-		AwsRegion:      defaultRegion,
+		AwsRegion:      m.region,
 		StreamViewType: table.StreamViewType,
 		TableName:      table.Name,
 		StreamARN:      table.LatestStreamArn,

--- a/internal/service/ecr/storage.go
+++ b/internal/service/ecr/storage.go
@@ -6,12 +6,16 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/sivchari/kumo/internal/storage"
 )
+
+// Default values.
+const defaultRegion = "us-east-1"
 
 // Error codes.
 const (
@@ -73,9 +77,14 @@ type repositoryData struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Repositories: make(map[string]*repositoryData),
-		region:       "us-east-1",
+		region:       region,
 		accountID:    "000000000000",
 	}
 	for _, o := range opts {

--- a/internal/service/ecs/storage.go
+++ b/internal/service/ecs/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -70,17 +71,24 @@ type MemoryStorage struct {
 	TaskDefFamilies map[string][]string         `json:"taskDefFamilies"`
 	Tasks           map[string]*Task            `json:"tasks"`
 	Services        map[string]*ServiceResource `json:"services"`
+	region          string
 	dataDir         string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Clusters:        make(map[string]*Cluster),
 		TaskDefinitions: make(map[string]*TaskDefinition),
 		TaskDefFamilies: make(map[string][]string),
 		Tasks:           make(map[string]*Task),
 		Services:        make(map[string]*ServiceResource),
+		region:          region,
 	}
 	for _, o := range opts {
 		o(s)
@@ -165,20 +173,20 @@ func newTimestamp() *Timestamp {
 	return &Timestamp{Time: time.Now()}
 }
 
-func clusterArn(name string) string {
-	return fmt.Sprintf("arn:aws:ecs:%s:%s:cluster/%s", defaultRegion, defaultAccountID, name)
+func (m *MemoryStorage) clusterArn(name string) string {
+	return fmt.Sprintf("arn:aws:ecs:%s:%s:cluster/%s", m.region, defaultAccountID, name)
 }
 
-func taskDefinitionArn(family string, revision int) string {
-	return fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s:%d", defaultRegion, defaultAccountID, family, revision)
+func (m *MemoryStorage) taskDefinitionArn(family string, revision int) string {
+	return fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s:%d", m.region, defaultAccountID, family, revision)
 }
 
-func taskArn(clusterName, taskID string) string {
-	return fmt.Sprintf("arn:aws:ecs:%s:%s:task/%s/%s", defaultRegion, defaultAccountID, clusterName, taskID)
+func (m *MemoryStorage) taskArn(clusterName, taskID string) string {
+	return fmt.Sprintf("arn:aws:ecs:%s:%s:task/%s/%s", m.region, defaultAccountID, clusterName, taskID)
 }
 
-func serviceArn(clusterName, serviceName string) string {
-	return fmt.Sprintf("arn:aws:ecs:%s:%s:service/%s/%s", defaultRegion, defaultAccountID, clusterName, serviceName)
+func (m *MemoryStorage) serviceArn(clusterName, serviceName string) string {
+	return fmt.Sprintf("arn:aws:ecs:%s:%s:service/%s/%s", m.region, defaultAccountID, clusterName, serviceName)
 }
 
 // CreateCluster creates a new ECS cluster.
@@ -191,7 +199,7 @@ func (m *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 		name = "default"
 	}
 
-	arn := clusterArn(name)
+	arn := m.clusterArn(name)
 
 	// Check if cluster already exists.
 	if existing, ok := m.Clusters[arn]; ok {
@@ -306,7 +314,7 @@ func (m *MemoryStorage) RegisterTaskDefinition(_ context.Context, req *RegisterT
 		revision = len(existing) + 1
 	}
 
-	arn := taskDefinitionArn(req.Family, revision)
+	arn := m.taskDefinitionArn(req.Family, revision)
 
 	td := &TaskDefinition{
 		TaskDefinitionArn:       arn,
@@ -434,11 +442,11 @@ func (m *MemoryStorage) createTasks(clusterArn string, td *TaskDefinition, req *
 
 func (m *MemoryStorage) createSingleTask(clusterArn string, td *TaskDefinition, tdArn string, req *RunTaskRequest, launchType string) Task {
 	taskID := generateID()
-	containers := createContainersFromDefinitions(td.ContainerDefinitions)
+	containers := m.createContainersFromDefinitions(td.ContainerDefinitions)
 	clusterName := extractClusterName(clusterArn)
 
 	return Task{
-		TaskArn:           taskArn(clusterName, taskID),
+		TaskArn:           m.taskArn(clusterName, taskID),
 		ClusterArn:        clusterArn,
 		TaskDefinitionArn: tdArn,
 		LastStatus:        statusRunning,
@@ -453,12 +461,12 @@ func (m *MemoryStorage) createSingleTask(clusterArn string, td *TaskDefinition, 
 	}
 }
 
-func createContainersFromDefinitions(defs []ContainerDefinition) []Container {
+func (m *MemoryStorage) createContainersFromDefinitions(defs []ContainerDefinition) []Container {
 	containers := make([]Container, 0, len(defs))
 
 	for i := range defs {
 		containers = append(containers, Container{
-			ContainerArn: fmt.Sprintf("arn:aws:ecs:%s:%s:container/%s", defaultRegion, defaultAccountID, generateID()),
+			ContainerArn: fmt.Sprintf("arn:aws:ecs:%s:%s:container/%s", m.region, defaultAccountID, generateID()),
 			Name:         defs[i].Name,
 			Image:        defs[i].Image,
 			LastStatus:   statusRunning,
@@ -566,7 +574,7 @@ func (m *MemoryStorage) CreateService(_ context.Context, req *CreateServiceReque
 	}
 
 	clusterName := extractClusterName(clusterArn)
-	arn := serviceArn(clusterName, req.ServiceName)
+	arn := m.serviceArn(clusterName, req.ServiceName)
 
 	// Check if service already exists.
 	if _, ok := m.Services[arn]; ok {
@@ -620,7 +628,7 @@ func (m *MemoryStorage) DeleteService(_ context.Context, cluster, service string
 
 	clusterArn := m.resolveClusterArn(cluster)
 	clusterName := extractClusterName(clusterArn)
-	svcArn := serviceArn(clusterName, service)
+	svcArn := m.serviceArn(clusterName, service)
 
 	// Try to find by ARN or name.
 	svc, ok := m.Services[svcArn]
@@ -663,7 +671,7 @@ func (m *MemoryStorage) UpdateService(_ context.Context, req *UpdateServiceReque
 
 	clusterArn := m.resolveClusterArn(req.Cluster)
 	clusterName := extractClusterName(clusterArn)
-	svcArn := serviceArn(clusterName, req.Service)
+	svcArn := m.serviceArn(clusterName, req.Service)
 
 	// Try to find by ARN or name.
 	svc, ok := m.Services[svcArn]
@@ -700,14 +708,14 @@ func (m *MemoryStorage) UpdateService(_ context.Context, req *UpdateServiceReque
 
 func (m *MemoryStorage) resolveClusterArn(cluster string) string {
 	if cluster == "" {
-		return clusterArn("default")
+		return m.clusterArn("default")
 	}
 
 	if strings.HasPrefix(cluster, "arn:") {
 		return cluster
 	}
 
-	return clusterArn(cluster)
+	return m.clusterArn(cluster)
 }
 
 func (m *MemoryStorage) resolveTaskDefinitionArn(taskDefinition string) string {
@@ -718,7 +726,7 @@ func (m *MemoryStorage) resolveTaskDefinitionArn(taskDefinition string) string {
 	// Try family:revision format.
 	parts := strings.Split(taskDefinition, ":")
 	if len(parts) == 2 {
-		return fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s", defaultRegion, defaultAccountID, taskDefinition)
+		return fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s", m.region, defaultAccountID, taskDefinition)
 	}
 
 	// Try to find latest revision.
@@ -726,7 +734,7 @@ func (m *MemoryStorage) resolveTaskDefinitionArn(taskDefinition string) string {
 		return arns[len(arns)-1]
 	}
 
-	return fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s:1", defaultRegion, defaultAccountID, taskDefinition)
+	return fmt.Sprintf("arn:aws:ecs:%s:%s:task-definition/%s:1", m.region, defaultAccountID, taskDefinition)
 }
 
 func extractClusterName(arn string) string {

--- a/internal/service/eks/storage.go
+++ b/internal/service/eks/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -18,6 +19,7 @@ const (
 	statusActive   = "ACTIVE"
 	statusDeleting = "DELETING"
 
+	defaultRegion            = "us-east-1"
 	defaultKubernetesVersion = "1.29"
 	defaultPlatformVersion   = "eks.1"
 )
@@ -62,10 +64,15 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Clusters:   make(map[string]*Cluster),
 		Nodegroups: make(map[string]map[string]*Nodegroup),
-		region:     "us-east-1",
+		region:     region,
 		accountID:  "123456789012",
 	}
 	for _, o := range opts {

--- a/internal/service/elasticache/storage.go
+++ b/internal/service/elasticache/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -49,14 +50,21 @@ type MemoryStorage struct {
 	mu                sync.RWMutex                 `json:"-"`
 	CacheClusters     map[string]*CacheCluster     `json:"cacheClusters"`
 	ReplicationGroups map[string]*ReplicationGroup `json:"replicationGroups"`
+	region            string
 	dataDir           string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		CacheClusters:     make(map[string]*CacheCluster),
 		ReplicationGroups: make(map[string]*ReplicationGroup),
+		region:            region,
 	}
 	for _, o := range opts {
 		o(s)
@@ -147,7 +155,7 @@ func (m *MemoryStorage) buildCacheCluster(input *CreateCacheClusterInput) *Cache
 
 	az := input.PreferredAvailabilityZone
 	if az == "" {
-		az = defaultRegion + "a"
+		az = m.region + "a"
 	}
 
 	port := input.Port
@@ -175,7 +183,7 @@ func (m *MemoryStorage) buildCacheCluster(input *CreateCacheClusterInput) *Cache
 		CacheNodes:                 m.buildCacheNodes(numNodes, az, port, now),
 		SecurityGroups:             buildSecurityGroups(input.SecurityGroupIDs),
 		ConfigurationEndpoint: &Endpoint{
-			Address: fmt.Sprintf("%s.%s.cfg.%s.cache.amazonaws.com", input.CacheClusterID, generateID(), defaultRegion),
+			Address: fmt.Sprintf("%s.%s.cfg.%s.cache.amazonaws.com", input.CacheClusterID, generateID(), m.region),
 			Port:    port,
 		},
 	}
@@ -195,7 +203,7 @@ func (m *MemoryStorage) buildCacheNodes(numNodes int32, az string, port int32, c
 			CustomerAvailabilityZone: az,
 			ParameterGroupStatus:     "in-sync",
 			Endpoint: &Endpoint{
-				Address: fmt.Sprintf("%s.%s.%s.cache.amazonaws.com", nodeID, generateID(), defaultRegion),
+				Address: fmt.Sprintf("%s.%s.%s.cache.amazonaws.com", nodeID, generateID(), m.region),
 				Port:    port,
 			},
 		})
@@ -355,7 +363,7 @@ func (m *MemoryStorage) buildReplicationGroup(input *CreateReplicationGroupInput
 		AutoMinorVersionUpgrade:    input.AutoMinorVersionUpgrade,
 		PreferredMaintenanceWindow: input.PreferredMaintenanceWindow,
 		ConfigurationEndpoint: &Endpoint{
-			Address: fmt.Sprintf("%s.%s.clustercfg.%s.cache.amazonaws.com", input.ReplicationGroupID, generateID(), defaultRegion),
+			Address: fmt.Sprintf("%s.%s.clustercfg.%s.cache.amazonaws.com", input.ReplicationGroupID, generateID(), m.region),
 			Port:    port,
 		},
 		NodeGroups: m.buildNodeGroups(input, port),
@@ -380,11 +388,11 @@ func (m *MemoryStorage) buildNodeGroups(input *CreateReplicationGroupInput, port
 			NodeGroupID: groupID,
 			Status:      ReplicationGroupStatusAvailable,
 			PrimaryEndpoint: &Endpoint{
-				Address: fmt.Sprintf("%s-%s.%s.%s.cache.amazonaws.com", input.ReplicationGroupID, groupID, generateID(), defaultRegion),
+				Address: fmt.Sprintf("%s-%s.%s.%s.cache.amazonaws.com", input.ReplicationGroupID, groupID, generateID(), m.region),
 				Port:    port,
 			},
 			ReaderEndpoint: &Endpoint{
-				Address: fmt.Sprintf("%s-%s-ro.%s.%s.cache.amazonaws.com", input.ReplicationGroupID, groupID, generateID(), defaultRegion),
+				Address: fmt.Sprintf("%s-%s-ro.%s.%s.cache.amazonaws.com", input.ReplicationGroupID, groupID, generateID(), m.region),
 				Port:    port,
 			},
 			NodeGroupMembers: m.buildNodeGroupMembers(input.ReplicationGroupID, groupID, replicas, port),
@@ -412,10 +420,10 @@ func (m *MemoryStorage) buildNodeGroupMembers(rgID, ngID string, replicas, port 
 		members = append(members, NodeGroupMember{
 			CacheClusterID:            clusterID,
 			CacheNodeID:               nodeID,
-			PreferredAvailabilityZone: defaultRegion + "a",
+			PreferredAvailabilityZone: m.region + "a",
 			CurrentRole:               role,
 			ReadEndpoint: &Endpoint{
-				Address: fmt.Sprintf("%s.%s.%s.cache.amazonaws.com", clusterID, generateID(), defaultRegion),
+				Address: fmt.Sprintf("%s.%s.%s.cache.amazonaws.com", clusterID, generateID(), m.region),
 				Port:    port,
 			},
 		})
@@ -472,11 +480,11 @@ func (m *MemoryStorage) DescribeReplicationGroups(_ context.Context, groupID str
 // Helper functions.
 
 func (m *MemoryStorage) cacheClusterArn(clusterID string) string {
-	return fmt.Sprintf("arn:aws:elasticache:%s:%s:cluster:%s", defaultRegion, defaultAccountID, clusterID)
+	return fmt.Sprintf("arn:aws:elasticache:%s:%s:cluster:%s", m.region, defaultAccountID, clusterID)
 }
 
 func (m *MemoryStorage) replicationGroupArn(groupID string) string {
-	return fmt.Sprintf("arn:aws:elasticache:%s:%s:replicationgroup:%s", defaultRegion, defaultAccountID, groupID)
+	return fmt.Sprintf("arn:aws:elasticache:%s:%s:replicationgroup:%s", m.region, defaultAccountID, groupID)
 }
 
 func (m *MemoryStorage) getDefaultPort(engine string) int32 {

--- a/internal/service/elasticbeanstalk/storage.go
+++ b/internal/service/elasticbeanstalk/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -64,14 +65,21 @@ type MemoryStorage struct {
 	mu           sync.RWMutex                       `json:"-"`
 	Applications map[string]*ApplicationDescription `json:"applications"`
 	Environments map[string]*EnvironmentDescription `json:"environments"`
+	region       string
 	dataDir      string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Applications: make(map[string]*ApplicationDescription),
 		Environments: make(map[string]*EnvironmentDescription),
+		region:       region,
 	}
 	for _, o := range opts {
 		o(s)
@@ -154,7 +162,7 @@ func (m *MemoryStorage) CreateApplication(_ context.Context, req *CreateApplicat
 		Description:     req.Description,
 		DateCreated:     now,
 		DateUpdated:     now,
-		ApplicationArn:  fmt.Sprintf("arn:aws:elasticbeanstalk:%s:%s:application/%s", defaultRegion, defaultAccountID, req.ApplicationName),
+		ApplicationArn:  fmt.Sprintf("arn:aws:elasticbeanstalk:%s:%s:application/%s", m.region, defaultAccountID, req.ApplicationName),
 	}
 
 	m.Applications[req.ApplicationName] = app
@@ -250,7 +258,7 @@ func (m *MemoryStorage) CreateEnvironment(_ context.Context, req *CreateEnvironm
 		Health:            "Green",
 		DateCreated:       now,
 		DateUpdated:       now,
-		EnvironmentArn:    fmt.Sprintf("arn:aws:elasticbeanstalk:%s:%s:environment/%s/%s", defaultRegion, defaultAccountID, req.ApplicationName, req.EnvironmentName),
+		EnvironmentArn:    fmt.Sprintf("arn:aws:elasticbeanstalk:%s:%s:environment/%s/%s", m.region, defaultAccountID, req.ApplicationName, req.EnvironmentName),
 	}
 
 	m.Environments[req.EnvironmentName] = env

--- a/internal/service/elbv2/storage.go
+++ b/internal/service/elbv2/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -74,16 +75,23 @@ type MemoryStorage struct {
 	TargetGroups  map[string]*TargetGroup  `json:"targetGroups"`  // keyed by ARN
 	Listeners     map[string]*Listener     `json:"listeners"`     // keyed by ARN
 	Targets       map[string][]Target      `json:"targets"`       // keyed by targetGroupArn
+	region        string
 	dataDir       string
 }
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		LoadBalancers: make(map[string]*LoadBalancer),
 		TargetGroups:  make(map[string]*TargetGroup),
 		Listeners:     make(map[string]*Listener),
 		Targets:       make(map[string][]Target),
+		region:        region,
 	}
 	for _, o := range opts {
 		o(s)
@@ -220,13 +228,13 @@ func (m *MemoryStorage) checkDuplicateLoadBalancerName(name string) error {
 func (m *MemoryStorage) buildLoadBalancer(req *CreateLoadBalancerRequest, defaults loadBalancerDefaults) *LoadBalancer {
 	lbID := uuid.New().String()[:17]
 	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:loadbalancer/%s/%s/%s",
-		defaultRegion, defaultAccountID, defaults.lbType[:3], req.Name, lbID)
-	dnsName := fmt.Sprintf("%s-%s.%s.elb.amazonaws.com", req.Name, lbID[:8], defaultRegion)
+		m.region, defaultAccountID, defaults.lbType[:3], req.Name, lbID)
+	dnsName := fmt.Sprintf("%s-%s.%s.elb.amazonaws.com", req.Name, lbID[:8], m.region)
 
 	azs := make([]AvailabilityZone, 0, len(req.Subnets))
 	for i, subnet := range req.Subnets {
 		azs = append(azs, AvailabilityZone{
-			ZoneName: fmt.Sprintf("%s%c", defaultRegion, 'a'+byte(i%3)),
+			ZoneName: fmt.Sprintf("%s%c", m.region, 'a'+byte(i%3)),
 			SubnetID: subnet,
 		})
 	}
@@ -412,7 +420,7 @@ func (m *MemoryStorage) checkDuplicateTargetGroupName(name string) error {
 func (m *MemoryStorage) buildTargetGroup(req *CreateTargetGroupRequest, defaults *targetGroupDefaults) *TargetGroup {
 	tgID := uuid.New().String()[:17]
 	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:targetgroup/%s/%s",
-		defaultRegion, defaultAccountID, req.Name, tgID)
+		m.region, defaultAccountID, req.Name, tgID)
 
 	return &TargetGroup{
 		TargetGroupArn:             arn,
@@ -584,7 +592,7 @@ func (m *MemoryStorage) CreateListener(_ context.Context, req *CreateListenerReq
 	lbType := lb.Type[:3]
 
 	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:listener/%s/%s/%s/%s",
-		defaultRegion, defaultAccountID, lbType, lb.LoadBalancerName, lbID, listenerID)
+		m.region, defaultAccountID, lbType, lb.LoadBalancerName, lbID, listenerID)
 
 	listener := &Listener{
 		ListenerArn:     arn,

--- a/internal/service/emrserverless/storage.go
+++ b/internal/service/emrserverless/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -125,9 +126,17 @@ func (m *MemoryStorage) Close() error {
 }
 
 const (
-	accountID = "123456789012"
-	region    = "us-east-1"
+	accountID     = "123456789012"
+	defaultRegion = "us-east-1"
 )
+
+var region = defaultRegion //nolint:gochecknoglobals // set once at init
+
+func init() {
+	if v := os.Getenv("AWS_DEFAULT_REGION"); v != "" {
+		region = v
+	}
+}
 
 // generateApplicationID generates a unique application ID.
 func generateApplicationID() string {

--- a/internal/service/finspace/storage.go
+++ b/internal/service/finspace/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"os"
 	"sync"
 	"time"
 
@@ -18,6 +19,7 @@ const (
 	errConflict         = "ConflictException"
 	errValidation       = "ValidationException"
 
+	defaultRegion = "us-east-1"
 	statusCreated = "CREATED"
 )
 
@@ -80,13 +82,18 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Environments: make(map[string]*KxEnvironment),
 		Databases:    make(map[string]*KxDatabase),
 		Users:        make(map[string]*KxUser),
 		Tags:         make(map[string]map[string]string),
 		accountID:    "123456789012",
-		region:       "us-east-1",
+		region:       region,
 	}
 	for _, o := range opts {
 		o(s)

--- a/internal/service/forecast/storage.go
+++ b/internal/service/forecast/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"slices"
 	"sync"
 	"time"
@@ -12,6 +13,9 @@ import (
 
 	"github.com/sivchari/kumo/internal/storage"
 )
+
+// Default values.
+const defaultRegion = "us-east-1"
 
 // Storage defines the interface for Forecast storage operations.
 type Storage interface {
@@ -71,13 +75,18 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Datasets:      make(map[string]*Dataset),
 		DatasetGroups: make(map[string]*DatasetGroup),
 		Predictors:    make(map[string]*Predictor),
 		Forecasts:     make(map[string]*Forecast),
 		accountID:     "123456789012",
-		region:        "us-east-1",
+		region:        region,
 	}
 	for _, o := range opts {
 		o(s)

--- a/internal/service/gamelift/storage.go
+++ b/internal/service/gamelift/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -108,12 +109,17 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Builds:         make(map[string]*Build),
 		Fleets:         make(map[string]*Fleet),
 		GameSessions:   make(map[string]*GameSession),
 		PlayerSessions: make(map[string]*PlayerSession),
-		region:         defaultRegion,
+		region:         region,
 		accountID:      defaultAccountID,
 	}
 	for _, o := range opts {

--- a/internal/service/kafka/storage.go
+++ b/internal/service/kafka/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +18,7 @@ const (
 	statusActive   = "ACTIVE"
 	statusDeleting = "DELETING"
 
+	defaultRegion       = "us-east-1"
 	defaultKafkaVersion = "3.6.0"
 	defaultInstanceType = "kafka.m5.large"
 	defaultVolumeSize   = 100
@@ -67,9 +69,14 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Clusters:  make(map[string]*ClusterInfo),
-		region:    "us-east-1",
+		region:    region,
 		accountID: "123456789012",
 	}
 	for _, o := range opts {

--- a/internal/service/kinesis/storage.go
+++ b/internal/service/kinesis/storage.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"os"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -26,6 +27,7 @@ const (
 
 // Default values.
 const (
+	defaultRegion           = "us-east-1"
 	defaultShardCount       = 1
 	defaultRetentionHours   = 24
 	maxRecordsPerGet        = 10000
@@ -101,10 +103,15 @@ type shardIteratorData struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Streams:        make(map[string]*StreamData),
 		shardIterators: make(map[string]*shardIteratorData),
-		region:         "us-east-1",
+		region:         region,
 		accountID:      "000000000000",
 	}
 	for _, o := range opts {

--- a/internal/service/kms/handlers.go
+++ b/internal/service/kms/handlers.go
@@ -10,6 +10,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// Default values.
+const defaultKeyPolicyName = "default"
+
 // handlerFunc is a type alias for handler functions.
 type handlerFunc func(http.ResponseWriter, *http.Request)
 
@@ -455,7 +458,7 @@ func (s *Service) GetKeyPolicy(w http.ResponseWriter, r *http.Request) {
 
 	writeKMSResponse(w, &GetKeyPolicyResponse{
 		Policy:     policy,
-		PolicyName: "default",
+		PolicyName: defaultKeyPolicyName,
 	})
 }
 
@@ -495,7 +498,7 @@ func (s *Service) ListKeyPolicies(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeKMSResponse(w, &ListKeyPoliciesResponse{
-		PolicyNames: []string{"default"},
+		PolicyNames: []string{defaultKeyPolicyName},
 		Truncated:   false,
 	})
 }

--- a/internal/service/kms/storage.go
+++ b/internal/service/kms/storage.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 	"time"
 
@@ -117,10 +118,15 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Keys:    make(map[string]*Key),
 		Aliases: make(map[string]*Alias),
-		region:  defaultRegion,
+		region:  region,
 	}
 	for _, o := range opts {
 		o(s)

--- a/internal/service/lambda/storage.go
+++ b/internal/service/lambda/storage.go
@@ -6,11 +6,15 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/sivchari/kumo/internal/storage"
 )
+
+// Default values.
+const defaultRegion = "us-east-1"
 
 // Storage defines the Lambda storage interface.
 type Storage interface {
@@ -75,11 +79,16 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Functions:           make(map[string]*Function),
 		EventSourceMappings: make(map[string]*EventSourceMapping),
 		baseURL:             baseURL,
-		region:              "us-east-1",
+		region:              region,
 		accountID:           "000000000000",
 	}
 	for _, o := range opts {

--- a/internal/service/location/storage.go
+++ b/internal/service/location/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"os"
 	"sync"
 	"time"
 
@@ -99,13 +100,18 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Maps:                make(map[string]*MapResource),
 		PlaceIndexes:        make(map[string]*PlaceIndex),
 		RouteCalculators:    make(map[string]*RouteCalculator),
 		GeofenceCollections: make(map[string]*GeofenceCollection),
 		Trackers:            make(map[string]*Tracker),
-		region:              defaultRegion,
+		region:              region,
 		accountID:           defaultAccountID,
 	}
 	for _, o := range opts {

--- a/internal/service/macie2/storage.go
+++ b/internal/service/macie2/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"sync"
 	"time"
@@ -105,13 +106,18 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		AllowLists:            make(map[string]*AllowList),
 		ClassificationJobs:    make(map[string]*ClassificationJob),
 		CustomDataIdentifiers: make(map[string]*CustomDataIdentifier),
 		FindingsFilters:       make(map[string]*FindingsFilter),
 		Findings:              make(map[string]*Finding),
-		region:                defaultRegion,
+		region:                region,
 		accountID:             defaultAccountID,
 	}
 	for _, o := range opts {

--- a/internal/service/mq/storage.go
+++ b/internal/service/mq/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -12,6 +13,9 @@ import (
 
 	"github.com/sivchari/kumo/internal/storage"
 )
+
+// Default values.
+const defaultRegion = "us-east-1"
 
 // Storage defines the MQ storage interface.
 type Storage interface {
@@ -52,10 +56,15 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Brokers:        make(map[string]*Broker),
 		Configurations: make(map[string]*Configuration),
-		region:         "us-east-1",
+		region:         region,
 		accountID:      "123456789012",
 	}
 	for _, o := range opts {

--- a/internal/service/organizations/storage.go
+++ b/internal/service/organizations/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -124,13 +125,18 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Accounts:            make(map[string]*Account),
 		OrganizationalUnits: make(map[string]*OrganizationalUnit),
 		OuParents:           make(map[string]string),
 		Policies:            make(map[string]*Policy),
 		PolicyAttachments:   make(map[string]map[string]bool),
-		region:              defaultRegion,
+		region:              region,
 		accountID:           defaultAccountID,
 	}
 

--- a/internal/service/pipes/storage.go
+++ b/internal/service/pipes/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -133,9 +134,17 @@ func (m *MemoryStorage) Close() error {
 }
 
 const (
-	accountID = "123456789012"
-	region    = "us-east-1"
+	accountID     = "123456789012"
+	defaultRegion = "us-east-1"
 )
+
+var region = defaultRegion //nolint:gochecknoglobals // set once at init
+
+func init() {
+	if v := os.Getenv("AWS_DEFAULT_REGION"); v != "" {
+		region = v
+	}
+}
 
 // generatePipeArn generates an ARN for a pipe.
 func generatePipeArn(name string) string {

--- a/internal/service/route53resolver/storage.go
+++ b/internal/service/route53resolver/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -18,6 +19,7 @@ const (
 	errResourceInUse    = "ResourceInUseException"
 	errInvalidParameter = "InvalidParameterException"
 
+	defaultRegion  = "us-east-1"
 	statusDeleting = "DELETING"
 )
 
@@ -70,12 +72,17 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Endpoints:    make(map[string]*ResolverEndpoint),
 		Rules:        make(map[string]*ResolverRule),
 		Associations: make(map[string]*ResolverRuleAssociation),
 		accountID:    "123456789012",
-		region:       "us-east-1",
+		region:       region,
 	}
 	for _, o := range opts {
 		o(s)

--- a/internal/service/s3control/storage.go
+++ b/internal/service/s3control/storage.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/sivchari/kumo/internal/storage"
 )
+
+// Default values.
+const defaultRegion = "us-east-1"
 
 // Storage is the interface for S3 Control storage operations.
 type Storage interface {
@@ -44,14 +48,21 @@ type MemoryStorage struct {
 	mu                 sync.RWMutex                               `json:"-"`
 	PublicAccessBlocks map[string]*PublicAccessBlockConfiguration `json:"publicAccessBlocks"` // key: accountID
 	AccessPoints       map[string]map[string]*AccessPoint         `json:"accessPoints"`       // key: accountID -> name -> AccessPoint
+	region             string
 	dataDir            string
 }
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		PublicAccessBlocks: make(map[string]*PublicAccessBlockConfiguration),
 		AccessPoints:       make(map[string]map[string]*AccessPoint),
+		region:             region,
 	}
 	for _, o := range opts {
 		o(s)
@@ -170,7 +181,7 @@ func (s *MemoryStorage) CreateAccessPoint(_ context.Context, accountID string, a
 
 	// Generate ARN and alias
 	ap.AccountID = accountID
-	ap.AccessPointArn = fmt.Sprintf("arn:aws:s3:%s:%s:accesspoint/%s", "us-east-1", accountID, ap.Name)
+	ap.AccessPointArn = fmt.Sprintf("arn:aws:s3:%s:%s:accesspoint/%s", s.region, accountID, ap.Name)
 	ap.Alias = fmt.Sprintf("%s-%s-s3alias", ap.Name, accountID[:12])
 
 	if ap.VpcConfiguration != nil {
@@ -180,7 +191,7 @@ func (s *MemoryStorage) CreateAccessPoint(_ context.Context, accountID string, a
 	}
 
 	ap.Endpoints = map[string]string{
-		"https": fmt.Sprintf("https://%s-%s.s3-accesspoint.us-east-1.amazonaws.com", ap.Name, accountID),
+		"https": fmt.Sprintf("https://%s-%s.s3-accesspoint.%s.amazonaws.com", ap.Name, accountID, s.region),
 	}
 
 	s.AccessPoints[accountID][ap.Name] = ap

--- a/internal/service/sagemaker/storage.go
+++ b/internal/service/sagemaker/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -85,12 +86,17 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		NotebookInstances: make(map[string]*NotebookInstance),
 		TrainingJobs:      make(map[string]*TrainingJob),
 		Models:            make(map[string]*Model),
 		Endpoints:         make(map[string]*Endpoint),
-		region:            defaultRegion,
+		region:            region,
 		accountID:         defaultAccountID,
 	}
 	for _, o := range opts {

--- a/internal/service/scheduler/storage.go
+++ b/internal/service/scheduler/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -69,10 +70,15 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	ms := &MemoryStorage{
 		Schedules:      make(map[string]*Schedule),
 		ScheduleGroups: make(map[string]*ScheduleGroup),
-		region:         defaultRegion,
+		region:         region,
 		accountID:      defaultAccountID,
 	}
 
@@ -87,7 +93,7 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	// Create default schedule group.
 	ms.ScheduleGroups[defaultGroupName] = &ScheduleGroup{
 		Name:         defaultGroupName,
-		ARN:          generateScheduleGroupARN(defaultRegion, defaultAccountID, defaultGroupName),
+		ARN:          generateScheduleGroupARN(ms.region, defaultAccountID, defaultGroupName),
 		State:        ScheduleGroupStateActive,
 		CreationDate: time.Now(),
 	}

--- a/internal/service/securitylake/storage.go
+++ b/internal/service/securitylake/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"slices"
 	"sync"
 	"time"
@@ -18,6 +19,7 @@ const (
 	errConflict         = "ConflictException"
 	errValidation       = "ValidationException"
 
+	defaultRegion   = "us-east-1"
 	statusCompleted = "COMPLETED"
 	statusActive    = "ACTIVE"
 )
@@ -78,13 +80,18 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		DataLakes:   make(map[string]*DataLake),
 		Subscribers: make(map[string]*Subscriber),
 		LogSources:  make(map[string]*LogSource),
 		Tags:        make(map[string][]*Tag),
 		accountID:   "123456789012",
-		region:      "us-east-1",
+		region:      region,
 	}
 	for _, o := range opts {
 		o(s)

--- a/internal/service/servicequotas/storage.go
+++ b/internal/service/servicequotas/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -92,12 +93,17 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new MemoryStorage with predefined services and quotas.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Services:      make(map[string]*ServiceInfo),
 		Quotas:        make(map[string]map[string]*ServiceQuota),
 		DefaultQuotas: make(map[string]map[string]*ServiceQuota),
 		Requests:      make(map[string]*QuotaChangeRequest),
-		region:        defaultRegion,
+		region:        region,
 		accountID:     defaultAccountID,
 	}
 

--- a/internal/service/sfn/handlers.go
+++ b/internal/service/sfn/handlers.go
@@ -9,6 +9,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// Validation result values.
+const validationResultOK = "OK"
+
 // handlerFunc is a type alias for handler functions.
 type handlerFunc func(http.ResponseWriter, *http.Request)
 
@@ -420,7 +423,7 @@ func (s *Service) SendTaskHeartbeat(w http.ResponseWriter, _ *http.Request) {
 // shape check.
 func (s *Service) ValidateStateMachineDefinition(w http.ResponseWriter, _ *http.Request) {
 	writeResponse(w, ValidateStateMachineDefinitionResponse{
-		Result:      "OK",
+		Result:      validationResultOK,
 		Diagnostics: []validateDiagnostic{},
 	})
 }

--- a/internal/service/ssm/storage.go
+++ b/internal/service/ssm/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -11,6 +12,9 @@ import (
 
 	"github.com/sivchari/kumo/internal/storage"
 )
+
+// Default values.
+const defaultRegion = "us-east-1"
 
 // Storage defines the SSM Parameter Store storage interface.
 type Storage interface {
@@ -54,10 +58,15 @@ type MemoryStorage struct {
 
 // NewMemoryStorage creates a new in-memory storage.
 func NewMemoryStorage(opts ...Option) *MemoryStorage {
+	region := os.Getenv("AWS_DEFAULT_REGION")
+	if region == "" {
+		region = defaultRegion
+	}
+
 	s := &MemoryStorage{
 		Parameters: make(map[string]*Parameter),
 		Tags:       make(map[string][]Tag),
-		region:     "us-east-1",
+		region:     region,
 		accountID:  "000000000000",
 	}
 	for _, o := range opts {


### PR DESCRIPTION
## Summary
- Add `AWS_DEFAULT_REGION` env override to all services that default to `us-east-1`
- Extract magic strings (`OK`, `OFF`, `default`) to package-level constants
- Closes #750

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `make lint` passes (0 issues)
- [x] `go test -race -shuffle=on ./...` passes