### PR TITLE
fix(dynamodb): fail closed on KeyConditionExpression and implement attribute_type

### DIFF
--- a/internal/service/dynamodb/condition.go
+++ b/internal/service/dynamodb/condition.go
@@ -127,8 +127,10 @@ func parsePrimary(expr string, item Item, values map[string]AttributeValue) (boo
 		return result, rest[1:], nil
 	}
 
-	// Function calls.
-	for _, fn := range []string{"attribute_exists", "attribute_not_exists", "begins_with", "contains"} {
+	// Function calls. attribute_type belongs here: like the others it takes a
+	// parenthesized argument list and returns a boolean. (size() is handled
+	// separately below because its syntax is "size(path) op value".)
+	for _, fn := range []string{"attribute_exists", "attribute_not_exists", "attribute_type", "begins_with", "contains"} {
 		if strings.HasPrefix(trimmed, fn+"(") {
 			return parseFunctionCall(fn, trimmed[len(fn):], item, values)
 		}
@@ -139,16 +141,6 @@ func parsePrimary(expr string, item Item, values map[string]AttributeValue) (boo
 		}
 	}
 
-	// attribute_type(path, :type). Handled separately from the function loop above
-	// because its name does not share a prefix with the attribute_exists family.
-	if strings.HasPrefix(trimmed, "attribute_type(") {
-		return parseAttributeType(trimmed[len("attribute_type"):], item, values)
-	}
-
-	if strings.HasPrefix(trimmed, "attribute_type (") {
-		return parseAttributeType(strings.TrimSpace(trimmed[len("attribute_type"):]), item, values)
-	}
-
 	// size() function used in comparison: size(path) op value
 	if strings.HasPrefix(trimmed, "size(") {
 		return parseSizeComparison(trimmed, item, values)
@@ -156,32 +148,6 @@ func parsePrimary(expr string, item Item, values map[string]AttributeValue) (boo
 
 	// Comparison: operand op operand
 	return parseComparison(trimmed, item, values)
-}
-
-// parseAttributeType evaluates attribute_type(path, :type). Per DynamoDB the
-// type argument must be an expression attribute value holding one of the type
-// descriptors (S, N, B, SS, NS, BS, M, L, NULL, BOOL).
-func parseAttributeType(argsStr string, item Item, values map[string]AttributeValue) (bool, string, error) {
-	args, rest, err := parseArgList(argsStr)
-	if err != nil {
-		return false, "", fmt.Errorf("failed to parse attribute_type arguments: %w", err)
-	}
-
-	if len(args) != 2 {
-		return false, "", fmt.Errorf("attribute_type requires 2 arguments")
-	}
-
-	typeVal := resolveOperand(strings.TrimSpace(args[1]), item, values)
-	if typeVal.S == nil {
-		return false, "", fmt.Errorf("attribute_type requires a string type operand")
-	}
-
-	av, exists := resolveItemPath(item, strings.TrimSpace(args[0]))
-	if !exists {
-		return false, rest, nil
-	}
-
-	return matchesAttributeType(av, *typeVal.S), rest, nil
 }
 
 // matchesAttributeType reports whether the attribute value is of the given
@@ -215,67 +181,108 @@ func matchesAttributeType(av AttributeValue, typ string) bool {
 	}
 }
 
-// parseFunctionCall parses and evaluates a function call.
+// parseFunctionCall parses a function's argument list and dispatches to the
+// matching evaluator. The remaining input after the argument list is the same
+// for every function, so it is returned here rather than by each evaluator.
 func parseFunctionCall(fn, argsStr string, item Item, values map[string]AttributeValue) (bool, string, error) {
 	args, rest, err := parseArgList(argsStr)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to parse %s arguments: %w", fn, err)
 	}
 
+	var result bool
+
 	switch fn {
 	case "attribute_exists":
-		if len(args) != 1 {
-			return false, "", fmt.Errorf("attribute_exists requires 1 argument")
-		}
-
-		path := strings.TrimSpace(args[0])
-		_, exists := resolveItemPath(item, path)
-
-		return exists, rest, nil
-
+		result, err = evalAttributeExists(args, item)
 	case "attribute_not_exists":
-		if len(args) != 1 {
-			return false, "", fmt.Errorf("attribute_not_exists requires 1 argument")
-		}
-
-		path := strings.TrimSpace(args[0])
-		_, exists := resolveItemPath(item, path)
-
-		return !exists, rest, nil
-
+		result, err = evalAttributeNotExists(args, item)
+	case "attribute_type":
+		result, err = evalAttributeType(args, item, values)
 	case "begins_with":
-		if len(args) != 2 {
-			return false, "", fmt.Errorf("begins_with requires 2 arguments")
-		}
-
-		path := strings.TrimSpace(args[0])
-		val := resolveOperand(strings.TrimSpace(args[1]), item, values)
-
-		av, exists := resolveItemPath(item, path)
-		if !exists || av.S == nil || val.S == nil {
-			return false, rest, nil
-		}
-
-		return strings.HasPrefix(*av.S, *val.S), rest, nil
-
+		result, err = evalBeginsWith(args, item, values)
 	case "contains":
-		if len(args) != 2 {
-			return false, "", fmt.Errorf("contains requires 2 arguments")
-		}
-
-		path := strings.TrimSpace(args[0])
-		val := resolveOperand(strings.TrimSpace(args[1]), item, values)
-
-		av, exists := resolveItemPath(item, path)
-		if !exists {
-			return false, rest, nil
-		}
-
-		return evalContains(av, val), rest, nil
-
+		result, err = evalContainsFunc(args, item, values)
 	default:
 		return false, "", fmt.Errorf("unknown function: %s", fn)
 	}
+
+	if err != nil {
+		return false, "", err
+	}
+
+	return result, rest, nil
+}
+
+func evalAttributeExists(args []string, item Item) (bool, error) {
+	if len(args) != 1 {
+		return false, fmt.Errorf("attribute_exists requires 1 argument")
+	}
+
+	_, exists := resolveItemPath(item, strings.TrimSpace(args[0]))
+
+	return exists, nil
+}
+
+func evalAttributeNotExists(args []string, item Item) (bool, error) {
+	if len(args) != 1 {
+		return false, fmt.Errorf("attribute_not_exists requires 1 argument")
+	}
+
+	_, exists := resolveItemPath(item, strings.TrimSpace(args[0]))
+
+	return !exists, nil
+}
+
+// evalAttributeType evaluates attribute_type(path, :type). Per DynamoDB the type
+// argument must be an expression attribute value holding one of the type
+// descriptors (S, N, B, SS, NS, BS, M, L, NULL, BOOL).
+func evalAttributeType(args []string, item Item, values map[string]AttributeValue) (bool, error) {
+	if len(args) != 2 {
+		return false, fmt.Errorf("attribute_type requires 2 arguments")
+	}
+
+	typeVal := resolveOperand(strings.TrimSpace(args[1]), item, values)
+	if typeVal.S == nil {
+		return false, fmt.Errorf("attribute_type requires a string type operand")
+	}
+
+	av, exists := resolveItemPath(item, strings.TrimSpace(args[0]))
+	if !exists {
+		return false, nil
+	}
+
+	return matchesAttributeType(av, *typeVal.S), nil
+}
+
+func evalBeginsWith(args []string, item Item, values map[string]AttributeValue) (bool, error) {
+	if len(args) != 2 {
+		return false, fmt.Errorf("begins_with requires 2 arguments")
+	}
+
+	val := resolveOperand(strings.TrimSpace(args[1]), item, values)
+
+	av, exists := resolveItemPath(item, strings.TrimSpace(args[0]))
+	if !exists || av.S == nil || val.S == nil {
+		return false, nil
+	}
+
+	return strings.HasPrefix(*av.S, *val.S), nil
+}
+
+func evalContainsFunc(args []string, item Item, values map[string]AttributeValue) (bool, error) {
+	if len(args) != 2 {
+		return false, fmt.Errorf("contains requires 2 arguments")
+	}
+
+	val := resolveOperand(strings.TrimSpace(args[1]), item, values)
+
+	av, exists := resolveItemPath(item, strings.TrimSpace(args[0]))
+	if !exists {
+		return false, nil
+	}
+
+	return evalContains(av, val), nil
 }
 
 // evalContains evaluates the contains function for various types.

