### PR TITLE
fix(cloudfront): support SHA256 signed cookie/URL verification

### DIFF
--- a/internal/service/cloudfront/edge_signing.go
+++ b/internal/service/cloudfront/edge_signing.go
@@ -3,7 +3,8 @@ package cloudfront
 import (
 	"crypto"
 	"crypto/rsa"
-	"crypto/sha1" //nolint:gosec // CloudFront uses RSA-SHA1 for signed URL/cookie verification.
+	"crypto/sha1" //nolint:gosec // CloudFront uses RSA-SHA1 for legacy signed URL/cookie verification.
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -19,15 +20,23 @@ import (
 const (
 	schemeHTTPS = "https"
 	schemeHTTP  = "http"
+
+	// hashAlgorithmSHA256 is the value AWS CloudFront sends in the
+	// CloudFront-Hash-Algorithm cookie / Hash-Algorithm query parameter
+	// when a request is signed with RSA-SHA256. CloudFront added SHA256
+	// signing on 2026-04-01; an empty or "SHA1" value means legacy
+	// RSA-SHA1.
+	hashAlgorithmSHA256 = "SHA256"
 )
 
 // signedCredentials holds the three components needed to verify a
 // CloudFront signed request (cookie or URL).
 type signedCredentials struct {
-	Policy    string // CF-Base64-encoded custom policy JSON, or "" for canned
-	Signature string // CF-Base64-encoded RSA-SHA1 signature
-	KeyPairID string // ID of the public key to use for verification
-	Expires   int64  // Unix epoch for canned policy (from Expires param)
+	Policy        string // CF-Base64-encoded custom policy JSON, or "" for canned
+	Signature     string // CF-Base64-encoded RSA-SHA1 or RSA-SHA256 signature
+	KeyPairID     string // ID of the public key to use for verification
+	Expires       int64  // Unix epoch for canned policy (from Expires param)
+	HashAlgorithm string // "SHA256" selects RSA-SHA256; empty or "SHA1" means legacy RSA-SHA1
 }
 
 // cfPolicy is the JSON structure of a CloudFront access policy.
@@ -80,9 +89,10 @@ func extractFromCookies(r *http.Request) *signedCredentials {
 	}
 
 	return &signedCredentials{
-		Policy:    cookieValue(r, "CloudFront-Policy"),
-		Signature: sig,
-		KeyPairID: kid,
+		Policy:        cookieValue(r, "CloudFront-Policy"),
+		Signature:     sig,
+		KeyPairID:     kid,
+		HashAlgorithm: cookieValue(r, "CloudFront-Hash-Algorithm"),
 	}
 }
 
@@ -96,8 +106,9 @@ func extractFromQuery(r *http.Request) *signedCredentials {
 	}
 
 	creds := &signedCredentials{
-		Signature: sig,
-		KeyPairID: kid,
+		Signature:     sig,
+		KeyPairID:     kid,
+		HashAlgorithm: q.Get("Hash-Algorithm"),
 	}
 
 	if policy := q.Get("Policy"); policy != "" {
@@ -161,7 +172,7 @@ func (s *Service) verifySigned(r *http.Request, dist *Distribution, creds *signe
 		return fmt.Errorf("invalid policy: %w", err)
 	}
 
-	if err := verifyRSASHA1(pubKey, policyBytes, creds.Signature); err != nil {
+	if err := verifySignature(pubKey, policyBytes, creds.Signature, creds.HashAlgorithm); err != nil {
 		return fmt.Errorf("signature verification failed: %w", err)
 	}
 
@@ -267,6 +278,7 @@ func requestResourceURL(r *http.Request) string {
 	q.Del("Signature")
 	q.Del("Key-Pair-Id")
 	q.Del("Policy")
+	q.Del("Hash-Algorithm")
 
 	if encoded := q.Encode(); encoded != "" {
 		base += "?" + encoded
@@ -290,6 +302,20 @@ func cfBase64Decode(s string) ([]byte, error) {
 	return decoded, nil
 }
 
+// verifySignature verifies an RSA signature against the message using
+// the hash algorithm advertised by CloudFront. hashAlg comes from the
+// CloudFront-Hash-Algorithm cookie or the Hash-Algorithm query
+// parameter. AWS CloudFront began supporting RSA-SHA256 signing on
+// 2026-04-01; an empty or "SHA1" value selects the legacy RSA-SHA1 path
+// so previously issued signatures keep working.
+func verifySignature(pub *rsa.PublicKey, message []byte, sig, hashAlg string) error {
+	if strings.EqualFold(hashAlg, hashAlgorithmSHA256) {
+		return verifyRSASHA256(pub, message, sig)
+	}
+
+	return verifyRSASHA1(pub, message, sig)
+}
+
 // verifyRSASHA1 verifies an RSA-SHA1 signature against the given
 // message using CloudFront's modified Base64 for the signature.
 func verifyRSASHA1(pub *rsa.PublicKey, message []byte, sig string) error {
@@ -298,9 +324,29 @@ func verifyRSASHA1(pub *rsa.PublicKey, message []byte, sig string) error {
 		return fmt.Errorf("decode signature: %w", err)
 	}
 
-	h := sha1.Sum(message) //nolint:gosec // CloudFront protocol mandates SHA1.
+	h := sha1.Sum(message) //nolint:gosec // CloudFront legacy signatures use SHA1.
 
 	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA1, h[:], sigBytes); err != nil {
+		return fmt.Errorf("rsa verify: %w", err)
+	}
+
+	return nil
+}
+
+// verifyRSASHA256 verifies an RSA-SHA256 signature against the given
+// message. Used when a request advertises CloudFront-Hash-Algorithm=
+// SHA256 (AWS CloudFront 2026-04 behavior). KMS-backed signers can only
+// produce SHA256 or stronger, so this is the path real CloudFront takes
+// for KMS-signed cookies.
+func verifyRSASHA256(pub *rsa.PublicKey, message []byte, sig string) error {
+	sigBytes, err := cfBase64Decode(sig)
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+
+	h := sha256.Sum256(message)
+
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, h[:], sigBytes); err != nil {
 		return fmt.Errorf("rsa verify: %w", err)
 	}
 

--- a/internal/service/cloudfront/edge_signing_test.go
+++ b/internal/service/cloudfront/edge_signing_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1" //nolint:gosec // Test helper for CloudFront RSA-SHA1 signatures.
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -52,6 +53,22 @@ func cfSign(t *testing.T, priv *rsa.PrivateKey, message []byte) string {
 	h := sha1.Sum(message)
 
 	sig, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA1, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	return cfBase64Encode(sig)
+}
+
+// cfSignSHA256 produces a CloudFront-Base64-encoded RSA-SHA256
+// signature, matching the format AWS CloudFront uses for SHA256-signed
+// cookies/URLs (and the only format a KMS-backed signer can produce).
+func cfSignSHA256(t *testing.T, priv *rsa.PrivateKey, message []byte) string {
+	t.Helper()
+
+	h := sha256.Sum256(message)
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, h[:])
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
@@ -195,6 +212,116 @@ func TestVerifyRSASHA1(t *testing.T) {
 	// Tampered message should fail.
 	if err := verifyRSASHA1(pub, []byte("tampered"), sig); err == nil {
 		t.Fatal("expected error for tampered message")
+	}
+}
+
+func TestVerifyRSASHA256(t *testing.T) {
+	t.Parallel()
+
+	priv, pubPEM := testKeyPair(t)
+
+	pub, err := parseRSAPublicKey(pubPEM)
+	if err != nil {
+		t.Fatalf("parse public key: %v", err)
+	}
+
+	message := []byte("hello world")
+	sig := cfSignSHA256(t, priv, message)
+
+	if err := verifyRSASHA256(pub, message, sig); err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+
+	// Tampered message should fail.
+	if err := verifyRSASHA256(pub, []byte("tampered"), sig); err == nil {
+		t.Fatal("expected error for tampered message")
+	}
+
+	// A SHA1 signature must not verify as SHA256.
+	if err := verifyRSASHA256(pub, message, cfSign(t, priv, message)); err == nil {
+		t.Fatal("expected error for SHA1 signature verified as SHA256")
+	}
+}
+
+// TestVerifySignature exercises the algorithm dispatch driven by the
+// CloudFront-Hash-Algorithm value. Empty/"SHA1" -> RSA-SHA1,
+// "SHA256" -> RSA-SHA256.
+func TestVerifySignature(t *testing.T) {
+	t.Parallel()
+
+	priv, pubPEM := testKeyPair(t)
+
+	pub, err := parseRSAPublicKey(pubPEM)
+	if err != nil {
+		t.Fatalf("parse public key: %v", err)
+	}
+
+	message := []byte("hello world")
+	sha1Sig := cfSign(t, priv, message)
+	sha256Sig := cfSignSHA256(t, priv, message)
+
+	tests := []struct {
+		name    string
+		sig     string
+		hashAlg string
+		wantErr bool
+	}{
+		{name: "empty algo accepts SHA1", sig: sha1Sig, hashAlg: "", wantErr: false},
+		{name: "SHA1 algo accepts SHA1", sig: sha1Sig, hashAlg: "SHA1", wantErr: false},
+		{name: "SHA256 algo accepts SHA256", sig: sha256Sig, hashAlg: "SHA256", wantErr: false},
+		{name: "SHA256 algo is case-insensitive", sig: sha256Sig, hashAlg: "sha256", wantErr: false},
+		{name: "SHA256 algo rejects SHA1 signature", sig: sha1Sig, hashAlg: "SHA256", wantErr: true},
+		{name: "empty algo rejects SHA256 signature", sig: sha256Sig, hashAlg: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifySignature(pub, message, tt.sig, tt.hashAlg)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestExtractSignedCredentials_CookiesSHA256(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t, "/kumo/cdn/E123/file.txt")
+	req.AddCookie(&http.Cookie{Name: "CloudFront-Policy", Value: testPolicyValue})
+	req.AddCookie(&http.Cookie{Name: "CloudFront-Signature", Value: "sig"})
+	req.AddCookie(&http.Cookie{Name: "CloudFront-Key-Pair-Id", Value: "KID"})
+	req.AddCookie(&http.Cookie{Name: "CloudFront-Hash-Algorithm", Value: "SHA256"})
+
+	creds := extractSignedCredentials(req)
+	if creds == nil {
+		t.Fatal("expected credentials from cookies")
+	}
+
+	if creds.HashAlgorithm != "SHA256" {
+		t.Errorf("HashAlgorithm = %q, want %q", creds.HashAlgorithm, "SHA256")
+	}
+}
+
+func TestExtractSignedCredentials_QuerySHA256(t *testing.T) {
+	t.Parallel()
+
+	req := newTestRequest(t,
+		"/kumo/cdn/E123/file.txt?Policy=abc&Signature=sig&Key-Pair-Id=KID&Hash-Algorithm=SHA256")
+
+	creds := extractSignedCredentials(req)
+	if creds == nil {
+		t.Fatal("expected credentials from query")
+	}
+
+	if creds.HashAlgorithm != "SHA256" {
+		t.Errorf("HashAlgorithm = %q, want %q", creds.HashAlgorithm, "SHA256")
 	}
 }
 
@@ -533,6 +660,134 @@ func TestCheckEdgeSigning_MissingCredentials(t *testing.T) {
 
 	if svc.checkEdgeSigning(rec, req, dist) {
 		t.Fatal("expected rejection when credentials are missing")
+	}
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+// newSignedDistribution registers a public key and key group backed by
+// pubPEM and returns a Distribution that trusts it, plus the public key
+// ID to use as CloudFront-Key-Pair-Id.
+func newSignedDistribution(t *testing.T, storage *MemoryStorage, pubPEM string) (*Distribution, string) {
+	t.Helper()
+
+	pk, err := storage.CreatePublicKey(context.Background(), &PublicKeyConfig{
+		CallerReference: "ref1",
+		Name:            "k1",
+		EncodedKey:      pubPEM,
+	})
+	if err != nil {
+		t.Fatalf("create public key: %v", err)
+	}
+
+	kg, err := storage.CreateKeyGroup(context.Background(), &KeyGroupConfig{
+		Name:  "g1",
+		Items: []string{pk.ID},
+	})
+	if err != nil {
+		t.Fatalf("create key group: %v", err)
+	}
+
+	dist := &Distribution{
+		DistributionConfig: &DistributionConfig{
+			DefaultCacheBehavior: &DefaultCacheBehavior{
+				TrustedKeyGroups: &TrustedKeyGroups{
+					Enabled:  true,
+					Quantity: 1,
+					Items:    []string{kg.ID},
+				},
+			},
+		},
+	}
+
+	return dist, pk.ID
+}
+
+// signedCookieRequest builds a request carrying a CloudFront signed
+// custom-policy cookie set. hashAlg is omitted from the cookies when
+// empty (legacy SHA1 behavior).
+func signedCookieRequest(t *testing.T, policy []byte, sig, keyID, hashAlg string) *http.Request {
+	t.Helper()
+
+	req := newTestRequest(t, "/kumo/cdn/E1/file.txt")
+	req.RemoteAddr = testRemoteAddr
+	req.AddCookie(&http.Cookie{Name: "CloudFront-Policy", Value: cfBase64Encode(policy)})
+	req.AddCookie(&http.Cookie{Name: "CloudFront-Signature", Value: sig})
+	req.AddCookie(&http.Cookie{Name: "CloudFront-Key-Pair-Id", Value: keyID})
+
+	if hashAlg != "" {
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Hash-Algorithm", Value: hashAlg})
+	}
+
+	return req
+}
+
+// validCustomPolicy is a custom policy that never expires, used by the
+// edge-signing E2E tests.
+var validCustomPolicy = []byte(
+	`{"Statement":[{"Resource":"*","Condition":{"DateLessThan":{"AWS:EpochTime":9999999999}}}]}`)
+
+// TestCheckEdgeSigning_SHA256Cookie covers the AWS 2026-04 behavior:
+// a SHA256-signed cookie carrying CloudFront-Hash-Algorithm=SHA256 is
+// accepted (delivery proceeds). This is the path KMS-signed cookies
+// take, since KMS cannot produce SHA1 signatures.
+func TestCheckEdgeSigning_SHA256Cookie(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+	svc := New(storage)
+	priv, pubPEM := testKeyPair(t)
+	dist, keyID := newSignedDistribution(t, storage, pubPEM)
+
+	sig := cfSignSHA256(t, priv, validCustomPolicy)
+	req := signedCookieRequest(t, validCustomPolicy, sig, keyID, "SHA256")
+
+	rec := httptest.NewRecorder()
+	if !svc.checkEdgeSigning(rec, req, dist) {
+		t.Fatalf("expected SHA256-signed request to pass, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCheckEdgeSigning_SHA1CookieBackwardCompat ensures legacy
+// SHA1-signed cookies without a hash algorithm still verify.
+func TestCheckEdgeSigning_SHA1CookieBackwardCompat(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+	svc := New(storage)
+	priv, pubPEM := testKeyPair(t)
+	dist, keyID := newSignedDistribution(t, storage, pubPEM)
+
+	sig := cfSign(t, priv, validCustomPolicy)
+	req := signedCookieRequest(t, validCustomPolicy, sig, keyID, "")
+
+	rec := httptest.NewRecorder()
+	if !svc.checkEdgeSigning(rec, req, dist) {
+		t.Fatalf("expected SHA1-signed request to pass, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCheckEdgeSigning_SHA256SignatureMismatch ensures a SHA256 request
+// whose signature does not match is still rejected with 403.
+func TestCheckEdgeSigning_SHA256SignatureMismatch(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+	svc := New(storage)
+	priv, pubPEM := testKeyPair(t)
+	dist, keyID := newSignedDistribution(t, storage, pubPEM)
+
+	// Sign a different policy than the one presented.
+	otherPolicy := []byte(
+		`{"Statement":[{"Resource":"*","Condition":{"DateLessThan":{"AWS:EpochTime":1}}}]}`)
+	sig := cfSignSHA256(t, priv, otherPolicy)
+	req := signedCookieRequest(t, validCustomPolicy, sig, keyID, "SHA256")
+
+	rec := httptest.NewRecorder()
+	if svc.checkEdgeSigning(rec, req, dist) {
+		t.Fatal("expected rejection for mismatched SHA256 signature")
 	}
 
 	if rec.Code != http.StatusForbidden {

--- a/test/integration/cloudfront_signing_test.go
+++ b/test/integration/cloudfront_signing_test.go
@@ -7,7 +7,8 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1" //nolint:gosec // CloudFront uses RSA-SHA1 for signed URL/cookie verification.
+	"crypto/sha1" //nolint:gosec // CloudFront uses RSA-SHA1 for legacy signed URL/cookie verification.
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -62,6 +63,22 @@ func signPolicy(t *testing.T, priv *rsa.PrivateKey, policy []byte) string {
 	h := sha1.Sum(policy)
 
 	sig, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA1, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	return cfBase64(sig)
+}
+
+// signPolicySHA256 signs a policy JSON with RSA-SHA256 and returns a
+// CloudFront-Base64-encoded signature. AWS CloudFront added SHA256
+// signing on 2026-04-01; KMS-backed signers can only produce SHA256+.
+func signPolicySHA256(t *testing.T, priv *rsa.PrivateKey, policy []byte) string {
+	t.Helper()
+
+	h := sha256.Sum256(policy)
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, h[:])
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
@@ -337,6 +354,65 @@ func TestCloudFront_EdgeSignedCookie(t *testing.T) {
 		req.AddCookie(&http.Cookie{Name: "CloudFront-Policy", Value: cfBase64(policy)})
 		req.AddCookie(&http.Cookie{Name: "CloudFront-Signature", Value: sig})
 		req.AddCookie(&http.Cookie{Name: "CloudFront-Key-Pair-Id", Value: pkID})
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+	})
+
+	t.Run("valid_sha256_signed_cookie_passes", func(t *testing.T) {
+		t.Parallel()
+
+		// AWS CloudFront 2026-04 SHA256 path: cookie carries
+		// CloudFront-Hash-Algorithm=SHA256 and an RSA-SHA256 signature.
+		policy := []byte(`{"Statement":[{"Resource":"*","Condition":{"DateLessThan":{"AWS:EpochTime":9999999999}}}]}`)
+		sig := signPolicySHA256(t, priv, policy)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, edgeURL, http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Policy", Value: cfBase64(policy)})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Signature", Value: sig})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Key-Pair-Id", Value: pkID})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Hash-Algorithm", Value: "SHA256"})
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Errorf("status = %d, want %d; body = %s", resp.StatusCode, http.StatusOK, body)
+		}
+	})
+
+	t.Run("sha256_header_with_sha1_signature_returns_403", func(t *testing.T) {
+		t.Parallel()
+
+		// Hash-Algorithm advertises SHA256 but the signature is SHA1 —
+		// must be rejected (no silent downgrade).
+		policy := []byte(`{"Statement":[{"Resource":"*","Condition":{"DateLessThan":{"AWS:EpochTime":9999999999}}}]}`)
+		sig := signPolicy(t, priv, policy)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, edgeURL, http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Policy", Value: cfBase64(policy)})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Signature", Value: sig})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Key-Pair-Id", Value: pkID})
+		req.AddCookie(&http.Cookie{Name: "CloudFront-Hash-Algorithm", Value: "SHA256"})
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {


### PR DESCRIPTION
## Summary

CloudFront signed cookie/URL verification was hardcoded to RSA-SHA1 and ignored the `CloudFront-Hash-Algorithm` cookie (and `Hash-Algorithm` query parameter). AWS CloudFront [added SHA256 signing on 2026-04-01](https://aws.amazon.com/about-aws/whats-new/2026/04/amazon-cloudfront-sha-256-signed-urls/), and since `kms:Sign` can only produce SHA256-or-stronger signatures, cookies signed with SHA256 were rejected by kumo with a 403.

## Changes

- Add `HashAlgorithm` to `signedCredentials` and read it from the `CloudFront-Hash-Algorithm` cookie / `Hash-Algorithm` query parameter.
- Dispatch in `verifySignature`: `SHA256` (case-insensitive) verifies with RSA-SHA256 (`sha256` + `crypto.SHA256`); empty or `SHA1` keeps the legacy RSA-SHA1 path (backward compatible).
- Strip `Hash-Algorithm` as a signing meta parameter when reconstructing the canned policy resource.

## Acceptance criteria

- [x] A cookie with `CloudFront-Hash-Algorithm=SHA256` and a SHA256 signature is delivered with 200.
- [x] Requests without the header / with SHA1 keep working (backward compatible).
- [x] A signature mismatch is still rejected with 403 (a SHA256 header with a SHA1 signature is also 403).

## Tests

- Unit: `TestVerifyRSASHA256` / `TestVerifySignature` (algorithm dispatch) / extraction tests / `checkEdgeSigning` E2E.
- Integration: added `valid_sha256_signed_cookie_passes` (200) and `sha256_header_with_sha1_signature_returns_403` (403) to `TestCloudFront_EdgeSignedCookie` over the full HTTP path.
- `go test ./...`, integration tests (with kumo running on :4566), and `golangci-lint run` all pass.