### PR TITLE
fix(dynamodb): fail closed on unparseable FilterExpression and implement IN

### DIFF
--- a/internal/service/dynamodb/condition.go
+++ b/internal/service/dynamodb/condition.go
@@ -360,6 +360,11 @@ func parseComparison(expr string, item Item, values map[string]AttributeValue) (
 		return parseBetween(leftToken, strings.TrimSpace(rest[7:]), item, values)
 	}
 
+	// Handle IN: operand IN (operand, operand, ...)
+	if startsWithKeyword(rest, "IN") {
+		return parseIn(leftToken, strings.TrimSpace(rest[2:]), item, values)
+	}
+
 	op, afterOp, err := parseComparisonOp(rest)
 	if err != nil {
 		return false, "", err
@@ -374,6 +379,41 @@ func parseComparison(expr string, item Item, values map[string]AttributeValue) (
 	right := resolveOperand(rightToken, item, values)
 
 	result := compareAttributeValues(left, right, op)
+
+	return result, finalRest, nil
+}
+
+// maxInOperands is DynamoDB's limit on the number of operands in an IN list.
+const maxInOperands = 100
+
+// parseIn handles "operand IN (operand, operand, ...)". The result is true if
+// the left operand equals any operand in the list.
+func parseIn(leftToken, rest string, item Item, values map[string]AttributeValue) (bool, string, error) {
+	args, finalRest, err := parseArgList(rest)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to parse IN operand list: %w", err)
+	}
+
+	if len(args) == 0 {
+		return false, "", fmt.Errorf("IN requires at least 1 operand")
+	}
+
+	if len(args) > maxInOperands {
+		return false, "", fmt.Errorf("IN accepts at most %d operands, got %d", maxInOperands, len(args))
+	}
+
+	val := resolveOperand(leftToken, item, values)
+
+	result := false
+
+	for _, arg := range args {
+		operand := resolveOperand(strings.TrimSpace(arg), item, values)
+		if compareAttributeValues(val, operand, "=") {
+			result = true
+
+			break
+		}
+	}
 
 	return result, finalRest, nil
 }