--- a/internal/service/dynamodb/condition.go
+++ b/internal/service/dynamodb/condition.go
@@ -139,6 +139,16 @@ func parsePrimary(expr string, item Item, values map[string]AttributeValue) (boo
 		}
 	}
 
+	// attribute_type(path, :type). Handled separately from the function loop above
+	// because its name does not share a prefix with the attribute_exists family.
+	if strings.HasPrefix(trimmed, "attribute_type(") {
+		return parseAttributeType(trimmed[len("attribute_type"):], item, values)
+	}
+
+	if strings.HasPrefix(trimmed, "attribute_type (") {
+		return parseAttributeType(strings.TrimSpace(trimmed[len("attribute_type"):]), item, values)
+	}
+
 	// size() function used in comparison: size(path) op value
 	if strings.HasPrefix(trimmed, "size(") {
 		return parseSizeComparison(trimmed, item, values)
@@ -146,6 +156,63 @@ func parsePrimary(expr string, item Item, values map[string]AttributeValue) (boo
 
 	// Comparison: operand op operand
 	return parseComparison(trimmed, item, values)
+}
+
+// parseAttributeType evaluates attribute_type(path, :type). Per DynamoDB the
+// type argument must be an expression attribute value holding one of the type
+// descriptors (S, N, B, SS, NS, BS, M, L, NULL, BOOL).
+func parseAttributeType(argsStr string, item Item, values map[string]AttributeValue) (bool, string, error) {
+	args, rest, err := parseArgList(argsStr)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to parse attribute_type arguments: %w", err)
+	}
+
+	if len(args) != 2 {
+		return false, "", fmt.Errorf("attribute_type requires 2 arguments")
+	}
+
+	typeVal := resolveOperand(strings.TrimSpace(args[1]), item, values)
+	if typeVal.S == nil {
+		return false, "", fmt.Errorf("attribute_type requires a string type operand")
+	}
+
+	av, exists := resolveItemPath(item, strings.TrimSpace(args[0]))
+	if !exists {
+		return false, rest, nil
+	}
+
+	return matchesAttributeType(av, *typeVal.S), rest, nil
+}
+
+// matchesAttributeType reports whether the attribute value is of the given
+// DynamoDB type descriptor.
+//
+//nolint:gocritic // hugeParam: AttributeValue passed by value intentionally.
+func matchesAttributeType(av AttributeValue, typ string) bool {
+	switch typ {
+	case "S":
+		return av.S != nil
+	case "N":
+		return av.N != nil
+	case "B":
+		return av.B != nil
+	case "SS":
+		return av.SS != nil
+	case "NS":
+		return av.NS != nil
+	case "BS":
+		return av.BS != nil
+	case "M":
+		return av.M != nil
+	case "L":
+		return av.L != nil
+	case "NULL":
+		return av.NULL != nil
+	case "BOOL":
+		return av.BOOL != nil
+	default:
+		return false
+	}
 }
 
 // parseFunctionCall parses and evaluates a function call.
