### PR TITLE
feat(apigateway): execute-api invoke for deployed stages (v1 + v2)

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -12,6 +12,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// localhostHost is the loopback host label used by kumo virtual-hosted URLs.
+const localhostHost = "localhost"
+
 // Route represents a registered HTTP route.
 type Route struct {
 	Method  string
@@ -19,12 +22,23 @@ type Route struct {
 	Handler http.HandlerFunc
 }
 
+// executeAPIDispatch handles a virtual-hosted execute-api request. It returns
+// false when apiID is not owned by the handler.
+type executeAPIDispatch func(w http.ResponseWriter, r *http.Request, apiID, invokePath string) bool
+
 // Router is the HTTP router for kumo.
 type Router struct {
-	mux           *http.ServeMux
-	routes        []Route
-	prefixRouters map[string]*http.ServeMux // Separate routers for services with prefixes
-	logger        *slog.Logger
+	mux                *http.ServeMux
+	routes             []Route
+	prefixRouters      map[string]*http.ServeMux // Separate routers for services with prefixes
+	executeAPIHandlers []executeAPIDispatch
+	logger             *slog.Logger
+}
+
+// AddExecuteAPIHandler registers a handler for virtual-hosted execute-api
+// requests ({apiId}.execute-api.<host>).
+func (r *Router) AddExecuteAPIHandler(fn executeAPIDispatch) {
+	r.executeAPIHandlers = append(r.executeAPIHandlers, fn)
 }
 
 // NewRouter creates a new router.
@@ -182,6 +196,24 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Virtual-hosted execute-api: a deployed API stage is invoked at
+	// {apiId}.execute-api.<host>/{stage}/{path}. Dispatch to the service
+	// that owns apiID (API Gateway v1 or v2).
+	if apiID, ok := extractExecuteAPIHost(req.Host); ok {
+		for _, h := range r.executeAPIHandlers {
+			if h(w, req, apiID, req.URL.Path) {
+				return
+			}
+		}
+
+		// No service owns this API id: real API Gateway answers 403.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"Forbidden"}`))
+
+		return
+	}
+
 	// Rewrite AWS S3 virtual-hosted-style requests so the rest of the
 	// router only deals with path-style. terraform / aws-sdk-go-v2
 	// default to virtual-hosted-style: the bucket goes in the Host
@@ -236,6 +268,44 @@ func (r *Router) Routes() []Route {
 	return r.routes
 }
 
+// extractExecuteAPIHost recognises API Gateway execute-api virtual-hosted
+// hosts and returns the API id. Empty/false means it is not such a host.
+//
+// Recognised shapes (the kumo-local form resolves to loopback):
+//
+//	{apiId}.execute-api.localhost(:port)
+//	{apiId}.execute-api.{region}.amazonaws.com
+func extractExecuteAPIHost(host string) (string, bool) {
+	if host == "" {
+		return "", false
+	}
+
+	if idx := strings.LastIndex(host, ":"); idx >= 0 {
+		host = host[:idx]
+	}
+
+	const marker = ".execute-api."
+
+	i := strings.Index(host, marker)
+	if i <= 0 {
+		return "", false
+	}
+
+	apiID := host[:i]
+	rest := host[i+len(marker):]
+
+	// The API id is a single label.
+	if apiID == "" || strings.Contains(apiID, ".") {
+		return "", false
+	}
+
+	if rest == localhostHost || strings.HasSuffix(rest, ".amazonaws.com") {
+		return apiID, true
+	}
+
+	return "", false
+}
+
 // extractBucketFromHost recognises AWS S3 virtual-hosted-style hosts
 // and returns the bucket name. Empty result means path-style (or a
 // non-S3 host) — caller leaves the URL untouched.
@@ -257,7 +327,7 @@ func extractBucketFromHost(host string) string {
 	}
 
 	// Localhost / loopback IPs are never virtual-hosted.
-	if host == "localhost" || host == "127.0.0.1" {
+	if host == localhostHost || host == "127.0.0.1" {
 		return ""
 	}
 
@@ -277,7 +347,7 @@ func extractBucketFromHost(host string) string {
 	}
 
 	switch {
-	case rest == "localhost":
+	case rest == localhostHost:
 		return bucket
 	case rest == "s3.amazonaws.com":
 		return bucket

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -171,6 +171,12 @@ func (s *Server) RegisterService(svc service.Service) {
 		s.logger.Debug("registered JSON protocol service", "name", svc.Name(), "prefix", jsonSvc.TargetPrefix())
 	}
 
+	// Check if service exposes an execute-api invoke surface.
+	if execSvc, ok := svc.(service.ExecuteAPIHandler); ok {
+		s.router.AddExecuteAPIHandler(execSvc.HandleExecuteAPI)
+		s.logger.Debug("registered execute-api handler", "name", svc.Name())
+	}
+
 	// Check if service implements Query protocol.
 	if querySvc, ok := svc.(service.QueryProtocolService); ok {
 		s.queryDispatcher.Register(querySvc.TargetPrefix(), querySvc.DispatchAction)

--- a/internal/service/apigateway/executeapi.go
+++ b/internal/service/apigateway/executeapi.go
@@ -1,0 +1,172 @@
+package apigateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service/execapi"
+)
+
+// maxExecuteResources bounds how many resources are scanned when resolving a
+// request path to a resource.
+const maxExecuteResources = 10000
+
+// HandleExecuteAPI implements service.ExecuteAPIHandler for REST APIs. It
+// returns false when apiID is not a REST API managed by this service, so the
+// router can try the v2 service.
+func (s *Service) HandleExecuteAPI(w http.ResponseWriter, r *http.Request, apiID, invokePath string) bool {
+	if _, err := s.storage.GetRestAPI(r.Context(), apiID); err != nil {
+		return false
+	}
+
+	// invokePath is /{stage}/{resource-path}; the first segment is the stage.
+	segs := execapi.SplitPath(invokePath)
+	if len(segs) == 0 {
+		writeExecuteError(w, http.StatusForbidden, "Missing Authentication Token")
+
+		return true
+	}
+
+	stage := segs[0]
+	reqPath := "/" + strings.Join(segs[1:], "/")
+
+	resolved, status := s.resolveExecuteTarget(r, apiID, stage, reqPath)
+	if status != 0 {
+		writeExecuteError(w, status, executeErrorMessage(status))
+
+		return true
+	}
+
+	execapi.Dispatch(w, r,
+		execapi.Target{
+			Type: resolved.method.MethodIntegration.Type,
+			URI:  resolved.method.MethodIntegration.URI,
+		},
+		&execapi.Request{
+			BaseURL:        s.baseURLOrDefault(),
+			APIID:          apiID,
+			Stage:          stage,
+			ResourcePath:   resolved.resource.Path,
+			PathParameters: resolved.pathParams,
+		},
+	)
+
+	return true
+}
+
+// resolvedTarget is the resource/method/params resolved for an execute-api
+// request.
+type resolvedTarget struct {
+	resource   *Resource
+	method     Method
+	pathParams map[string]string
+}
+
+// resolveExecuteTarget validates the stage and resolves the resource, method,
+// and path parameters. A non-zero status is the HTTP error to return.
+func (s *Service) resolveExecuteTarget(r *http.Request, apiID, stage, reqPath string) (resolvedTarget, int) {
+	if _, err := s.storage.GetStage(r.Context(), apiID, stage); err != nil {
+		return resolvedTarget{}, http.StatusNotFound
+	}
+
+	resources, _, err := s.storage.GetResources(r.Context(), apiID, maxExecuteResources, "")
+	if err != nil {
+		return resolvedTarget{}, http.StatusNotFound
+	}
+
+	resource, pathParams, ok := matchResource(resources, reqPath)
+	if !ok {
+		return resolvedTarget{}, http.StatusForbidden
+	}
+
+	method, ok := matchMethod(resource, r.Method)
+	if !ok {
+		return resolvedTarget{}, http.StatusForbidden
+	}
+
+	if method.MethodIntegration == nil {
+		return resolvedTarget{}, http.StatusInternalServerError
+	}
+
+	return resolvedTarget{resource: resource, method: method, pathParams: pathParams}, 0
+}
+
+// executeErrorMessage maps an execute-api error status to its AWS message.
+func executeErrorMessage(status int) string {
+	switch status {
+	case http.StatusNotFound:
+		return "Not Found"
+	case http.StatusInternalServerError:
+		return "Internal server error"
+	default:
+		return "Missing Authentication Token"
+	}
+}
+
+// baseURLOrDefault returns the configured base URL, defaulting to the local
+// kumo server when unset.
+func (s *Service) baseURLOrDefault() string {
+	if s.baseURL == "" {
+		return execapi.DefaultBaseURL
+	}
+
+	return s.baseURL
+}
+
+// matchResource finds the most specific resource whose Path matches reqPath,
+// returning any captured path parameters. Specificity prefers literal
+// segments over {param} and greedy {proxy+} segments.
+func matchResource(resources []*Resource, reqPath string) (*Resource, map[string]string, bool) {
+	reqSegs := execapi.SplitPath(reqPath)
+
+	var (
+		best      *Resource
+		bestVals  map[string]string
+		bestScore = -1
+	)
+
+	for _, res := range resources {
+		vals, score, ok := execapi.MatchPath(res.Path, reqSegs)
+		if !ok {
+			continue
+		}
+
+		if score > bestScore {
+			best = res
+			bestVals = vals
+			bestScore = score
+		}
+	}
+
+	if best == nil {
+		return nil, nil, false
+	}
+
+	return best, bestVals, true
+}
+
+// matchMethod returns the resource method for the request method, falling back
+// to an "ANY" method when defined.
+func matchMethod(resource *Resource, httpMethod string) (Method, bool) {
+	if m, ok := resource.ResourceMethods[httpMethod]; ok {
+		return m, true
+	}
+
+	if m, ok := resource.ResourceMethods["ANY"]; ok {
+		return m, true
+	}
+
+	return Method{}, false
+}
+
+// writeExecuteError writes an API Gateway style error body for the pre-dispatch
+// resolution failures (404 / 403 / 500).
+func writeExecuteError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"message": message})
+}

