### PR TITLE
fix(dynamodb): support legacy KeyConditions in Query

### DIFF
--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -360,6 +360,9 @@ func (s *Service) Query(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Convert legacy KeyConditions to KeyConditionExpression if needed.
+	applyLegacyKeyConditions(&req)
+
 	scanForward := true
 	if req.ScanIndexForward != nil {
 		scanForward = *req.ScanIndexForward
@@ -1038,4 +1041,73 @@ func (s *Service) DescribeContinuousBackups(w http.ResponseWriter, r *http.Reque
 	writeJSONResponse(w, DescribeContinuousBackupsResponse{
 		ContinuousBackupsDescription: *desc,
 	})
+}
+
+// applyLegacyKeyConditions converts legacy KeyConditions to
+// KeyConditionExpression + ExpressionAttributeValues when needed.
+func applyLegacyKeyConditions(req *QueryRequest) {
+	if req.KeyConditionExpression != "" || len(req.KeyConditions) == 0 {
+		return
+	}
+
+	expr, vals := convertKeyConditionsToExpression(req.KeyConditions)
+	req.KeyConditionExpression = expr
+
+	if req.ExpressionAttributeValues == nil {
+		req.ExpressionAttributeValues = vals
+
+		return
+	}
+
+	for k := range vals {
+		req.ExpressionAttributeValues[k] = vals[k]
+	}
+}
+
+// comparisonOperatorFormats maps legacy ComparisonOperator values to
+// format strings for KeyConditionExpression conversion.
+var comparisonOperatorFormats = map[string]string{
+	"EQ":          "%s = %s",
+	"LE":          "%s <= %s",
+	"LT":          "%s < %s",
+	"GE":          "%s >= %s",
+	"GT":          "%s > %s",
+	"BEGINS_WITH": "begins_with(%s, %s)",
+}
+
+// convertKeyConditionsToExpression converts legacy KeyConditions (v1 API) to
+// a KeyConditionExpression string and synthetic ExpressionAttributeValues.
+// Supported operators: EQ, LE, LT, GE, GT, BEGINS_WITH, BETWEEN.
+func convertKeyConditionsToExpression(conditions map[string]KeyCondition) (string, map[string]AttributeValue) {
+	exprValues := make(map[string]AttributeValue)
+
+	var parts []string
+
+	idx := 0
+
+	for attrName := range conditions {
+		cond := conditions[attrName]
+		placeholder := fmt.Sprintf(":kcv%d", idx)
+		idx++
+
+		if format, ok := comparisonOperatorFormats[cond.ComparisonOperator]; ok {
+			if len(cond.AttributeValueList) < 1 {
+				continue
+			}
+
+			exprValues[placeholder] = cond.AttributeValueList[0]
+
+			parts = append(parts, fmt.Sprintf(format, attrName, placeholder))
+		} else if cond.ComparisonOperator == "BETWEEN" && len(cond.AttributeValueList) >= 2 {
+			placeholder2 := fmt.Sprintf(":kcv%d", idx)
+			idx++
+
+			exprValues[placeholder] = cond.AttributeValueList[0]
+			exprValues[placeholder2] = cond.AttributeValueList[1]
+
+			parts = append(parts, fmt.Sprintf("%s BETWEEN %s AND %s", attrName, placeholder, placeholder2))
+		}
+	}
+
+	return strings.Join(parts, " AND "), exprValues
 }

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -369,11 +369,18 @@ type UpdateItemResponse struct {
 	Attributes Item `json:"Attributes,omitempty"`
 }
 
+// KeyCondition represents a legacy v1 key condition used in KeyConditions.
+type KeyCondition struct {
+	AttributeValueList []AttributeValue `json:"AttributeValueList"`
+	ComparisonOperator string           `json:"ComparisonOperator"`
+}
+
 // QueryRequest is the request for Query.
 type QueryRequest struct {
 	TableName                 string                    `json:"TableName"`
 	IndexName                 string                    `json:"IndexName,omitempty"`
 	KeyConditionExpression    string                    `json:"KeyConditionExpression,omitempty"`
+	KeyConditions             map[string]KeyCondition   `json:"KeyConditions,omitempty"`
 	FilterExpression          string                    `json:"FilterExpression,omitempty"`
 	ProjectionExpression      string                    `json:"ProjectionExpression,omitempty"`
 	ExpressionAttributeNames  map[string]string         `json:"ExpressionAttributeNames,omitempty"`

--- a/test/go.mod
+++ b/test/go.mod
@@ -91,6 +91,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go v1.55.8 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
@@ -105,6 +106,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )
 
 replace github.com/sivchari/kumo => ../

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,3 +1,5 @@
+github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
+github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=
@@ -194,5 +196,13 @@ github.com/aws/aws-sdk-go-v2/service/xray v1.36.17 h1:b480fLepDHf9B7FXgcgB7XVDN3
 github.com/aws/aws-sdk-go-v2/service/xray v1.36.17/go.mod h1:ASKVut5pRPVm4bF9/P01ClCthnIopv1PjxWsLOTjKPU=
 github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
 github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sivchari/golden v0.3.0 h1:WUtMlhvqeH8mXcX4hsZwyfrA5jeNz5F9IL1w+u7Ew7w=
 github.com/sivchari/golden v0.3.0/go.mod h1:gddwjsjxPtLYRCq0M471x9WD9khQWty82Yn/PZ/2I8E=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -7,6 +7,11 @@ import (
 	"errors"
 	"testing"
 
+	awsv1 "github.com/aws/aws-sdk-go/aws"
+	awsv1creds "github.com/aws/aws-sdk-go/aws/credentials"
+	awsv1session "github.com/aws/aws-sdk-go/aws/session"
+	dynamodbv1 "github.com/aws/aws-sdk-go/service/dynamodb"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -31,6 +36,21 @@ func newDynamoDBClient(t *testing.T) *dynamodb.Client {
 	return dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
 		o.BaseEndpoint = aws.String("http://localhost:4566")
 	})
+}
+
+func newDynamoDBV1Client(t *testing.T) *dynamodbv1.DynamoDB {
+	t.Helper()
+
+	sess, err := awsv1session.NewSession(&awsv1.Config{
+		Region:      awsv1.String("us-east-1"),
+		Endpoint:    awsv1.String("http://localhost:4566"),
+		Credentials: awsv1creds.NewStaticCredentials("test", "test", ""),
+	})
+	if err != nil {
+		t.Fatalf("failed to create v1 session: %v", err)
+	}
+
+	return dynamodbv1.New(sess)
 }
 
 func TestDynamoDB_CreateAndDeleteTable(t *testing.T) {
@@ -1574,4 +1594,205 @@ func TestDynamoDB_DescribeContinuousBackups(t *testing.T) {
 		t.Fatal(err)
 	}
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), backupsOutput)
+}
+
+// TestDynamoDB_QueryKeyConditions tests the legacy v1 KeyConditions format
+// used by libraries like guregu/dynamo.
+func TestDynamoDB_QueryKeyConditions(t *testing.T) {
+	v2Client := newDynamoDBClient(t)
+	v1Client := newDynamoDBV1Client(t)
+	ctx := t.Context()
+	tableName := "test-table-query-keyconditions"
+
+	// Create table with PK only (no sort key) — matches the reported bug scenario.
+	_, err := v2Client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{
+				AttributeName: aws.String("PK"),
+				KeyType:       types.KeyTypeHash,
+			},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{
+				AttributeName: aws.String("PK"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = v2Client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Put a single item.
+	_, err = v2Client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"PK":   &types.AttributeValueMemberS{Value: "existing-key"},
+			"data": &types.AttributeValueMemberS{Value: "some-data"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to put item: %v", err)
+	}
+
+	// Query with legacy KeyConditions for a non-existent PK — must return empty.
+	t.Run("non_existent_pk", func(t *testing.T) {
+		out, err := v1Client.QueryWithContext(ctx, &dynamodbv1.QueryInput{
+			TableName: awsv1.String(tableName),
+			KeyConditions: map[string]*dynamodbv1.Condition{
+				"PK": {
+					AttributeValueList: []*dynamodbv1.AttributeValue{
+						{S: awsv1.String("non-existent-key")},
+					},
+					ComparisonOperator: awsv1.String("EQ"),
+				},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		golden.New(t).Assert(t.Name(), out)
+	})
+
+	// Query with legacy KeyConditions for the existing PK — must return the item.
+	t.Run("existing_pk", func(t *testing.T) {
+		out, err := v1Client.QueryWithContext(ctx, &dynamodbv1.QueryInput{
+			TableName: awsv1.String(tableName),
+			KeyConditions: map[string]*dynamodbv1.Condition{
+				"PK": {
+					AttributeValueList: []*dynamodbv1.AttributeValue{
+						{S: awsv1.String("existing-key")},
+					},
+					ComparisonOperator: awsv1.String("EQ"),
+				},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		golden.New(t).Assert(t.Name(), out)
+	})
+}
+
+// TestDynamoDB_QueryKeyConditionsWithSortKey tests legacy KeyConditions
+// with both partition key and sort key conditions.
+func TestDynamoDB_QueryKeyConditionsWithSortKey(t *testing.T) {
+	v2Client := newDynamoDBClient(t)
+	v1Client := newDynamoDBV1Client(t)
+	ctx := t.Context()
+	tableName := "test-table-query-keyconditions-sk"
+
+	// Create table with PK + SK.
+	_, err := v2Client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{
+				AttributeName: aws.String("PK"),
+				KeyType:       types.KeyTypeHash,
+			},
+			{
+				AttributeName: aws.String("SK"),
+				KeyType:       types.KeyTypeRange,
+			},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{
+				AttributeName: aws.String("PK"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("SK"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = v2Client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Put items.
+	for _, item := range []struct{ pk, sk, data string }{
+		{"user-1", "item-1", "data1"},
+		{"user-1", "item-2", "data2"},
+		{"user-1", "item-3", "data3"},
+		{"user-2", "item-1", "data4"},
+	} {
+		_, err = v2Client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item: map[string]types.AttributeValue{
+				"PK":   &types.AttributeValueMemberS{Value: item.pk},
+				"SK":   &types.AttributeValueMemberS{Value: item.sk},
+				"data": &types.AttributeValueMemberS{Value: item.data},
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed to put item: %v", err)
+		}
+	}
+
+	// Query with KeyConditions: PK=EQ + SK=BEGINS_WITH.
+	t.Run("pk_eq_sk_begins_with", func(t *testing.T) {
+		out, err := v1Client.QueryWithContext(ctx, &dynamodbv1.QueryInput{
+			TableName: awsv1.String(tableName),
+			KeyConditions: map[string]*dynamodbv1.Condition{
+				"PK": {
+					AttributeValueList: []*dynamodbv1.AttributeValue{
+						{S: awsv1.String("user-1")},
+					},
+					ComparisonOperator: awsv1.String("EQ"),
+				},
+				"SK": {
+					AttributeValueList: []*dynamodbv1.AttributeValue{
+						{S: awsv1.String("item-")},
+					},
+					ComparisonOperator: awsv1.String("BEGINS_WITH"),
+				},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		golden.New(t).Assert(t.Name(), out)
+	})
+
+	// Query with KeyConditions: PK=EQ + SK=BETWEEN.
+	t.Run("pk_eq_sk_between", func(t *testing.T) {
+		out, err := v1Client.QueryWithContext(ctx, &dynamodbv1.QueryInput{
+			TableName: awsv1.String(tableName),
+			KeyConditions: map[string]*dynamodbv1.Condition{
+				"PK": {
+					AttributeValueList: []*dynamodbv1.AttributeValue{
+						{S: awsv1.String("user-1")},
+					},
+					ComparisonOperator: awsv1.String("EQ"),
+				},
+				"SK": {
+					AttributeValueList: []*dynamodbv1.AttributeValue{
+						{S: awsv1.String("item-1")},
+						{S: awsv1.String("item-2")},
+					},
+					ComparisonOperator: awsv1.String("BETWEEN"),
+				},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		golden.New(t).Assert(t.Name(), out)
+	})
 }

--- a/test/integration/testdata/dynamodb_test_func2_TestDynamoDB_QueryKeyConditions/non_existent_pk.golden.go
+++ b/test/integration/testdata/dynamodb_test_func2_TestDynamoDB_QueryKeyConditions/non_existent_pk.golden.go
@@ -1,0 +1,7 @@
+{
+  "ConsumedCapacity": null,
+  "Count": 0,
+  "Items": [],
+  "LastEvaluatedKey": null,
+  "ScannedCount": 1
+}

--- a/test/integration/testdata/dynamodb_test_func2_TestDynamoDB_QueryKeyConditionsWithSortKey/pk_eq_sk_begins_with.golden.go
+++ b/test/integration/testdata/dynamodb_test_func2_TestDynamoDB_QueryKeyConditionsWithSortKey/pk_eq_sk_begins_with.golden.go
@@ -1,0 +1,122 @@
+{
+  "ConsumedCapacity": null,
+  "Count": 3,
+  "Items": [
+    {
+      "PK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "user-1",
+        "SS": null
+      },
+      "SK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "item-1",
+        "SS": null
+      },
+      "data": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "data1",
+        "SS": null
+      }
+    },
+    {
+      "PK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "user-1",
+        "SS": null
+      },
+      "SK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "item-2",
+        "SS": null
+      },
+      "data": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "data2",
+        "SS": null
+      }
+    },
+    {
+      "PK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "user-1",
+        "SS": null
+      },
+      "SK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "item-3",
+        "SS": null
+      },
+      "data": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "data3",
+        "SS": null
+      }
+    }
+  ],
+  "LastEvaluatedKey": null,
+  "ScannedCount": 4
+}

--- a/test/integration/testdata/dynamodb_test_func3_TestDynamoDB_QueryKeyConditions/existing_pk.golden.go
+++ b/test/integration/testdata/dynamodb_test_func3_TestDynamoDB_QueryKeyConditions/existing_pk.golden.go
@@ -1,0 +1,34 @@
+{
+  "ConsumedCapacity": null,
+  "Count": 1,
+  "Items": [
+    {
+      "PK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "existing-key",
+        "SS": null
+      },
+      "data": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "some-data",
+        "SS": null
+      }
+    }
+  ],
+  "LastEvaluatedKey": null,
+  "ScannedCount": 1
+}

--- a/test/integration/testdata/dynamodb_test_func3_TestDynamoDB_QueryKeyConditionsWithSortKey/pk_eq_sk_between.golden.go
+++ b/test/integration/testdata/dynamodb_test_func3_TestDynamoDB_QueryKeyConditionsWithSortKey/pk_eq_sk_between.golden.go
@@ -1,0 +1,84 @@
+{
+  "ConsumedCapacity": null,
+  "Count": 2,
+  "Items": [
+    {
+      "PK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "user-1",
+        "SS": null
+      },
+      "SK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "item-1",
+        "SS": null
+      },
+      "data": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "data1",
+        "SS": null
+      }
+    },
+    {
+      "PK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "user-1",
+        "SS": null
+      },
+      "SK": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "item-2",
+        "SS": null
+      },
+      "data": {
+        "B": null,
+        "BOOL": null,
+        "BS": null,
+        "L": null,
+        "M": null,
+        "N": null,
+        "NS": null,
+        "NULL": null,
+        "S": "data2",
+        "SS": null
+      }
+    }
+  ],
+  "LastEvaluatedKey": null,
+  "ScannedCount": 4
+}


### PR DESCRIPTION
## Summary

- `QueryRequest` was missing the `KeyConditions` field, so legacy v1 API queries (used by `guregu/dynamo` and AWS SDK v1) were silently ignored. This caused Query to return **all table items** instead of filtering by partition key.
- Added `KeyCondition` type and `KeyConditions` field to `QueryRequest`, with handler-layer conversion to `KeyConditionExpression` + `ExpressionAttributeValues`
- Supports all key condition operators: EQ, LE, LT, GE, GT, BEGINS_WITH, BETWEEN

## Test plan

- [x] Integration tests using AWS SDK v1 (`github.com/aws/aws-sdk-go`) to verify legacy `KeyConditions` format
  - PK-only table: non-existent PK returns empty, existing PK returns correct item
  - PK+SK table: BEGINS_WITH and BETWEEN operators filter correctly
- [x] Golden files generated and committed
- [x] All unit tests pass (`go test -race -shuffle=on ./...`)
- [x] Lint passes (`make lint` — 0 issues)