### PR TITLE
fix(dynamodb): accept space-separated values for --key-schema and --attribute-definitions

### DIFF
--- a/cli/dynamodb.go
+++ b/cli/dynamodb.go
@@ -42,7 +42,7 @@ func newDynamoDBCreateTableCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create-table",
 		Short: "Create a DynamoDB table",
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := newAWSConfig(cmd.Context())
 			if err != nil {
 				return err
@@ -58,6 +58,17 @@ func newDynamoDBCreateTableCmd() *cobra.Command {
 
 			if billingMode != "" {
 				input.BillingMode = ddbTypes.BillingMode(billingMode)
+			}
+
+			// StringArray keeps only the first of several space-separated values
+			// (e.g. --key-schema <pk> <sk>), so route the rest back by their key.
+			for _, arg := range args {
+				switch kv := parseKV(arg); {
+				case kv["KeyType"] != "":
+					keySchema = append(keySchema, arg)
+				case kv["AttributeType"] != "":
+					attrDefs = append(attrDefs, arg)
+				}
 			}
 
 			input.AttributeDefinitions = parseAttributeDefinitions(attrDefs)


### PR DESCRIPTION
## Summary
`kumo dynamodb create-table` silently dropped all but the first element of `--key-schema` and `--attribute-definitions` when they were passed in the shorthand list form (a single flag followed by several space-separated values).
As a result, composite-key tables were created with only their partition key.

## Problem
These flags are registered with cobra's `StringArrayVar`, which captures only the first value after a flag. The remaining space-separated values fall through to positional args and were ignored by `RunE`, so the range key / extra attribute definitions were lost.

```bash
kumo dynamodb create-table \
  --table-name repro \
  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
  --billing-mode PAY_PER_REQUEST

# describe-table afterwards:
#   KeySchema:            [pk(HASH)]   ❌  sk(RANGE) dropped
#   AttributeDefinitions: [pk]         ❌  sk dropped
```

The repeated-flag form (`--key-schema A --key-schema B`) already worked; only the space-separated form was affected. 
`--global-secondary-indexes` /
`--local-secondary-indexes` are unaffected because they take a single JSON
string.

## Fix
In `cli/dynamodb.go`, route the leftover positional args back into the key-schema / attribute-definition slices by their shorthand key (`KeyType=` vs `AttributeType=`), preserving command-line order. Both the space-separated and repeated-flag forms now produce the same composite key.

## Test plan
- [x] `go build ./...`
- [x] `make lint`
- [x] `make test`
- [x] Verified `describe-table` now returns `pk(HASH)` + `sk(RANGE)` for the repro above