--- a/internal/service/apigateway/service.go
+++ b/internal/service/apigateway/service.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/sivchari/kumo/internal/service"
+	"github.com/sivchari/kumo/internal/service/execapi"
 )
 
 // Compile-time check that Service implements io.Closer.
@@ -18,12 +19,16 @@ func init() {
 		opts = append(opts, WithDataDir(dir))
 	}
 
-	service.Register(New(NewMemoryStorage(opts...)))
+	svc := New(NewMemoryStorage(opts...))
+	svc.baseURL = execapi.ResolveBaseURL()
+
+	service.Register(svc)
 }
 
 // Service implements the API Gateway service.
 type Service struct {
 	storage Storage
+	baseURL string
 }
 
 // New creates a new API Gateway service.

--- a/internal/service/apigatewayv2/executeapi.go
+++ b/internal/service/apigatewayv2/executeapi.go
@@ -1,0 +1,197 @@
+package apigatewayv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service/execapi"
+)
+
+// defaultStageName is the HTTP API auto-deploy catch-all stage.
+const defaultStageName = "$default"
+
+// defaultPayloadFormatVersion is the HTTP API default when an integration does
+// not specify one.
+const defaultPayloadFormatVersion = "2.0"
+
+// HandleExecuteAPI implements service.ExecuteAPIHandler for HTTP APIs. It
+// returns false when apiID is not an API managed by this service.
+func (s *Service) HandleExecuteAPI(w http.ResponseWriter, r *http.Request, apiID, invokePath string) bool {
+	if _, err := s.storage.GetAPI(r.Context(), apiID); err != nil {
+		return false
+	}
+
+	stage, routePath := s.resolveStage(r, apiID, invokePath)
+	if stage == "" {
+		writeExecuteErrorV2(w, http.StatusNotFound, "Not Found")
+
+		return true
+	}
+
+	routes, err := s.storage.GetRoutes(r.Context(), apiID)
+	if err != nil {
+		writeExecuteErrorV2(w, http.StatusNotFound, "Not Found")
+
+		return true
+	}
+
+	route, pathParams, ok := matchRoute(routes, r.Method, routePath)
+	if !ok {
+		writeExecuteErrorV2(w, http.StatusNotFound, "Not Found")
+
+		return true
+	}
+
+	integration, ok := s.integrationForRoute(r, apiID, route)
+	if !ok {
+		writeExecuteErrorV2(w, http.StatusInternalServerError, "Internal server error")
+
+		return true
+	}
+
+	payloadFormat := integration.PayloadFormatVersion
+	if payloadFormat == "" {
+		payloadFormat = defaultPayloadFormatVersion
+	}
+
+	execapi.Dispatch(w, r,
+		execapi.Target{
+			Type:                 integration.IntegrationType,
+			URI:                  integration.IntegrationURI,
+			PayloadFormatVersion: payloadFormat,
+		},
+		&execapi.Request{
+			BaseURL:        s.baseURLOrDefault(),
+			APIID:          apiID,
+			Stage:          stage,
+			ResourcePath:   routePath,
+			RouteKey:       route.RouteKey,
+			PathParameters: pathParams,
+		},
+	)
+
+	return true
+}
+
+// resolveStage determines the stage and the route path from the invoke path.
+// The path is /{stage}/{route} for a named stage, or /{route} for $default.
+func (s *Service) resolveStage(r *http.Request, apiID, invokePath string) (stage, routePath string) {
+	segs := execapi.SplitPath(invokePath)
+
+	if len(segs) > 0 {
+		if _, err := s.storage.GetStage(r.Context(), apiID, segs[0]); err == nil {
+			return segs[0], normalizeRoutePath(segs[1:])
+		}
+	}
+
+	if _, err := s.storage.GetStage(r.Context(), apiID, defaultStageName); err == nil {
+		return defaultStageName, normalizeRoutePath(segs)
+	}
+
+	return "", ""
+}
+
+// integrationForRoute resolves the integration referenced by a route's target
+// (of the form "integrations/{integrationId}").
+func (s *Service) integrationForRoute(r *http.Request, apiID string, route *Route) (*Integration, bool) {
+	id := strings.TrimPrefix(route.Target, "integrations/")
+	if id == "" || id == route.Target {
+		return nil, false
+	}
+
+	integration, err := s.storage.GetIntegration(r.Context(), apiID, id)
+	if err != nil {
+		return nil, false
+	}
+
+	return integration, true
+}
+
+// baseURLOrDefault returns the configured base URL, defaulting to the local
+// kumo server when unset.
+func (s *Service) baseURLOrDefault() string {
+	if s.baseURL == "" {
+		return execapi.DefaultBaseURL
+	}
+
+	return s.baseURL
+}
+
+// matchRoute selects the route matching the request method and path. An exact
+// "METHOD /path" (or "ANY /path") match wins by specificity; the "$default"
+// route is the catch-all fallback.
+func matchRoute(routes []*Route, method, routePath string) (*Route, map[string]string, bool) {
+	reqSegs := execapi.SplitPath(routePath)
+
+	var (
+		best     *Route
+		bestVals map[string]string
+		// bestScore starts below the $default sentinel so any real match wins.
+		bestScore = -2
+		fallback  *Route
+	)
+
+	for _, route := range routes {
+		if route.RouteKey == defaultStageName { // "$default"
+			fallback = route
+
+			continue
+		}
+
+		routeMethod, routeTemplate, ok := splitRouteKey(route.RouteKey)
+		if !ok || (routeMethod != method && routeMethod != "ANY") {
+			continue
+		}
+
+		vals, score, ok := execapi.MatchPath(routeTemplate, reqSegs)
+		if !ok {
+			continue
+		}
+
+		if score > bestScore {
+			best = route
+			bestVals = vals
+			bestScore = score
+		}
+	}
+
+	if best != nil {
+		return best, bestVals, true
+	}
+
+	if fallback != nil {
+		return fallback, nil, true
+	}
+
+	return nil, nil, false
+}
+
+// splitRouteKey splits a route key like "GET /items" into method and path.
+func splitRouteKey(routeKey string) (method, path string, ok bool) {
+	parts := strings.SplitN(routeKey, " ", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+
+	return parts[0], parts[1], true
+}
+
+// normalizeRoutePath joins remaining segments into a leading-slash path.
+func normalizeRoutePath(segs []string) string {
+	if len(segs) == 0 {
+		return "/"
+	}
+
+	return "/" + strings.Join(segs, "/")
+}
+
+// writeExecuteErrorV2 writes an API Gateway style error body.
+func writeExecuteErrorV2(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"message": message})
+}