@@ -288,24 +355,16 @@ func parseSizeComparison(expr string, item Item, values map[string]AttributeValu
 	path := strings.TrimSpace(inner[:idx])
 	rest := strings.TrimSpace(inner[idx+1:])
 
-	// Get the size of the attribute.
-	av, exists := resolveItemPath(item, path)
-	if !exists {
-		return false, "", fmt.Errorf("attribute %s not found for size()", path)
-	}
-
-	sizeVal := attributeSize(av)
-
-	// Parse operator.
+	// Parse operator and right operand first so the remaining string (finalRest)
+	// is consumed correctly even when the attribute is absent.
 	op, afterOp, err := parseComparisonOp(rest)
 	if err != nil {
 		return false, "", err
 	}
 
-	// Parse right operand.
 	rightToken, finalRest := nextToken(strings.TrimSpace(afterOp))
-	rightVal := resolveOperand(rightToken, item, values)
 
+	rightVal := resolveOperand(rightToken, item, values)
 	if rightVal.N == nil {
 		return false, "", fmt.Errorf("size() comparison requires numeric operand")
 	}
@@ -315,7 +374,14 @@ func parseSizeComparison(expr string, item Item, values map[string]AttributeValu
 		return false, "", fmt.Errorf("invalid number: %s", *rightVal.N)
 	}
 
-	result := compareNumbers(float64(sizeVal), rightNum, op)
+	// A missing attribute is not an error: like any other comparison against an
+	// absent attribute, the item simply does not match (DynamoDB does not fail).
+	av, exists := resolveItemPath(item, path)
+	if !exists {
+		return false, finalRest, nil
+	}
+
+	result := compareNumbers(float64(attributeSize(av)), rightNum, op)
 
 	return result, finalRest, nil
 }

