### PR TITLE
feat(kms): support Sign, Verify, GetPublicKey and asymmetric keys

### DIFF
--- a/cli/kms.go
+++ b/cli/kms.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/spf13/cobra"
 )
 
@@ -19,13 +21,18 @@ func newKMSCmd() *cobra.Command {
 	cmd.AddCommand(
 		newKMSCreateKeyCmd(),
 		newKMSCreateAliasCmd(),
+		newKMSSignCmd(),
+		newKMSVerifyCmd(),
+		newKMSGetPublicKeyCmd(),
 	)
 
 	return cmd
 }
 
 func newKMSCreateKeyCmd() *cobra.Command {
-	return &cobra.Command{
+	var description, keyUsage, keySpec string
+
+	cmd := &cobra.Command{
 		Use:   "create-key",
 		Short: "Create a KMS key",
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -38,7 +45,20 @@ func newKMSCreateKeyCmd() *cobra.Command {
 				o.BaseEndpoint = aws.String(endpointURL)
 			})
 
-			out, err := client.CreateKey(cmd.Context(), &kms.CreateKeyInput{})
+			input := &kms.CreateKeyInput{}
+			if description != "" {
+				input.Description = aws.String(description)
+			}
+
+			if keyUsage != "" {
+				input.KeyUsage = types.KeyUsageType(keyUsage)
+			}
+
+			if keySpec != "" {
+				input.KeySpec = types.KeySpec(keySpec)
+			}
+
+			out, err := client.CreateKey(cmd.Context(), input)
 			if err != nil {
 				return fmt.Errorf("create-key failed: %w", err)
 			}
@@ -50,6 +70,147 @@ func newKMSCreateKeyCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&description, "description", "", "Key description")
+	cmd.Flags().StringVar(&keyUsage, "key-usage", "", "Key usage (ENCRYPT_DECRYPT or SIGN_VERIFY)")
+	cmd.Flags().StringVar(&keySpec, "key-spec", "", "Key spec (e.g. SYMMETRIC_DEFAULT, RSA_2048, ECC_NIST_P256)")
+
+	return cmd
+}
+
+func newKMSSignCmd() *cobra.Command {
+	var keyID, message, messageType, signingAlgorithm string
+
+	cmd := &cobra.Command{
+		Use:   "sign",
+		Short: "Sign a message with an asymmetric KMS key",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := kms.NewFromConfig(cfg, func(o *kms.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &kms.SignInput{
+				KeyId:            aws.String(keyID),
+				Message:          []byte(message),
+				SigningAlgorithm: types.SigningAlgorithmSpec(signingAlgorithm),
+			}
+			if messageType != "" {
+				input.MessageType = types.MessageType(messageType)
+			}
+
+			out, err := client.Sign(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("sign failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&keyID, "key-id", "", "Key ID, ARN, or alias")
+	cmd.Flags().StringVar(&message, "message", "", "Message to sign")
+	cmd.Flags().StringVar(&messageType, "message-type", "", "Message type (RAW or DIGEST)")
+	cmd.Flags().StringVar(&signingAlgorithm, "signing-algorithm", "", "Signing algorithm (e.g. RSASSA_PKCS1_V1_5_SHA_256)")
+
+	return cmd
+}
+
+func newKMSVerifyCmd() *cobra.Command {
+	var keyID, message, messageType, signingAlgorithm, signature string
+
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verify a signature with an asymmetric KMS key",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := kms.NewFromConfig(cfg, func(o *kms.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			sig, err := base64.StdEncoding.DecodeString(signature)
+			if err != nil {
+				return fmt.Errorf("decode signature: %w", err)
+			}
+
+			input := &kms.VerifyInput{
+				KeyId:            aws.String(keyID),
+				Message:          []byte(message),
+				Signature:        sig,
+				SigningAlgorithm: types.SigningAlgorithmSpec(signingAlgorithm),
+			}
+			if messageType != "" {
+				input.MessageType = types.MessageType(messageType)
+			}
+
+			out, err := client.Verify(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("verify failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&keyID, "key-id", "", "Key ID, ARN, or alias")
+	cmd.Flags().StringVar(&message, "message", "", "Message that was signed")
+	cmd.Flags().StringVar(&signature, "signature", "", "Base64-encoded signature")
+	cmd.Flags().StringVar(&messageType, "message-type", "", "Message type (RAW or DIGEST)")
+	cmd.Flags().StringVar(&signingAlgorithm, "signing-algorithm", "", "Signing algorithm (e.g. RSASSA_PKCS1_V1_5_SHA_256)")
+
+	return cmd
+}
+
+func newKMSGetPublicKeyCmd() *cobra.Command {
+	var keyID string
+
+	cmd := &cobra.Command{
+		Use:   "get-public-key",
+		Short: "Get the public key of an asymmetric KMS key",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := kms.NewFromConfig(cfg, func(o *kms.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			out, err := client.GetPublicKey(cmd.Context(), &kms.GetPublicKeyInput{
+				KeyId: aws.String(keyID),
+			})
+			if err != nil {
+				return fmt.Errorf("get-public-key failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&keyID, "key-id", "", "Key ID, ARN, or alias")
+
+	return cmd
 }
 
 func newKMSCreateAliasCmd() *cobra.Command {

--- a/internal/service/kms/asymmetric.go
+++ b/internal/service/kms/asymmetric.go
@@ -1,0 +1,271 @@
+package kms
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	_ "crypto/sha256" // register SHA-256 for crypto.Hash.New
+	_ "crypto/sha512" // register SHA-384/512 for crypto.Hash.New
+	"crypto/x509"
+	"fmt"
+	"strings"
+)
+
+// isAsymmetricSpec reports whether the key spec is an asymmetric (RSA/ECC) spec.
+func isAsymmetricSpec(spec KeySpec) bool {
+	switch spec { //nolint:exhaustive // only RSA/ECC specs are asymmetric; the rest default to false
+	case KeySpecRSA2048, KeySpecRSA3072, KeySpecRSA4096,
+		KeySpecECCNistP256, KeySpecECCNistP384, KeySpecECCNistP521:
+		return true
+	default:
+		return false
+	}
+}
+
+// isRSASpec reports whether the key spec is an RSA spec.
+func isRSASpec(spec KeySpec) bool {
+	switch spec { //nolint:exhaustive // only RSA specs match; the rest default to false
+	case KeySpecRSA2048, KeySpecRSA3072, KeySpecRSA4096:
+		return true
+	default:
+		return false
+	}
+}
+
+// generateAsymmetricKey generates a private key for the given asymmetric spec
+// and returns it PKCS#8 DER-encoded.
+func generateAsymmetricKey(spec KeySpec) ([]byte, error) {
+	var priv crypto.PrivateKey
+
+	switch spec { //nolint:exhaustive // non-asymmetric specs are rejected by the default case
+	case KeySpecRSA2048:
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return nil, fmt.Errorf("generate RSA 2048 key: %w", err)
+		}
+
+		priv = k
+	case KeySpecRSA3072:
+		k, err := rsa.GenerateKey(rand.Reader, 3072)
+		if err != nil {
+			return nil, fmt.Errorf("generate RSA 3072 key: %w", err)
+		}
+
+		priv = k
+	case KeySpecRSA4096:
+		k, err := rsa.GenerateKey(rand.Reader, 4096)
+		if err != nil {
+			return nil, fmt.Errorf("generate RSA 4096 key: %w", err)
+		}
+
+		priv = k
+	case KeySpecECCNistP256:
+		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("generate ECC P256 key: %w", err)
+		}
+
+		priv = k
+	case KeySpecECCNistP384:
+		k, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("generate ECC P384 key: %w", err)
+		}
+
+		priv = k
+	case KeySpecECCNistP521:
+		k, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("generate ECC P521 key: %w", err)
+		}
+
+		priv = k
+	default:
+		return nil, fmt.Errorf("unsupported key spec %q", spec)
+	}
+
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("marshal private key: %w", err)
+	}
+
+	return der, nil
+}
+
+// hashForAlgorithm returns the hash function implied by a signing algorithm.
+func hashForAlgorithm(algo SigningAlgorithm) (crypto.Hash, error) {
+	switch {
+	case strings.HasSuffix(string(algo), "SHA_256"):
+		return crypto.SHA256, nil
+	case strings.HasSuffix(string(algo), "SHA_384"):
+		return crypto.SHA384, nil
+	case strings.HasSuffix(string(algo), "SHA_512"):
+		return crypto.SHA512, nil
+	default:
+		return 0, &ServiceError{
+			Code:    errInvalidKeyUsage,
+			Message: fmt.Sprintf("Unsupported signing algorithm %q", algo),
+		}
+	}
+}
+
+// digestMessage returns the digest to sign/verify. When messageType is DIGEST
+// the message is already hashed and used as-is; otherwise it is hashed with the
+// algorithm's hash function.
+func digestMessage(message []byte, h crypto.Hash, messageType MessageType) []byte {
+	if messageType == MessageTypeDigest {
+		return message
+	}
+
+	hasher := h.New()
+	hasher.Write(message)
+
+	return hasher.Sum(nil)
+}
+
+// signDigest signs a message with the PKCS#8 DER private key using the algorithm.
+func signDigest(der, message []byte, algo SigningAlgorithm, messageType MessageType) ([]byte, error) {
+	h, err := hashForAlgorithm(algo)
+	if err != nil {
+		return nil, err
+	}
+
+	priv, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+
+	digest := digestMessage(message, h, messageType)
+	isRSA := strings.HasPrefix(string(algo), "RSASSA")
+
+	switch key := priv.(type) {
+	case *rsa.PrivateKey:
+		if !isRSA {
+			return nil, &ServiceError{Code: errInvalidKeyUsage, Message: "Signing algorithm is incompatible with the RSA key."}
+		}
+
+		if strings.HasPrefix(string(algo), "RSASSA_PSS") {
+			sig, err := rsa.SignPSS(rand.Reader, key, h, digest, &rsa.PSSOptions{
+				SaltLength: rsa.PSSSaltLengthEqualsHash,
+				Hash:       h,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("sign RSA-PSS: %w", err)
+			}
+
+			return sig, nil
+		}
+
+		sig, err := rsa.SignPKCS1v15(rand.Reader, key, h, digest)
+		if err != nil {
+			return nil, fmt.Errorf("sign RSA-PKCS1v15: %w", err)
+		}
+
+		return sig, nil
+	case *ecdsa.PrivateKey:
+		if isRSA {
+			return nil, &ServiceError{Code: errInvalidKeyUsage, Message: "Signing algorithm is incompatible with the ECC key."}
+		}
+
+		sig, err := ecdsa.SignASN1(rand.Reader, key, digest)
+		if err != nil {
+			return nil, fmt.Errorf("sign ECDSA: %w", err)
+		}
+
+		return sig, nil
+	default:
+		return nil, &ServiceError{Code: errInvalidKeyUsage, Message: "Key type does not support signing."}
+	}
+}
+
+// verifyDigest verifies a signature against a message using the PKCS#8 DER private key.
+func verifyDigest(der, message, signature []byte, algo SigningAlgorithm, messageType MessageType) (bool, error) {
+	h, err := hashForAlgorithm(algo)
+	if err != nil {
+		return false, err
+	}
+
+	priv, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return false, fmt.Errorf("parse private key: %w", err)
+	}
+
+	digest := digestMessage(message, h, messageType)
+	isRSA := strings.HasPrefix(string(algo), "RSASSA")
+
+	switch key := priv.(type) {
+	case *rsa.PrivateKey:
+		if !isRSA {
+			return false, &ServiceError{Code: errInvalidKeyUsage, Message: "Signing algorithm is incompatible with the RSA key."}
+		}
+
+		if strings.HasPrefix(string(algo), "RSASSA_PSS") {
+			err = rsa.VerifyPSS(&key.PublicKey, h, digest, signature, &rsa.PSSOptions{
+				SaltLength: rsa.PSSSaltLengthAuto,
+				Hash:       h,
+			})
+		} else {
+			err = rsa.VerifyPKCS1v15(&key.PublicKey, h, digest, signature)
+		}
+
+		return err == nil, nil
+	case *ecdsa.PrivateKey:
+		if isRSA {
+			return false, &ServiceError{Code: errInvalidKeyUsage, Message: "Signing algorithm is incompatible with the ECC key."}
+		}
+
+		return ecdsa.VerifyASN1(&key.PublicKey, digest, signature), nil
+	default:
+		return false, &ServiceError{Code: errInvalidKeyUsage, Message: "Key type does not support verification."}
+	}
+}
+
+// publicKeyDER returns the DER-encoded SubjectPublicKeyInfo for the key's public part.
+func publicKeyDER(der []byte) ([]byte, error) {
+	priv, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+
+	signer, ok := priv.(crypto.Signer)
+	if !ok {
+		return nil, &ServiceError{Code: errInvalidKeyUsage, Message: "Key does not expose a public key."}
+	}
+
+	pub, err := x509.MarshalPKIXPublicKey(signer.Public())
+	if err != nil {
+		return nil, fmt.Errorf("marshal public key: %w", err)
+	}
+
+	return pub, nil
+}
+
+// signingAlgorithmsForSpec returns the signing algorithms supported by a key spec.
+func signingAlgorithmsForSpec(spec KeySpec) []string {
+	switch spec { //nolint:exhaustive // only asymmetric signing specs have signing algorithms; others return nil
+	case KeySpecRSA2048, KeySpecRSA3072, KeySpecRSA4096:
+		return []string{
+			string(SigningAlgorithmRSASSAPSSSha256), string(SigningAlgorithmRSASSAPSSSha384), string(SigningAlgorithmRSASSAPSSSha512),
+			string(SigningAlgorithmRSASSAPKCS1V15Sha256), string(SigningAlgorithmRSASSAPKCS1V15Sha384), string(SigningAlgorithmRSASSAPKCS1V15Sha512),
+		}
+	case KeySpecECCNistP256:
+		return []string{string(SigningAlgorithmECDSASha256)}
+	case KeySpecECCNistP384:
+		return []string{string(SigningAlgorithmECDSASha384)}
+	case KeySpecECCNistP521:
+		return []string{string(SigningAlgorithmECDSASha512)}
+	default:
+		return nil
+	}
+}
+
+// encryptionAlgorithmsForSpec returns the encryption algorithms supported by a key spec.
+func encryptionAlgorithmsForSpec(spec KeySpec) []string {
+	if isRSASpec(spec) {
+		return []string{string(EncryptionAlgorithmRSAESOAEPSha1), string(EncryptionAlgorithmRSAESOAEPSha256)}
+	}
+
+	return nil
+}

--- a/internal/service/kms/asymmetric_test.go
+++ b/internal/service/kms/asymmetric_test.go
@@ -1,0 +1,110 @@
+package kms
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestSignVerifyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec KeySpec
+		algo SigningAlgorithm
+	}{
+		{"RSA2048 PKCS1 SHA256", KeySpecRSA2048, SigningAlgorithmRSASSAPKCS1V15Sha256},
+		{"RSA2048 PKCS1 SHA384", KeySpecRSA2048, SigningAlgorithmRSASSAPKCS1V15Sha384},
+		{"RSA2048 PKCS1 SHA512", KeySpecRSA2048, SigningAlgorithmRSASSAPKCS1V15Sha512},
+		{"RSA2048 PSS SHA256", KeySpecRSA2048, SigningAlgorithmRSASSAPSSSha256},
+		{"RSA3072 PSS SHA384", KeySpecRSA3072, SigningAlgorithmRSASSAPSSSha384},
+		{"ECC P256", KeySpecECCNistP256, SigningAlgorithmECDSASha256},
+		{"ECC P384", KeySpecECCNistP384, SigningAlgorithmECDSASha384},
+		{"ECC P521", KeySpecECCNistP521, SigningAlgorithmECDSASha512},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			der, err := generateAsymmetricKey(tt.spec)
+			if err != nil {
+				t.Fatalf("generateAsymmetricKey: %v", err)
+			}
+
+			message := []byte("the quick brown fox")
+
+			sig, err := signDigest(der, message, tt.algo, MessageTypeRaw)
+			if err != nil {
+				t.Fatalf("signDigest: %v", err)
+			}
+
+			valid, err := verifyDigest(der, message, sig, tt.algo, MessageTypeRaw)
+			if err != nil {
+				t.Fatalf("verifyDigest: %v", err)
+			}
+
+			if !valid {
+				t.Error("expected signature to verify")
+			}
+
+			// A tampered message must not verify.
+			tampered, err := verifyDigest(der, []byte("tampered"), sig, tt.algo, MessageTypeRaw)
+			if err != nil {
+				t.Fatalf("verifyDigest tampered: %v", err)
+			}
+
+			if tampered {
+				t.Error("expected tampered message to fail verification")
+			}
+		})
+	}
+}
+
+func TestSignDigest_AlgorithmKeyMismatch(t *testing.T) {
+	t.Parallel()
+
+	rsaKey, err := generateAsymmetricKey(KeySpecRSA2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eccKey, err := generateAsymmetricKey(KeySpecECCNistP256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// RSA algorithm against an ECC key must be rejected.
+	if _, err := signDigest(eccKey, []byte("msg"), SigningAlgorithmRSASSAPSSSha256, MessageTypeRaw); err == nil {
+		t.Error("expected error signing ECC key with RSA algorithm")
+	}
+
+	// ECDSA algorithm against an RSA key must be rejected.
+	if _, err := signDigest(rsaKey, []byte("msg"), SigningAlgorithmECDSASha256, MessageTypeRaw); err == nil {
+		t.Error("expected error signing RSA key with ECDSA algorithm")
+	}
+}
+
+func TestHashForAlgorithm_Unsupported(t *testing.T) {
+	t.Parallel()
+
+	_, err := hashForAlgorithm(SigningAlgorithm("BOGUS_ALGO"))
+
+	var svcErr *ServiceError
+	if !errors.As(err, &svcErr) || svcErr.Code != errInvalidKeyUsage {
+		t.Errorf("expected InvalidKeyUsage ServiceError, got %v", err)
+	}
+}
+
+func TestDigestMessage_DigestPassthrough(t *testing.T) {
+	t.Parallel()
+
+	// When MessageType is DIGEST, the message is returned unchanged.
+	digest := []byte("already-a-digest")
+
+	got := digestMessage(digest, 0, MessageTypeDigest)
+	if !bytes.Equal(got, digest) {
+		t.Errorf("expected passthrough, got %q", got)
+	}
+}

--- a/internal/service/kms/handlers.go
+++ b/internal/service/kms/handlers.go
@@ -28,6 +28,9 @@ func (s *Service) getActionHandlers() map[string]handlerFunc {
 		"Encrypt":             s.Encrypt,
 		"Decrypt":             s.Decrypt,
 		"GenerateDataKey":     s.GenerateDataKey,
+		"Sign":                s.Sign,
+		"Verify":              s.Verify,
+		"GetPublicKey":        s.GetPublicKey,
 		"CreateAlias":         s.CreateAlias,
 		"DeleteAlias":         s.DeleteAlias,
 		"ListAliases":         s.ListAliases,
@@ -294,6 +297,102 @@ func (s *Service) GenerateDataKey(w http.ResponseWriter, r *http.Request) {
 	writeKMSResponse(w, resp)
 }
 
+// Sign handles the Sign API.
+func (s *Service) Sign(w http.ResponseWriter, r *http.Request) {
+	var req SignRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	messageType := MessageType(req.MessageType)
+	if messageType == "" {
+		messageType = MessageTypeRaw
+	}
+
+	signature, key, err := s.storage.Sign(r.Context(), req.KeyID, req.Message, SigningAlgorithm(req.SigningAlgorithm), messageType)
+	if err != nil {
+		handleKMSError(w, err)
+
+		return
+	}
+
+	writeKMSResponse(w, &SignResponse{
+		KeyID:            key.Arn,
+		Signature:        signature,
+		SigningAlgorithm: req.SigningAlgorithm,
+	})
+}
+
+// Verify handles the Verify API.
+func (s *Service) Verify(w http.ResponseWriter, r *http.Request) {
+	var req VerifyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	messageType := MessageType(req.MessageType)
+	if messageType == "" {
+		messageType = MessageTypeRaw
+	}
+
+	valid, key, err := s.storage.Verify(r.Context(), req.KeyID, req.Message, req.Signature, SigningAlgorithm(req.SigningAlgorithm), messageType)
+	if err != nil {
+		handleKMSError(w, err)
+
+		return
+	}
+
+	// AWS returns KMSInvalidSignatureException when the signature does not match.
+	if !valid {
+		writeKMSError(w, errInvalidSignature, "The signature was not generated for the specified message, signing algorithm, and key.", http.StatusBadRequest)
+
+		return
+	}
+
+	writeKMSResponse(w, &VerifyResponse{
+		KeyID:            key.Arn,
+		SignatureValid:   valid,
+		SigningAlgorithm: req.SigningAlgorithm,
+	})
+}
+
+// GetPublicKey handles the GetPublicKey API.
+func (s *Service) GetPublicKey(w http.ResponseWriter, r *http.Request) {
+	var req GetPublicKeyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	der, key, err := s.storage.GetPublicKey(r.Context(), req.KeyID)
+	if err != nil {
+		handleKMSError(w, err)
+
+		return
+	}
+
+	resp := &GetPublicKeyResponse{
+		KeyID:                 key.Arn,
+		PublicKey:             der,
+		CustomerMasterKeySpec: string(key.KeySpec),
+		KeySpec:               string(key.KeySpec),
+		KeyUsage:              string(key.KeyUsage),
+	}
+
+	if key.KeyUsage == KeyUsageSignVerify {
+		resp.SigningAlgorithms = signingAlgorithmsForSpec(key.KeySpec)
+	} else {
+		resp.EncryptionAlgorithms = encryptionAlgorithmsForSpec(key.KeySpec)
+	}
+
+	writeKMSResponse(w, resp)
+}
+
 // CreateAlias handles the CreateAlias API.
 func (s *Service) CreateAlias(w http.ResponseWriter, r *http.Request) {
 	var req CreateAliasRequest
@@ -383,8 +482,13 @@ func keyToMetadata(key *Key) *KeyMetadata {
 		MultiRegion:  key.MultiRegion,
 	}
 
-	if key.KeyUsage == KeyUsageEncryptDecrypt {
-		metadata.EncryptionAlgorithms = []string{"SYMMETRIC_DEFAULT"}
+	switch {
+	case isAsymmetricSpec(key.KeySpec) && key.KeyUsage == KeyUsageSignVerify:
+		metadata.SigningAlgorithms = signingAlgorithmsForSpec(key.KeySpec)
+	case isAsymmetricSpec(key.KeySpec):
+		metadata.EncryptionAlgorithms = encryptionAlgorithmsForSpec(key.KeySpec)
+	case key.KeyUsage == KeyUsageEncryptDecrypt:
+		metadata.EncryptionAlgorithms = []string{string(EncryptionAlgorithmSymmetricDefault)}
 	}
 
 	if key.DeletionDate != nil {

--- a/internal/service/kms/storage.go
+++ b/internal/service/kms/storage.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -39,6 +40,7 @@ const (
 	errIncorrectKey      = "IncorrectKeyException"
 	errDisabled          = "DisabledException"
 	errInvalidKeyUsage   = "InvalidKeyUsageException"
+	errInvalidSignature  = "KMSInvalidSignatureException"
 )
 
 // determineKeySize returns the key size based on key spec or number of bytes.
@@ -71,6 +73,11 @@ type Storage interface {
 	Encrypt(ctx context.Context, keyID string, plaintext []byte, encryptionContext map[string]string) ([]byte, error)
 	Decrypt(ctx context.Context, ciphertextBlob []byte, encryptionContext map[string]string, keyID string) ([]byte, string, error)
 	GenerateDataKey(ctx context.Context, keyID string, keySpec string, numberOfBytes int32, encryptionContext map[string]string) ([]byte, []byte, error)
+
+	// Asymmetric operations.
+	Sign(ctx context.Context, keyID string, message []byte, algorithm SigningAlgorithm, messageType MessageType) ([]byte, *Key, error)
+	Verify(ctx context.Context, keyID string, message, signature []byte, algorithm SigningAlgorithm, messageType MessageType) (bool, *Key, error)
+	GetPublicKey(ctx context.Context, keyID string) ([]byte, *Key, error)
 
 	// Policy operations.
 	GetKeyPolicy(ctx context.Context, keyID string) (string, error)
@@ -208,6 +215,26 @@ func (s *MemoryStorage) Close() error {
 	return nil
 }
 
+// generateKeyMaterial produces the key material for a new key. Asymmetric specs
+// return a PKCS#8 DER private key; symmetric specs return a 256-bit AES key.
+func generateKeyMaterial(keySpec KeySpec) (symmetric, asymmetric []byte, err error) {
+	if isAsymmetricSpec(keySpec) {
+		der, genErr := generateAsymmetricKey(keySpec)
+		if genErr != nil {
+			return nil, nil, &ServiceError{Code: errDependencyTimeout, Message: "Failed to generate key material"}
+		}
+
+		return nil, der, nil
+	}
+
+	material := make([]byte, 32)
+	if _, readErr := io.ReadFull(rand.Reader, material); readErr != nil {
+		return nil, nil, &ServiceError{Code: errDependencyTimeout, Message: "Failed to generate key material"}
+	}
+
+	return material, nil, nil
+}
+
 // CreateKey creates a new KMS key.
 func (s *MemoryStorage) CreateKey(_ context.Context, req *CreateKeyRequest) (*Key, error) {
 	s.mu.Lock()
@@ -215,12 +242,6 @@ func (s *MemoryStorage) CreateKey(_ context.Context, req *CreateKeyRequest) (*Ke
 
 	keyID := uuid.New().String()
 	arn := fmt.Sprintf("arn:aws:kms:%s:%s:key/%s", s.region, defaultAccountID, keyID)
-
-	// Generate random key material (256-bit for AES-256).
-	keyMaterial := make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, keyMaterial); err != nil {
-		return nil, &ServiceError{Code: errDependencyTimeout, Message: "Failed to generate key material"}
-	}
 
 	keyUsage := KeyUsageEncryptDecrypt
 	if req.KeyUsage != "" {
@@ -230,6 +251,11 @@ func (s *MemoryStorage) CreateKey(_ context.Context, req *CreateKeyRequest) (*Ke
 	keySpec := KeySpecSymmetricDefault
 	if req.KeySpec != "" {
 		keySpec = KeySpec(req.KeySpec)
+	}
+
+	keyMaterial, asymmetricKey, err := generateKeyMaterial(keySpec)
+	if err != nil {
+		return nil, err
 	}
 
 	origin := "AWS_KMS"
@@ -248,20 +274,21 @@ func (s *MemoryStorage) CreateKey(_ context.Context, req *CreateKeyRequest) (*Ke
 	}
 
 	key := &Key{
-		KeyID:        keyID,
-		Arn:          arn,
-		Description:  req.Description,
-		KeyState:     KeyStateEnabled,
-		KeyUsage:     keyUsage,
-		KeySpec:      keySpec,
-		KeyManager:   KeyManagerCustomer,
-		CreationDate: time.Now(),
-		Enabled:      true,
-		Origin:       origin,
-		MultiRegion:  req.MultiRegion,
-		Tags:         tags,
-		Policy:       policy,
-		KeyMaterial:  keyMaterial,
+		KeyID:         keyID,
+		Arn:           arn,
+		Description:   req.Description,
+		KeyState:      KeyStateEnabled,
+		KeyUsage:      keyUsage,
+		KeySpec:       keySpec,
+		KeyManager:    KeyManagerCustomer,
+		CreationDate:  time.Now(),
+		Enabled:       true,
+		Origin:        origin,
+		MultiRegion:   req.MultiRegion,
+		Tags:          tags,
+		Policy:        policy,
+		KeyMaterial:   keyMaterial,
+		AsymmetricKey: asymmetricKey,
 	}
 
 	s.Keys[keyID] = key
@@ -584,6 +611,91 @@ func (s *MemoryStorage) GenerateDataKey(_ context.Context, keyID, keySpec string
 	encryptedKey = append(encryptedKey, ciphertext...)
 
 	return plaintext, encryptedKey, nil
+}
+
+// Sign signs a message with an asymmetric key.
+func (s *MemoryStorage) Sign(_ context.Context, keyID string, message []byte, algorithm SigningAlgorithm, messageType MessageType) ([]byte, *Key, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key, err := s.getKeyLocked(keyID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if key.KeyState != KeyStateEnabled {
+		return nil, nil, &ServiceError{Code: errDisabled, Message: "Key " + keyID + " is disabled."}
+	}
+
+	if key.KeyUsage != KeyUsageSignVerify || len(key.AsymmetricKey) == 0 {
+		return nil, nil, &ServiceError{Code: errInvalidKeyUsage, Message: "Key " + keyID + " is not configured for signing."}
+	}
+
+	signature, err := signDigest(key.AsymmetricKey, message, algorithm, messageType)
+	if err != nil {
+		return nil, nil, wrapSigningError(err)
+	}
+
+	return signature, key, nil
+}
+
+// Verify verifies a signature against a message with an asymmetric key.
+func (s *MemoryStorage) Verify(_ context.Context, keyID string, message, signature []byte, algorithm SigningAlgorithm, messageType MessageType) (bool, *Key, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key, err := s.getKeyLocked(keyID)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if key.KeyState != KeyStateEnabled {
+		return false, nil, &ServiceError{Code: errDisabled, Message: "Key " + keyID + " is disabled."}
+	}
+
+	if key.KeyUsage != KeyUsageSignVerify || len(key.AsymmetricKey) == 0 {
+		return false, nil, &ServiceError{Code: errInvalidKeyUsage, Message: "Key " + keyID + " is not configured for verification."}
+	}
+
+	valid, err := verifyDigest(key.AsymmetricKey, message, signature, algorithm, messageType)
+	if err != nil {
+		return false, nil, wrapSigningError(err)
+	}
+
+	return valid, key, nil
+}
+
+// GetPublicKey returns the DER-encoded public key of an asymmetric key.
+func (s *MemoryStorage) GetPublicKey(_ context.Context, keyID string) ([]byte, *Key, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key, err := s.getKeyLocked(keyID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(key.AsymmetricKey) == 0 {
+		return nil, nil, &ServiceError{Code: errInvalidKeyUsage, Message: "Key " + keyID + " is not an asymmetric key."}
+	}
+
+	der, err := publicKeyDER(key.AsymmetricKey)
+	if err != nil {
+		return nil, nil, wrapSigningError(err)
+	}
+
+	return der, key, nil
+}
+
+// wrapSigningError returns the error as-is when it is already a ServiceError,
+// otherwise wraps it in an InvalidKeyUsage ServiceError.
+func wrapSigningError(err error) error {
+	var svcErr *ServiceError
+	if errors.As(err, &svcErr) {
+		return svcErr
+	}
+
+	return &ServiceError{Code: errInvalidKeyUsage, Message: err.Error()}
 }
 
 // CreateAlias creates an alias for a key.

--- a/internal/service/kms/types.go
+++ b/internal/service/kms/types.go
@@ -45,6 +45,41 @@ const (
 	KeySpecHMAC512          KeySpec = "HMAC_512"
 )
 
+// SigningAlgorithm represents a signing algorithm spec.
+type SigningAlgorithm string
+
+// Signing algorithms.
+const (
+	SigningAlgorithmRSASSAPSSSha256      SigningAlgorithm = "RSASSA_PSS_SHA_256"
+	SigningAlgorithmRSASSAPSSSha384      SigningAlgorithm = "RSASSA_PSS_SHA_384"
+	SigningAlgorithmRSASSAPSSSha512      SigningAlgorithm = "RSASSA_PSS_SHA_512"
+	SigningAlgorithmRSASSAPKCS1V15Sha256 SigningAlgorithm = "RSASSA_PKCS1_V1_5_SHA_256"
+	SigningAlgorithmRSASSAPKCS1V15Sha384 SigningAlgorithm = "RSASSA_PKCS1_V1_5_SHA_384"
+	SigningAlgorithmRSASSAPKCS1V15Sha512 SigningAlgorithm = "RSASSA_PKCS1_V1_5_SHA_512"
+	SigningAlgorithmECDSASha256          SigningAlgorithm = "ECDSA_SHA_256"
+	SigningAlgorithmECDSASha384          SigningAlgorithm = "ECDSA_SHA_384"
+	SigningAlgorithmECDSASha512          SigningAlgorithm = "ECDSA_SHA_512"
+)
+
+// EncryptionAlgorithm represents an encryption algorithm spec.
+type EncryptionAlgorithm string
+
+// Encryption algorithms.
+const (
+	EncryptionAlgorithmSymmetricDefault EncryptionAlgorithm = "SYMMETRIC_DEFAULT"
+	EncryptionAlgorithmRSAESOAEPSha1    EncryptionAlgorithm = "RSAES_OAEP_SHA_1"
+	EncryptionAlgorithmRSAESOAEPSha256  EncryptionAlgorithm = "RSAES_OAEP_SHA_256"
+)
+
+// MessageType represents whether a Sign/Verify message is RAW or a DIGEST.
+type MessageType string
+
+// Message types.
+const (
+	MessageTypeRaw    MessageType = "RAW"
+	MessageTypeDigest MessageType = "DIGEST"
+)
+
 // KeyManager represents who manages the key material.
 type KeyManager string
 
@@ -75,8 +110,11 @@ type Key struct {
 	PendingDeletionWindow int32
 	Tags                  map[string]string
 	Policy                string // IAM key policy document
-	// Simulated key material for encryption/decryption.
+	// Simulated key material for symmetric encryption/decryption (AES-GCM).
 	KeyMaterial []byte
+	// AsymmetricKey holds the PKCS#8 DER-encoded private key for asymmetric
+	// (RSA/ECC) keys used by Sign/Verify/GetPublicKey. Nil for symmetric keys.
+	AsymmetricKey []byte
 }
 
 // MultiRegionConfig represents multi-region key configuration.
@@ -428,4 +466,56 @@ type GetKeyRotationStatusRequest struct {
 // GetKeyRotationStatusResponse is the response for GetKeyRotationStatus.
 type GetKeyRotationStatusResponse struct {
 	KeyRotationEnabled bool `json:"KeyRotationEnabled"`
+}
+
+// SignRequest is the request for Sign.
+type SignRequest struct {
+	KeyID            string   `json:"KeyId"`
+	Message          []byte   `json:"Message"`
+	MessageType      string   `json:"MessageType,omitempty"`
+	SigningAlgorithm string   `json:"SigningAlgorithm"`
+	GrantTokens      []string `json:"GrantTokens,omitempty"`
+	DryRun           bool     `json:"DryRun,omitempty"`
+}
+
+// SignResponse is the response for Sign.
+type SignResponse struct {
+	KeyID            string `json:"KeyId"`
+	Signature        []byte `json:"Signature"`
+	SigningAlgorithm string `json:"SigningAlgorithm"`
+}
+
+// VerifyRequest is the request for Verify.
+type VerifyRequest struct {
+	KeyID            string   `json:"KeyId"`
+	Message          []byte   `json:"Message"`
+	Signature        []byte   `json:"Signature"`
+	MessageType      string   `json:"MessageType,omitempty"`
+	SigningAlgorithm string   `json:"SigningAlgorithm"`
+	GrantTokens      []string `json:"GrantTokens,omitempty"`
+	DryRun           bool     `json:"DryRun,omitempty"`
+}
+
+// VerifyResponse is the response for Verify.
+type VerifyResponse struct {
+	KeyID            string `json:"KeyId"`
+	SignatureValid   bool   `json:"SignatureValid"`
+	SigningAlgorithm string `json:"SigningAlgorithm"`
+}
+
+// GetPublicKeyRequest is the request for GetPublicKey.
+type GetPublicKeyRequest struct {
+	KeyID       string   `json:"KeyId"`
+	GrantTokens []string `json:"GrantTokens,omitempty"`
+}
+
+// GetPublicKeyResponse is the response for GetPublicKey.
+type GetPublicKeyResponse struct {
+	KeyID                 string   `json:"KeyId"`
+	PublicKey             []byte   `json:"PublicKey"`
+	CustomerMasterKeySpec string   `json:"CustomerMasterKeySpec,omitempty"`
+	KeySpec               string   `json:"KeySpec,omitempty"`
+	KeyUsage              string   `json:"KeyUsage,omitempty"`
+	EncryptionAlgorithms  []string `json:"EncryptionAlgorithms,omitempty"`
+	SigningAlgorithms     []string `json:"SigningAlgorithms,omitempty"`
 }

--- a/test/integration/kms_test.go
+++ b/test/integration/kms_test.go
@@ -4,6 +4,10 @@ package integration
 
 import (
 	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -456,6 +460,188 @@ func TestKMS_KeyPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_list", listOutput)
+}
+
+func TestKMS_SignVerify(t *testing.T) {
+	client := newKMSClient(t)
+	ctx := t.Context()
+
+	// Create an RSA asymmetric signing key.
+	createOutput, err := client.CreateKey(ctx, &kms.CreateKeyInput{
+		Description: aws.String("Test RSA signing key"),
+		KeyUsage:    types.KeyUsageTypeSignVerify,
+		KeySpec:     types.KeySpecRsa2048,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "KeyId", "Arn", "CreationDate")).Assert(t.Name()+"_create", createOutput)
+
+	keyID := *createOutput.KeyMetadata.KeyId
+
+	t.Cleanup(func() {
+		_, _ = client.ScheduleKeyDeletion(context.Background(), &kms.ScheduleKeyDeletionInput{
+			KeyId:               aws.String(keyID),
+			PendingWindowInDays: aws.Int32(7),
+		})
+	})
+
+	message := []byte("CloudFront signed cookie payload")
+
+	// Sign the message.
+	signOutput, err := client.Sign(ctx, &kms.SignInput{
+		KeyId:            aws.String(keyID),
+		Message:          message,
+		SigningAlgorithm: types.SigningAlgorithmSpecRsassaPkcs1V15Sha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(signOutput.Signature) == 0 {
+		t.Fatal("signature is empty")
+	}
+
+	// Verify the signature.
+	verifyOutput, err := client.Verify(ctx, &kms.VerifyInput{
+		KeyId:            aws.String(keyID),
+		Message:          message,
+		Signature:        signOutput.Signature,
+		SigningAlgorithm: types.SigningAlgorithmSpecRsassaPkcs1V15Sha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !verifyOutput.SignatureValid {
+		t.Error("expected signature to be valid")
+	}
+
+	// Verifying a tampered message must fail.
+	_, err = client.Verify(ctx, &kms.VerifyInput{
+		KeyId:            aws.String(keyID),
+		Message:          []byte("tampered payload"),
+		Signature:        signOutput.Signature,
+		SigningAlgorithm: types.SigningAlgorithmSpecRsassaPkcs1V15Sha256,
+	})
+	if err == nil {
+		t.Error("expected verification of tampered message to fail")
+	}
+}
+
+func TestKMS_SignVerifyECC(t *testing.T) {
+	client := newKMSClient(t)
+	ctx := t.Context()
+
+	createOutput, err := client.CreateKey(ctx, &kms.CreateKeyInput{
+		Description: aws.String("Test ECC signing key"),
+		KeyUsage:    types.KeyUsageTypeSignVerify,
+		KeySpec:     types.KeySpecEccNistP256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "KeyId", "Arn", "CreationDate")).Assert(t.Name()+"_create", createOutput)
+
+	keyID := *createOutput.KeyMetadata.KeyId
+
+	t.Cleanup(func() {
+		_, _ = client.ScheduleKeyDeletion(context.Background(), &kms.ScheduleKeyDeletionInput{
+			KeyId:               aws.String(keyID),
+			PendingWindowInDays: aws.Int32(7),
+		})
+	})
+
+	message := []byte("hello ecc")
+
+	signOutput, err := client.Sign(ctx, &kms.SignInput{
+		KeyId:            aws.String(keyID),
+		Message:          message,
+		SigningAlgorithm: types.SigningAlgorithmSpecEcdsaSha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verifyOutput, err := client.Verify(ctx, &kms.VerifyInput{
+		KeyId:            aws.String(keyID),
+		Message:          message,
+		Signature:        signOutput.Signature,
+		SigningAlgorithm: types.SigningAlgorithmSpecEcdsaSha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !verifyOutput.SignatureValid {
+		t.Error("expected signature to be valid")
+	}
+}
+
+func TestKMS_GetPublicKey(t *testing.T) {
+	client := newKMSClient(t)
+	ctx := t.Context()
+
+	createOutput, err := client.CreateKey(ctx, &kms.CreateKeyInput{
+		Description: aws.String("Test get public key"),
+		KeyUsage:    types.KeyUsageTypeSignVerify,
+		KeySpec:     types.KeySpecRsa2048,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyID := *createOutput.KeyMetadata.KeyId
+
+	t.Cleanup(func() {
+		_, _ = client.ScheduleKeyDeletion(context.Background(), &kms.ScheduleKeyDeletionInput{
+			KeyId:               aws.String(keyID),
+			PendingWindowInDays: aws.Int32(7),
+		})
+	})
+
+	pubOutput, err := client.GetPublicKey(ctx, &kms.GetPublicKeyInput{
+		KeyId: aws.String(keyID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pubOutput.PublicKey) == 0 {
+		t.Fatal("public key is empty")
+	}
+
+	// The returned public key must be a parseable DER SubjectPublicKeyInfo and
+	// must verify a signature produced by the same key (offline verification).
+	pubKey, err := x509.ParsePKIXPublicKey(pubOutput.PublicKey)
+	if err != nil {
+		t.Fatalf("failed to parse public key: %v", err)
+	}
+
+	rsaPub, ok := pubKey.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("expected RSA public key, got %T", pubKey)
+	}
+
+	message := []byte("offline verification")
+	signOutput, err := client.Sign(ctx, &kms.SignInput{
+		KeyId:            aws.String(keyID),
+		Message:          message,
+		SigningAlgorithm: types.SigningAlgorithmSpecRsassaPkcs1V15Sha256,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digest := sha256.Sum256(message)
+	if err := rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, digest[:], signOutput.Signature); err != nil {
+		t.Errorf("offline verification failed: %v", err)
+	}
+
+	// PublicKey and key identifiers are dynamic; assert the stable shape only.
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "KeyId", "PublicKey")).Assert(t.Name(), pubOutput)
 }
 
 func TestKMS_TagOperations(t *testing.T) {

--- a/test/integration/testdata/kms_test_TestKMS_GetPublicKey_TestKMS_GetPublicKey.golden.go
+++ b/test/integration/testdata/kms_test_TestKMS_GetPublicKey_TestKMS_GetPublicKey.golden.go
@@ -1,0 +1,18 @@
+{
+  "CustomerMasterKeySpec": "RSA_2048",
+  "EncryptionAlgorithms": null,
+  "KeyAgreementAlgorithms": null,
+  "KeyId": "arn:aws:kms:us-east-1:000000000000:key/b152f6bc-425e-4738-a274-56620df561a8",
+  "KeySpec": "RSA_2048",
+  "KeyUsage": "SIGN_VERIFY",
+  "PublicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA724rdQjaizrCCDltavH2fWrORGOkBauXeVCs33LC8jpvEoT+Bld/uUqDHmIXwZ2/jv+FZyg/IYxJNSxf7sytwAEpobxJq7EZL6AKXrcS+NxIDnY1O+EJNDmUn3DOj3DwDph7e+NZLYvkTaM0h2WGMSeOqdKktqE518bKez03KQ8S4g+ycpEkXHjJ+Km45NqTVFkSmRYs1O6WHTkcYKtw+/WAJ/XQNSxFH+rxZti7OyoIE8mrtH9AU2pUr07+PlT8VJCk2U47YAUmj5KNEFFroPGfgYjYbRsFfQX1KCqE5+hjOY8+sHzh4yIKLYDRz3MdIpIVGFVOFiPap5bIIZyBSwIDAQAB",
+  "SigningAlgorithms": [
+    "RSASSA_PSS_SHA_256",
+    "RSASSA_PSS_SHA_384",
+    "RSASSA_PSS_SHA_512",
+    "RSASSA_PKCS1_V1_5_SHA_256",
+    "RSASSA_PKCS1_V1_5_SHA_384",
+    "RSASSA_PKCS1_V1_5_SHA_512"
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/kms_test_TestKMS_SignVerifyECC_TestKMS_SignVerifyECC_create.golden.go
+++ b/test/integration/testdata/kms_test_TestKMS_SignVerifyECC_TestKMS_SignVerifyECC_create.golden.go
@@ -1,0 +1,33 @@
+{
+  "KeyMetadata": {
+    "KeyId": "a473c01b-f2b8-4fdc-891f-8fdc5a4e19c8",
+    "AWSAccountId": "000000000000",
+    "Arn": "arn:aws:kms:us-east-1:000000000000:key/a473c01b-f2b8-4fdc-891f-8fdc5a4e19c8",
+    "CloudHsmClusterId": null,
+    "CreationDate": "2026-05-29T12:54:36Z",
+    "CurrentKeyMaterialId": null,
+    "CustomKeyStoreId": null,
+    "CustomerMasterKeySpec": "",
+    "DeletionDate": null,
+    "Description": "Test ECC signing key",
+    "Enabled": true,
+    "EncryptionAlgorithms": null,
+    "ExpirationModel": "",
+    "KeyAgreementAlgorithms": null,
+    "KeyManager": "CUSTOMER",
+    "KeySpec": "ECC_NIST_P256",
+    "KeyState": "Enabled",
+    "KeyUsage": "SIGN_VERIFY",
+    "MacAlgorithms": null,
+    "MultiRegion": null,
+    "MultiRegionConfiguration": null,
+    "Origin": "AWS_KMS",
+    "PendingDeletionWindowInDays": null,
+    "SigningAlgorithms": [
+      "ECDSA_SHA_256"
+    ],
+    "ValidTo": null,
+    "XksKeyConfiguration": null
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/kms_test_TestKMS_SignVerify_TestKMS_SignVerify_create.golden.go
+++ b/test/integration/testdata/kms_test_TestKMS_SignVerify_TestKMS_SignVerify_create.golden.go
@@ -1,0 +1,38 @@
+{
+  "KeyMetadata": {
+    "KeyId": "135058e7-fcc3-4969-8656-b50787254971",
+    "AWSAccountId": "000000000000",
+    "Arn": "arn:aws:kms:us-east-1:000000000000:key/135058e7-fcc3-4969-8656-b50787254971",
+    "CloudHsmClusterId": null,
+    "CreationDate": "2026-05-29T12:54:36Z",
+    "CurrentKeyMaterialId": null,
+    "CustomKeyStoreId": null,
+    "CustomerMasterKeySpec": "",
+    "DeletionDate": null,
+    "Description": "Test RSA signing key",
+    "Enabled": true,
+    "EncryptionAlgorithms": null,
+    "ExpirationModel": "",
+    "KeyAgreementAlgorithms": null,
+    "KeyManager": "CUSTOMER",
+    "KeySpec": "RSA_2048",
+    "KeyState": "Enabled",
+    "KeyUsage": "SIGN_VERIFY",
+    "MacAlgorithms": null,
+    "MultiRegion": null,
+    "MultiRegionConfiguration": null,
+    "Origin": "AWS_KMS",
+    "PendingDeletionWindowInDays": null,
+    "SigningAlgorithms": [
+      "RSASSA_PSS_SHA_256",
+      "RSASSA_PSS_SHA_384",
+      "RSASSA_PSS_SHA_512",
+      "RSASSA_PKCS1_V1_5_SHA_256",
+      "RSASSA_PKCS1_V1_5_SHA_384",
+      "RSASSA_PKCS1_V1_5_SHA_512"
+    ],
+    "ValidTo": null,
+    "XksKeyConfiguration": null
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
- Add asymmetric key support to the KMS emulator so CloudFront signed cookie/URL flows can run locally. Previously KMS only handled symmetric (AES-GCM) keys, so the redeem step that signs with KMS could not run.
- `CreateKey` now generates RSA (2048/3072/4096) and ECC (NIST P256/P384/P521) key pairs when an asymmetric `KeySpec` is requested, stored as PKCS#8 DER.
- New actions `Sign`, `Verify`, `GetPublicKey`. Signature encoding matches AWS (PKCS#1 for RSA, ASN.1 DER for ECDSA); `Verify` returns `KMSInvalidSignatureException` on mismatch.
- `DescribeKey`/`CreateKey` metadata now reports `SigningAlgorithms` for asymmetric signing keys.
- CLI: `create-key` gains `--key-usage`/`--key-spec`/`--description`; new `sign`, `verify`, `get-public-key` subcommands.

## Details
- Signing algorithms: `RSASSA_PSS_SHA_{256,384,512}`, `RSASSA_PKCS1_V1_5_SHA_{256,384,512}`, `ECDSA_SHA_{256,384,512}`.
- `GetPublicKey` returns the DER-encoded SubjectPublicKeyInfo (X.509), verified by parsing it back and confirming offline signature verification in tests.
- Out of scope (rejected with `InvalidKeyUsageException`): SM2, ML-DSA, ED25519, `ECC_SECG_P256K1` — not needed for CloudFront.
- API field names and signature formats were verified against the AWS SDK for Go v2 KMS types (v1.49.5).

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./...` (main module)
- [x] `make lint` (0 issues)
- [x] KMS integration golden tests (14 total): new `TestKMS_SignVerify` (RSA), `TestKMS_SignVerifyECC`, `TestKMS_GetPublicKey` (incl. offline verification + tampered-message rejection)
- [x] Unit tests in `asymmetric_test.go`: sign/verify round-trip across 8 algorithms, algorithm/key-type mismatch, unsupported-algorithm handling