--- a/internal/service/apigatewayv2/service.go
+++ b/internal/service/apigatewayv2/service.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/sivchari/kumo/internal/service"
+	"github.com/sivchari/kumo/internal/service/execapi"
 )
 
 const (
@@ -27,12 +28,16 @@ func init() {
 		opts = append(opts, WithDataDir(dir))
 	}
 
-	service.Register(New(NewMemoryStorage(opts...)))
+	svc := New(NewMemoryStorage(opts...))
+	svc.baseURL = execapi.ResolveBaseURL()
+
+	service.Register(svc)
 }
 
 // Service implements the API Gateway v2 service.
 type Service struct {
 	storage Storage
+	baseURL string
 }
 
 // New creates a new API Gateway v2 service.

--- a/internal/service/execapi/baseurl.go
+++ b/internal/service/execapi/baseurl.go
@@ -1,0 +1,30 @@
+package execapi
+
+import (
+	"fmt"
+	"os"
+)
+
+// DefaultBaseURL is the kumo server URL used for in-process self-calls
+// (execute-api -> Lambda invoke) when KUMO_HOST/KUMO_PORT are not set.
+const DefaultBaseURL = "http://localhost:4566"
+
+// ResolveBaseURL builds the kumo server base URL from KUMO_HOST / KUMO_PORT,
+// mirroring the convention used by other services that self-call kumo
+// endpoints (e.g. eventbridge -> lambda).
+func ResolveBaseURL() string {
+	if host := os.Getenv("KUMO_HOST"); host != "" {
+		port := os.Getenv("KUMO_PORT")
+		if port == "" {
+			port = "4566"
+		}
+
+		return fmt.Sprintf("http://%s:%s", host, port)
+	}
+
+	if port := os.Getenv("KUMO_PORT"); port != "" {
+		return fmt.Sprintf("http://localhost:%s", port)
+	}
+
+	return DefaultBaseURL
+}