--- a/internal/service/dynamodb/condition_test.go
+++ b/internal/service/dynamodb/condition_test.go
@@ -612,6 +612,68 @@ func TestEvaluateCondition(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "attribute_type matches string",
+			item: Item{"pk": {S: ptr("1")}, "name": {S: ptr("Alice")}},
+			cond: ConditionInput{
+				Expression: "attribute_type(name, :t)",
+				ExprValues: map[string]AttributeValue{":t": {S: ptr("S")}},
+			},
+			want: true,
+		},
+		{
+			name: "attribute_type mismatch returns false",
+			item: Item{"pk": {S: ptr("1")}, "name": {S: ptr("Alice")}},
+			cond: ConditionInput{
+				Expression: "attribute_type(name, :t)",
+				ExprValues: map[string]AttributeValue{":t": {S: ptr("N")}},
+			},
+			want: false,
+		},
+		{
+			name: "attribute_type on list",
+			item: Item{"pk": {S: ptr("1")}, "tags": {L: []*AttributeValue{{S: ptr("a")}}}},
+			cond: ConditionInput{
+				Expression: "attribute_type(tags, :t)",
+				ExprValues: map[string]AttributeValue{":t": {S: ptr("L")}},
+			},
+			want: true,
+		},
+		{
+			name: "attribute_type on missing attribute returns false (no error)",
+			item: Item{"pk": {S: ptr("1")}},
+			cond: ConditionInput{
+				Expression: "attribute_type(name, :t)",
+				ExprValues: map[string]AttributeValue{":t": {S: ptr("S")}},
+			},
+			want: false,
+		},
+		{
+			name: "attribute_type with non-string type operand errors",
+			item: Item{"pk": {S: ptr("1")}, "name": {S: ptr("Alice")}},
+			cond: ConditionInput{
+				Expression: "attribute_type(name, :t)",
+				ExprValues: map[string]AttributeValue{":t": {N: ptr("1")}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "size on missing attribute returns false (no error)",
+			item: Item{"pk": {S: ptr("1")}},
+			cond: ConditionInput{
+				Expression: "size(items) > :min",
+				ExprValues: map[string]AttributeValue{":min": {N: ptr("2")}},
+			},
+			want: false,
+		},
+		{
+			name: "size compared to attribute operand matches",
+			item: Item{"pk": {S: ptr("1")}, "items": {L: []*AttributeValue{{S: ptr("a")}, {S: ptr("b")}}}, "minLen": {N: ptr("1")}},
+			cond: ConditionInput{
+				Expression: "size(items) > minLen",
+			},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -841,5 +903,52 @@ func TestFilterExpressionFailsClosed(t *testing.T) {
 
 	if len(queryItems) != 0 || queryScanned != 0 {
 		t.Fatalf("invalid filter must not return results, got %d items (scanned %d)", len(queryItems), queryScanned)
+	}
+}
+
+// TestExpressionValidationEdgeCases covers the follow-up gaps to PR #808: an
+// invalid filter must be rejected even on an empty table (not only when an item
+// is scanned), and an unparseable KeyConditionExpression must be a
+// ValidationException rather than a silent empty result.
+func TestExpressionValidationEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	const errCodeValidation = "ValidationException"
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := s.CreateTable(ctx, &CreateTableRequest{
+		TableName:            "edge",
+		KeySchema:            []KeySchemaElement{{AttributeName: "pk", KeyType: "HASH"}},
+		AttributeDefinitions: []AttributeDefinition{{AttributeName: "pk", AttributeType: "S"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var tErr *TableError
+
+	// Empty table: an invalid filter must still be a ValidationException, not an
+	// empty 200 result (the table has no items, so the per-item loop never runs).
+	if _, _, _, err := s.Scan(ctx, "edge", "complete garbage !!!", nil, nil, 0, nil, nil, nil); !errors.As(err, &tErr) || tErr.Code != errCodeValidation {
+		t.Fatalf("empty-table scan with invalid filter: expected ValidationException, got: %v", err)
+	}
+
+	if _, _, _, err := s.Query(ctx, "edge", "", "pk = :pk", "complete garbage !!!", nil,
+		map[string]AttributeValue{":pk": {S: ptr("missing")}}, 0, nil, true); !errors.As(err, &tErr) || tErr.Code != errCodeValidation {
+		t.Fatalf("empty-table query with invalid filter: expected ValidationException, got: %v", err)
+	}
+
+	// Unparseable KeyConditionExpression must be a ValidationException, not a
+	// silent empty result.
+	_, err = s.PutItem(ctx, "edge", Item{"pk": {S: ptr("1")}}, false, ConditionInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, err := s.Query(ctx, "edge", "", "complete garbage !!!", "", nil,
+		map[string]AttributeValue{":pk": {S: ptr("1")}}, 0, nil, true); !errors.As(err, &tErr) || tErr.Code != errCodeValidation {
+		t.Fatalf("query with invalid KeyConditionExpression: expected ValidationException, got: %v", err)
 	}
 }

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -677,6 +677,18 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 		resolvedKeyCondExpr = strings.ReplaceAll(resolvedKeyCondExpr, placeholder, name)
 	}
 
+	// Validate expressions up front so unparseable ones are rejected even when no
+	// item is evaluated (empty table or no key match).
+	if resolvedKeyCondExpr != "" {
+		if _, err := evaluateCondition(Item{}, ConditionInput{Expression: resolvedKeyCondExpr, ExprValues: exprValues}); err != nil {
+			return nil, nil, 0, invalidKeyConditionExpression(err)
+		}
+	}
+
+	if err := m.validateFilterExpression(filterExpr, exprNames, exprValues); err != nil {
+		return nil, nil, 0, err
+	}
+
 	// Collect matching items.
 	var results []Item
 
@@ -703,7 +715,11 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 				ExprValues: exprValues,
 			}
 
-			ok, _ := evaluateCondition(item, keyCond)
+			ok, err := evaluateCondition(item, keyCond)
+			if err != nil {
+				return nil, nil, 0, invalidKeyConditionExpression(err)
+			}
+
 			if !ok {
 				continue
 			}
@@ -799,30 +815,16 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 		return nil, nil, 0, err
 	}
 
-	// Collect all items.
-	var results []Item
+	// Validate the filter up front so an unparseable FilterExpression is rejected
+	// even when the table is empty, instead of returning an empty result.
+	if err := m.validateFilterExpression(filterExpr, exprNames, exprValues); err != nil {
+		return nil, nil, 0, err
+	}
 
-	scannedCount := 0
-
-	for _, item := range td.Items {
-		key := m.serializeKey(td.Table, item)
-		if !scanSegmentMatches(key, segment, totalSegments) {
-			continue
-		}
-
-		scannedCount++
-
-		// Apply filter expression.
-		match, err := m.filterItem(item, filterExpr, exprNames, exprValues)
-		if err != nil {
-			return nil, nil, 0, err
-		}
-
-		if !match {
-			continue
-		}
-
-		results = append(results, m.copyItem(item))
+	// Collect all items matching the segment and filter.
+	results, scannedCount, err := m.scanCollectMatches(td, filterExpr, exprNames, exprValues, segment, totalSegments)
+	if err != nil {
+		return nil, nil, 0, err
 	}
 
 	// Sort by key for consistent pagination. Pre-compute keys once so the
@@ -874,6 +876,37 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 	}
 
 	return results, lastEvaluatedKey, scannedCount, nil
+}
+
+// scanCollectMatches walks every item, applies parallel-scan segment filtering
+// and the filter expression, and returns the matched items plus the scanned
+// count. A filter parse error is returned as a ValidationException.
+func (m *MemoryStorage) scanCollectMatches(td *tableData, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, segment, totalSegments *int) ([]Item, int, error) {
+	var results []Item
+
+	scannedCount := 0
+
+	for _, item := range td.Items {
+		key := m.serializeKey(td.Table, item)
+		if !scanSegmentMatches(key, segment, totalSegments) {
+			continue
+		}
+
+		scannedCount++
+
+		match, err := m.filterItem(item, filterExpr, exprNames, exprValues)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if !match {
+			continue
+		}
+
+		results = append(results, m.copyItem(item))
+	}
+
+	return results, scannedCount, nil
 }
 
 func validateScanSegment(segment, totalSegments *int) error {
@@ -1168,6 +1201,30 @@ func (m *MemoryStorage) filterItem(item Item, filterExpr string, exprNames map[s
 	}
 
 	return m.evaluateFilterExpression(item, filterExpr, exprNames, exprValues)
+}
+
+// validateFilterExpression rejects an unparseable FilterExpression up front, so
+// the error surfaces even when no item is evaluated (empty table or zero key
+// matches) rather than only when an item happens to be scanned.
+func (m *MemoryStorage) validateFilterExpression(filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue) error {
+	if filterExpr == "" {
+		return nil
+	}
+
+	// evaluateFilterExpression returns a ValidationException TableError on a
+	// parse error; the match result against the synthetic item is discarded.
+	_, err := m.evaluateFilterExpression(Item{}, filterExpr, exprNames, exprValues)
+
+	return err
+}
+
+// invalidKeyConditionExpression builds the ValidationException returned for an
+// unparseable KeyConditionExpression.
+func invalidKeyConditionExpression(err error) *TableError {
+	return &TableError{
+		Code:    "ValidationException",
+		Message: fmt.Sprintf("Invalid KeyConditionExpression: %s", err),
+	}
 }
 
 // evaluateFilterExpression evaluates a filter expression against an item. An

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"errors"
+	"sort"
 	"testing"
 
 	awsv1 "github.com/aws/aws-sdk-go/aws"
@@ -1880,6 +1881,185 @@ func TestDynamoDB_ScanFilterExpressionIn(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected ValidationException for invalid FilterExpression")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("expected ValidationException, got: %T: %v", err, err)
+	}
+}
+
+// sortItemsByPK orders scan results deterministically for golden comparison.
+func sortItemsByPK(items []map[string]types.AttributeValue) {
+	sort.Slice(items, func(i, j int) bool {
+		return itemPKValue(items[i]) < itemPKValue(items[j])
+	})
+}
+
+func itemPKValue(item map[string]types.AttributeValue) string {
+	if v, ok := item["pk"].(*types.AttributeValueMemberS); ok {
+		return v.Value
+	}
+
+	return ""
+}
+
+func createSimpleStringKeyTable(t *testing.T, client *dynamodb.Client, tableName string) {
+	t.Helper()
+
+	_, err := client.CreateTable(t.Context(), &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+}
+
+// TestDynamoDB_ScanFilterExpressionAttributeType verifies the attribute_type
+// function in a FilterExpression returns only items whose attribute matches the
+// requested type.
+func TestDynamoDB_ScanFilterExpressionAttributeType(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-scan-attr-type"
+
+	createSimpleStringKeyTable(t, client, tableName)
+
+	items := []map[string]types.AttributeValue{
+		{"pk": &types.AttributeValueMemberS{Value: "a"}, "val": &types.AttributeValueMemberS{Value: "text"}},
+		{"pk": &types.AttributeValueMemberS{Value: "b"}, "val": &types.AttributeValueMemberN{Value: "42"}},
+		{"pk": &types.AttributeValueMemberS{Value: "c"}, "val": &types.AttributeValueMemberL{Value: []types.AttributeValue{
+			&types.AttributeValueMemberS{Value: "x"},
+		}}},
+	}
+	for _, it := range items {
+		if _, err := client.PutItem(ctx, &dynamodb.PutItemInput{TableName: aws.String(tableName), Item: it}); err != nil {
+			t.Fatalf("failed to put item: %v", err)
+		}
+	}
+
+	out, err := client.Scan(ctx, &dynamodb.ScanInput{
+		TableName:                 aws.String(tableName),
+		FilterExpression:          aws.String("attribute_type(val, :t)"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{":t": &types.AttributeValueMemberS{Value: "S"}},
+	})
+	if err != nil {
+		t.Fatalf("scan with attribute_type filter failed: %v", err)
+	}
+
+	if out.Count != 1 {
+		t.Fatalf("attribute_type(val, S) should match 1 item, got %d", out.Count)
+	}
+
+	sortItemsByPK(out.Items)
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), out)
+}
+
+// TestDynamoDB_ScanFilterExpressionSizeMixedAttributes is the regression test
+// for size() over a table where some items lack the attribute: those items must
+// simply not match, and the scan must succeed (not fail with ValidationException).
+func TestDynamoDB_ScanFilterExpressionSizeMixedAttributes(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-scan-size-mixed"
+
+	createSimpleStringKeyTable(t, client, tableName)
+
+	items := []map[string]types.AttributeValue{
+		{"pk": &types.AttributeValueMemberS{Value: "a"}, "tags": &types.AttributeValueMemberL{Value: []types.AttributeValue{
+			&types.AttributeValueMemberS{Value: "x"},
+			&types.AttributeValueMemberS{Value: "y"},
+			&types.AttributeValueMemberS{Value: "z"},
+		}}},
+		{"pk": &types.AttributeValueMemberS{Value: "b"}, "tags": &types.AttributeValueMemberL{Value: []types.AttributeValue{
+			&types.AttributeValueMemberS{Value: "x"},
+		}}},
+		{"pk": &types.AttributeValueMemberS{Value: "c"}}, // no tags attribute
+	}
+	for _, it := range items {
+		if _, err := client.PutItem(ctx, &dynamodb.PutItemInput{TableName: aws.String(tableName), Item: it}); err != nil {
+			t.Fatalf("failed to put item: %v", err)
+		}
+	}
+
+	out, err := client.Scan(ctx, &dynamodb.ScanInput{
+		TableName:                 aws.String(tableName),
+		FilterExpression:          aws.String("size(tags) > :two"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{":two": &types.AttributeValueMemberN{Value: "2"}},
+	})
+	if err != nil {
+		t.Fatalf("scan with size() over mixed attributes must not error: %v", err)
+	}
+
+	if out.Count != 1 {
+		t.Fatalf("size(tags) > 2 should match only item a, got %d", out.Count)
+	}
+
+	sortItemsByPK(out.Items)
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), out)
+}
+
+// TestDynamoDB_QueryInvalidKeyConditionExpression verifies an unparseable
+// KeyConditionExpression is rejected with ValidationException rather than a
+// silent empty result.
+func TestDynamoDB_QueryInvalidKeyConditionExpression(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-query-invalid-keycond"
+
+	createSimpleStringKeyTable(t, client, tableName)
+
+	if _, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item:      map[string]types.AttributeValue{"pk": &types.AttributeValueMemberS{Value: "1"}},
+	}); err != nil {
+		t.Fatalf("failed to put item: %v", err)
+	}
+
+	_, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:                 aws.String(tableName),
+		KeyConditionExpression:    aws.String("complete garbage !!!"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{":pk": &types.AttributeValueMemberS{Value: "1"}},
+	})
+	if err == nil {
+		t.Fatal("expected ValidationException for invalid KeyConditionExpression")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("expected ValidationException, got: %T: %v", err, err)
+	}
+}
+
+// TestDynamoDB_ScanInvalidFilterEmptyTable verifies an invalid FilterExpression
+// is rejected with ValidationException even when the table is empty (the bug
+// where validation only happened inside the per-item loop).
+func TestDynamoDB_ScanInvalidFilterEmptyTable(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-scan-invalid-empty"
+
+	createSimpleStringKeyTable(t, client, tableName)
+
+	out, err := client.Scan(ctx, &dynamodb.ScanInput{
+		TableName:        aws.String(tableName),
+		FilterExpression: aws.String("complete garbage !!!"),
+	})
+	if err == nil {
+		t.Fatalf("expected ValidationException on empty table, got %d items", len(out.Items))
 	}
 
 	var apiErr smithy.APIError

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_ScanFilterExpressionAttributeType_TestDynamoDB_ScanFilterExpressionAttributeType.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_ScanFilterExpressionAttributeType_TestDynamoDB_ScanFilterExpressionAttributeType.golden.go
@@ -1,0 +1,17 @@
+{
+  "ConsumedCapacity": null,
+  "Count": 1,
+  "Items": [
+    {
+      "pk": {
+        "Value": "a"
+      },
+      "val": {
+        "Value": "text"
+      }
+    }
+  ],
+  "LastEvaluatedKey": null,
+  "ScannedCount": 3,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_ScanFilterExpressionSizeMixedAttributes_TestDynamoDB_ScanFilterExpressionSizeMixedAttributes.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_ScanFilterExpressionSizeMixedAttributes_TestDynamoDB_ScanFilterExpressionSizeMixedAttributes.golden.go
@@ -1,0 +1,27 @@
+{
+  "ConsumedCapacity": null,
+  "Count": 1,
+  "Items": [
+    {
+      "pk": {
+        "Value": "a"
+      },
+      "tags": {
+        "Value": [
+          {
+            "Value": "x"
+          },
+          {
+            "Value": "y"
+          },
+          {
+            "Value": "z"
+          }
+        ]
+      }
+    }
+  ],
+  "LastEvaluatedKey": null,
+  "ScannedCount": 3,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary

Follow-up to #808 (which made `FilterExpression` fail closed and implemented `IN`). It closes the remaining gaps in the DynamoDB expression evaluator described in #807:

- **KeyConditionExpression fails open in the opposite direction.** An unparseable `KeyConditionExpression` had its parse error swallowed (`ok, _ := evaluateCondition(...)`), so `Query` silently returned an empty result instead of an error. It now returns `ValidationException: Invalid KeyConditionExpression: ...`, mirroring the FilterExpression handling.
- **`attribute_type` was unimplemented.** `attribute_type(path, :type)` is now supported for all DynamoDB type descriptors (`S`, `N`, `B`, `SS`, `NS`, `BS`, `M`, `L`, `NULL`, `BOOL`), and the type argument must be an expression attribute value as AWS requires.
- **Empty tables still failed open.** #808 validates the filter only inside the per-item loop, so an invalid `FilterExpression` against an empty table (or a `Query` with no key match) returned an empty `200` with no error. Validation now runs once up front, so `ValidationException` is returned regardless of table contents.
- **`size()` against a missing attribute aborted the whole request.** After #808's fail-closed change, `size(#a) > :n` returned `ValidationException` as soon as it hit an item lacking `#a`. Like any comparison against an absent attribute, it now evaluates to no-match (the item is simply excluded) and the scan succeeds, matching DynamoDB. Genuine syntax errors still return `ValidationException`.

Behavior verified against the AWS [Comparison operator and function reference](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html).

The `Scan` item loop is extracted into `scanCollectMatches` to keep cyclomatic complexity within the linter limit.

## Test plan

- [x] `make lint` (0 issues)
- [x] `go test -race -shuffle=on ./internal/service/dynamodb/`
- [x] `go test ./...`
- [x] Unit: `attribute_type` match/mismatch/missing/non-string-type-operand; `size()` missing attribute -> no match (no error) and against an attribute operand; invalid `KeyConditionExpression` -> `ValidationException`; empty-table invalid filter -> `ValidationException` on Scan and Query
- [x] Integration (golden): `attribute_type` filter; `size()` over a table with mixed presence of the attribute; invalid `KeyConditionExpression` -> `ValidationException`; empty-table invalid filter -> `ValidationException`