### PR TITLE
feat(cloudfront): Signed Cookie / Signed URL verification on Edge proxy

### DIFF
--- a/internal/service/cloudfront/edge.go
+++ b/internal/service/cloudfront/edge.go
@@ -268,6 +268,10 @@ func (s *Service) Edge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !s.checkEdgeSigning(w, r, dist) {
+		return
+	}
+
 	originURL, ok := edgeOriginURL(dist, r.PathValue("path"), r.URL.RawQuery)
 	if !ok {
 		http.Error(w, "distribution has no usable origin", http.StatusServiceUnavailable)
@@ -640,7 +644,7 @@ func edgeOriginURL(dist *Distribution, path, rawQuery string) (string, bool) {
 		full = customOriginURL(&o, path)
 	default:
 		// No config block — assume HTTPS to the bare DomainName.
-		full = "https://" + o.DomainName + o.OriginPath + "/" + path
+		full = schemeHTTPS + "://" + o.DomainName + o.OriginPath + "/" + path
 	}
 
 	if rawQuery != "" {
@@ -676,19 +680,19 @@ func selectOrigin(dist *Distribution) (Origin, bool) {
 
 // customOriginURL builds the URL for an HTTP(S) custom origin.
 func customOriginURL(o *Origin, path string) string {
-	scheme := "https"
+	scheme := schemeHTTPS
 	host := o.DomainName
 
 	if o.CustomOriginConfig != nil {
 		switch o.CustomOriginConfig.OriginProtocolPolicy {
 		case "http-only":
-			scheme = "http"
+			scheme = schemeHTTP
 
 			if o.CustomOriginConfig.HTTPPort > 0 && o.CustomOriginConfig.HTTPPort != 80 {
 				host = o.DomainName + ":" + strconv.Itoa(o.CustomOriginConfig.HTTPPort)
 			}
 		case "https-only", "match-viewer":
-			scheme = "https"
+			scheme = schemeHTTPS
 		}
 	}
 

--- a/internal/service/cloudfront/edge_signing.go
+++ b/internal/service/cloudfront/edge_signing.go
@@ -1,0 +1,395 @@
+package cloudfront
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha1" //nolint:gosec // CloudFront uses RSA-SHA1 for signed URL/cookie verification.
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	schemeHTTPS = "https"
+	schemeHTTP  = "http"
+)
+
+// signedCredentials holds the three components needed to verify a
+// CloudFront signed request (cookie or URL).
+type signedCredentials struct {
+	Policy    string // CF-Base64-encoded custom policy JSON, or "" for canned
+	Signature string // CF-Base64-encoded RSA-SHA1 signature
+	KeyPairID string // ID of the public key to use for verification
+	Expires   int64  // Unix epoch for canned policy (from Expires param)
+}
+
+// cfPolicy is the JSON structure of a CloudFront access policy.
+//
+//nolint:tagliatelle // AWS CloudFront policy JSON uses PascalCase keys.
+type cfPolicy struct {
+	Statement []cfStatement `json:"Statement"`
+}
+
+//nolint:tagliatelle // AWS CloudFront policy JSON uses PascalCase keys.
+type cfStatement struct {
+	Resource  string      `json:"Resource"`
+	Condition cfCondition `json:"Condition"`
+}
+
+//nolint:tagliatelle // AWS CloudFront policy JSON uses PascalCase keys.
+type cfCondition struct {
+	DateLessThan    *cfEpoch  `json:"DateLessThan,omitempty"`
+	DateGreaterThan *cfEpoch  `json:"DateGreaterThan,omitempty"`
+	IPAddress       *cfIPAddr `json:"IpAddress,omitempty"`
+}
+
+//nolint:tagliatelle // AWS CloudFront policy JSON uses PascalCase keys.
+type cfEpoch struct {
+	EpochTime int64 `json:"AWS:EpochTime"`
+}
+
+//nolint:tagliatelle // AWS CloudFront policy JSON uses PascalCase keys.
+type cfIPAddr struct {
+	SourceIP string `json:"AWS:SourceIp"`
+}
+
+// extractSignedCredentials tries to find signed credentials first in
+// cookies, then in query parameters. Returns nil if no credentials
+// are present.
+func extractSignedCredentials(r *http.Request) *signedCredentials {
+	if creds := extractFromCookies(r); creds != nil {
+		return creds
+	}
+
+	return extractFromQuery(r)
+}
+
+func extractFromCookies(r *http.Request) *signedCredentials {
+	sig := cookieValue(r, "CloudFront-Signature")
+	kid := cookieValue(r, "CloudFront-Key-Pair-Id")
+
+	if sig == "" || kid == "" {
+		return nil
+	}
+
+	return &signedCredentials{
+		Policy:    cookieValue(r, "CloudFront-Policy"),
+		Signature: sig,
+		KeyPairID: kid,
+	}
+}
+
+func extractFromQuery(r *http.Request) *signedCredentials {
+	q := r.URL.Query()
+	sig := q.Get("Signature")
+	kid := q.Get("Key-Pair-Id")
+
+	if sig == "" || kid == "" {
+		return nil
+	}
+
+	creds := &signedCredentials{
+		Signature: sig,
+		KeyPairID: kid,
+	}
+
+	if policy := q.Get("Policy"); policy != "" {
+		creds.Policy = policy
+	} else if expires := q.Get("Expires"); expires != "" {
+		exp, err := strconv.ParseInt(expires, 10, 64)
+		if err == nil {
+			creds.Expires = exp
+		}
+	}
+
+	return creds
+}
+
+func cookieValue(r *http.Request, name string) string {
+	c, err := r.Cookie(name)
+	if err != nil {
+		return ""
+	}
+
+	return c.Value
+}
+
+// checkEdgeSigning enforces signed cookie / signed URL verification
+// when the distribution's DefaultCacheBehavior has TrustedKeyGroups
+// enabled. Returns true when the request may proceed (either because
+// signing is not required or the credentials are valid), false when an
+// error response has already been written to w.
+func (s *Service) checkEdgeSigning(w http.ResponseWriter, r *http.Request, dist *Distribution) bool {
+	if !requiresSigning(dist) {
+		return true
+	}
+
+	creds := extractSignedCredentials(r)
+	if creds == nil {
+		http.Error(w, "missing CloudFront signed credentials", http.StatusForbidden)
+
+		return false
+	}
+
+	if err := s.verifySigned(r, dist, creds, time.Now()); err != nil {
+		http.Error(w, "access denied: "+err.Error(), http.StatusForbidden)
+
+		return false
+	}
+
+	return true
+}
+
+// verifySigned checks the signed credentials against the distribution's
+// trusted key groups. Returns nil on success, or an error describing
+// the failure.
+func (s *Service) verifySigned(r *http.Request, dist *Distribution, creds *signedCredentials, now time.Time) error {
+	pubKey, err := s.resolvePublicKey(r, dist, creds.KeyPairID)
+	if err != nil {
+		return err
+	}
+
+	policyBytes, err := policyDocument(creds, r)
+	if err != nil {
+		return fmt.Errorf("invalid policy: %w", err)
+	}
+
+	if err := verifyRSASHA1(pubKey, policyBytes, creds.Signature); err != nil {
+		return fmt.Errorf("signature verification failed: %w", err)
+	}
+
+	var policy cfPolicy
+	if err := json.Unmarshal(policyBytes, &policy); err != nil {
+		return fmt.Errorf("policy parse failed: %w", err)
+	}
+
+	return evaluatePolicy(&policy, r, now)
+}
+
+// resolvePublicKey finds the PEM-encoded public key matching keyPairID
+// through the distribution's TrustedKeyGroups.
+func (s *Service) resolvePublicKey(r *http.Request, dist *Distribution, keyPairID string) (*rsa.PublicKey, error) {
+	dcb := dist.DistributionConfig.DefaultCacheBehavior
+	if dcb == nil || dcb.TrustedKeyGroups == nil || !dcb.TrustedKeyGroups.Enabled {
+		return nil, fmt.Errorf("distribution has no trusted key groups")
+	}
+
+	for _, kgID := range dcb.TrustedKeyGroups.Items {
+		kg, err := s.storage.GetKeyGroup(r.Context(), kgID)
+		if err != nil {
+			continue
+		}
+
+		for _, pkID := range kg.KeyGroupConfig.Items {
+			if pkID != keyPairID {
+				continue
+			}
+
+			pk, err := s.storage.GetPublicKey(r.Context(), pkID)
+			if err != nil {
+				continue
+			}
+
+			return parseRSAPublicKey(pk.PublicKeyConfig.EncodedKey)
+		}
+	}
+
+	return nil, fmt.Errorf("key pair %s not found in trusted key groups", keyPairID)
+}
+
+// parseRSAPublicKey parses a PEM-encoded RSA public key.
+func parseRSAPublicKey(encoded string) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(encoded))
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse public key: %w", err)
+	}
+
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not an RSA public key")
+	}
+
+	return rsaPub, nil
+}
+
+// policyDocument returns the JSON bytes that the signature covers.
+// For custom policies, it decodes the CF-Base64-encoded Policy field.
+// For canned policies, it constructs the canonical JSON from the URL
+// and Expires.
+func policyDocument(creds *signedCredentials, r *http.Request) ([]byte, error) {
+	if creds.Policy != "" {
+		return cfBase64Decode(creds.Policy)
+	}
+
+	if creds.Expires == 0 {
+		return nil, fmt.Errorf("no policy or expires provided")
+	}
+
+	resource := requestResourceURL(r)
+
+	// Canned policy JSON must be compact with no whitespace — the
+	// signer produces this exact layout and signs it.
+	//nolint:gocritic // Canned policy JSON must match the exact format the signer produced; %q escapes differ from JSON.
+	policy := fmt.Sprintf(
+		`{"Statement":[{"Resource":"%s","Condition":{"DateLessThan":{"AWS:EpochTime":%d}}}]}`,
+		resource, creds.Expires,
+	)
+
+	return []byte(policy), nil
+}
+
+// requestResourceURL reconstructs the resource URL for canned policy
+// verification. Strips signing query parameters (Expires, Signature,
+// Key-Pair-Id) so the base URL matches what the signer produced.
+func requestResourceURL(r *http.Request) string {
+	scheme := schemeHTTPS
+	if r.TLS == nil {
+		scheme = schemeHTTP
+	}
+
+	base := scheme + "://" + r.Host + r.URL.Path
+
+	// Preserve non-signing query params.
+	q := r.URL.Query()
+	q.Del("Expires")
+	q.Del("Signature")
+	q.Del("Key-Pair-Id")
+	q.Del("Policy")
+
+	if encoded := q.Encode(); encoded != "" {
+		base += "?" + encoded
+	}
+
+	return base
+}
+
+// cfBase64Decode decodes CloudFront's modified Base64 encoding.
+// CloudFront replaces: + -> -, = -> _, / -> ~.
+func cfBase64Decode(s string) ([]byte, error) {
+	s = strings.ReplaceAll(s, "-", "+")
+	s = strings.ReplaceAll(s, "_", "=")
+	s = strings.ReplaceAll(s, "~", "/")
+
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode: %w", err)
+	}
+
+	return decoded, nil
+}
+
+// verifyRSASHA1 verifies an RSA-SHA1 signature against the given
+// message using CloudFront's modified Base64 for the signature.
+func verifyRSASHA1(pub *rsa.PublicKey, message []byte, sig string) error {
+	sigBytes, err := cfBase64Decode(sig)
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+
+	h := sha1.Sum(message) //nolint:gosec // CloudFront protocol mandates SHA1.
+
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA1, h[:], sigBytes); err != nil {
+		return fmt.Errorf("rsa verify: %w", err)
+	}
+
+	return nil
+}
+
+// evaluatePolicy checks the policy conditions against the current
+// request context (time, IP).
+func evaluatePolicy(policy *cfPolicy, r *http.Request, now time.Time) error {
+	if len(policy.Statement) == 0 {
+		return fmt.Errorf("policy has no statements")
+	}
+
+	stmt := policy.Statement[0]
+	cond := stmt.Condition
+
+	if cond.DateLessThan != nil {
+		if now.Unix() > cond.DateLessThan.EpochTime {
+			return fmt.Errorf("access expired at %d", cond.DateLessThan.EpochTime)
+		}
+	}
+
+	if cond.DateGreaterThan != nil {
+		if now.Unix() < cond.DateGreaterThan.EpochTime {
+			return fmt.Errorf("access not yet valid until %d", cond.DateGreaterThan.EpochTime)
+		}
+	}
+
+	if cond.IPAddress != nil && cond.IPAddress.SourceIP != "" {
+		if err := checkIPCondition(r, cond.IPAddress.SourceIP); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkIPCondition verifies the client IP is within the allowed range.
+func checkIPCondition(r *http.Request, allowedCIDR string) error {
+	clientIP := extractClientIP(r)
+	if clientIP == "" {
+		return fmt.Errorf("cannot determine client IP")
+	}
+
+	_, ipNet, err := net.ParseCIDR(allowedCIDR)
+	if err != nil {
+		// Not a CIDR — try as bare IP (append /32 or /128).
+		ip := net.ParseIP(allowedCIDR)
+		if ip == nil {
+			return fmt.Errorf("invalid IP condition: %s", allowedCIDR)
+		}
+
+		if clientIP != ip.String() {
+			return fmt.Errorf("client IP %s not allowed", clientIP)
+		}
+
+		return nil
+	}
+
+	client := net.ParseIP(clientIP)
+	if client == nil || !ipNet.Contains(client) {
+		return fmt.Errorf("client IP %s not in allowed range %s", clientIP, allowedCIDR)
+	}
+
+	return nil
+}
+
+// extractClientIP returns the client's IP from RemoteAddr, stripping
+// the port if present.
+func extractClientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+
+	return host
+}
+
+// requiresSigning reports whether the distribution requires signed
+// access (via TrustedKeyGroups on the DefaultCacheBehavior).
+func requiresSigning(dist *Distribution) bool {
+	if dist == nil || dist.DistributionConfig == nil {
+		return false
+	}
+
+	dcb := dist.DistributionConfig.DefaultCacheBehavior
+	if dcb == nil {
+		return false
+	}
+
+	return dcb.TrustedKeyGroups != nil && dcb.TrustedKeyGroups.Enabled
+}

--- a/internal/service/cloudfront/edge_signing_test.go
+++ b/internal/service/cloudfront/edge_signing_test.go
@@ -1,0 +1,541 @@
+package cloudfront
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" //nolint:gosec // Test helper for CloudFront RSA-SHA1 signatures.
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testPolicyValue = "abc"
+	testRemoteAddr  = "127.0.0.1:12345"
+)
+
+// testKeyPair generates a fresh RSA key pair and returns the private
+// key plus the PEM-encoded public key string suitable for
+// PublicKeyConfig.EncodedKey.
+func testKeyPair(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	pubDER, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	return priv, string(pubPEM)
+}
+
+// cfSign produces a CloudFront-Base64-encoded RSA-SHA1 signature.
+func cfSign(t *testing.T, priv *rsa.PrivateKey, message []byte) string {
+	t.Helper()
+
+	//nolint:gosec // CloudFront protocol mandates SHA1.
+	h := sha1.Sum(message)
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA1, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	return cfBase64Encode(sig)
+}
+
+// cfBase64Encode encodes to CloudFront's modified Base64.
+func cfBase64Encode(data []byte) string {
+	s := base64.StdEncoding.EncodeToString(data)
+	s = strings.ReplaceAll(s, "+", "-")
+	s = strings.ReplaceAll(s, "=", "_")
+	s = strings.ReplaceAll(s, "/", "~")
+
+	return s
+}
+
+// newTestRequest builds an *http.Request with a background context
+// for unit tests. Satisfies the noctx linter.
+func newTestRequest(t *testing.T, target string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, target, http.NoBody)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	return req
+}
+
+func TestExtractSignedCredentials_Cookies(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t, "/kumo/cdn/E123/file.txt")
+	req.AddCookie(&http.Cookie{Name: "CloudFront-Policy", Value: testPolicyValue})
+	req.AddCookie(&http.Cookie{Name: "CloudFront-Signature", Value: "sig"})
+	req.AddCookie(&http.Cookie{Name: "CloudFront-Key-Pair-Id", Value: "KID"})
+
+	creds := extractSignedCredentials(req)
+	if creds == nil {
+		t.Fatal("expected credentials from cookies")
+	}
+
+	if creds.Policy != testPolicyValue {
+		t.Errorf("Policy = %q, want %q", creds.Policy, testPolicyValue)
+	}
+
+	if creds.Signature != "sig" {
+		t.Errorf("Signature = %q, want %q", creds.Signature, "sig")
+	}
+
+	if creds.KeyPairID != "KID" {
+		t.Errorf("KeyPairID = %q, want %q", creds.KeyPairID, "KID")
+	}
+}
+
+func TestExtractSignedCredentials_QueryCanned(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t,
+		"/kumo/cdn/E123/file.txt?Expires=1700000000&Signature=sig&Key-Pair-Id=KID")
+
+	creds := extractSignedCredentials(req)
+	if creds == nil {
+		t.Fatal("expected credentials from query")
+	}
+
+	if creds.Expires != 1700000000 {
+		t.Errorf("Expires = %d, want 1700000000", creds.Expires)
+	}
+
+	if creds.Policy != "" {
+		t.Errorf("Policy = %q, want empty", creds.Policy)
+	}
+}
+
+func TestExtractSignedCredentials_QueryCustom(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t,
+		"/kumo/cdn/E123/file.txt?Policy=abc&Signature=sig&Key-Pair-Id=KID")
+
+	creds := extractSignedCredentials(req)
+	if creds == nil {
+		t.Fatal("expected credentials from query")
+	}
+
+	if creds.Policy != testPolicyValue {
+		t.Errorf("Policy = %q, want %q", creds.Policy, testPolicyValue)
+	}
+}
+
+func TestExtractSignedCredentials_None(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t, "/kumo/cdn/E123/file.txt")
+
+	creds := extractSignedCredentials(req)
+	if creds != nil {
+		t.Fatalf("expected nil, got %+v", creds)
+	}
+}
+
+func TestCFBase64RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := []byte(`{"Statement":[{"Resource":"*"}]}`)
+	encoded := cfBase64Encode(original)
+
+	if strings.ContainsAny(encoded, "+=/") {
+		t.Errorf("encoded contains forbidden chars: %q", encoded)
+	}
+
+	decoded, err := cfBase64Decode(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if !bytes.Equal(decoded, original) {
+		t.Errorf("round-trip mismatch: got %q, want %q", decoded, original)
+	}
+}
+
+func TestVerifyRSASHA1(t *testing.T) {
+	t.Parallel()
+
+	priv, pubPEM := testKeyPair(t)
+
+	pub, err := parseRSAPublicKey(pubPEM)
+	if err != nil {
+		t.Fatalf("parse public key: %v", err)
+	}
+
+	message := []byte("hello world")
+	sig := cfSign(t, priv, message)
+
+	if err := verifyRSASHA1(pub, message, sig); err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+
+	// Tampered message should fail.
+	if err := verifyRSASHA1(pub, []byte("tampered"), sig); err == nil {
+		t.Fatal("expected error for tampered message")
+	}
+}
+
+func TestEvaluatePolicy_Valid(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1700000000, 0)
+	policy := &cfPolicy{
+		Statement: []cfStatement{{
+			Resource: "*",
+			Condition: cfCondition{
+				DateLessThan: &cfEpoch{EpochTime: 1700001000},
+			},
+		}},
+	}
+
+	req := newTestRequest(t, "/file.txt")
+	req.RemoteAddr = testRemoteAddr
+
+	if err := evaluatePolicy(policy, req, now); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEvaluatePolicy_Expired(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1700002000, 0)
+	policy := &cfPolicy{
+		Statement: []cfStatement{{
+			Resource: "*",
+			Condition: cfCondition{
+				DateLessThan: &cfEpoch{EpochTime: 1700001000},
+			},
+		}},
+	}
+
+	req := newTestRequest(t, "/file.txt")
+	req.RemoteAddr = testRemoteAddr
+
+	err := evaluatePolicy(policy, req, now)
+	if err == nil {
+		t.Fatal("expected error for expired policy")
+	}
+
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("error = %q, want 'expired' substring", err.Error())
+	}
+}
+
+func TestEvaluatePolicy_NotYetValid(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1699999000, 0)
+	policy := &cfPolicy{
+		Statement: []cfStatement{{
+			Resource: "*",
+			Condition: cfCondition{
+				DateLessThan:    &cfEpoch{EpochTime: 1700010000},
+				DateGreaterThan: &cfEpoch{EpochTime: 1700000000},
+			},
+		}},
+	}
+
+	req := newTestRequest(t, "/file.txt")
+	req.RemoteAddr = testRemoteAddr
+
+	err := evaluatePolicy(policy, req, now)
+	if err == nil {
+		t.Fatal("expected error for not-yet-valid policy")
+	}
+
+	if !strings.Contains(err.Error(), "not yet valid") {
+		t.Errorf("error = %q, want 'not yet valid' substring", err.Error())
+	}
+}
+
+func TestEvaluatePolicy_IPAllowed(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1700000000, 0)
+	policy := &cfPolicy{
+		Statement: []cfStatement{{
+			Resource: "*",
+			Condition: cfCondition{
+				DateLessThan: &cfEpoch{EpochTime: 1700010000},
+				IPAddress:    &cfIPAddr{SourceIP: "192.168.1.0/24"},
+			},
+		}},
+	}
+
+	req := newTestRequest(t, "/file.txt")
+	req.RemoteAddr = "192.168.1.42:12345"
+
+	if err := evaluatePolicy(policy, req, now); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEvaluatePolicy_IPDenied(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1700000000, 0)
+	policy := &cfPolicy{
+		Statement: []cfStatement{{
+			Resource: "*",
+			Condition: cfCondition{
+				DateLessThan: &cfEpoch{EpochTime: 1700010000},
+				IPAddress:    &cfIPAddr{SourceIP: "10.0.0.0/8"},
+			},
+		}},
+	}
+
+	req := newTestRequest(t, "/file.txt")
+	req.RemoteAddr = "192.168.1.42:12345"
+
+	err := evaluatePolicy(policy, req, now)
+	if err == nil {
+		t.Fatal("expected error for denied IP")
+	}
+
+	if !strings.Contains(err.Error(), "not in allowed range") {
+		t.Errorf("error = %q, want 'not in allowed range' substring", err.Error())
+	}
+}
+
+func TestRequiresSigning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		dist *Distribution
+		want bool
+	}{
+		{
+			name: "nil distribution",
+			dist: nil,
+			want: false,
+		},
+		{
+			name: "no trusted key groups",
+			dist: &Distribution{
+				DistributionConfig: &DistributionConfig{
+					DefaultCacheBehavior: &DefaultCacheBehavior{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "trusted key groups disabled",
+			dist: &Distribution{
+				DistributionConfig: &DistributionConfig{
+					DefaultCacheBehavior: &DefaultCacheBehavior{
+						TrustedKeyGroups: &TrustedKeyGroups{Enabled: false},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "trusted key groups enabled",
+			dist: &Distribution{
+				DistributionConfig: &DistributionConfig{
+					DefaultCacheBehavior: &DefaultCacheBehavior{
+						TrustedKeyGroups: &TrustedKeyGroups{Enabled: true, Quantity: 1, Items: []string{"kg1"}},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := requiresSigning(tt.dist)
+			if got != tt.want {
+				t.Errorf("requiresSigning() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRSAPublicKey(t *testing.T) {
+	t.Parallel()
+
+	_, pubPEM := testKeyPair(t)
+
+	pub, err := parseRSAPublicKey(pubPEM)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	if pub == nil {
+		t.Fatal("expected non-nil public key")
+	}
+}
+
+func TestParseRSAPublicKey_Invalid(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseRSAPublicKey("not a pem")
+	if err == nil {
+		t.Fatal("expected error for invalid PEM")
+	}
+}
+
+func TestRequestResourceURL(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t,
+		"http://localhost:4566/kumo/cdn/E123/path/file.txt?Expires=123&Signature=sig&Key-Pair-Id=KID&color=red")
+
+	got := requestResourceURL(req)
+	want := "http://localhost:4566/kumo/cdn/E123/path/file.txt?color=red"
+
+	if got != want {
+		t.Errorf("requestResourceURL() = %q, want %q", got, want)
+	}
+}
+
+func TestRequestResourceURL_NoExtraQuery(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t,
+		"http://localhost:4566/kumo/cdn/E123/file.txt?Expires=123&Signature=sig&Key-Pair-Id=KID")
+
+	got := requestResourceURL(req)
+	want := "http://localhost:4566/kumo/cdn/E123/file.txt"
+
+	if got != want {
+		t.Errorf("requestResourceURL() = %q, want %q", got, want)
+	}
+}
+
+// signCanned signs a canned policy for the given URL and expiry.
+// Used by integration-level tests in this package.
+func signCanned(t *testing.T, priv *rsa.PrivateKey, resource string, expires int64) string {
+	t.Helper()
+
+	//nolint:gocritic // Canned policy must match the exact JSON the verifier reconstructs.
+	policy := fmt.Sprintf(
+		`{"Statement":[{"Resource":"%s","Condition":{"DateLessThan":{"AWS:EpochTime":%d}}}]}`,
+		resource, expires,
+	)
+
+	return cfSign(t, priv, []byte(policy))
+}
+
+// signCustom signs a custom policy JSON document.
+// Used by integration-level tests in this package.
+func signCustom(t *testing.T, priv *rsa.PrivateKey, policyJSON []byte) string {
+	t.Helper()
+
+	return cfSign(t, priv, policyJSON)
+}
+
+// TestSignHelpers ensures signCanned and signCustom produce verifiable signatures.
+func TestSignHelpers(t *testing.T) {
+	t.Parallel()
+
+	priv, pubPEM := testKeyPair(t)
+
+	pub, err := parseRSAPublicKey(pubPEM)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	t.Run("canned", func(t *testing.T) {
+		t.Parallel()
+
+		resource := "http://localhost:4566/kumo/cdn/E1/file.txt"
+		expires := int64(1700010000)
+		sig := signCanned(t, priv, resource, expires)
+
+		//nolint:gocritic // Must match the exact canned policy layout.
+		policy := fmt.Sprintf(
+			`{"Statement":[{"Resource":"%s","Condition":{"DateLessThan":{"AWS:EpochTime":%d}}}]}`,
+			resource, expires,
+		)
+
+		if err := verifyRSASHA1(pub, []byte(policy), sig); err != nil {
+			t.Fatalf("canned signature verification failed: %v", err)
+		}
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		t.Parallel()
+
+		policy := []byte(`{"Statement":[{"Resource":"*","Condition":{"DateLessThan":{"AWS:EpochTime":9999999999}}}]}`)
+		sig := signCustom(t, priv, policy)
+
+		if err := verifyRSASHA1(pub, policy, sig); err != nil {
+			t.Fatalf("custom signature verification failed: %v", err)
+		}
+	})
+}
+
+// TestCheckEdgeSigning_NoTrustedKeyGroups verifies that requests pass
+// through when the distribution does not require signing.
+func TestCheckEdgeSigning_NoTrustedKeyGroups(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+	dist := &Distribution{
+		DistributionConfig: &DistributionConfig{
+			DefaultCacheBehavior: &DefaultCacheBehavior{},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := newTestRequest(t, "/kumo/cdn/E1/file.txt")
+
+	if !svc.checkEdgeSigning(rec, req, dist) {
+		t.Fatal("expected pass-through when signing is not required")
+	}
+}
+
+// TestCheckEdgeSigning_MissingCredentials verifies that a 403 is
+// returned when signed credentials are absent.
+func TestCheckEdgeSigning_MissingCredentials(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+	dist := &Distribution{
+		DistributionConfig: &DistributionConfig{
+			DefaultCacheBehavior: &DefaultCacheBehavior{
+				TrustedKeyGroups: &TrustedKeyGroups{Enabled: true, Quantity: 1, Items: []string{"kg1"}},
+			},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := newTestRequest(t, "/kumo/cdn/E1/file.txt")
+
+	if svc.checkEdgeSigning(rec, req, dist) {
+		t.Fatal("expected rejection when credentials are missing")
+	}
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}

--- a/test/integration/cloudfront_signing_test.go
+++ b/test/integration/cloudfront_signing_test.go
@@ -1,0 +1,351 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" //nolint:gosec // CloudFront uses RSA-SHA1 for signed URL/cookie verification.
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cfapi "github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	"github.com/sivchari/golden"
+)
+
+// generateTestKeyPair creates a 2048-bit RSA key pair for testing.
+func generateTestKeyPair(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	pubDER, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	return priv, string(pubPEM)
+}
+
+// cfBase64 encodes bytes using CloudFront's modified Base64.
+func cfBase64(data []byte) string {
+	s := base64.StdEncoding.EncodeToString(data)
+	s = strings.ReplaceAll(s, "+", "-")
+	s = strings.ReplaceAll(s, "=", "_")
+	s = strings.ReplaceAll(s, "/", "~")
+
+	return s
+}
+
+// signPolicy signs a policy JSON with RSA-SHA1 and returns a
+// CloudFront-Base64-encoded signature.
+func signPolicy(t *testing.T, priv *rsa.PrivateKey, policy []byte) string {
+	t.Helper()
+
+	//nolint:gosec // CloudFront mandates SHA1.
+	h := sha1.Sum(policy)
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA1, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	return cfBase64(sig)
+}
+
+func TestCloudFront_PublicKeyAndKeyGroup(t *testing.T) {
+	t.Parallel()
+
+	client := newCloudFrontClient(t)
+	ctx := t.Context()
+
+	_, pubPEM := generateTestKeyPair(t)
+
+	// Create PublicKey.
+	pkResult, err := client.CreatePublicKey(ctx, &cfapi.CreatePublicKeyInput{
+		PublicKeyConfig: &types.PublicKeyConfig{
+			CallerReference: aws.String("test-pk-signing"),
+			Name:            aws.String("test-signing-key"),
+			EncodedKey:      aws.String(pubPEM),
+			Comment:         aws.String("Integration test key"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeletePublicKey(context.Background(), &cfapi.DeletePublicKeyInput{
+			Id:      pkResult.PublicKey.Id,
+			IfMatch: pkResult.ETag,
+		})
+	})
+
+	golden.New(t, golden.WithIgnoreFields(
+		"Id",
+		"CreatedTime",
+		"ETag",
+		"EncodedKey",
+		"ResultMetadata",
+	)).Assert(t.Name()+"_create_public_key", pkResult)
+
+	// Create KeyGroup referencing the PublicKey.
+	kgResult, err := client.CreateKeyGroup(ctx, &cfapi.CreateKeyGroupInput{
+		KeyGroupConfig: &types.KeyGroupConfig{
+			Name:    aws.String("test-key-group"),
+			Items:   []string{*pkResult.PublicKey.Id},
+			Comment: aws.String("Integration test key group"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteKeyGroup(context.Background(), &cfapi.DeleteKeyGroupInput{
+			Id:      kgResult.KeyGroup.Id,
+			IfMatch: kgResult.ETag,
+		})
+	})
+
+	golden.New(t, golden.WithIgnoreFields(
+		"Id",
+		"LastModifiedTime",
+		"ETag",
+		"Items",
+		"ResultMetadata",
+	)).Assert(t.Name()+"_create_key_group", kgResult)
+}
+
+func TestCloudFront_EdgeSignedCookie(t *testing.T) {
+	t.Parallel()
+
+	client := newCloudFrontClient(t)
+	ctx := t.Context()
+
+	priv, pubPEM := generateTestKeyPair(t)
+
+	// 1. Create PublicKey.
+	pkResult, err := client.CreatePublicKey(ctx, &cfapi.CreatePublicKeyInput{
+		PublicKeyConfig: &types.PublicKeyConfig{
+			CallerReference: aws.String("test-edge-signed-cookie"),
+			Name:            aws.String("edge-signing-key"),
+			EncodedKey:      aws.String(pubPEM),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkID := *pkResult.PublicKey.Id
+
+	t.Cleanup(func() {
+		_, _ = client.DeletePublicKey(context.Background(), &cfapi.DeletePublicKeyInput{
+			Id:      pkResult.PublicKey.Id,
+			IfMatch: pkResult.ETag,
+		})
+	})
+
+	// 2. Create KeyGroup.
+	kgResult, err := client.CreateKeyGroup(ctx, &cfapi.CreateKeyGroupInput{
+		KeyGroupConfig: &types.KeyGroupConfig{
+			Name:  aws.String("edge-key-group"),
+			Items: []string{pkID},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kgID := *kgResult.KeyGroup.Id
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteKeyGroup(context.Background(), &cfapi.DeleteKeyGroupInput{
+			Id:      kgResult.KeyGroup.Id,
+			IfMatch: kgResult.ETag,
+		})
+	})
+
+	// 3. Start a test origin that always returns 200.
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, "origin-ok")
+	}))
+	t.Cleanup(origin.Close)
+
+	// Parse origin host:port for the Distribution config.
+	originAddr := strings.TrimPrefix(origin.URL, "http://")
+	originHost, originPort := originAddr, 80
+
+	if parts := strings.SplitN(originAddr, ":", 2); len(parts) == 2 {
+		originHost = parts[0]
+		fmt.Sscanf(parts[1], "%d", &originPort)
+	}
+
+	// 4. Create Distribution with TrustedKeyGroups and the test origin.
+	distResult, err := client.CreateDistribution(ctx, &cfapi.CreateDistributionInput{
+		DistributionConfig: &types.DistributionConfig{
+			CallerReference: aws.String("test-edge-signed-cookie-dist"),
+			Origins: &types.Origins{
+				Quantity: aws.Int32(1),
+				Items: []types.Origin{{
+					Id:         aws.String("test-origin"),
+					DomainName: aws.String(originHost),
+					CustomOriginConfig: &types.CustomOriginConfig{
+						HTTPPort:             aws.Int32(int32(originPort)),
+						HTTPSPort:            aws.Int32(443),
+						OriginProtocolPolicy: types.OriginProtocolPolicyHttpOnly,
+					},
+				}},
+			},
+			DefaultCacheBehavior: &types.DefaultCacheBehavior{
+				TargetOriginId:       aws.String("test-origin"),
+				ViewerProtocolPolicy: types.ViewerProtocolPolicyAllowAll,
+				TrustedKeyGroups: &types.TrustedKeyGroups{
+					Enabled:  aws.Bool(true),
+					Quantity: aws.Int32(1),
+					Items:    []string{kgID},
+				},
+				MinTTL:     aws.Int64(0),
+				DefaultTTL: aws.Int64(0),
+				MaxTTL:     aws.Int64(0),
+				ForwardedValues: &types.ForwardedValues{
+					QueryString: aws.Bool(false),
+					Cookies:     &types.CookiePreference{Forward: types.ItemSelectionNone},
+				},
+			},
+			Comment: aws.String("Signed cookie test"),
+			Enabled: aws.Bool(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	distID := *distResult.Distribution.Id
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteDistribution(context.Background(), &cfapi.DeleteDistributionInput{
+			Id:      distResult.Distribution.Id,
+			IfMatch: distResult.ETag,
+		})
+	})
+
+	edgeURL := fmt.Sprintf("http://localhost:4566/kumo/cdn/%s/test.txt", distID)
+
+	t.Run("no_credentials_returns_403", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, edgeURL, http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+	})
+
+	t.Run("valid_signed_cookie_passes", func(t *testing.T) {
+		t.Parallel()
+
+		// Build a custom policy with a far-future expiry.
+		policy := []byte(`{"Statement":[{"Resource":"*","Condition":{"DateLessThan":{"AWS:EpochTime":9999999999}}}]}`)
+		sig := signPolicy(t, priv, policy)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, edgeURL, http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Policy", Value: cfBase64(policy)})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Signature", Value: sig})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Key-Pair-Id", Value: pkID})
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		// The origin (kumo's root) returns 200.
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Errorf("status = %d, want %d; body = %s", resp.StatusCode, http.StatusOK, body)
+		}
+	})
+
+	t.Run("bad_signature_returns_403", func(t *testing.T) {
+		t.Parallel()
+
+		policy := []byte(`{"Statement":[{"Resource":"*","Condition":{"DateLessThan":{"AWS:EpochTime":9999999999}}}]}`)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, edgeURL, http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Policy", Value: cfBase64(policy)})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Signature", Value: "invalid-signature"})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Key-Pair-Id", Value: pkID})
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+	})
+
+	t.Run("expired_policy_returns_403", func(t *testing.T) {
+		t.Parallel()
+
+		// Policy with epoch 0 = expired.
+		policy := []byte(`{"Statement":[{"Resource":"*","Condition":{"DateLessThan":{"AWS:EpochTime":0}}}]}`)
+		sig := signPolicy(t, priv, policy)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, edgeURL, http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Policy", Value: cfBase64(policy)})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Signature", Value: sig})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Key-Pair-Id", Value: pkID})
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+	})
+}

--- a/test/integration/testdata/cloudfront_signing_test_TestCloudFront_PublicKeyAndKeyGroup_TestCloudFront_PublicKeyAndKeyGroup_create_key_group.golden.go
+++ b/test/integration/testdata/cloudfront_signing_test_TestCloudFront_PublicKeyAndKeyGroup_TestCloudFront_PublicKeyAndKeyGroup_create_key_group.golden.go
@@ -1,0 +1,16 @@
+{
+  "ETag": "E4f8cd241-2739-4a3a-83cf-8b0f2848",
+  "KeyGroup": {
+    "Id": "AC255A8EA615C6A7F8407C73987EE28D96EF",
+    "KeyGroupConfig": {
+      "Items": [
+        "KA7F2BF67FBE8B"
+      ],
+      "Name": "test-key-group",
+      "Comment": "Integration test key group"
+    },
+    "LastModifiedTime": "2026-05-28T07:23:53Z"
+  },
+  "Location": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cloudfront_signing_test_TestCloudFront_PublicKeyAndKeyGroup_TestCloudFront_PublicKeyAndKeyGroup_create_public_key.golden.go
+++ b/test/integration/testdata/cloudfront_signing_test_TestCloudFront_PublicKeyAndKeyGroup_TestCloudFront_PublicKeyAndKeyGroup_create_public_key.golden.go
@@ -1,0 +1,15 @@
+{
+  "ETag": "E5487f1e2-0c9d-4ffa-aaa8-2091cfa0",
+  "Location": null,
+  "PublicKey": {
+    "CreatedTime": "2026-05-28T07:23:53Z",
+    "Id": "KA7F2BF67FBE8B",
+    "PublicKeyConfig": {
+      "CallerReference": "test-pk-signing",
+      "EncodedKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuoYwPBR1lwmDKOEE1rIo\nrfAF6DZ7vMQHE4hlK/PXphtwg9ul4lxVkzdn15ALzbzBPhdGMOnSQMNLZLInh0jt\nIA/R836A01B33E2NGTk0zKCkk4QmMF6pZnxTkrHm+C3w5m/gGrM6CI6yb43dbFFM\nNmWBGQMmKx6/G945oQK3DtmxzMqc3HjLkfOUvBWamg5PHhrR3WUg2z0lZeqJfou/\nHVnxAczFG6jExWwyB94btZa0MSwElJjNGN78bm/l8WkNEuwFQXBlWW6UX3O0A0tE\nv0fo/2G3+/0PWNWIq48rhXxM+75BqnmTR+TifL0t+cHddxDr7kwZFs76OxXprTG2\n5QIDAQAB\n-----END PUBLIC KEY-----\n",
+      "Name": "test-signing-key",
+      "Comment": "Integration test key"
+    }
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

- Add RSA-SHA1 signature verification to the CloudFront edge proxy (`/kumo/cdn/{distId}/...`) when `TrustedKeyGroups` is enabled on the Distribution's `DefaultCacheBehavior`
- Support both canned policies (Expires-based) and custom policies (Base64-encoded JSON with DateLessThan, DateGreaterThan, IpAddress conditions)
- Extract signed credentials from cookies (`CloudFront-Policy`, `CloudFront-Signature`, `CloudFront-Key-Pair-Id`) or query parameters (`Policy`/`Expires`, `Signature`, `Key-Pair-Id`)

## Test plan

- [x] Unit tests: credential extraction, CF-Base64 round-trip, RSA-SHA1 verification, policy condition evaluation (valid/expired/not-yet-valid/IP-allowed/IP-denied), `requiresSigning` detection, public key parsing, URL reconstruction
- [x] Integration tests (golden): PublicKey + KeyGroup CRUD via AWS SDK
- [x] Integration tests (E2E): Edge proxy signed cookie flow (no creds -> 403, valid cookie -> 200, bad signature -> 403, expired policy -> 403)
- [x] `go test -race -shuffle=on ./...` passes
- [x] `golangci-lint run` passes
- [x] `lefthook` pre-commit and pre-push hooks pass