--- a/internal/service/execapi/event.go
+++ b/internal/service/execapi/event.go
@@ -1,0 +1,182 @@
+package execapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// proxyEventV1 is the API Gateway proxy integration input event for REST APIs
+// and HTTP API payload format 1.0.
+type proxyEventV1 struct {
+	Resource                        string              `json:"resource"`
+	Path                            string              `json:"path"`
+	HTTPMethod                      string              `json:"httpMethod"`
+	Headers                         map[string]string   `json:"headers"`
+	MultiValueHeaders               map[string][]string `json:"multiValueHeaders"`
+	QueryStringParameters           map[string]string   `json:"queryStringParameters"`
+	MultiValueQueryStringParameters map[string][]string `json:"multiValueQueryStringParameters"`
+	PathParameters                  map[string]string   `json:"pathParameters"`
+	StageVariables                  map[string]string   `json:"stageVariables"`
+	RequestContext                  requestContextV1    `json:"requestContext"`
+	Body                            string              `json:"body"`
+	IsBase64Encoded                 bool                `json:"isBase64Encoded"`
+}
+
+type requestContextV1 struct {
+	ResourcePath string `json:"resourcePath"`
+	HTTPMethod   string `json:"httpMethod"`
+	Path         string `json:"path"`
+	APIID        string `json:"apiId"`
+	Stage        string `json:"stage"`
+	RequestID    string `json:"requestId"`
+}
+
+// buildEventV1 builds the payload-1.0 proxy event from the HTTP request.
+func buildEventV1(r *http.Request, req *Request, body []byte) ([]byte, error) {
+	headers, multiHeaders := collectHeaders(r)
+	query, multiQuery := collectQuery(r)
+
+	event := proxyEventV1{
+		Resource:                        req.ResourcePath,
+		Path:                            req.ResourcePath,
+		HTTPMethod:                      r.Method,
+		Headers:                         headers,
+		MultiValueHeaders:               multiHeaders,
+		QueryStringParameters:           emptyToNil(query),
+		MultiValueQueryStringParameters: emptyMultiToNil(multiQuery),
+		PathParameters:                  emptyToNil(req.PathParameters),
+		Body:                            string(body),
+		RequestContext: requestContextV1{
+			ResourcePath: req.ResourcePath,
+			HTTPMethod:   r.Method,
+			Path:         "/" + req.Stage + req.ResourcePath,
+			APIID:        req.APIID,
+			Stage:        req.Stage,
+			RequestID:    uuid.New().String(),
+		},
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		return nil, fmt.Errorf("marshal v1 event: %w", err)
+	}
+
+	return data, nil
+}
+
+// proxyEventV2 is the HTTP API payload format 2.0 input event.
+type proxyEventV2 struct {
+	Version               string            `json:"version"`
+	RouteKey              string            `json:"routeKey"`
+	RawPath               string            `json:"rawPath"`
+	RawQueryString        string            `json:"rawQueryString"`
+	Headers               map[string]string `json:"headers"`
+	QueryStringParameters map[string]string `json:"queryStringParameters,omitempty"`
+	PathParameters        map[string]string `json:"pathParameters,omitempty"`
+	StageVariables        map[string]string `json:"stageVariables,omitempty"`
+	RequestContext        requestContextV2  `json:"requestContext"`
+	Body                  string            `json:"body,omitempty"`
+	IsBase64Encoded       bool              `json:"isBase64Encoded"`
+}
+
+type requestContextV2 struct {
+	APIID     string `json:"apiId"`
+	Stage     string `json:"stage"`
+	RouteKey  string `json:"routeKey"`
+	RequestID string `json:"requestId"`
+	HTTP      httpV2 `json:"http"`
+}
+
+type httpV2 struct {
+	Method   string `json:"method"`
+	Path     string `json:"path"`
+	Protocol string `json:"protocol"`
+	SourceIP string `json:"sourceIp"`
+}
+
+// buildEventV2 builds the payload-2.0 proxy event from the HTTP request.
+func buildEventV2(r *http.Request, req *Request, body []byte) ([]byte, error) {
+	headers, _ := collectHeaders(r)
+	query, _ := collectQuery(r)
+
+	path := "/" + req.Stage + req.ResourcePath
+
+	event := proxyEventV2{
+		Version:               "2.0",
+		RouteKey:              req.RouteKey,
+		RawPath:               path,
+		RawQueryString:        r.URL.RawQuery,
+		Headers:               headers,
+		QueryStringParameters: emptyToNil(query),
+		PathParameters:        emptyToNil(req.PathParameters),
+		Body:                  string(body),
+		RequestContext: requestContextV2{
+			APIID:     req.APIID,
+			Stage:     req.Stage,
+			RouteKey:  req.RouteKey,
+			RequestID: uuid.New().String(),
+			HTTP: httpV2{
+				Method:   r.Method,
+				Path:     path,
+				Protocol: r.Proto,
+				SourceIP: r.RemoteAddr,
+			},
+		},
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		return nil, fmt.Errorf("marshal v2 event: %w", err)
+	}
+
+	return data, nil
+}
+
+func collectHeaders(r *http.Request) (map[string]string, map[string][]string) {
+	single := map[string]string{}
+	multi := map[string][]string{}
+
+	for k, vs := range r.Header {
+		multi[k] = vs
+
+		if len(vs) > 0 {
+			single[k] = vs[len(vs)-1]
+		}
+	}
+
+	return single, multi
+}
+
+func collectQuery(r *http.Request) (map[string]string, map[string][]string) {
+	single := map[string]string{}
+	multi := map[string][]string{}
+
+	for k, vs := range r.URL.Query() {
+		multi[k] = vs
+
+		if len(vs) > 0 {
+			single[k] = vs[len(vs)-1]
+		}
+	}
+
+	return single, multi
+}
+
+func emptyToNil(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+
+	return m
+}
+
+func emptyMultiToNil(m map[string][]string) map[string][]string {
+	if len(m) == 0 {
+		return nil
+	}
+
+	return m
+}

