### PR TITLE
fix(ci): improve fuzz workflow and fix dynamodbstreams golden test

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -5,6 +5,10 @@ on:
     - cron: '0 18 * * *' # UTC 18:00 = JST 3:00
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   fuzz:
     name: Fuzz tests
@@ -15,4 +19,14 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Run fuzz tests
+        id: fuzz
         run: make test-fuzz
+      - name: Create issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Fuzz test failure on $(date -u +%Y-%m-%d)" \
+            --body "Daily fuzz test failed. See [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details." \
+            --label bug

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,12 @@ test-integration:
 	go test -C test -v -tags=integration ./integration/...
 
 test-fuzz:
-	go test -fuzz=FuzzParseByteRangeInvariants -fuzztime=60s ./internal/service/s3/...
-	go test -fuzz=FuzzParseCopySourceAndRangeNoPanic -fuzztime=60s ./internal/service/s3/...
-	go test -fuzz=FuzzConditionExpressionNoPanic -fuzztime=60s ./internal/service/dynamodb/...
-	go test -fuzz=FuzzAttributeValueJSONRoundTrip -fuzztime=60s ./internal/service/dynamodb/...
+	@grep -rl '^func Fuzz' internal/ | xargs -I{} dirname {} | sort -u | while read pkg; do \
+		grep -oh 'func \(Fuzz[A-Za-z]*\)' "$$pkg"/*_test.go | sed 's/func //' | while read fn; do \
+			echo "=== fuzzing $$fn in $$pkg ==="; \
+			go test -fuzz="$$fn" -fuzztime=60s "./$$pkg/..." || exit 1; \
+		done; \
+	done
 
 test-helm-e2e:
 	bash test/e2e/helm-e2e.sh

--- a/test/integration/dynamodbstreams_test.go
+++ b/test/integration/dynamodbstreams_test.go
@@ -87,6 +87,7 @@ func TestDynamoDBStreams_DescribeStream(t *testing.T) {
 
 	golden.New(t, golden.WithIgnoreFields(
 		"ResultMetadata", "StreamArn", "StreamLabel", "CreationRequestDateTime",
+		"StartingSequenceNumber",
 	)).Assert(t.Name(), describeOutput)
 }
 

--- a/test/integration/testdata/dynamodbstreams_test_TestDynamoDBStreams_DescribeStream_TestDynamoDBStreams_DescribeStream.golden.go
+++ b/test/integration/testdata/dynamodbstreams_test_TestDynamoDBStreams_DescribeStream_TestDynamoDBStreams_DescribeStream.golden.go
@@ -1,6 +1,6 @@
 {
   "StreamDescription": {
-    "CreationRequestDateTime": "2026-05-18T15:45:55Z",
+    "CreationRequestDateTime": "2026-05-19T02:24:12Z",
     "KeySchema": [
       {
         "AttributeName": "pk",
@@ -18,8 +18,8 @@
         "ShardId": "shardId-000000000000"
       }
     ],
-    "StreamArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-streams-describe/stream/2026-05-19T00:45:55.479",
-    "StreamLabel": "2026-05-19T00:45:55.479",
+    "StreamArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-streams-describe/stream/2026-05-19T11:24:12.960",
+    "StreamLabel": "2026-05-19T11:24:12.960",
     "StreamStatus": "ENABLED",
     "StreamViewType": "NEW_AND_OLD_IMAGES",
     "TableName": "test-streams-describe"

--- a/test/integration/testdata/dynamodbstreams_test_TestDynamoDBStreams_GetShardIteratorAndGetRecords_TestDynamoDBStreams_GetShardIteratorAndGetRecords_records.golden.go
+++ b/test/integration/testdata/dynamodbstreams_test_TestDynamoDBStreams_GetShardIteratorAndGetRecords_TestDynamoDBStreams_GetShardIteratorAndGetRecords_records.golden.go
@@ -1,10 +1,10 @@
 {
-  "NextShardIterator": "YXJuOmF3czpkeW5hbW9kYjp1cy1lYXN0LTE6MDAwMDAwMDAwMDAwOnRhYmxlL3Rlc3Qtc3RyZWFtcy1yZWNvcmRzL3N0cmVhbS8yMDI2LTA1LTE5VDAwOjQ1OjU1LjQ4MzpzaGFyZElkLTAwMDAwMDAwMDAwMDoxOjE3NzkxMTkxNTU1ODcwODgwMDA=",
+  "NextShardIterator": "YXJuOmF3czpkeW5hbW9kYjp1cy1lYXN0LTE6MDAwMDAwMDAwMDAwOnRhYmxlL3Rlc3Qtc3RyZWFtcy1yZWNvcmRzL3N0cmVhbS8yMDI2LTA1LTE5VDExOjI0OjEyLjk2NDpzaGFyZElkLTAwMDAwMDAwMDAwMDoxOjE3NzkxNTc0NTMwNjg1MzgwMDA=",
   "Records": [
     {
       "AwsRegion": "us-east-1",
       "Dynamodb": {
-        "ApproximateCreationDateTime": "2026-05-18T15:45:55Z",
+        "ApproximateCreationDateTime": "2026-05-19T02:24:12Z",
         "Keys": {
           "pk": {
             "Value": "stream-item-1"
@@ -23,7 +23,7 @@
         "SizeBytes": 100,
         "StreamViewType": "NEW_AND_OLD_IMAGES"
       },
-      "EventID": "6bf2a4e8-cb18-4e56-8b94-de762eb3c90f",
+      "EventID": "09b68334-456d-45e6-81a6-e192ccbb3587",
       "EventName": "INSERT",
       "EventSource": "aws:dynamodb",
       "EventVersion": "1.1",

--- a/test/integration/testdata/dynamodbstreams_test_TestDynamoDBStreams_MultipleOperations_TestDynamoDBStreams_MultipleOperations_records.golden.go
+++ b/test/integration/testdata/dynamodbstreams_test_TestDynamoDBStreams_MultipleOperations_TestDynamoDBStreams_MultipleOperations_records.golden.go
@@ -1,10 +1,10 @@
 {
-  "NextShardIterator": "YXJuOmF3czpkeW5hbW9kYjp1cy1lYXN0LTE6MDAwMDAwMDAwMDAwOnRhYmxlL3Rlc3Qtc3RyZWFtcy1tdWx0aS1vcHMvc3RyZWFtLzIwMjYtMDUtMTlUMDA6NDU6NTUuNTg4OnNoYXJkSWQtMDAwMDAwMDAwMDAwOjM6MTc3OTExOTE1NTY5Mjk3MzAwMA==",
+  "NextShardIterator": "YXJuOmF3czpkeW5hbW9kYjp1cy1lYXN0LTE6MDAwMDAwMDAwMDAwOnRhYmxlL3Rlc3Qtc3RyZWFtcy1tdWx0aS1vcHMvc3RyZWFtLzIwMjYtMDUtMTlUMTE6MjQ6MTMuMDcxOnNoYXJkSWQtMDAwMDAwMDAwMDAwOjM6MTc3OTE1NzQ1MzE3NDk1ODAwMA==",
   "Records": [
     {
       "AwsRegion": "us-east-1",
       "Dynamodb": {
-        "ApproximateCreationDateTime": "2026-05-18T15:45:55Z",
+        "ApproximateCreationDateTime": "2026-05-19T02:24:13Z",
         "Keys": {
           "pk": {
             "Value": "multi-1"
@@ -23,7 +23,7 @@
         "SizeBytes": 100,
         "StreamViewType": "NEW_AND_OLD_IMAGES"
       },
-      "EventID": "f578ad21-f228-491a-8244-ff018c85d516",
+      "EventID": "ec5d7692-a5fa-4594-8110-2e9d4219d755",
       "EventName": "INSERT",
       "EventSource": "aws:dynamodb",
       "EventVersion": "1.1",
@@ -32,7 +32,7 @@
     {
       "AwsRegion": "us-east-1",
       "Dynamodb": {
-        "ApproximateCreationDateTime": "2026-05-18T15:45:55Z",
+        "ApproximateCreationDateTime": "2026-05-19T02:24:13Z",
         "Keys": {
           "pk": {
             "Value": "multi-1"
@@ -58,7 +58,7 @@
         "SizeBytes": 100,
         "StreamViewType": "NEW_AND_OLD_IMAGES"
       },
-      "EventID": "a4aee6c8-e2d5-42d7-84a2-79acd07a3f8a",
+      "EventID": "ac8f7794-75c1-44e9-bd7d-497b73343b91",
       "EventName": "MODIFY",
       "EventSource": "aws:dynamodb",
       "EventVersion": "1.1",
@@ -67,7 +67,7 @@
     {
       "AwsRegion": "us-east-1",
       "Dynamodb": {
-        "ApproximateCreationDateTime": "2026-05-18T15:45:55Z",
+        "ApproximateCreationDateTime": "2026-05-19T02:24:13Z",
         "Keys": {
           "pk": {
             "Value": "multi-1"
@@ -86,7 +86,7 @@
         "SizeBytes": 100,
         "StreamViewType": "NEW_AND_OLD_IMAGES"
       },
-      "EventID": "5b5be5a8-ab7d-4e17-aa23-7fcdc0474113",
+      "EventID": "2aa3cf53-442f-416d-845f-e04d692420cb",
       "EventName": "REMOVE",
       "EventSource": "aws:dynamodb",
       "EventVersion": "1.1",


### PR DESCRIPTION
## Summary
- Auto-discover fuzz functions in `make test-fuzz` instead of hardcoding each function name
- Create GitHub issue automatically when daily fuzz test fails
- Add `StartingSequenceNumber` to dynamodbstreams golden test ignore fields
- Update CLAUDE.md with golden test ignore rules

## Test plan
- [x] make lint passes
- [x] make test passes
- [x] Integration test builds