--- a/internal/service/dynamodb/condition_test.go
+++ b/internal/service/dynamodb/condition_test.go
@@ -3,6 +3,8 @@ package dynamodb
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -627,5 +629,217 @@ func TestEvaluateCondition(t *testing.T) {
 				t.Errorf("evaluateCondition() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+//nolint:funlen // Table-driven test covering the IN operator cases.
+func TestEvaluateConditionIn(t *testing.T) {
+	t.Parallel()
+
+	item := Item{
+		"pk":     {S: ptr("1")},
+		"status": {S: ptr("running")},
+		"count":  {N: ptr("5")},
+		"other":  {S: ptr("running")},
+	}
+
+	tests := []struct {
+		name    string
+		expr    string
+		values  map[string]AttributeValue
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:   "IN matches first operand",
+			expr:   "status IN (:a, :b)",
+			values: map[string]AttributeValue{":a": {S: ptr("running")}, ":b": {S: ptr("pending")}},
+			want:   true,
+		},
+		{
+			name:   "IN matches later operand",
+			expr:   "status IN (:a, :b, :c)",
+			values: map[string]AttributeValue{":a": {S: ptr("pending")}, ":b": {S: ptr("done")}, ":c": {S: ptr("running")}},
+			want:   true,
+		},
+		{
+			name:   "IN with no matching operand",
+			expr:   "status IN (:a, :b)",
+			values: map[string]AttributeValue{":a": {S: ptr("pending")}, ":b": {S: ptr("done")}},
+			want:   false,
+		},
+		{
+			name:   "IN with attribute path operand",
+			expr:   "status IN (other)",
+			values: nil,
+			want:   true,
+		},
+		{
+			name:   "IN with numeric operands",
+			expr:   "count IN (:a, :b)",
+			values: map[string]AttributeValue{":a": {N: ptr("3")}, ":b": {N: ptr("5")}},
+			want:   true,
+		},
+		{
+			name:   "lowercase in keyword",
+			expr:   "status in (:a)",
+			values: map[string]AttributeValue{":a": {S: ptr("running")}},
+			want:   true,
+		},
+		{
+			name:   "NOT IN composition",
+			expr:   "NOT status IN (:a, :b)",
+			values: map[string]AttributeValue{":a": {S: ptr("pending")}, ":b": {S: ptr("done")}},
+			want:   true,
+		},
+		{
+			name:   "IN combined with AND",
+			expr:   "pk = :pk AND status IN (:a, :b)",
+			values: map[string]AttributeValue{":pk": {S: ptr("1")}, ":a": {S: ptr("running")}, ":b": {S: ptr("done")}},
+			want:   true,
+		},
+		{
+			name:   "parenthesized IN in OR chain",
+			expr:   "(status IN (:a)) OR count = :n",
+			values: map[string]AttributeValue{":a": {S: ptr("done")}, ":n": {N: ptr("5")}},
+			want:   true,
+		},
+		{
+			name:    "IN without parenthesized list",
+			expr:    "status IN :a",
+			values:  map[string]AttributeValue{":a": {S: ptr("running")}},
+			wantErr: true,
+		},
+		{
+			name:    "IN with empty operand list",
+			expr:    "status IN ()",
+			values:  nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := evaluateCondition(item, ConditionInput{
+				Expression: tt.expr,
+				ExprValues: tt.values,
+			})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got result %v", tt.expr, got)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.expr, err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("evaluateCondition(%q) = %v, want %v", tt.expr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateConditionInOperandLimit(t *testing.T) {
+	t.Parallel()
+
+	item := Item{"status": {S: ptr("running")}}
+
+	// Build an IN list with one operand over the DynamoDB limit.
+	operands := make([]string, 0, maxInOperands+1)
+	values := make(map[string]AttributeValue, maxInOperands+1)
+
+	for i := range maxInOperands + 1 {
+		ph := fmt.Sprintf(":v%d", i)
+		operands = append(operands, ph)
+		values[ph] = AttributeValue{S: ptr(fmt.Sprintf("state%d", i))}
+	}
+
+	_, err := evaluateCondition(item, ConditionInput{
+		Expression: "status IN (" + strings.Join(operands, ", ") + ")",
+		ExprValues: values,
+	})
+	if err == nil {
+		t.Fatalf("expected error for IN list with %d operands", maxInOperands+1)
+	}
+}
+
+// TestFilterExpressionFailsClosed verifies that Scan and Query reject an
+// unparseable FilterExpression with ValidationException instead of silently
+// matching every item (or none).
+//
+//nolint:funlen // Exercises the Scan and Query fail-closed paths sequentially.
+func TestFilterExpressionFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := s.CreateTable(ctx, &CreateTableRequest{
+		TableName: "filter-test",
+		KeySchema: []KeySchemaElement{
+			{AttributeName: "pk", KeyType: "HASH"},
+		},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "pk", AttributeType: "S"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, status := range []string{"pending", "running", "done"} {
+		_, err := s.PutItem(ctx, "filter-test", Item{
+			"pk":     {S: ptr(fmt.Sprintf("%d", i))},
+			"status": {S: ptr(status)},
+		}, false, ConditionInput{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// IN now filters correctly on Scan.
+	items, _, scanned, err := s.Scan(ctx, "filter-test", "#s IN (:a, :b)",
+		map[string]string{"#s": "status"},
+		map[string]AttributeValue{":a": {S: ptr("pending")}, ":b": {S: ptr("running")}},
+		0, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("scan with IN filter: %v", err)
+	}
+
+	if len(items) != 2 || scanned != 3 {
+		t.Fatalf("expected 2 of 3 items to match IN filter, got %d of %d", len(items), scanned)
+	}
+
+	const errCodeValidation = "ValidationException"
+
+	// An unparseable filter is a ValidationException, not match-all.
+	items, _, scanned, err = s.Scan(ctx, "filter-test", "complete garbage !!!",
+		nil, nil, 0, nil, nil, nil)
+
+	var tErr *TableError
+	if !errors.As(err, &tErr) || tErr.Code != errCodeValidation {
+		t.Fatalf("expected ValidationException for invalid scan filter, got: %v", err)
+	}
+
+	if len(items) != 0 || scanned != 0 {
+		t.Fatalf("invalid filter must not return results, got %d items (scanned %d)", len(items), scanned)
+	}
+
+	// Query takes the same path.
+	queryItems, _, queryScanned, err := s.Query(ctx, "filter-test", "", "pk = :pk", "complete garbage !!!",
+		nil, map[string]AttributeValue{":pk": {S: ptr("0")}}, 0, nil, true)
+
+	if !errors.As(err, &tErr) || tErr.Code != errCodeValidation {
+		t.Fatalf("expected ValidationException for invalid query filter, got: %v", err)
+	}
+
+	if len(queryItems) != 0 || queryScanned != 0 {
+		t.Fatalf("invalid filter must not return results, got %d items (scanned %d)", len(queryItems), queryScanned)
 	}
 }

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -710,7 +710,12 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 		}
 
 		// Apply filter expression.
-		if filterExpr != "" && !m.evaluateFilterExpression(item, filterExpr, exprNames, exprValues) {
+		match, err := m.filterItem(item, filterExpr, exprNames, exprValues)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+
+		if !match {
 			continue
 		}
 
@@ -808,7 +813,12 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 		scannedCount++
 
 		// Apply filter expression.
-		if filterExpr != "" && !m.evaluateFilterExpression(item, filterExpr, exprNames, exprValues) {
+		match, err := m.filterItem(item, filterExpr, exprNames, exprValues)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+
+		if !match {
 			continue
 		}
 
@@ -1150,18 +1160,33 @@ func (m *MemoryStorage) extractPartitionKeyValue(keyCondExpr, partitionKeyName s
 	return nil
 }
 
-// evaluateFilterExpression evaluates a filter expression against an item.
-func (m *MemoryStorage) evaluateFilterExpression(item Item, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue) bool {
+// filterItem reports whether an item passes a filter expression, where an
+// empty expression passes everything.
+func (m *MemoryStorage) filterItem(item Item, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue) (bool, error) {
+	if filterExpr == "" {
+		return true, nil
+	}
+
+	return m.evaluateFilterExpression(item, filterExpr, exprNames, exprValues)
+}
+
+// evaluateFilterExpression evaluates a filter expression against an item. An
+// expression the parser cannot handle is a ValidationException, matching
+// DynamoDB; it must never silently match (or filter out) items.
+func (m *MemoryStorage) evaluateFilterExpression(item Item, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue) (bool, error) {
 	result, err := evaluateCondition(item, ConditionInput{
 		Expression: filterExpr,
 		ExprNames:  exprNames,
 		ExprValues: exprValues,
 	})
 	if err != nil {
-		return true
+		return false, &TableError{
+			Code:    "ValidationException",
+			Message: fmt.Sprintf("Invalid FilterExpression: %s", err),
+		}
 	}
 
-	return result
+	return result, nil
 }
 
 // attributeValuesEqual compares two attribute values for equality.

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
 	"github.com/sivchari/golden"
 )
 
@@ -1795,4 +1796,94 @@ func TestDynamoDB_QueryKeyConditionsWithSortKey(t *testing.T) {
 		}
 		golden.New(t).Assert(t.Name(), out)
 	})
+}
+
+// TestDynamoDB_ScanFilterExpressionIn covers the IN operator in a
+// FilterExpression and asserts that an invalid expression is rejected with
+// ValidationException instead of silently matching every item.
+func TestDynamoDB_ScanFilterExpressionIn(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-scan-filter-in"
+
+	// Create table.
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{
+				AttributeName: aws.String("pk"),
+				KeyType:       types.KeyTypeHash,
+			},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{
+				AttributeName: aws.String("pk"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	// Put items in three distinct states.
+	for i, status := range []string{"pending", "running", "done"} {
+		_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item: map[string]types.AttributeValue{
+				"pk":     &types.AttributeValueMemberS{Value: "item-" + string(rune('a'+i))},
+				"status": &types.AttributeValueMemberS{Value: status},
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed to put item: %v", err)
+		}
+	}
+
+	// Scan with an IN filter must return only the two matching items.
+	scanOutput, err := client.Scan(ctx, &dynamodb.ScanInput{
+		TableName:                aws.String(tableName),
+		FilterExpression:         aws.String("#s IN (:a, :b)"),
+		ExpressionAttributeNames: map[string]string{"#s": "status"},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":a": &types.AttributeValueMemberS{Value: "pending"},
+			":b": &types.AttributeValueMemberS{Value: "running"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("scan with IN filter failed: %v", err)
+	}
+
+	if scanOutput.Count != 2 || scanOutput.ScannedCount != 3 {
+		t.Fatalf("expected Count=2 ScannedCount=3, got Count=%d ScannedCount=%d", scanOutput.Count, scanOutput.ScannedCount)
+	}
+
+	for _, item := range scanOutput.Items {
+		status, ok := item["status"].(*types.AttributeValueMemberS)
+		if !ok || (status.Value != "pending" && status.Value != "running") {
+			t.Fatalf("item with status %v must not pass the IN filter", item["status"])
+		}
+	}
+
+	// An expression the parser cannot handle must be a ValidationException,
+	// never a silent match-all.
+	_, err = client.Scan(ctx, &dynamodb.ScanInput{
+		TableName:        aws.String(tableName),
+		FilterExpression: aws.String("complete garbage !!!"),
+	})
+	if err == nil {
+		t.Fatal("expected ValidationException for invalid FilterExpression")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("expected ValidationException, got: %T: %v", err, err)
+	}
 }


### PR DESCRIPTION
Closes #807

## Summary

`Scan`/`Query` treated an unparseable `FilterExpression` as a match: `evaluateFilterExpression` returned `true` on parse errors, so any unsupported syntax silently disabled filtering and returned the entire table — with HTTP 200 and no log line. The easiest way to hit this was the `IN` operator, which the condition grammar did not implement (#807).

Two changes, mirroring the issue:

- **Fail closed on parse errors.** `evaluateFilterExpression` now propagates the parse error, and `Scan`/`Query` return `ValidationException: Invalid FilterExpression: ...` — the same mapping conditional writes (`PutItem`/`DeleteItem`/`UpdateItem`) already use for `ConditionExpression`.
- **Implement `IN`.** `operand IN (operand, operand, ...)` evaluates to true when the left operand equals any list member, reusing the existing `parseArgList` and `=` comparison semantics, capped at DynamoDB's 100-operand limit. Composes with `AND`/`OR`/`NOT`/parentheses like any other comparison.

## Test plan

- [x] `make lint` (0 issues)
- [x] `go test -race ./...`
- [x] Unit: IN match/no-match, attribute-path operands, numeric operands, lowercase keyword, composition with NOT/AND/OR/parens, missing parens → error, empty list → error, 101 operands → error
- [x] Unit: Scan and Query return `ValidationException` for an unparseable filter; IN filters correctly through storage
- [x] Integration `TestDynamoDB_ScanFilterExpressionIn`: Scan with `#s IN (:a, :b)` returns Count=2/ScannedCount=3; invalid expression → `ValidationException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