--- a/internal/service/execapi/execapi.go
+++ b/internal/service/execapi/execapi.go
@@ -1,0 +1,288 @@
+// Package execapi provides the shared execute-api data-plane engine used by
+// the API Gateway v1 (REST) and v2 (HTTP) services: it builds the Lambda
+// proxy-integration event, invokes the function via kumo's own Lambda invoke
+// endpoint (delegating execution to the function's InvokeEndpoint), unwraps
+// the proxy response envelope, and forwards HTTP_PROXY integrations.
+package execapi
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// Integration types.
+const (
+	TypeAWSProxy  = "AWS_PROXY"
+	TypeHTTPProxy = "HTTP_PROXY"
+)
+
+// payloadFormat2 is the HTTP API payload format version with the simplified
+// request/response shape and optional statusCode.
+const payloadFormat2 = "2.0"
+
+// Target is the resolved integration to dispatch to.
+type Target struct {
+	Type string
+	URI  string
+	// PayloadFormatVersion selects the Lambda event/response shape: "2.0"
+	// uses the HTTP API v2 format; anything else uses the 1.0 / REST proxy
+	// format.
+	PayloadFormatVersion string
+}
+
+// Request carries the metadata needed to build the Lambda event.
+type Request struct {
+	BaseURL        string
+	APIID          string
+	Stage          string
+	ResourcePath   string // matched resource path template (v1) or route path
+	RouteKey       string // v2 route key, e.g. "GET /items" or "$default"
+	PathParameters map[string]string
+}
+
+// Dispatch resolves the integration target and writes the HTTP response. It is
+// the single entry point shared by the v1 and v2 execute-api handlers.
+func Dispatch(w http.ResponseWriter, r *http.Request, t Target, req *Request) {
+	switch t.Type {
+	case TypeAWSProxy:
+		invokeLambda(w, r, t, req)
+	case TypeHTTPProxy:
+		forwardHTTP(w, r, t.URI)
+	default:
+		// AWS / HTTP (non-proxy) and MOCK require VTL mapping templates,
+		// which kumo execute-api does not yet emulate.
+		slog.Warn("execute-api: unsupported integration type", "type", t.Type, "apiId", req.APIID)
+		writeError(w, http.StatusInternalServerError)
+	}
+}
+
+// invokeLambda builds the proxy event, invokes the Lambda, and writes the
+// unwrapped response.
+func invokeLambda(w http.ResponseWriter, r *http.Request, t Target, req *Request) {
+	name := lambdaFunctionNameFromURI(t.URI)
+	if name == "" {
+		writeError(w, http.StatusInternalServerError)
+
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError)
+
+		return
+	}
+
+	var event []byte
+	if t.PayloadFormatVersion == payloadFormat2 {
+		event, err = buildEventV2(r, req, body)
+	} else {
+		event, err = buildEventV1(r, req, body)
+	}
+
+	if err != nil {
+		writeError(w, http.StatusInternalServerError)
+
+		return
+	}
+
+	respBody, err := invoke(r, req.BaseURL, name, event)
+	if err != nil {
+		slog.Error("execute-api: lambda invoke failed", "function", name, "error", err)
+		writeError(w, http.StatusInternalServerError)
+
+		return
+	}
+
+	writeProxyResponse(w, respBody, t.PayloadFormatVersion == payloadFormat2)
+}
+
+// invoke POSTs the event to kumo's own Lambda invoke endpoint and returns the
+// function's response body.
+func invoke(r *http.Request, baseURL, name string, event []byte) ([]byte, error) {
+	endpoint := fmt.Sprintf("%s/lambda/2015-03-31/functions/%s/invocations", baseURL, name)
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, endpoint, bytes.NewReader(event))
+	if err != nil {
+		return nil, fmt.Errorf("build invoke request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Amz-Invocation-Type", "RequestResponse")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("invoke lambda: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read invoke response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("lambda invoke returned status %d", resp.StatusCode)
+	}
+
+	return respBody, nil
+}
+
+// proxyResponseEnvelope is the response a Lambda proxy integration returns.
+// StatusCode is a pointer to distinguish "absent" from zero.
+type proxyResponseEnvelope struct {
+	StatusCode        *int                `json:"statusCode"`
+	Headers           map[string]string   `json:"headers"`
+	MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
+	Body              string              `json:"body"`
+	IsBase64Encoded   bool                `json:"isBase64Encoded"`
+}
+
+// writeProxyResponse unwraps the Lambda proxy response envelope and writes it.
+//
+// For 1.0 a missing statusCode is a malformed response -> 502 (matching real
+// API Gateway). For 2.0, per the HTTP API spec, a response without statusCode
+// that is valid JSON is returned as a 200 with that JSON as the body.
+func writeProxyResponse(w http.ResponseWriter, respBody []byte, v2 bool) {
+	var env proxyResponseEnvelope
+
+	err := json.Unmarshal(respBody, &env)
+	if err != nil || env.StatusCode == nil {
+		if v2 && err == nil {
+			// Valid JSON without statusCode: 2.0 returns it as the body.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(respBody)
+
+			return
+		}
+
+		writeError(w, http.StatusBadGateway)
+
+		return
+	}
+
+	out := []byte(env.Body)
+
+	if env.IsBase64Encoded {
+		decoded, derr := base64.StdEncoding.DecodeString(env.Body)
+		if derr != nil {
+			writeError(w, http.StatusBadGateway)
+
+			return
+		}
+
+		out = decoded
+	}
+
+	for k, v := range env.Headers {
+		w.Header().Set(k, v)
+	}
+
+	for k, vs := range env.MultiValueHeaders {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+
+	w.WriteHeader(*env.StatusCode)
+	_, _ = w.Write(out)
+}
+
+// forwardHTTP proxies the request verbatim to an HTTP_PROXY integration URI.
+func forwardHTTP(w http.ResponseWriter, r *http.Request, uri string) {
+	if uri == "" {
+		writeError(w, http.StatusInternalServerError)
+
+		return
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, uri, r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadGateway)
+
+		return
+	}
+
+	for k, vs := range r.Header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		writeError(w, http.StatusBadGateway)
+
+		return
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		writeError(w, http.StatusBadGateway)
+
+		return
+	}
+
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(body)
+}
+
+// lambdaFunctionNameFromURI extracts the Lambda function name from an
+// AWS_PROXY integration URI. It accepts both the v1 REST form
+//
+//	arn:aws:apigateway:{region}:lambda:path/2015-03-31/functions/{lambdaArn}/invocations
+//
+// and the v2 HTTP API form, which is the bare Lambda function ARN
+//
+//	arn:aws:lambda:{region}:{account}:function:{name}[:qualifier]
+func lambdaFunctionNameFromURI(uri string) string {
+	const (
+		marker = "/functions/"
+		suffix = "/invocations"
+	)
+
+	rest := uri
+
+	if start := strings.Index(uri, marker); start >= 0 {
+		rest = uri[start+len(marker):]
+		if end := strings.Index(rest, suffix); end >= 0 {
+			rest = rest[:end]
+		}
+	}
+
+	// rest is the Lambda ARN (or bare name).
+	if strings.Contains(rest, ":function:") {
+		parts := strings.Split(rest, ":")
+		if len(parts) >= 7 {
+			return parts[6]
+		}
+	}
+
+	return rest
+}
+
+// writeError writes an API Gateway style error body.
+func writeError(w http.ResponseWriter, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("x-amzn-RequestId", uuid.New().String())
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"message": "Internal server error"})
+}

