### PR TITLE
refactor: simplify service handlers to drop complexity nolints

### DIFF
--- a/internal/service/emrserverless/storage.go
+++ b/internal/service/emrserverless/storage.go
@@ -168,24 +168,17 @@ func generateJobRunArn(applicationID, jobRunID string) string {
 }
 
 // CreateApplication creates a new application.
-//
-//nolint:funlen // validation and struct initialization require more lines
 func (m *MemoryStorage) CreateApplication(_ context.Context, req *CreateApplicationInput) (*Application, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Validate required fields.
-	if req.Type == "" {
-		return nil, &Error{
-			Code:    errValidationException,
-			Message: "Type is required",
-		}
-	}
-
-	if req.ReleaseLabel == "" {
-		return nil, &Error{
-			Code:    errValidationException,
-			Message: "ReleaseLabel is required",
+	// Validate required fields (first empty wins).
+	for _, f := range []struct{ name, value string }{
+		{"Type", req.Type},
+		{"ReleaseLabel", req.ReleaseLabel},
+	} {
+		if f.value == "" {
+			return nil, &Error{Code: errValidationException, Message: f.name + " is required"}
 		}
 	}
 
@@ -193,27 +186,7 @@ func (m *MemoryStorage) CreateApplication(_ context.Context, req *CreateApplicat
 	applicationID := generateApplicationID()
 	arn := generateApplicationArn(applicationID)
 
-	architecture := req.Architecture
-	if architecture == "" {
-		architecture = ArchitectureX8664
-	}
-
-	// Default auto stop configuration.
-	autoStopConfig := req.AutoStopConfiguration
-	if autoStopConfig == nil {
-		autoStopConfig = &AutoStopConfiguration{
-			Enabled:            true,
-			IdleTimeoutMinutes: 15,
-		}
-	}
-
-	// Default auto start configuration.
-	autoStartConfig := req.AutoStartConfiguration
-	if autoStartConfig == nil {
-		autoStartConfig = &AutoStartConfiguration{
-			Enabled: true,
-		}
-	}
+	architecture, autoStopConfig, autoStartConfig := applicationDefaults(req)
 
 	app := &Application{
 		ApplicationID:           applicationID,
@@ -240,6 +213,32 @@ func (m *MemoryStorage) CreateApplication(_ context.Context, req *CreateApplicat
 	m.saveLocked()
 
 	return app, nil
+}
+
+// applicationDefaults resolves the architecture and auto-start/stop configuration
+// for a new application, applying kumo's defaults when the request omits them.
+func applicationDefaults(req *CreateApplicationInput) (string, *AutoStopConfiguration, *AutoStartConfiguration) {
+	architecture := req.Architecture
+	if architecture == "" {
+		architecture = ArchitectureX8664
+	}
+
+	autoStop := req.AutoStopConfiguration
+	if autoStop == nil {
+		autoStop = &AutoStopConfiguration{
+			Enabled:            true,
+			IdleTimeoutMinutes: 15,
+		}
+	}
+
+	autoStart := req.AutoStartConfiguration
+	if autoStart == nil {
+		autoStart = &AutoStartConfiguration{
+			Enabled: true,
+		}
+	}
+
+	return architecture, autoStop, autoStart
 }
 
 // GetApplication retrieves an application by ID.

--- a/internal/service/forecast/storage.go
+++ b/internal/service/forecast/storage.go
@@ -477,44 +477,13 @@ func (m *MemoryStorage) UpdateDatasetGroup(_ context.Context, datasetGroupArn st
 // Predictor operations.
 
 // CreatePredictor creates a new predictor.
-//
-//nolint:funlen // validation and struct initialization require more lines
 func (m *MemoryStorage) CreatePredictor(_ context.Context, req *CreatePredictorInput) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Check for duplicate name.
-	for _, p := range m.Predictors {
-		if p.PredictorName == req.PredictorName {
-			return "", &Error{
-				Code:    errResourceAlreadyExistsException,
-				Message: fmt.Sprintf("A predictor with name %s already exists", req.PredictorName),
-			}
-		}
-	}
-
-	// Validate dataset group exists.
-	if req.InputDataConfig == nil || req.InputDataConfig.DatasetGroupArn == "" {
-		return "", &Error{
-			Code:    errInvalidInputException,
-			Message: "InputDataConfig.DatasetGroupArn is required",
-		}
-	}
-
-	dg, exists := m.DatasetGroups[req.InputDataConfig.DatasetGroupArn]
-	if !exists {
-		return "", &Error{
-			Code:    errResourceNotFoundException,
-			Message: fmt.Sprintf("Dataset group %s not found", req.InputDataConfig.DatasetGroupArn),
-		}
-	}
-
-	// Validate forecast horizon.
-	if req.ForecastHorizon < 1 || req.ForecastHorizon > 500 {
-		return "", &Error{
-			Code:    errInvalidInputException,
-			Message: "ForecastHorizon must be between 1 and 500",
-		}
+	dg, verr := m.validateCreatePredictor(req)
+	if verr != nil {
+		return "", verr
 	}
 
 	predictorID := uuid.New().String()[:8]
@@ -546,6 +515,44 @@ func (m *MemoryStorage) CreatePredictor(_ context.Context, req *CreatePredictorI
 	m.saveLocked()
 
 	return predictorArn, nil
+}
+
+// validateCreatePredictor validates a CreatePredictor request and returns the
+// resolved dataset group. It must be called with m.mu held.
+func (m *MemoryStorage) validateCreatePredictor(req *CreatePredictorInput) (*DatasetGroup, *Error) {
+	// Check for duplicate name.
+	for _, p := range m.Predictors {
+		if p.PredictorName == req.PredictorName {
+			return nil, &Error{
+				Code:    errResourceAlreadyExistsException,
+				Message: fmt.Sprintf("A predictor with name %s already exists", req.PredictorName),
+			}
+		}
+	}
+
+	if req.InputDataConfig == nil || req.InputDataConfig.DatasetGroupArn == "" {
+		return nil, &Error{
+			Code:    errInvalidInputException,
+			Message: "InputDataConfig.DatasetGroupArn is required",
+		}
+	}
+
+	dg, exists := m.DatasetGroups[req.InputDataConfig.DatasetGroupArn]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFoundException,
+			Message: fmt.Sprintf("Dataset group %s not found", req.InputDataConfig.DatasetGroupArn),
+		}
+	}
+
+	if req.ForecastHorizon < 1 || req.ForecastHorizon > 500 {
+		return nil, &Error{
+			Code:    errInvalidInputException,
+			Message: "ForecastHorizon must be between 1 and 500",
+		}
+	}
+
+	return dg, nil
 }
 
 // DescribePredictor returns a predictor.

--- a/internal/service/lambda/handlers.go
+++ b/internal/service/lambda/handlers.go
@@ -864,8 +864,6 @@ func (s *Service) GetPolicy(w http.ResponseWriter, r *http.Request) {
 }
 
 // AddPermission adds a permission to a Lambda function's resource policy.
-//
-//nolint:funlen // Permission handling with validation and policy construction.
 func (s *Service) AddPermission(w http.ResponseWriter, r *http.Request) {
 	name := extractFunctionNameForListChild(r.URL.Path, "policy")
 	if name == "" {
@@ -881,22 +879,17 @@ func (s *Service) AddPermission(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.StatementID == "" {
-		writeFunctionError(w, ErrInvalidParameterValue, "StatementId is required", http.StatusBadRequest)
+	// Validate required fields (first empty wins).
+	for _, f := range []struct{ name, value string }{
+		{"StatementId", req.StatementID},
+		{"Action", req.Action},
+		{"Principal", req.Principal},
+	} {
+		if f.value == "" {
+			writeFunctionError(w, ErrInvalidParameterValue, f.name+" is required", http.StatusBadRequest)
 
-		return
-	}
-
-	if req.Action == "" {
-		writeFunctionError(w, ErrInvalidParameterValue, "Action is required", http.StatusBadRequest)
-
-		return
-	}
-
-	if req.Principal == "" {
-		writeFunctionError(w, ErrInvalidParameterValue, "Principal is required", http.StatusBadRequest)
-
-		return
+			return
+		}
 	}
 
 	fn, err := s.storage.GetFunction(r.Context(), name)
@@ -906,12 +899,35 @@ func (s *Service) AddPermission(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	stmt := buildPermissionStatement(&req, fn.FunctionArn)
+
+	if err := s.storage.AddPermission(r.Context(), name, stmt); err != nil {
+		handleFunctionError(w, err)
+
+		return
+	}
+
+	stmtJSON, err := json.Marshal(stmt)
+	if err != nil {
+		writeFunctionError(w, ErrServiceException, "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, http.StatusCreated, addPermissionResponse{
+		Statement: string(stmtJSON),
+	})
+}
+
+// buildPermissionStatement builds the resource-policy statement for AddPermission,
+// attaching SourceArn/SourceAccount conditions when present.
+func buildPermissionStatement(req *addPermissionRequest, resourceArn string) *PolicyStatement {
 	stmt := &PolicyStatement{
 		Sid:       req.StatementID,
 		Effect:    "Allow",
 		Principal: map[string]string{"Service": req.Principal},
 		Action:    req.Action,
-		Resource:  fn.FunctionArn,
+		Resource:  resourceArn,
 	}
 
 	if req.SourceArn != "" {
@@ -932,22 +948,7 @@ func (s *Service) AddPermission(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := s.storage.AddPermission(r.Context(), name, stmt); err != nil {
-		handleFunctionError(w, err)
-
-		return
-	}
-
-	stmtJSON, err := json.Marshal(stmt)
-	if err != nil {
-		writeFunctionError(w, ErrServiceException, "Internal server error", http.StatusInternalServerError)
-
-		return
-	}
-
-	writeJSONResponse(w, http.StatusCreated, addPermissionResponse{
-		Statement: string(stmtJSON),
-	})
+	return stmt
 }
 
 // RemovePermission removes a permission from a Lambda function's resource policy.

--- a/internal/service/pipes/storage.go
+++ b/internal/service/pipes/storage.go
@@ -161,8 +161,6 @@ func generatePipeArn(name string) string {
 }
 
 // CreatePipe creates a new pipe.
-//
-//nolint:funlen // validation and struct initialization require more lines
 func (m *MemoryStorage) CreatePipe(_ context.Context, req *CreatePipeInput) (*Pipe, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -175,25 +173,14 @@ func (m *MemoryStorage) CreatePipe(_ context.Context, req *CreatePipeInput) (*Pi
 		}
 	}
 
-	// Validate required fields.
-	if req.Source == "" {
-		return nil, &Error{
-			Code:    errValidationException,
-			Message: "Source is required",
-		}
-	}
-
-	if req.Target == "" {
-		return nil, &Error{
-			Code:    errValidationException,
-			Message: "Target is required",
-		}
-	}
-
-	if req.RoleArn == "" {
-		return nil, &Error{
-			Code:    errValidationException,
-			Message: "RoleArn is required",
+	// Validate required fields (first empty wins).
+	for _, f := range []struct{ name, value string }{
+		{"Source", req.Source},
+		{"Target", req.Target},
+		{"RoleArn", req.RoleArn},
+	} {
+		if f.value == "" {
+			return nil, &Error{Code: errValidationException, Message: f.name + " is required"}
 		}
 	}
 

--- a/internal/service/route53/handlers.go
+++ b/internal/service/route53/handlers.go
@@ -15,21 +15,89 @@ import (
 	"github.com/google/uuid"
 )
 
-// CreateHostedZone handles the CreateHostedZone API.
-//
-//nolint:funlen // Handler includes validation and response building
-func (s *Service) CreateHostedZone(w http.ResponseWriter, r *http.Request) {
+// readXMLBody reads and XML-decodes the request body into v, writing an
+// InvalidInput error response and returning false on failure.
+func readXMLBody(w http.ResponseWriter, r *http.Request, v any) bool {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		writeErrorResponse(w, http.StatusBadRequest, "InvalidInput", "Failed to read request body")
 
-		return
+		return false
 	}
 
-	var req CreateHostedZoneRequest
-	if err := xml.Unmarshal(body, &req); err != nil {
+	if err := xml.Unmarshal(body, v); err != nil {
 		writeErrorResponse(w, http.StatusBadRequest, "InvalidInput", "Failed to parse request body")
 
+		return false
+	}
+
+	return true
+}
+
+// defaultDelegationSet returns the fixed name servers kumo reports for a zone.
+func defaultDelegationSet() DelegationSet {
+	return DelegationSet{
+		NameServers: []string{
+			"ns-1.kumo.local",
+			"ns-2.kumo.local",
+			"ns-3.kumo.local",
+			"ns-4.kumo.local",
+		},
+	}
+}
+
+// recordInSyncChange creates an INSYNC ChangeInfo, persists it, and returns it.
+func (s *Service) recordInSyncChange(comment string) (ChangeInfo, error) {
+	ci := ChangeInfo{
+		ID:          "/change/" + uuid.New().String(),
+		Status:      "INSYNC",
+		SubmittedAt: time.Now().UTC().Format(time.RFC3339),
+		Comment:     comment,
+	}
+
+	if err := s.storage.PutChange(&ci); err != nil {
+		return ChangeInfo{}, fmt.Errorf("put change: %w", err)
+	}
+
+	return ci, nil
+}
+
+// parseMaxItems reads a maxitems query value, clamped to (0,100], default 100.
+func parseMaxItems(maxItemsStr string) int {
+	maxItems := 100
+
+	if maxItemsStr != "" {
+		if parsed, err := strconv.Atoi(maxItemsStr); err == nil && parsed > 0 && parsed <= 100 {
+			maxItems = parsed
+		}
+	}
+
+	return maxItems
+}
+
+// pageHostedZones returns the page [startIdx, startIdx+maxItems) of zones as
+// values, the index just past the page (len(zones) when not truncated), and
+// whether more zones remain.
+func pageHostedZones(zones []*HostedZone, startIdx, maxItems int) ([]HostedZone, int, bool) {
+	endIdx := startIdx + maxItems
+
+	truncated := endIdx < len(zones)
+	if !truncated {
+		endIdx = len(zones)
+	}
+
+	page := make([]HostedZone, 0, endIdx-startIdx)
+	for i := startIdx; i < endIdx; i++ {
+		page = append(page, *zones[i])
+	}
+
+	return page, endIdx, truncated
+}
+
+// CreateHostedZone handles the CreateHostedZone API.
+func (s *Service) CreateHostedZone(w http.ResponseWriter, r *http.Request) {
+	var req CreateHostedZoneRequest
+	if !readXMLBody(w, r, &req) {
 		return
 	}
 
@@ -72,29 +140,18 @@ func (s *Service) CreateHostedZone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ci := ChangeInfo{
-		ID:          "/change/" + uuid.New().String(),
-		Status:      "INSYNC",
-		SubmittedAt: time.Now().UTC().Format(time.RFC3339),
-	}
-	if err := s.storage.PutChange(&ci); err != nil {
+	ci, err := s.recordInSyncChange("")
+	if err != nil {
 		writeErrorResponse(w, http.StatusInternalServerError, "InternalError", err.Error())
 
 		return
 	}
 
 	resp := CreateHostedZoneResponse{
-		XMLNS:      xmlns,
-		HostedZone: *zone,
-		ChangeInfo: ci,
-		DelegationSet: DelegationSet{
-			NameServers: []string{
-				"ns-1.kumo.local",
-				"ns-2.kumo.local",
-				"ns-3.kumo.local",
-				"ns-4.kumo.local",
-			},
-		},
+		XMLNS:         xmlns,
+		HostedZone:    *zone,
+		ChangeInfo:    ci,
+		DelegationSet: defaultDelegationSet(),
 	}
 
 	w.Header().Set("Location", fmt.Sprintf("https://route53.amazonaws.com/2013-04-01%s", zone.ID))
@@ -126,36 +183,18 @@ func (s *Service) GetHostedZone(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := GetHostedZoneResponse{
-		XMLNS:      xmlns,
-		HostedZone: *zone,
-		DelegationSet: DelegationSet{
-			NameServers: []string{
-				"ns-1.kumo.local",
-				"ns-2.kumo.local",
-				"ns-3.kumo.local",
-				"ns-4.kumo.local",
-			},
-		},
+		XMLNS:         xmlns,
+		HostedZone:    *zone,
+		DelegationSet: defaultDelegationSet(),
 	}
 
 	writeXMLResponse(w, http.StatusOK, resp)
 }
 
 // ListHostedZones handles the ListHostedZones API.
-//
-//nolint:funlen // Handler includes pagination logic
 func (s *Service) ListHostedZones(w http.ResponseWriter, r *http.Request) {
-	// Parse pagination parameters
 	marker := r.URL.Query().Get("marker")
-	maxItemsStr := r.URL.Query().Get("maxitems")
-
-	maxItems := 100 // Default value
-
-	if maxItemsStr != "" {
-		if parsed, err := strconv.Atoi(maxItemsStr); err == nil && parsed > 0 && parsed <= 100 {
-			maxItems = parsed
-		}
-	}
+	maxItems := parseMaxItems(r.URL.Query().Get("maxitems"))
 
 	zones, err := s.storage.ListHostedZones()
 	if err != nil {
@@ -164,12 +203,12 @@ func (s *Service) ListHostedZones(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Sort zones by ID for consistent pagination
+	// Sort zones by ID for consistent pagination.
 	sort.Slice(zones, func(i, j int) bool {
 		return zones[i].ID < zones[j].ID
 	})
 
-	// Find starting position based on marker
+	// Find starting position based on marker.
 	startIdx := 0
 
 	if marker != "" {
@@ -183,24 +222,7 @@ func (s *Service) ListHostedZones(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Calculate pagination
-	endIdx := startIdx + maxItems
-	isTruncated := false
-	nextMarker := ""
-
-	if endIdx < len(zones) {
-		isTruncated = true
-		// Extract zone ID without "/hostedzone/" prefix
-		nextMarker = strings.TrimPrefix(zones[endIdx].ID, "/hostedzone/")
-	} else {
-		endIdx = len(zones)
-	}
-
-	// Build response with paginated results
-	hostedZones := make([]HostedZone, 0, endIdx-startIdx)
-	for i := startIdx; i < endIdx; i++ {
-		hostedZones = append(hostedZones, *zones[i])
-	}
+	hostedZones, endIdx, isTruncated := pageHostedZones(zones, startIdx, maxItems)
 
 	resp := ListHostedZonesResponse{
 		XMLNS:       xmlns,
@@ -214,7 +236,7 @@ func (s *Service) ListHostedZones(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if isTruncated {
-		resp.NextMarker = nextMarker
+		resp.NextMarker = strings.TrimPrefix(zones[endIdx].ID, "/hostedzone/")
 	}
 
 	writeXMLResponse(w, http.StatusOK, resp)
@@ -225,20 +247,10 @@ func (s *Service) ListHostedZones(w http.ResponseWriter, r *http.Request) {
 // sources such as aws_route53_zone). The dnsname query parameter, when
 // supplied, filters to zones with Name >= dnsname; an exact-match dnsname
 // yields a single-zone response with that zone first.
-//
-//nolint:funlen // Handler bundles parsing, sorting, and pagination by design
 func (s *Service) ListHostedZonesByName(w http.ResponseWriter, r *http.Request) {
 	dnsname := normalizeDNSName(r.URL.Query().Get("dnsname"))
 	hostedZoneID := r.URL.Query().Get("hostedzoneid")
-	maxItemsStr := r.URL.Query().Get("maxitems")
-
-	maxItems := 100
-
-	if maxItemsStr != "" {
-		if parsed, err := strconv.Atoi(maxItemsStr); err == nil && parsed > 0 && parsed <= 100 {
-			maxItems = parsed
-		}
-	}
+	maxItems := parseMaxItems(r.URL.Query().Get("maxitems"))
 
 	zones, err := s.storage.ListHostedZones()
 	if err != nil {
@@ -265,33 +277,20 @@ func (s *Service) ListHostedZonesByName(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	endIdx := startIdx + maxItems
-	isTruncated := false
-	nextDNSName := ""
-	nextHostedZoneID := ""
-
-	if endIdx < len(zones) {
-		isTruncated = true
-		nextDNSName = zones[endIdx].Name
-		nextHostedZoneID = strings.TrimPrefix(zones[endIdx].ID, "/hostedzone/")
-	} else {
-		endIdx = len(zones)
-	}
-
-	hostedZones := make([]HostedZone, 0, endIdx-startIdx)
-	for i := startIdx; i < endIdx; i++ {
-		hostedZones = append(hostedZones, *zones[i])
-	}
+	hostedZones, endIdx, isTruncated := pageHostedZones(zones, startIdx, maxItems)
 
 	resp := ListHostedZonesByNameResponse{
-		XMLNS:            xmlns,
-		HostedZones:      hostedZones,
-		DNSName:          dnsname,
-		HostedZoneID:     hostedZoneID,
-		IsTruncated:      isTruncated,
-		NextDNSName:      nextDNSName,
-		NextHostedZoneID: nextHostedZoneID,
-		MaxItems:         strconv.Itoa(maxItems),
+		XMLNS:        xmlns,
+		HostedZones:  hostedZones,
+		DNSName:      dnsname,
+		HostedZoneID: hostedZoneID,
+		IsTruncated:  isTruncated,
+		MaxItems:     strconv.Itoa(maxItems),
+	}
+
+	if isTruncated {
+		resp.NextDNSName = zones[endIdx].Name
+		resp.NextHostedZoneID = strings.TrimPrefix(zones[endIdx].ID, "/hostedzone/")
 	}
 
 	writeXMLResponse(w, http.StatusOK, resp)
@@ -342,12 +341,8 @@ func (s *Service) DeleteHostedZone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ci := ChangeInfo{
-		ID:          "/change/" + uuid.New().String(),
-		Status:      "INSYNC",
-		SubmittedAt: time.Now().UTC().Format(time.RFC3339),
-	}
-	if err := s.storage.PutChange(&ci); err != nil {
+	ci, err := s.recordInSyncChange("")
+	if err != nil {
 		writeErrorResponse(w, http.StatusInternalServerError, "InternalError", err.Error())
 
 		return
@@ -363,7 +358,35 @@ func (s *Service) DeleteHostedZone(w http.ResponseWriter, r *http.Request) {
 
 // ChangeResourceRecordSets handles the ChangeResourceRecordSets API.
 //
-//nolint:funlen // Handler includes validation and error handling for multiple cases
+// changeRecordSetsErrors maps storage sentinels from ChangeRecordSets to their
+// HTTP error response, checked in order.
+var changeRecordSetsErrors = []struct {
+	err     error
+	status  int
+	code    string
+	message string
+}{
+	{ErrHostedZoneNotFound, http.StatusNotFound, "NoSuchHostedZone", "Hosted zone not found"},
+	{ErrRecordSetAlreadyExists, http.StatusBadRequest, "ResourceRecordAlreadyExists", "Resource record already exists"},
+	{ErrRecordSetNotFound, http.StatusBadRequest, "InvalidChangeBatch", "Resource record not found"},
+	{ErrInvalidInput, http.StatusBadRequest, "InvalidInput", "Invalid change action"},
+}
+
+// writeChangeRecordSetsError maps a ChangeRecordSets error to its response,
+// falling back to InternalError for an unrecognized error.
+func writeChangeRecordSetsError(w http.ResponseWriter, err error) {
+	for _, m := range changeRecordSetsErrors {
+		if errors.Is(err, m.err) {
+			writeErrorResponse(w, m.status, m.code, m.message)
+
+			return
+		}
+	}
+
+	writeErrorResponse(w, http.StatusInternalServerError, "InternalError", err.Error())
+}
+
+// ChangeResourceRecordSets handles the ChangeResourceRecordSets API.
 func (s *Service) ChangeResourceRecordSets(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -372,17 +395,8 @@ func (s *Service) ChangeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		writeErrorResponse(w, http.StatusBadRequest, "InvalidInput", "Failed to read request body")
-
-		return
-	}
-
 	var req ChangeResourceRecordSetsRequest
-	if err := xml.Unmarshal(body, &req); err != nil {
-		writeErrorResponse(w, http.StatusBadRequest, "InvalidInput", "Failed to parse request body")
-
+	if !readXMLBody(w, r, &req) {
 		return
 	}
 
@@ -395,42 +409,13 @@ func (s *Service) ChangeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 	zoneID := "/hostedzone/" + id
 
 	if err := s.storage.ChangeRecordSets(zoneID, req.ChangeBatch.Changes); err != nil {
-		if errors.Is(err, ErrHostedZoneNotFound) {
-			writeErrorResponse(w, http.StatusNotFound, "NoSuchHostedZone", "Hosted zone not found")
-
-			return
-		}
-
-		if errors.Is(err, ErrRecordSetAlreadyExists) {
-			writeErrorResponse(w, http.StatusBadRequest, "ResourceRecordAlreadyExists", "Resource record already exists")
-
-			return
-		}
-
-		if errors.Is(err, ErrRecordSetNotFound) {
-			writeErrorResponse(w, http.StatusBadRequest, "InvalidChangeBatch", "Resource record not found")
-
-			return
-		}
-
-		if errors.Is(err, ErrInvalidInput) {
-			writeErrorResponse(w, http.StatusBadRequest, "InvalidInput", "Invalid change action")
-
-			return
-		}
-
-		writeErrorResponse(w, http.StatusInternalServerError, "InternalError", err.Error())
+		writeChangeRecordSetsError(w, err)
 
 		return
 	}
 
-	ci := ChangeInfo{
-		ID:          "/change/" + uuid.New().String(),
-		Status:      "INSYNC",
-		SubmittedAt: time.Now().UTC().Format(time.RFC3339),
-		Comment:     req.ChangeBatch.Comment,
-	}
-	if err := s.storage.PutChange(&ci); err != nil {
+	ci, err := s.recordInSyncChange(req.ChangeBatch.Comment)
+	if err != nil {
 		writeErrorResponse(w, http.StatusInternalServerError, "InternalError", err.Error())
 
 		return

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -116,73 +116,41 @@ func (s *Service) HandleCORSPreflight(w http.ResponseWriter, r *http.Request) {
 
 // handleBucketGet dispatches GET /{bucket} requests based on query parameters.
 //
-//nolint:funlen // It's a straightforward dispatch, and splitting it up would just add indirection.
+// bucketGetSubresources maps a GET query-parameter key to its handler, in the
+// order they must be checked. AWS treats these subresource selectors as
+// mutually exclusive, so the first present key wins.
+var bucketGetSubresources = []struct {
+	key     string
+	handler func(*Service, http.ResponseWriter, *http.Request)
+}{
+	{"versioning", (*Service).GetBucketVersioning},
+	{"publicAccessBlock", (*Service).GetPublicAccessBlock},
+	{"encryption", (*Service).GetBucketEncryption},
+	{"policy", (*Service).GetBucketPolicy},
+	{"logging", (*Service).GetBucketLogging},
+	{"versions", (*Service).ListObjectVersions},
+	{"uploads", (*Service).ListMultipartUploads},
+	{"website", (*Service).GetBucketWebsite},
+	{"lifecycle", (*Service).GetBucketLifecycleConfiguration},
+	{"cors", (*Service).GetBucketCors},
+}
+
 func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
-	if _, ok := r.URL.Query()["versioning"]; ok {
-		s.GetBucketVersioning(w, r)
+	query := r.URL.Query()
 
-		return
-	}
+	for _, sub := range bucketGetSubresources {
+		if _, ok := query[sub.key]; ok {
+			sub.handler(s, w, r)
 
-	if _, ok := r.URL.Query()["publicAccessBlock"]; ok {
-		s.GetPublicAccessBlock(w, r)
-
-		return
-	}
-
-	if _, ok := r.URL.Query()["encryption"]; ok {
-		s.GetBucketEncryption(w, r)
-
-		return
-	}
-
-	if _, ok := r.URL.Query()["policy"]; ok {
-		s.GetBucketPolicy(w, r)
-
-		return
-	}
-
-	if _, ok := r.URL.Query()["logging"]; ok {
-		s.GetBucketLogging(w, r)
-
-		return
-	}
-
-	if _, ok := r.URL.Query()["versions"]; ok {
-		s.ListObjectVersions(w, r)
-
-		return
-	}
-
-	if _, ok := r.URL.Query()["uploads"]; ok {
-		s.ListMultipartUploads(w, r)
-
-		return
-	}
-
-	if _, ok := r.URL.Query()["website"]; ok {
-		s.GetBucketWebsite(w, r)
-
-		return
-	}
-
-	if _, ok := r.URL.Query()["lifecycle"]; ok {
-		s.GetBucketLifecycleConfiguration(w, r)
-
-		return
-	}
-
-	if _, ok := r.URL.Query()["cors"]; ok {
-		s.GetBucketCors(w, r)
-
-		return
+			return
+		}
 	}
 
 	if handled := s.serveBucketSubresourceStub(w, r); handled {
 		return
 	}
 
-	if r.URL.Query().Get("list-type") == "2" {
+	if query.Get("list-type") == "2" {
 		s.ListObjects(w, r)
 
 		return

--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -151,55 +151,74 @@ func (e *executionEngine) executeTaskState(ctx context.Context, name string, sta
 
 // resolveParameters resolves parameter values, handling JSONPath references
 // (keys ending with ".$" whose values are JSONPath expressions like "$.field").
-//
-//nolint:nestif // JSONPath resolution requires nested type checks.
 func resolveParameters(params map[string]any, input string) (map[string]any, error) {
 	if params == nil {
 		return map[string]any{}, nil
 	}
 
+	// inputData is parsed lazily on the first JSONPath reference and reused.
 	var inputData map[string]any
 
 	resolved := make(map[string]any, len(params))
 
 	for key, value := range params {
+		// A ".$" suffix marks a JSONPath reference; otherwise it is a static value.
 		if strings.HasSuffix(key, ".$") {
-			// This is a JSONPath reference.
-			actualKey := strings.TrimSuffix(key, ".$")
-
-			pathStr, ok := value.(string)
-			if !ok {
-				return nil, fmt.Errorf("jsonPath reference for key %q must be a string", key)
-			}
-
-			if inputData == nil {
-				if err := json.Unmarshal([]byte(input), &inputData); err != nil {
-					return nil, fmt.Errorf("parse input for JSONPath: %w", err)
-				}
-			}
-
-			resolvedValue, err := resolveJSONPath(inputData, pathStr)
+			resolvedValue, parsed, err := resolveJSONPathRef(key, value, input, inputData)
 			if err != nil {
-				return nil, fmt.Errorf("resolve JSONPath %q for key %q: %w", pathStr, key, err)
+				return nil, err
 			}
 
-			resolved[actualKey] = resolvedValue
-		} else {
-			// Static value -- recurse into nested maps.
-			if subMap, ok := value.(map[string]any); ok {
-				subResolved, err := resolveParameters(subMap, input)
-				if err != nil {
-					return nil, err
-				}
+			inputData = parsed
+			resolved[strings.TrimSuffix(key, ".$")] = resolvedValue
 
-				resolved[key] = subResolved
-			} else {
-				resolved[key] = value
-			}
+			continue
 		}
+
+		resolvedValue, err := resolveStaticValue(value, input)
+		if err != nil {
+			return nil, err
+		}
+
+		resolved[key] = resolvedValue
 	}
 
 	return resolved, nil
+}
+
+// resolveJSONPathRef resolves a "key.$" JSONPath reference against the input.
+// inputData is the lazily-parsed input (nil until first use); the possibly newly
+// parsed map is returned so the caller can reuse it for later references,
+// keeping the input JSON unmarshaled at most once per resolveParameters call.
+func resolveJSONPathRef(key string, value any, input string, inputData map[string]any) (any, map[string]any, error) {
+	pathStr, ok := value.(string)
+	if !ok {
+		return nil, inputData, fmt.Errorf("jsonPath reference for key %q must be a string", key)
+	}
+
+	if inputData == nil {
+		if err := json.Unmarshal([]byte(input), &inputData); err != nil {
+			return nil, inputData, fmt.Errorf("parse input for JSONPath: %w", err)
+		}
+	}
+
+	resolvedValue, err := resolveJSONPath(inputData, pathStr)
+	if err != nil {
+		return nil, inputData, fmt.Errorf("resolve JSONPath %q for key %q: %w", pathStr, key, err)
+	}
+
+	return resolvedValue, inputData, nil
+}
+
+// resolveStaticValue returns a non-reference parameter value, recursing into
+// nested maps and leaving scalars unchanged.
+func resolveStaticValue(value any, input string) (any, error) {
+	subMap, ok := value.(map[string]any)
+	if !ok {
+		return value, nil
+	}
+
+	return resolveParameters(subMap, input)
 }
 
 // resolveJSONPath resolves a simple JSONPath expression ("$" or "$.field") against the input data.

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -532,54 +532,83 @@ func matchesSingleCondition(raw json.RawMessage, value string, exists bool) bool
 // matchesOperator handles object-form conditions like {"exists": true},
 // {"prefix": "pay"}, {"anything-but": ["x"]}.
 //
-//nolint:nestif // Multiple operator branches each need their own type assertion.
+// matchesOperator evaluates a single SNS filter-policy operator object. Each
+// operator returns (result, matched); an unparseable operator value is treated
+// as not-matched so evaluation falls through, preserving the original behavior.
 func matchesOperator(obj map[string]json.RawMessage, value string, exists bool) bool {
-	// {"exists": true/false}
-	if raw, ok := obj["exists"]; ok {
-		var want bool
-		if err := json.Unmarshal(raw, &want); err == nil {
-			if want {
-				return exists
-			}
-
-			return !exists
-		}
+	if result, matched := matchExists(obj, exists); matched {
+		return result
 	}
 
-	// {"prefix": "val"}
-	if raw, ok := obj["prefix"]; ok {
-		var prefix string
-		if err := json.Unmarshal(raw, &prefix); err == nil {
-			return exists && strings.HasPrefix(value, prefix)
-		}
+	if result, matched := matchPrefix(obj, value, exists); matched {
+		return result
 	}
 
-	// {"anything-but": ["v1","v2",...]}  or  {"anything-but": "v1"}
-	if raw, ok := obj["anything-but"]; ok {
-		if !exists {
-			return false
-		}
-
-		// Try array.
-		var arr []string
-		if err := json.Unmarshal(raw, &arr); err == nil {
-			for _, deny := range arr {
-				if value == deny {
-					return false
-				}
-			}
-
-			return true
-		}
-
-		// Try single string.
-		var single string
-		if err := json.Unmarshal(raw, &single); err == nil {
-			return value != single
-		}
+	if result, matched := matchAnythingBut(obj, value, exists); matched {
+		return result
 	}
 
 	return false
+}
+
+// matchExists handles {"exists": true/false}.
+func matchExists(obj map[string]json.RawMessage, exists bool) (bool, bool) {
+	raw, ok := obj["exists"]
+	if !ok {
+		return false, false
+	}
+
+	var want bool
+	if err := json.Unmarshal(raw, &want); err != nil {
+		return false, false
+	}
+
+	return want == exists, true
+}
+
+// matchPrefix handles {"prefix": "val"}.
+func matchPrefix(obj map[string]json.RawMessage, value string, exists bool) (bool, bool) {
+	raw, ok := obj["prefix"]
+	if !ok {
+		return false, false
+	}
+
+	var prefix string
+	if err := json.Unmarshal(raw, &prefix); err != nil {
+		return false, false
+	}
+
+	return exists && strings.HasPrefix(value, prefix), true
+}
+
+// matchAnythingBut handles {"anything-but": ["v1",...]} or {"anything-but": "v1"}.
+func matchAnythingBut(obj map[string]json.RawMessage, value string, exists bool) (bool, bool) {
+	raw, ok := obj["anything-but"]
+	if !ok {
+		return false, false
+	}
+
+	if !exists {
+		return false, true
+	}
+
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		for _, deny := range arr {
+			if value == deny {
+				return false, true
+			}
+		}
+
+		return true, true
+	}
+
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return value != single, true
+	}
+
+	return false, false
 }
 
 // deliverMessage delivers a message to a subscription.

--- a/internal/service/sqs/handlers.go
+++ b/internal/service/sqs/handlers.go
@@ -749,50 +749,39 @@ func writeSQSError(w http.ResponseWriter, code, message string, status int) {
 	})
 }
 
+// sqsActions maps an X-Amz-Target action name to its handler method.
+var sqsActions = map[string]func(*Service, http.ResponseWriter, *http.Request){
+	"CreateQueue":                  (*Service).CreateQueue,
+	"ListQueueTags":                (*Service).ListQueueTags,
+	"TagQueue":                     (*Service).TagQueue,
+	"UntagQueue":                   (*Service).UntagQueue,
+	"DeleteQueue":                  (*Service).DeleteQueue,
+	"ListQueues":                   (*Service).ListQueues,
+	"GetQueueUrl":                  (*Service).GetQueueURL,
+	"SendMessage":                  (*Service).SendMessage,
+	"SendMessageBatch":             (*Service).SendMessageBatch,
+	"ReceiveMessage":               (*Service).ReceiveMessage,
+	"DeleteMessage":                (*Service).DeleteMessage,
+	"DeleteMessageBatch":           (*Service).DeleteMessageBatch,
+	"PurgeQueue":                   (*Service).PurgeQueue,
+	"GetQueueAttributes":           (*Service).GetQueueAttributes,
+	"SetQueueAttributes":           (*Service).SetQueueAttributes,
+	"ChangeMessageVisibility":      (*Service).ChangeMessageVisibility,
+	"ChangeMessageVisibilityBatch": (*Service).ChangeMessageVisibilityBatch,
+}
+
 // DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.
 // This method implements the JSONProtocolService interface.
-//
-//nolint:cyclop // flat switch over SQS actions; complexity comes from action count, not logic.
 func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 	target := r.Header.Get("X-Amz-Target")
 	action := strings.TrimPrefix(target, "AmazonSQS.")
 
-	switch action {
-	case "CreateQueue":
-		s.CreateQueue(w, r)
-	case "ListQueueTags":
-		s.ListQueueTags(w, r)
-	case "TagQueue":
-		s.TagQueue(w, r)
-	case "UntagQueue":
-		s.UntagQueue(w, r)
-	case "DeleteQueue":
-		s.DeleteQueue(w, r)
-	case "ListQueues":
-		s.ListQueues(w, r)
-	case "GetQueueUrl":
-		s.GetQueueURL(w, r)
-	case "SendMessage":
-		s.SendMessage(w, r)
-	case "SendMessageBatch":
-		s.SendMessageBatch(w, r)
-	case "ReceiveMessage":
-		s.ReceiveMessage(w, r)
-	case "DeleteMessage":
-		s.DeleteMessage(w, r)
-	case "DeleteMessageBatch":
-		s.DeleteMessageBatch(w, r)
-	case "PurgeQueue":
-		s.PurgeQueue(w, r)
-	case "GetQueueAttributes":
-		s.GetQueueAttributes(w, r)
-	case "SetQueueAttributes":
-		s.SetQueueAttributes(w, r)
-	case "ChangeMessageVisibility":
-		s.ChangeMessageVisibility(w, r)
-	case "ChangeMessageVisibilityBatch":
-		s.ChangeMessageVisibilityBatch(w, r)
-	default:
+	handler, ok := sqsActions[action]
+	if !ok {
 		writeSQSError(w, "InvalidAction", "The action "+action+" is not valid", http.StatusBadRequest)
+
+		return
 	}
+
+	handler(s, w, r)
 }


### PR DESCRIPTION
## Summary

Continues the lint-driven-verbosity cleanup (Tier 1) across services beyond dynamodb (#811). Each change restructures a function so the complexity linters (cyclop / funlen / gocognit / nestif) pass **naturally**, letting the `//nolint` suppression be removed. Pure readability cleanup — no behavior change.

- **s3 `handleBucketGet`**: replace 10 sequential `if query.Has(key)` blocks with an ordered dispatch table (key order and trailing fallbacks preserved).
- **sqs `DispatchAction`**: replace the 17-case `X-Amz-Target` switch with a method-dispatch map.
- **route53**: table-driven `ChangeRecordSets` error mapping (`writeChangeRecordSetsError`); shared `parseMaxItems` / `pageHostedZones` pagination; `readXMLBody`, `defaultDelegationSet`, and `recordInSyncChange` helpers deduplicate the handlers.
- **sns `matchesOperator`**: split into `matchExists` / `matchPrefix` / `matchAnythingBut`, preserving the parse-failure fall-through semantics.
- **sfn `resolveParameters`**: extract `resolveJSONPathRef` / `resolveStaticValue`, keeping the lazy single-parse of the input JSON.
- **lambda `AddPermission`**: loop-based required-field validation + `buildPermissionStatement`.
- **pipes `CreatePipe`, emrserverless `CreateApplication`, forecast `CreatePredictor`**: loop-based required-field validation and extracted defaults/validation helpers.

Functions whose length is inherent (s3 `ListObjects`/`CopyObject`, sfn lambda-invoke, pipes `UpdatePipe`) keep their suppressions.

## Test plan

- [x] `make lint` (0 issues; targeted complexity nolints removed)
- [x] `go test -race -shuffle=on ./...`
- [x] Integration suites for every touched service (s3, sqs, route53, sns, sfn, lambda, pipes, emrserverless, forecast) in **compare mode** (no `GOLDEN_UPDATE`): all golden files unchanged, confirming behavior is preserved