--- a/internal/service/execapi/path.go
+++ b/internal/service/execapi/path.go
@@ -1,0 +1,58 @@
+package execapi
+
+import "strings"
+
+// SplitPath splits a URL path into non-empty segments. "/" yields nil.
+func SplitPath(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+// MatchPath matches a path template against request segments. Template
+// segments may be literal, a single-segment wildcard {name}, or a greedy
+// wildcard {name+} matching the remainder. It returns captured parameters and
+// a specificity score (number of literal segments matched), or ok=false.
+func MatchPath(template string, reqSegs []string) (map[string]string, int, bool) {
+	tmplSegs := SplitPath(template)
+	params := map[string]string{}
+	score := 0
+
+	for i := range tmplSegs {
+		seg := tmplSegs[i]
+
+		// Greedy wildcard {name+} matches the entire remainder.
+		if strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "+}") {
+			name := strings.TrimSuffix(strings.TrimPrefix(seg, "{"), "+}")
+			params[name] = strings.Join(reqSegs[i:], "/")
+
+			return params, score, true
+		}
+
+		if i >= len(reqSegs) {
+			return nil, -1, false
+		}
+
+		if strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}") {
+			name := strings.TrimSuffix(strings.TrimPrefix(seg, "{"), "}")
+			params[name] = reqSegs[i]
+
+			continue
+		}
+
+		if seg != reqSegs[i] {
+			return nil, -1, false
+		}
+
+		score++
+	}
+
+	if len(tmplSegs) != len(reqSegs) {
+		return nil, -1, false
+	}
+
+	return params, score, true
+}

--- a/internal/service/interface.go
+++ b/internal/service/interface.go
@@ -29,6 +29,17 @@ type Handler interface {
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
 }
 
+// ExecuteAPIHandler is an optional interface for services that expose a
+// deployed API invoke surface (execute-api). The router dispatches
+// virtual-hosted execute-api requests ({apiId}.execute-api.<host>) to it.
+type ExecuteAPIHandler interface {
+	// HandleExecuteAPI handles an invocation for apiID. invokePath is the
+	// request path after the host, e.g. "/dev/items" (including the stage
+	// segment). It returns false when apiID is not managed by this service,
+	// so the router can try another handler.
+	HandleExecuteAPI(w http.ResponseWriter, r *http.Request, apiID, invokePath string) bool
+}
+
 // JSONProtocolService is an optional interface for services using AWS JSON 1.0 protocol.
 // Services implementing this interface will have their handlers dispatched via
 // a unified POST / endpoint based on the X-Amz-Target header.

--- a/test/integration/apigateway_executeapi_test.go
+++ b/test/integration/apigateway_executeapi_test.go
@@ -1,0 +1,314 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
+)
+
+const kumoEndpoint = "http://localhost:4566"
+
+// executeAPIClient builds an API Gateway client targeting kumoEndpoint, so
+// resources are created on the same server the stage URL is invoked against.
+func executeAPIClient(t *testing.T) *apigateway.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	return apigateway.NewFromConfig(cfg, func(o *apigateway.Options) {
+		o.BaseEndpoint = aws.String(kumoEndpoint + "/apigateway")
+	})
+}
+
+// rootResourceID returns the id of the "/" resource of a REST API.
+func rootResourceID(t *testing.T, client *apigateway.Client, apiID *string) string {
+	t.Helper()
+
+	out, err := client.GetResources(t.Context(), &apigateway.GetResourcesInput{RestApiId: apiID})
+	if err != nil {
+		t.Fatalf("GetResources: %v", err)
+	}
+
+	for _, r := range out.Items {
+		if r.Path != nil && *r.Path == "/" {
+			return *r.Id
+		}
+	}
+
+	t.Fatal("root resource not found")
+
+	return ""
+}
+
+// createLambdaWithEndpoint creates a Lambda function whose InvokeEndpoint is
+// the given URL, using the raw HTTP API (InvokeEndpoint is a kumo extension
+// the SDK cannot send).
+func createLambdaWithEndpoint(t *testing.T, name, invokeEndpoint string) {
+	t.Helper()
+
+	body, _ := json.Marshal(map[string]any{
+		"FunctionName":   name,
+		"Runtime":        "provided.al2",
+		"Role":           "arn:aws:iam::000000000000:role/test-role",
+		"Handler":        "index.handler",
+		"InvokeEndpoint": invokeEndpoint,
+		"Code":           map[string]any{"ZipFile": []byte("fake")},
+	})
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		kumoEndpoint+"/lambda/2015-03-31/functions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create lambda: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create lambda status %d: %s", resp.StatusCode, b)
+	}
+
+	t.Cleanup(func() {
+		delReq, _ := http.NewRequestWithContext(context.Background(), http.MethodDelete,
+			kumoEndpoint+"/lambda/2015-03-31/functions/"+name, nil)
+
+		if dr, _ := http.DefaultClient.Do(delReq); dr != nil {
+			_ = dr.Body.Close()
+		}
+	})
+}
+
+// buildLambdaAPI wires a REST API with a single GET /items route backed by an
+// AWS_PROXY Lambda integration, deployed to the given stage. Returns the API id.
+func buildLambdaAPI(t *testing.T, client *apigateway.Client, apiName, functionName, stage string) string {
+	t.Helper()
+
+	api, err := client.CreateRestApi(t.Context(), &apigateway.CreateRestApiInput{Name: aws.String(apiName)})
+	if err != nil {
+		t.Fatalf("CreateRestApi: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteRestApi(context.Background(), &apigateway.DeleteRestApiInput{RestApiId: api.Id})
+	})
+
+	root := rootResourceID(t, client, api.Id)
+
+	res, err := client.CreateResource(t.Context(), &apigateway.CreateResourceInput{
+		RestApiId: api.Id,
+		ParentId:  aws.String(root),
+		PathPart:  aws.String("items"),
+	})
+	if err != nil {
+		t.Fatalf("CreateResource: %v", err)
+	}
+
+	if _, err := client.PutMethod(t.Context(), &apigateway.PutMethodInput{
+		RestApiId:         api.Id,
+		ResourceId:        res.Id,
+		HttpMethod:        aws.String("GET"),
+		AuthorizationType: aws.String("NONE"),
+	}); err != nil {
+		t.Fatalf("PutMethod: %v", err)
+	}
+
+	uri := fmt.Sprintf(
+		"arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:%s/invocations",
+		functionName,
+	)
+
+	if _, err := client.PutIntegration(t.Context(), &apigateway.PutIntegrationInput{
+		RestApiId:             api.Id,
+		ResourceId:            res.Id,
+		HttpMethod:            aws.String("GET"),
+		Type:                  types.IntegrationTypeAwsProxy,
+		IntegrationHttpMethod: aws.String("POST"),
+		Uri:                   aws.String(uri),
+	}); err != nil {
+		t.Fatalf("PutIntegration: %v", err)
+	}
+
+	if _, err := client.CreateDeployment(t.Context(), &apigateway.CreateDeploymentInput{
+		RestApiId: api.Id,
+		StageName: aws.String(stage),
+	}); err != nil {
+		t.Fatalf("CreateDeployment: %v", err)
+	}
+
+	return *api.Id
+}
+
+// callStage invokes a deployed stage via the virtual-hosted execute-api
+// endpoint: it connects to the kumo server but sets the Host header to
+// {apiId}.execute-api.localhost so the router dispatches it as execute-api
+// (this is how a real client reaches the api_endpoint).
+func callStage(t *testing.T, method, apiID, stage, path string) (int, string) {
+	t.Helper()
+
+	url := fmt.Sprintf("%s/%s%s", kumoEndpoint, stage, path)
+
+	req, _ := http.NewRequestWithContext(t.Context(), method, url, nil)
+	req.Host = apiID + ".execute-api.localhost"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("call stage: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	return resp.StatusCode, string(body)
+}
+
+// TestExecuteAPI_LambdaProxy proves a Lambda function created in kumo is
+// actually invoked through the deployed stage URL and its proxy response is
+// returned to the caller.
+func TestExecuteAPI_LambdaProxy(t *testing.T) {
+	client := executeAPIClient(t)
+
+	// Mock Lambda handler: returns a proxy-integration envelope and echoes
+	// the received event path so we can assert the gateway shaped it.
+	lambda := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&event)
+
+		resp := map[string]any{
+			"statusCode": 201,
+			"headers":    map[string]string{"X-Handler": "kumo-test"},
+			"body":       fmt.Sprintf("hello from lambda: path=%v", event["path"]),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(lambda.Close)
+
+	fn := "executeapi-lambda-fn"
+	createLambdaWithEndpoint(t, fn, lambda.URL)
+
+	apiID := buildLambdaAPI(t, client, "executeapi-lambda", fn, "dev")
+
+	status, body := callStage(t, http.MethodGet, apiID, "dev", "/items")
+
+	if status != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%q", status, body)
+	}
+
+	if want := "hello from lambda: path=/items"; body != want {
+		t.Errorf("body = %q, want %q", body, want)
+	}
+}
+
+// TestExecuteAPI_HTTPProxy proves an HTTP_PROXY integration forwards the
+// request to the backend and returns its response.
+func TestExecuteAPI_HTTPProxy(t *testing.T) {
+	client := executeAPIClient(t)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("from http backend"))
+	}))
+	t.Cleanup(backend.Close)
+
+	api, err := client.CreateRestApi(t.Context(), &apigateway.CreateRestApiInput{Name: aws.String("executeapi-http")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteRestApi(context.Background(), &apigateway.DeleteRestApiInput{RestApiId: api.Id})
+	})
+
+	root := rootResourceID(t, client, api.Id)
+
+	res, err := client.CreateResource(t.Context(), &apigateway.CreateResourceInput{
+		RestApiId: api.Id, ParentId: aws.String(root), PathPart: aws.String("ping"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.PutMethod(t.Context(), &apigateway.PutMethodInput{
+		RestApiId: api.Id, ResourceId: res.Id, HttpMethod: aws.String("GET"), AuthorizationType: aws.String("NONE"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.PutIntegration(t.Context(), &apigateway.PutIntegrationInput{
+		RestApiId:             api.Id,
+		ResourceId:            res.Id,
+		HttpMethod:            aws.String("GET"),
+		Type:                  types.IntegrationTypeHttpProxy,
+		IntegrationHttpMethod: aws.String("GET"),
+		Uri:                   aws.String(backend.URL),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := client.CreateDeployment(t.Context(), &apigateway.CreateDeploymentInput{
+		RestApiId: api.Id, StageName: aws.String("dev"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	status, body := callStage(t, http.MethodGet, *api.Id, "dev", "/ping")
+	if status != http.StatusOK || body != "from http backend" {
+		t.Errorf("status=%d body=%q, want 200 'from http backend'", status, body)
+	}
+}
+
+// TestExecuteAPI_NoInvokeEndpoint asserts that without a wired InvokeEndpoint
+// the Lambda echoes the event (no statusCode), so the gateway returns 502 —
+// matching a malformed Lambda proxy response on real AWS.
+func TestExecuteAPI_NoInvokeEndpoint(t *testing.T) {
+	client := executeAPIClient(t)
+
+	fn := "executeapi-noendpoint-fn"
+	createLambdaWithEndpoint(t, fn, "") // empty -> echo stub
+
+	apiID := buildLambdaAPI(t, client, "executeapi-noendpoint", fn, "dev")
+
+	status, _ := callStage(t, http.MethodGet, apiID, "dev", "/items")
+	if status != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", status)
+	}
+}
+
+// TestExecuteAPI_UnknownRoute asserts an unmatched path returns the real AWS
+// 403 "Missing Authentication Token".
+func TestExecuteAPI_UnknownRoute(t *testing.T) {
+	client := executeAPIClient(t)
+
+	fn := "executeapi-unknownroute-fn"
+	createLambdaWithEndpoint(t, fn, "")
+
+	apiID := buildLambdaAPI(t, client, "executeapi-unknownroute", fn, "dev")
+
+	status, body := callStage(t, http.MethodGet, apiID, "dev", "/does-not-exist")
+	if status != http.StatusForbidden {
+		t.Errorf("status = %d, want 403; body=%q", status, body)
+	}
+}

--- a/test/integration/apigatewayv2_executeapi_test.go
+++ b/test/integration/apigatewayv2_executeapi_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
+)
+
+func executeAPIV2Client(t *testing.T) *apigatewayv2.Client {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	return apigatewayv2.NewFromConfig(cfg, func(o *apigatewayv2.Options) {
+		o.BaseEndpoint = aws.String(kumoEndpoint + "/apigatewayv2")
+	})
+}
+
+// TestExecuteAPIV2_LambdaProxy proves an HTTP API (v2) route backed by an
+// AWS_PROXY Lambda is invoked through the deployed stage URL, using the
+// payload format 2.0 event.
+func TestExecuteAPIV2_LambdaProxy(t *testing.T) {
+	client := executeAPIV2Client(t)
+
+	// Mock Lambda: returns a v2 proxy envelope and echoes rawPath so we can
+	// assert the gateway built the 2.0 event.
+	lambda := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&event)
+
+		resp := map[string]any{
+			"statusCode": 200,
+			"body":       fmt.Sprintf("v2 hello: rawPath=%v version=%v", event["rawPath"], event["version"]),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(lambda.Close)
+
+	fn := "executeapi-v2-fn"
+	createLambdaWithEndpoint(t, fn, lambda.URL)
+
+	api, err := client.CreateApi(t.Context(), &apigatewayv2.CreateApiInput{
+		Name:         aws.String("executeapi-v2"),
+		ProtocolType: types.ProtocolTypeHttp,
+	})
+	if err != nil {
+		t.Fatalf("CreateApi: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteApi(t.Context(), &apigatewayv2.DeleteApiInput{ApiId: api.ApiId})
+	})
+
+	integ, err := client.CreateIntegration(t.Context(), &apigatewayv2.CreateIntegrationInput{
+		ApiId:                api.ApiId,
+		IntegrationType:      types.IntegrationTypeAwsProxy,
+		IntegrationUri:       aws.String("arn:aws:lambda:us-east-1:000000000000:function:" + fn),
+		PayloadFormatVersion: aws.String("2.0"),
+	})
+	if err != nil {
+		t.Fatalf("CreateIntegration: %v", err)
+	}
+
+	if _, err := client.CreateRoute(t.Context(), &apigatewayv2.CreateRouteInput{
+		ApiId:    api.ApiId,
+		RouteKey: aws.String("GET /items"),
+		Target:   aws.String("integrations/" + *integ.IntegrationId),
+	}); err != nil {
+		t.Fatalf("CreateRoute: %v", err)
+	}
+
+	if _, err := client.CreateStage(t.Context(), &apigatewayv2.CreateStageInput{
+		ApiId:      api.ApiId,
+		StageName:  aws.String("dev"),
+		AutoDeploy: aws.Bool(true),
+	}); err != nil {
+		t.Fatalf("CreateStage: %v", err)
+	}
+
+	status, body := callStage(t, http.MethodGet, *api.ApiId, "dev", "/items")
+
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", status, body)
+	}
+
+	if want := "v2 hello: rawPath=/dev/items version=2.0"; body != want {
+		t.Errorf("body = %q, want %q", body, want)
+	}
+}
+
+// TestExecuteAPIV2_UnknownRoute asserts an unmatched route on a real API
+// returns 404 (and a known API id is owned by the v2 service).
+func TestExecuteAPIV2_UnknownRoute(t *testing.T) {
+	client := executeAPIV2Client(t)
+
+	api, err := client.CreateApi(t.Context(), &apigatewayv2.CreateApiInput{
+		Name:         aws.String("executeapi-v2-unknown"),
+		ProtocolType: types.ProtocolTypeHttp,
+	})
+	if err != nil {
+		t.Fatalf("CreateApi: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteApi(t.Context(), &apigatewayv2.DeleteApiInput{ApiId: api.ApiId})
+	})
+
+	if _, err := client.CreateStage(t.Context(), &apigatewayv2.CreateStageInput{
+		ApiId:     api.ApiId,
+		StageName: aws.String("dev"),
+	}); err != nil {
+		t.Fatalf("CreateStage: %v", err)
+	}
+
+	status, _ := callStage(t, http.MethodGet, *api.ApiId, "dev", "/missing")
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", status)
+	}
+}


### PR DESCRIPTION
## Summary

- Implement the data-plane half of API Gateway: invoking a deployed stage URL now routes through the resource/method/integration (v1) or route/integration (v2) to the integration target, instead of returning 404 (#606).
- Faithful to AWS, the invoke surface is the virtual-hosted endpoint `{apiId}.execute-api.<host>/{stage}/{route}` — no path-style is invented (AWS has none). The router detects this `Host` (reusing the S3 vhost pattern) and dispatches to whichever service owns the API id. The kumo-local form `{apiId}.execute-api.localhost` resolves to loopback.
- New shared engine `internal/service/execapi`: builds the Lambda proxy event (payload 1.0 for REST, 1.0/2.0 for HTTP API), invokes the function via kumo's own Lambda invoke endpoint (delegating execution to the function's `InvokeEndpoint`, like eventbridge -> lambda), and strictly unwraps the `{statusCode, headers, body, isBase64Encoded}` envelope. A malformed/absent `statusCode` yields 502 for 1.0; for 2.0 a valid JSON without `statusCode` is returned as 200 (the AWS spec rule). `HTTP_PROXY` forwards verbatim.
- `service.ExecuteAPIHandler` optional interface; the server registers implementers and the router fans out to them by `Host`.

### Behaviour (matches real AWS)

- v1 routing by stage -> resource (literal / `{param}` / `{proxy+}`) -> method (exact or `ANY`); v2 by stage -> routeKey (incl. `$default`).
- Unmatched route -> 403 `Missing Authentication Token` (v1) / 404 (v2); missing integration -> 500.
- VTL-dependent integration types (`AWS`/`HTTP` non-proxy, `MOCK`) are not yet emulated (500, logged) pending a VTL engine. Authorizers are not yet evaluated. These are documented gaps for follow-up.

### Notes

- Execution is delegated, not run by kumo (same model as RDS pointing at a real DB). The function's `InvokeEndpoint` can be any HTTP endpoint that accepts the event and returns the envelope: a plain handler, or AWS RIE running an unmodified `lambda.Start` binary. Running real `lambda.Start` binaries against kumo without external RIE (a kumo-native Runtime API) is tracked as a separate follow-up.
- Stacked on #772 (apigatewayv2 CRUD); base will retarget to `main` once that merges.

## Test plan

- [x] `go build ./...`, `golangci-lint run` (0 issues), `go test -race -shuffle=on ./...`
- [x] Integration (golden-free, behaviour-asserting) tests run against the branch binary:
  - v1: a kumo-created Lambda is actually invoked through the stage URL and its 201/headers/body returned; `HTTP_PROXY` forwarded; no `InvokeEndpoint` -> 502; unknown route -> 403
  - v2: HTTP API route invokes the Lambda with a payload-2.0 event; unknown route -> 404
- [x] Manual: live `curl` against a running kumo with a Go Lambda handler returned the handler's response through the gateway

Closes #606