### PR TITLE
refactor: consolidate duplicated readJSONRequest into service.ReadJSONRequest

### DIFF
--- a/internal/service/acm/handlers.go
+++ b/internal/service/acm/handlers.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // DispatchAction routes ACM requests based on the X-Amz-Target header.
@@ -51,7 +52,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // RequestCertificate handles the RequestCertificate operation.
 func (s *Service) RequestCertificate(w http.ResponseWriter, r *http.Request) {
 	var req RequestCertificateInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -72,7 +73,7 @@ func (s *Service) RequestCertificate(w http.ResponseWriter, r *http.Request) {
 // DescribeCertificate handles the DescribeCertificate operation.
 func (s *Service) DescribeCertificate(w http.ResponseWriter, r *http.Request) {
 	var req DescribeCertificateInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -124,7 +125,7 @@ func (s *Service) DescribeCertificate(w http.ResponseWriter, r *http.Request) {
 // ListCertificates handles the ListCertificates operation.
 func (s *Service) ListCertificates(w http.ResponseWriter, r *http.Request) {
 	var req ListCertificatesInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -183,7 +184,7 @@ func (s *Service) ListCertificates(w http.ResponseWriter, r *http.Request) {
 // DeleteCertificate handles the DeleteCertificate operation.
 func (s *Service) DeleteCertificate(w http.ResponseWriter, r *http.Request) {
 	var req DeleteCertificateInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -209,7 +210,7 @@ func (s *Service) DeleteCertificate(w http.ResponseWriter, r *http.Request) {
 // GetCertificate handles the GetCertificate operation.
 func (s *Service) GetCertificate(w http.ResponseWriter, r *http.Request) {
 	var req GetCertificateInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -237,7 +238,7 @@ func (s *Service) GetCertificate(w http.ResponseWriter, r *http.Request) {
 // ImportCertificate handles the ImportCertificate operation.
 func (s *Service) ImportCertificate(w http.ResponseWriter, r *http.Request) {
 	var req ImportCertificateInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -256,24 +257,6 @@ func (s *Service) ImportCertificate(w http.ResponseWriter, r *http.Request) {
 }
 
 // Helper functions.
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
-}
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {

--- a/internal/service/appsync/handlers.go
+++ b/internal/service/appsync/handlers.go
@@ -3,18 +3,18 @@ package appsync
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // CreateGraphqlAPI handles the CreateGraphqlAPI operation.
 func (s *Service) CreateGraphqlAPI(w http.ResponseWriter, r *http.Request) {
 	var req CreateGraphqlAPIInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -130,7 +130,7 @@ func (s *Service) CreateDataSource(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req CreateDataSourceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -179,7 +179,7 @@ func (s *Service) CreateResolver(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req CreateResolverInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -216,7 +216,7 @@ func (s *Service) StartSchemaCreation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req StartSchemaCreationInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -257,24 +257,6 @@ func extractPathParam(r *http.Request, param string) string {
 	}
 
 	return ""
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.

--- a/internal/service/athena/handlers.go
+++ b/internal/service/athena/handlers.go
@@ -3,12 +3,12 @@ package athena
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // Error codes for Athena handlers.
@@ -20,7 +20,7 @@ const (
 // StartQueryExecution handles the StartQueryExecution action.
 func (s *Service) StartQueryExecution(w http.ResponseWriter, r *http.Request) {
 	var req StartQueryExecutionRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeAthenaError(w, errInvalidRequestException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -47,7 +47,7 @@ func (s *Service) StartQueryExecution(w http.ResponseWriter, r *http.Request) {
 // StopQueryExecution handles the StopQueryExecution action.
 func (s *Service) StopQueryExecution(w http.ResponseWriter, r *http.Request) {
 	var req StopQueryExecutionRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeAthenaError(w, errInvalidRequestException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -71,7 +71,7 @@ func (s *Service) StopQueryExecution(w http.ResponseWriter, r *http.Request) {
 // GetQueryExecution handles the GetQueryExecution action.
 func (s *Service) GetQueryExecution(w http.ResponseWriter, r *http.Request) {
 	var req GetQueryExecutionRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeAthenaError(w, errInvalidRequestException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -98,7 +98,7 @@ func (s *Service) GetQueryExecution(w http.ResponseWriter, r *http.Request) {
 // GetQueryResults handles the GetQueryResults action.
 func (s *Service) GetQueryResults(w http.ResponseWriter, r *http.Request) {
 	var req GetQueryResultsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeAthenaError(w, errInvalidRequestException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -126,7 +126,7 @@ func (s *Service) GetQueryResults(w http.ResponseWriter, r *http.Request) {
 // ListQueryExecutions handles the ListQueryExecutions action.
 func (s *Service) ListQueryExecutions(w http.ResponseWriter, r *http.Request) {
 	var req ListQueryExecutionsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeAthenaError(w, errInvalidRequestException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -148,7 +148,7 @@ func (s *Service) ListQueryExecutions(w http.ResponseWriter, r *http.Request) {
 // CreateWorkGroup handles the CreateWorkGroup action.
 func (s *Service) CreateWorkGroup(w http.ResponseWriter, r *http.Request) {
 	var req CreateWorkGroupRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeAthenaError(w, errInvalidRequestException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -172,7 +172,7 @@ func (s *Service) CreateWorkGroup(w http.ResponseWriter, r *http.Request) {
 // DeleteWorkGroup handles the DeleteWorkGroup action.
 func (s *Service) DeleteWorkGroup(w http.ResponseWriter, r *http.Request) {
 	var req DeleteWorkGroupRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeAthenaError(w, errInvalidRequestException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -344,24 +344,6 @@ func convertResultSetToOutput(rs *ResultSet) *ResultSetOutput {
 	}
 
 	return output
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.

--- a/internal/service/batch/handlers.go
+++ b/internal/service/batch/handlers.go
@@ -3,18 +3,18 @@ package batch
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // CreateComputeEnvironment handles the CreateComputeEnvironment operation.
 func (s *Service) CreateComputeEnvironment(w http.ResponseWriter, r *http.Request) {
 	var req CreateComputeEnvironmentInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -48,7 +48,7 @@ func (s *Service) CreateComputeEnvironment(w http.ResponseWriter, r *http.Reques
 // DeleteComputeEnvironment handles the DeleteComputeEnvironment operation.
 func (s *Service) DeleteComputeEnvironment(w http.ResponseWriter, r *http.Request) {
 	var req DeleteComputeEnvironmentInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -75,7 +75,7 @@ func (s *Service) DeleteComputeEnvironment(w http.ResponseWriter, r *http.Reques
 // DescribeComputeEnvironments handles the DescribeComputeEnvironments operation.
 func (s *Service) DescribeComputeEnvironments(w http.ResponseWriter, r *http.Request) {
 	var req DescribeComputeEnvironmentsInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -103,7 +103,7 @@ func (s *Service) DescribeComputeEnvironments(w http.ResponseWriter, r *http.Req
 // CreateJobQueue handles the CreateJobQueue operation.
 func (s *Service) CreateJobQueue(w http.ResponseWriter, r *http.Request) {
 	var req CreateJobQueueInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -137,7 +137,7 @@ func (s *Service) CreateJobQueue(w http.ResponseWriter, r *http.Request) {
 // DeleteJobQueue handles the DeleteJobQueue operation.
 func (s *Service) DeleteJobQueue(w http.ResponseWriter, r *http.Request) {
 	var req DeleteJobQueueInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -163,7 +163,7 @@ func (s *Service) DeleteJobQueue(w http.ResponseWriter, r *http.Request) {
 // DescribeJobQueues handles the DescribeJobQueues operation.
 func (s *Service) DescribeJobQueues(w http.ResponseWriter, r *http.Request) {
 	var req DescribeJobQueuesInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -190,7 +190,7 @@ func (s *Service) DescribeJobQueues(w http.ResponseWriter, r *http.Request) {
 // RegisterJobDefinition handles the RegisterJobDefinition operation.
 func (s *Service) RegisterJobDefinition(w http.ResponseWriter, r *http.Request) {
 	var req RegisterJobDefinitionInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -225,7 +225,7 @@ func (s *Service) RegisterJobDefinition(w http.ResponseWriter, r *http.Request) 
 // SubmitJob handles the SubmitJob operation.
 func (s *Service) SubmitJob(w http.ResponseWriter, r *http.Request) {
 	var req SubmitJobInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -266,7 +266,7 @@ func (s *Service) SubmitJob(w http.ResponseWriter, r *http.Request) {
 // DescribeJobs handles the DescribeJobs operation.
 func (s *Service) DescribeJobs(w http.ResponseWriter, r *http.Request) {
 	var req DescribeJobsInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -293,7 +293,7 @@ func (s *Service) DescribeJobs(w http.ResponseWriter, r *http.Request) {
 // TerminateJob handles the TerminateJob operation.
 func (s *Service) TerminateJob(w http.ResponseWriter, r *http.Request) {
 	var req TerminateJobInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -332,24 +332,6 @@ func extractResourceName(arnOrName string) string {
 	}
 
 	return arnOrName
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.

--- a/internal/service/cloudwatch/handlers.go
+++ b/internal/service/cloudwatch/handlers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/sivchari/kumo/internal/server"
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // Error codes for CloudWatch.
@@ -26,7 +26,7 @@ const (
 // PutMetricData handles the PutMetricData action.
 func (s *Service) PutMetricData(w http.ResponseWriter, r *http.Request) {
 	var req PutMetricDataRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -57,7 +57,7 @@ func (s *Service) PutMetricData(w http.ResponseWriter, r *http.Request) {
 // GetMetricData handles the GetMetricData action.
 func (s *Service) GetMetricData(w http.ResponseWriter, r *http.Request) {
 	var req GetMetricDataRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -85,7 +85,7 @@ func (s *Service) GetMetricData(w http.ResponseWriter, r *http.Request) {
 // GetMetricStatistics handles the GetMetricStatistics action.
 func (s *Service) GetMetricStatistics(w http.ResponseWriter, r *http.Request) {
 	var req GetMetricStatisticsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -119,7 +119,7 @@ func (s *Service) GetMetricStatistics(w http.ResponseWriter, r *http.Request) {
 // ListMetrics handles the ListMetrics action.
 func (s *Service) ListMetrics(w http.ResponseWriter, r *http.Request) {
 	var req ListMetricsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -142,7 +142,7 @@ func (s *Service) ListMetrics(w http.ResponseWriter, r *http.Request) {
 // PutMetricAlarm handles the PutMetricAlarm action.
 func (s *Service) PutMetricAlarm(w http.ResponseWriter, r *http.Request) {
 	var req PutMetricAlarmRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -189,7 +189,7 @@ func (s *Service) PutMetricAlarm(w http.ResponseWriter, r *http.Request) {
 // DeleteAlarms handles the DeleteAlarms action.
 func (s *Service) DeleteAlarms(w http.ResponseWriter, r *http.Request) {
 	var req DeleteAlarmsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -218,7 +218,7 @@ func (s *Service) DeleteAlarms(w http.ResponseWriter, r *http.Request) {
 // DescribeAlarms handles the DescribeAlarms action.
 func (s *Service) DescribeAlarms(w http.ResponseWriter, r *http.Request) {
 	var req DescribeAlarmsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -245,7 +245,7 @@ func (s *Service) DescribeAlarms(w http.ResponseWriter, r *http.Request) {
 // SetAlarmState handles the SetAlarmState action via JSON protocol.
 func (s *Service) SetAlarmState(w http.ResponseWriter, r *http.Request) {
 	var req SetAlarmStateRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -269,7 +269,7 @@ func (s *Service) SetAlarmState(w http.ResponseWriter, r *http.Request) {
 // ListTagsForResource returns the tags attached to a CloudWatch resource.
 func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 	var req ListTagsForResourceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -305,7 +305,7 @@ func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 // TagResource attaches tags to a CloudWatch resource.
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -332,7 +332,7 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 // UntagResource removes tags from a CloudWatch resource.
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -404,24 +404,6 @@ func handleCloudWatchError(w http.ResponseWriter, err error) {
 	}
 
 	writeCloudWatchError(w, errInternalServiceError, "Internal server error", http.StatusInternalServerError)
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.

--- a/internal/service/cloudwatchlogs/handlers.go
+++ b/internal/service/cloudwatchlogs/handlers.go
@@ -3,12 +3,12 @@ package cloudwatchlogs
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // Error codes for CloudWatch Logs.
@@ -21,7 +21,7 @@ const (
 // CreateLogGroup handles the CreateLogGroup action.
 func (s *Service) CreateLogGroup(w http.ResponseWriter, r *http.Request) {
 	var req CreateLogGroupRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -45,7 +45,7 @@ func (s *Service) CreateLogGroup(w http.ResponseWriter, r *http.Request) {
 // DeleteLogGroup handles the DeleteLogGroup action.
 func (s *Service) DeleteLogGroup(w http.ResponseWriter, r *http.Request) {
 	var req DeleteLogGroupRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -69,7 +69,7 @@ func (s *Service) DeleteLogGroup(w http.ResponseWriter, r *http.Request) {
 // CreateLogStream handles the CreateLogStream action.
 func (s *Service) CreateLogStream(w http.ResponseWriter, r *http.Request) {
 	var req CreateLogStreamRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -93,7 +93,7 @@ func (s *Service) CreateLogStream(w http.ResponseWriter, r *http.Request) {
 // DeleteLogStream handles the DeleteLogStream action.
 func (s *Service) DeleteLogStream(w http.ResponseWriter, r *http.Request) {
 	var req DeleteLogStreamRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -117,7 +117,7 @@ func (s *Service) DeleteLogStream(w http.ResponseWriter, r *http.Request) {
 // PutLogEvents handles the PutLogEvents action.
 func (s *Service) PutLogEvents(w http.ResponseWriter, r *http.Request) {
 	var req PutLogEventsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -148,7 +148,7 @@ func (s *Service) PutLogEvents(w http.ResponseWriter, r *http.Request) {
 // GetLogEvents handles the GetLogEvents action.
 func (s *Service) GetLogEvents(w http.ResponseWriter, r *http.Request) {
 	var req GetLogEventsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -173,7 +173,7 @@ func (s *Service) GetLogEvents(w http.ResponseWriter, r *http.Request) {
 // FilterLogEvents handles the FilterLogEvents action.
 func (s *Service) FilterLogEvents(w http.ResponseWriter, r *http.Request) {
 	var req FilterLogEventsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -198,7 +198,7 @@ func (s *Service) FilterLogEvents(w http.ResponseWriter, r *http.Request) {
 // DescribeLogGroups handles the DescribeLogGroups action.
 func (s *Service) DescribeLogGroups(w http.ResponseWriter, r *http.Request) {
 	var req DescribeLogGroupsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -217,7 +217,7 @@ func (s *Service) DescribeLogGroups(w http.ResponseWriter, r *http.Request) {
 // DescribeLogStreams handles the DescribeLogStreams action.
 func (s *Service) DescribeLogStreams(w http.ResponseWriter, r *http.Request) {
 	var req DescribeLogStreamsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -242,7 +242,7 @@ func (s *Service) DescribeLogStreams(w http.ResponseWriter, r *http.Request) {
 // PutRetentionPolicy handles the PutRetentionPolicy action.
 func (s *Service) PutRetentionPolicy(w http.ResponseWriter, r *http.Request) {
 	var req PutRetentionPolicyRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -272,7 +272,7 @@ func (s *Service) PutRetentionPolicy(w http.ResponseWriter, r *http.Request) {
 // DeleteRetentionPolicy handles the DeleteRetentionPolicy action.
 func (s *Service) DeleteRetentionPolicy(w http.ResponseWriter, r *http.Request) {
 	var req DeleteRetentionPolicyRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -343,24 +343,6 @@ func handleLogsError(w http.ResponseWriter, err error) {
 	}
 
 	writeLogsError(w, errInternalServiceError, "Internal server error", http.StatusInternalServerError)
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.

--- a/internal/service/codeconnections/handlers.go
+++ b/internal/service/codeconnections/handlers.go
@@ -4,12 +4,12 @@ package codeconnections
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // Error codes for CodeConnections handlers.
@@ -68,7 +68,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateConnection handles the CreateConnection action.
 func (s *Service) CreateConnection(w http.ResponseWriter, r *http.Request) {
 	var req CreateConnectionRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -96,7 +96,7 @@ func (s *Service) CreateConnection(w http.ResponseWriter, r *http.Request) {
 // GetConnection handles the GetConnection action.
 func (s *Service) GetConnection(w http.ResponseWriter, r *http.Request) {
 	var req GetConnectionRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -123,7 +123,7 @@ func (s *Service) GetConnection(w http.ResponseWriter, r *http.Request) {
 // DeleteConnection handles the DeleteConnection action.
 func (s *Service) DeleteConnection(w http.ResponseWriter, r *http.Request) {
 	var req DeleteConnectionRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -147,7 +147,7 @@ func (s *Service) DeleteConnection(w http.ResponseWriter, r *http.Request) {
 // ListConnections handles the ListConnections action.
 func (s *Service) ListConnections(w http.ResponseWriter, r *http.Request) {
 	var req ListConnectionsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -174,7 +174,7 @@ func (s *Service) ListConnections(w http.ResponseWriter, r *http.Request) {
 // CreateHost handles the CreateHost action.
 func (s *Service) CreateHost(w http.ResponseWriter, r *http.Request) {
 	var req CreateHostRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -216,7 +216,7 @@ func (s *Service) CreateHost(w http.ResponseWriter, r *http.Request) {
 // GetHost handles the GetHost action.
 func (s *Service) GetHost(w http.ResponseWriter, r *http.Request) {
 	var req GetHostRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -247,7 +247,7 @@ func (s *Service) GetHost(w http.ResponseWriter, r *http.Request) {
 // DeleteHost handles the DeleteHost action.
 func (s *Service) DeleteHost(w http.ResponseWriter, r *http.Request) {
 	var req DeleteHostRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -271,7 +271,7 @@ func (s *Service) DeleteHost(w http.ResponseWriter, r *http.Request) {
 // ListHosts handles the ListHosts action.
 func (s *Service) ListHosts(w http.ResponseWriter, r *http.Request) {
 	var req ListHostsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -298,7 +298,7 @@ func (s *Service) ListHosts(w http.ResponseWriter, r *http.Request) {
 // UpdateHost handles the UpdateHost action.
 func (s *Service) UpdateHost(w http.ResponseWriter, r *http.Request) {
 	var req UpdateHostRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -324,7 +324,7 @@ func (s *Service) UpdateHost(w http.ResponseWriter, r *http.Request) {
 // CreateRepositoryLink handles the CreateRepositoryLink action.
 func (s *Service) CreateRepositoryLink(w http.ResponseWriter, r *http.Request) {
 	var req CreateRepositoryLinkRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -363,7 +363,7 @@ func (s *Service) CreateRepositoryLink(w http.ResponseWriter, r *http.Request) {
 // GetRepositoryLink handles the GetRepositoryLink action.
 func (s *Service) GetRepositoryLink(w http.ResponseWriter, r *http.Request) {
 	var req GetRepositoryLinkRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -390,7 +390,7 @@ func (s *Service) GetRepositoryLink(w http.ResponseWriter, r *http.Request) {
 // DeleteRepositoryLink handles the DeleteRepositoryLink action.
 func (s *Service) DeleteRepositoryLink(w http.ResponseWriter, r *http.Request) {
 	var req DeleteRepositoryLinkRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -414,7 +414,7 @@ func (s *Service) DeleteRepositoryLink(w http.ResponseWriter, r *http.Request) {
 // ListRepositoryLinks handles the ListRepositoryLinks action.
 func (s *Service) ListRepositoryLinks(w http.ResponseWriter, r *http.Request) {
 	var req ListRepositoryLinksRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -441,7 +441,7 @@ func (s *Service) ListRepositoryLinks(w http.ResponseWriter, r *http.Request) {
 // UpdateRepositoryLink handles the UpdateRepositoryLink action.
 func (s *Service) UpdateRepositoryLink(w http.ResponseWriter, r *http.Request) {
 	var req UpdateRepositoryLinkRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -468,7 +468,7 @@ func (s *Service) UpdateRepositoryLink(w http.ResponseWriter, r *http.Request) {
 // ListTagsForResource handles the ListTagsForResource action.
 func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 	var req ListTagsForResourceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -495,7 +495,7 @@ func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 // TagResource handles the TagResource action.
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -525,7 +525,7 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 // UntagResource handles the UntagResource action.
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeCodeConnectionsError(w, errInvalidInputException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -616,24 +616,6 @@ func convertRepositoryLinkToOutput(link *RepositoryLink) *RepositoryLinkOutput {
 		RepositoryName:    link.RepositoryName,
 		EncryptionKeyArn:  link.EncryptionKeyArn,
 	}
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.

--- a/internal/service/documentdb/handlers.go
+++ b/internal/service/documentdb/handlers.go
@@ -2,15 +2,15 @@
 package documentdb
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const docdbXMLNS = "http://rds.amazonaws.com/doc/2014-10-31/"
@@ -42,7 +42,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateDBCluster handles the CreateDBCluster action.
 func (s *Service) CreateDBCluster(w http.ResponseWriter, r *http.Request) {
 	var req CreateDBClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -71,7 +71,7 @@ func (s *Service) CreateDBCluster(w http.ResponseWriter, r *http.Request) {
 // DeleteDBCluster handles the DeleteDBCluster action.
 func (s *Service) DeleteDBCluster(w http.ResponseWriter, r *http.Request) {
 	var req DeleteDBClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -100,7 +100,7 @@ func (s *Service) DeleteDBCluster(w http.ResponseWriter, r *http.Request) {
 // DescribeDBClusters handles the DescribeDBClusters action.
 func (s *Service) DescribeDBClusters(w http.ResponseWriter, r *http.Request) {
 	var req DescribeDBClustersInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -128,7 +128,7 @@ func (s *Service) DescribeDBClusters(w http.ResponseWriter, r *http.Request) {
 // ModifyDBCluster handles the ModifyDBCluster action.
 func (s *Service) ModifyDBCluster(w http.ResponseWriter, r *http.Request) {
 	var req ModifyDBClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -157,7 +157,7 @@ func (s *Service) ModifyDBCluster(w http.ResponseWriter, r *http.Request) {
 // CreateDBInstance handles the CreateDBInstance action.
 func (s *Service) CreateDBInstance(w http.ResponseWriter, r *http.Request) {
 	var req CreateDBInstanceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -192,7 +192,7 @@ func (s *Service) CreateDBInstance(w http.ResponseWriter, r *http.Request) {
 // DeleteDBInstance handles the DeleteDBInstance action.
 func (s *Service) DeleteDBInstance(w http.ResponseWriter, r *http.Request) {
 	var req DeleteDBInstanceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -221,7 +221,7 @@ func (s *Service) DeleteDBInstance(w http.ResponseWriter, r *http.Request) {
 // DescribeDBInstances handles the DescribeDBInstances action.
 func (s *Service) DescribeDBInstances(w http.ResponseWriter, r *http.Request) {
 	var req DescribeDBInstancesInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -257,23 +257,6 @@ func extractAction(r *http.Request) string {
 	}
 
 	return r.URL.Query().Get("Action")
-}
-
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 func writeXMLResponse(w http.ResponseWriter, v any) {

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -4,17 +4,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // CreateTable handles the CreateTable action.
 func (s *Service) CreateTable(w http.ResponseWriter, r *http.Request) {
 	var req CreateTableRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -54,7 +55,7 @@ func (s *Service) CreateTable(w http.ResponseWriter, r *http.Request) {
 // DeleteTable handles the DeleteTable action.
 func (s *Service) DeleteTable(w http.ResponseWriter, r *http.Request) {
 	var req DeleteTableRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -88,7 +89,7 @@ func (s *Service) DeleteTable(w http.ResponseWriter, r *http.Request) {
 // ListTables handles the ListTables action.
 func (s *Service) ListTables(w http.ResponseWriter, r *http.Request) {
 	var req ListTablesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -110,7 +111,7 @@ func (s *Service) ListTables(w http.ResponseWriter, r *http.Request) {
 // DescribeTable handles the DescribeTable action.
 func (s *Service) DescribeTable(w http.ResponseWriter, r *http.Request) {
 	var req DescribeTableRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -144,7 +145,7 @@ func (s *Service) DescribeTable(w http.ResponseWriter, r *http.Request) {
 // PutItem handles the PutItem action.
 func (s *Service) PutItem(w http.ResponseWriter, r *http.Request) {
 	var req PutItemRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -194,7 +195,7 @@ func (s *Service) PutItem(w http.ResponseWriter, r *http.Request) {
 // GetItem handles the GetItem action.
 func (s *Service) GetItem(w http.ResponseWriter, r *http.Request) {
 	var req GetItemRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -236,7 +237,7 @@ func (s *Service) GetItem(w http.ResponseWriter, r *http.Request) {
 // DeleteItem handles the DeleteItem action.
 func (s *Service) DeleteItem(w http.ResponseWriter, r *http.Request) {
 	var req DeleteItemRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -286,7 +287,7 @@ func (s *Service) DeleteItem(w http.ResponseWriter, r *http.Request) {
 // UpdateItem handles the UpdateItem action.
 func (s *Service) UpdateItem(w http.ResponseWriter, r *http.Request) {
 	var req UpdateItemRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -348,7 +349,7 @@ func (s *Service) UpdateItem(w http.ResponseWriter, r *http.Request) {
 // Query handles the Query action.
 func (s *Service) Query(w http.ResponseWriter, r *http.Request) {
 	var req QueryRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -406,7 +407,7 @@ func (s *Service) Query(w http.ResponseWriter, r *http.Request) {
 // Scan handles the Scan action.
 func (s *Service) Scan(w http.ResponseWriter, r *http.Request) {
 	var req ScanRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -533,24 +534,6 @@ func lsiToDescription(table *Table, lsi *LocalSecondaryIndex) LocalSecondaryInde
 	}
 }
 
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
-}
-
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
@@ -573,7 +556,7 @@ func writeDynamoDBError(w http.ResponseWriter, code, message string, status int)
 // UpdateTimeToLive handles the UpdateTimeToLive action.
 func (s *Service) UpdateTimeToLive(w http.ResponseWriter, r *http.Request) {
 	var req UpdateTimeToLiveRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -606,7 +589,7 @@ func (s *Service) UpdateTimeToLive(w http.ResponseWriter, r *http.Request) {
 // DescribeTimeToLive handles the DescribeTimeToLive action.
 func (s *Service) DescribeTimeToLive(w http.ResponseWriter, r *http.Request) {
 	var req DescribeTimeToLiveRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -648,7 +631,7 @@ func (s *Service) DescribeTimeToLive(w http.ResponseWriter, r *http.Request) {
 // TransactWriteItems handles the TransactWriteItems action.
 func (s *Service) TransactWriteItems(w http.ResponseWriter, r *http.Request) {
 	var req TransactWriteItemsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -698,7 +681,7 @@ func (s *Service) TransactWriteItems(w http.ResponseWriter, r *http.Request) {
 // TransactGetItems handles the TransactGetItems action.
 func (s *Service) TransactGetItems(w http.ResponseWriter, r *http.Request) {
 	var req TransactGetItemsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -777,7 +760,7 @@ func (s *Service) actionHandlers() map[string]func(http.ResponseWriter, *http.Re
 // BatchWriteItem handles the BatchWriteItem action.
 func (s *Service) BatchWriteItem(w http.ResponseWriter, r *http.Request) {
 	var req BatchWriteItemRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -820,7 +803,7 @@ func (s *Service) BatchWriteItem(w http.ResponseWriter, r *http.Request) {
 // BatchGetItem handles the BatchGetItem action.
 func (s *Service) BatchGetItem(w http.ResponseWriter, r *http.Request) {
 	var req BatchGetItemRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -946,7 +929,7 @@ func convertAttributeUpdates(req *UpdateItemRequest) {
 // UnknownOperationException and destroy fails.
 func (s *Service) UpdateTable(w http.ResponseWriter, r *http.Request) {
 	var req UpdateTableRequest
-	if err := readJSONRequest(r, &req); err != nil || req.TableName == "" {
+	if err := service.ReadJSONRequest(r, &req); err != nil || req.TableName == "" {
 		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
 
 		return
@@ -967,7 +950,7 @@ func (s *Service) UpdateTable(w http.ResponseWriter, r *http.Request) {
 // ListTagsOfResource returns the tags for a DynamoDB resource.
 func (s *Service) ListTagsOfResource(w http.ResponseWriter, r *http.Request) {
 	var req ListTagsOfResourceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -986,7 +969,7 @@ func (s *Service) ListTagsOfResource(w http.ResponseWriter, r *http.Request) {
 // TagResource adds tags to a DynamoDB resource.
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -1004,7 +987,7 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 // UntagResource removes tags from a DynamoDB resource.
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -1024,7 +1007,7 @@ func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 // match AWS semantics that terraform refresh paths depend on.
 func (s *Service) DescribeContinuousBackups(w http.ResponseWriter, r *http.Request) {
 	var req DescribeContinuousBackupsRequest
-	if err := readJSONRequest(r, &req); err != nil || req.TableName == "" {
+	if err := service.ReadJSONRequest(r, &req); err != nil || req.TableName == "" {
 		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
 
 		return

--- a/internal/service/ecs/handlers.go
+++ b/internal/service/ecs/handlers.go
@@ -4,12 +4,12 @@ package ecs
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.
@@ -51,7 +51,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateCluster handles the CreateCluster action.
 func (s *Service) CreateCluster(w http.ResponseWriter, r *http.Request) {
 	var req CreateClusterRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -79,7 +79,7 @@ func (s *Service) CreateCluster(w http.ResponseWriter, r *http.Request) {
 // DeleteCluster handles the DeleteCluster action.
 func (s *Service) DeleteCluster(w http.ResponseWriter, r *http.Request) {
 	var req DeleteClusterRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -113,7 +113,7 @@ func (s *Service) DeleteCluster(w http.ResponseWriter, r *http.Request) {
 // DescribeClusters handles the DescribeClusters action.
 func (s *Service) DescribeClusters(w http.ResponseWriter, r *http.Request) {
 	var req DescribeClustersRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -135,7 +135,7 @@ func (s *Service) DescribeClusters(w http.ResponseWriter, r *http.Request) {
 // ListClusters handles the ListClusters action.
 func (s *Service) ListClusters(w http.ResponseWriter, r *http.Request) {
 	var req ListClustersRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -164,7 +164,7 @@ func (s *Service) ListClusters(w http.ResponseWriter, r *http.Request) {
 // RegisterTaskDefinition handles the RegisterTaskDefinition action.
 func (s *Service) RegisterTaskDefinition(w http.ResponseWriter, r *http.Request) {
 	var req RegisterTaskDefinitionRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -205,7 +205,7 @@ func (s *Service) RegisterTaskDefinition(w http.ResponseWriter, r *http.Request)
 // DeregisterTaskDefinition handles the DeregisterTaskDefinition action.
 func (s *Service) DeregisterTaskDefinition(w http.ResponseWriter, r *http.Request) {
 	var req DeregisterTaskDefinitionRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -239,7 +239,7 @@ func (s *Service) DeregisterTaskDefinition(w http.ResponseWriter, r *http.Reques
 // RunTask handles the RunTask action.
 func (s *Service) RunTask(w http.ResponseWriter, r *http.Request) {
 	var req RunTaskRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -274,7 +274,7 @@ func (s *Service) RunTask(w http.ResponseWriter, r *http.Request) {
 // StopTask handles the StopTask action.
 func (s *Service) StopTask(w http.ResponseWriter, r *http.Request) {
 	var req StopTaskRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -308,7 +308,7 @@ func (s *Service) StopTask(w http.ResponseWriter, r *http.Request) {
 // DescribeTasks handles the DescribeTasks action.
 func (s *Service) DescribeTasks(w http.ResponseWriter, r *http.Request) {
 	var req DescribeTasksRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -336,7 +336,7 @@ func (s *Service) DescribeTasks(w http.ResponseWriter, r *http.Request) {
 // CreateService handles the CreateService action.
 func (s *Service) CreateService(w http.ResponseWriter, r *http.Request) {
 	var req CreateServiceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -376,7 +376,7 @@ func (s *Service) CreateService(w http.ResponseWriter, r *http.Request) {
 // DeleteService handles the DeleteService action.
 func (s *Service) DeleteService(w http.ResponseWriter, r *http.Request) {
 	var req DeleteServiceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -410,7 +410,7 @@ func (s *Service) DeleteService(w http.ResponseWriter, r *http.Request) {
 // UpdateService handles the UpdateService action.
 func (s *Service) UpdateService(w http.ResponseWriter, r *http.Request) {
 	var req UpdateServiceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeECSError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -439,24 +439,6 @@ func (s *Service) UpdateService(w http.ResponseWriter, r *http.Request) {
 	writeJSONResponse(w, UpdateServiceResponse{
 		Service: svc,
 	})
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.

--- a/internal/service/elasticache/handlers.go
+++ b/internal/service/elasticache/handlers.go
@@ -2,15 +2,15 @@
 package elasticache
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const elasticacheXMLNS = "http://elasticache.amazonaws.com/doc/2015-02-02/"
@@ -42,7 +42,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateCacheCluster handles the CreateCacheCluster action.
 func (s *Service) CreateCacheCluster(w http.ResponseWriter, r *http.Request) {
 	var req CreateCacheClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -83,7 +83,7 @@ func (s *Service) CreateCacheCluster(w http.ResponseWriter, r *http.Request) {
 // DeleteCacheCluster handles the DeleteCacheCluster action.
 func (s *Service) DeleteCacheCluster(w http.ResponseWriter, r *http.Request) {
 	var req DeleteCacheClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -112,7 +112,7 @@ func (s *Service) DeleteCacheCluster(w http.ResponseWriter, r *http.Request) {
 // DescribeCacheClusters handles the DescribeCacheClusters action.
 func (s *Service) DescribeCacheClusters(w http.ResponseWriter, r *http.Request) {
 	var req DescribeCacheClustersInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -140,7 +140,7 @@ func (s *Service) DescribeCacheClusters(w http.ResponseWriter, r *http.Request) 
 // ModifyCacheCluster handles the ModifyCacheCluster action.
 func (s *Service) ModifyCacheCluster(w http.ResponseWriter, r *http.Request) {
 	var req ModifyCacheClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -169,7 +169,7 @@ func (s *Service) ModifyCacheCluster(w http.ResponseWriter, r *http.Request) {
 // CreateReplicationGroup handles the CreateReplicationGroup action.
 func (s *Service) CreateReplicationGroup(w http.ResponseWriter, r *http.Request) {
 	var req CreateReplicationGroupInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -204,7 +204,7 @@ func (s *Service) CreateReplicationGroup(w http.ResponseWriter, r *http.Request)
 // DeleteReplicationGroup handles the DeleteReplicationGroup action.
 func (s *Service) DeleteReplicationGroup(w http.ResponseWriter, r *http.Request) {
 	var req DeleteReplicationGroupInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -233,7 +233,7 @@ func (s *Service) DeleteReplicationGroup(w http.ResponseWriter, r *http.Request)
 // DescribeReplicationGroups handles the DescribeReplicationGroups action.
 func (s *Service) DescribeReplicationGroups(w http.ResponseWriter, r *http.Request) {
 	var req DescribeReplicationGroupsInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -269,23 +269,6 @@ func extractAction(r *http.Request) string {
 	}
 
 	return r.URL.Query().Get("Action")
-}
-
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 func writeXMLResponse(w http.ResponseWriter, v any) {

--- a/internal/service/elasticbeanstalk/handlers.go
+++ b/internal/service/elasticbeanstalk/handlers.go
@@ -2,15 +2,15 @@
 package elasticbeanstalk
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // DispatchAction routes the request to the appropriate handler based on Action parameter.
@@ -40,7 +40,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateApplication handles the CreateApplication action.
 func (s *Service) CreateApplication(w http.ResponseWriter, r *http.Request) {
 	var req CreateApplicationInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errAppNotFound, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -69,7 +69,7 @@ func (s *Service) CreateApplication(w http.ResponseWriter, r *http.Request) {
 // DescribeApplications handles the DescribeApplications action.
 func (s *Service) DescribeApplications(w http.ResponseWriter, r *http.Request) {
 	var req DescribeApplicationsInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errAppNotFound, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -97,7 +97,7 @@ func (s *Service) DescribeApplications(w http.ResponseWriter, r *http.Request) {
 // UpdateApplication handles the UpdateApplication action.
 func (s *Service) UpdateApplication(w http.ResponseWriter, r *http.Request) {
 	var req UpdateApplicationInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errAppNotFound, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -126,7 +126,7 @@ func (s *Service) UpdateApplication(w http.ResponseWriter, r *http.Request) {
 // DeleteApplication handles the DeleteApplication action.
 func (s *Service) DeleteApplication(w http.ResponseWriter, r *http.Request) {
 	var req DeleteApplicationInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errAppNotFound, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -153,7 +153,7 @@ func (s *Service) DeleteApplication(w http.ResponseWriter, r *http.Request) {
 // CreateEnvironment handles the CreateEnvironment action.
 func (s *Service) CreateEnvironment(w http.ResponseWriter, r *http.Request) {
 	var req CreateEnvironmentInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errEnvNotFound, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -188,7 +188,7 @@ func (s *Service) CreateEnvironment(w http.ResponseWriter, r *http.Request) {
 // DescribeEnvironments handles the DescribeEnvironments action.
 func (s *Service) DescribeEnvironments(w http.ResponseWriter, r *http.Request) {
 	var req DescribeEnvironmentsInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errEnvNotFound, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -217,7 +217,7 @@ func (s *Service) DescribeEnvironments(w http.ResponseWriter, r *http.Request) {
 // TerminateEnvironment handles the TerminateEnvironment action.
 func (s *Service) TerminateEnvironment(w http.ResponseWriter, r *http.Request) {
 	var req TerminateEnvironmentInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errEnvNotFound, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -280,23 +280,6 @@ func extractAction(r *http.Request) string {
 	}
 
 	return r.URL.Query().Get("Action")
-}
-
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 func writeXMLResponse(w http.ResponseWriter, v any) {

--- a/internal/service/glue/handlers.go
+++ b/internal/service/glue/handlers.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // DispatchAction routes Glue requests based on the X-Amz-Target header.
@@ -63,7 +64,7 @@ func (s *Service) actionHandlers() map[string]http.HandlerFunc {
 // CreateDatabase handles the CreateDatabase operation.
 func (s *Service) CreateDatabase(w http.ResponseWriter, r *http.Request) {
 	var req CreateDatabaseInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -87,7 +88,7 @@ func (s *Service) CreateDatabase(w http.ResponseWriter, r *http.Request) {
 // GetDatabase handles the GetDatabase operation.
 func (s *Service) GetDatabase(w http.ResponseWriter, r *http.Request) {
 	var req GetDatabaseInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -122,7 +123,7 @@ func (s *Service) GetDatabase(w http.ResponseWriter, r *http.Request) {
 // GetDatabases handles the GetDatabases operation.
 func (s *Service) GetDatabases(w http.ResponseWriter, r *http.Request) {
 	var req GetDatabasesInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -158,7 +159,7 @@ func (s *Service) GetDatabases(w http.ResponseWriter, r *http.Request) {
 // DeleteDatabase handles the DeleteDatabase operation.
 func (s *Service) DeleteDatabase(w http.ResponseWriter, r *http.Request) {
 	var req DeleteDatabaseInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -182,7 +183,7 @@ func (s *Service) DeleteDatabase(w http.ResponseWriter, r *http.Request) {
 // CreateTable handles the CreateTable operation.
 func (s *Service) CreateTable(w http.ResponseWriter, r *http.Request) {
 	var req CreateTableInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -212,7 +213,7 @@ func (s *Service) CreateTable(w http.ResponseWriter, r *http.Request) {
 // GetTable handles the GetTable operation.
 func (s *Service) GetTable(w http.ResponseWriter, r *http.Request) {
 	var req GetTableInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -262,7 +263,7 @@ func (s *Service) GetTable(w http.ResponseWriter, r *http.Request) {
 // GetTables handles the GetTables operation.
 func (s *Service) GetTables(w http.ResponseWriter, r *http.Request) {
 	var req GetTablesInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -313,7 +314,7 @@ func (s *Service) GetTables(w http.ResponseWriter, r *http.Request) {
 // DeleteTable handles the DeleteTable operation.
 func (s *Service) DeleteTable(w http.ResponseWriter, r *http.Request) {
 	var req DeleteTableInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -343,7 +344,7 @@ func (s *Service) DeleteTable(w http.ResponseWriter, r *http.Request) {
 // CreateJob handles the CreateJob operation.
 func (s *Service) CreateJob(w http.ResponseWriter, r *http.Request) {
 	var req CreateJobInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -364,7 +365,7 @@ func (s *Service) CreateJob(w http.ResponseWriter, r *http.Request) {
 // DeleteJob handles the DeleteJob operation.
 func (s *Service) DeleteJob(w http.ResponseWriter, r *http.Request) {
 	var req DeleteJobInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -388,7 +389,7 @@ func (s *Service) DeleteJob(w http.ResponseWriter, r *http.Request) {
 // StartJobRun handles the StartJobRun operation.
 func (s *Service) StartJobRun(w http.ResponseWriter, r *http.Request) {
 	var req StartJobRunInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -413,24 +414,6 @@ func (s *Service) StartJobRun(w http.ResponseWriter, r *http.Request) {
 }
 
 // Helper functions.
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
-}
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
@@ -474,7 +457,7 @@ func handleStorageError(w http.ResponseWriter, err error) {
 // GetTags handles the GetTags operation.
 func (s *Service) GetTags(w http.ResponseWriter, r *http.Request) {
 	var req GetTagsInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -493,7 +476,7 @@ func (s *Service) GetTags(w http.ResponseWriter, r *http.Request) {
 // TagResource handles the TagResource operation.
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -511,7 +494,7 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 // UntagResource handles the UntagResource operation.
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidInput, "Invalid request body", http.StatusBadRequest)
 
 		return

--- a/internal/service/neptune/handlers.go
+++ b/internal/service/neptune/handlers.go
@@ -2,15 +2,15 @@
 package neptune
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const neptuneXMLNS = "http://rds.amazonaws.com/doc/2014-10-31/"
@@ -40,7 +40,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateDBCluster handles the CreateDBCluster action.
 func (s *Service) CreateDBCluster(w http.ResponseWriter, r *http.Request) {
 	var req CreateDBClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -69,7 +69,7 @@ func (s *Service) CreateDBCluster(w http.ResponseWriter, r *http.Request) {
 // DeleteDBCluster handles the DeleteDBCluster action.
 func (s *Service) DeleteDBCluster(w http.ResponseWriter, r *http.Request) {
 	var req DeleteDBClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -98,7 +98,7 @@ func (s *Service) DeleteDBCluster(w http.ResponseWriter, r *http.Request) {
 // DescribeDBClusters handles the DescribeDBClusters action.
 func (s *Service) DescribeDBClusters(w http.ResponseWriter, r *http.Request) {
 	var req DescribeDBClustersInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -126,7 +126,7 @@ func (s *Service) DescribeDBClusters(w http.ResponseWriter, r *http.Request) {
 // CreateDBInstance handles the CreateDBInstance action.
 func (s *Service) CreateDBInstance(w http.ResponseWriter, r *http.Request) {
 	var req CreateDBInstanceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -161,7 +161,7 @@ func (s *Service) CreateDBInstance(w http.ResponseWriter, r *http.Request) {
 // DeleteDBInstance handles the DeleteDBInstance action.
 func (s *Service) DeleteDBInstance(w http.ResponseWriter, r *http.Request) {
 	var req DeleteDBInstanceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -190,7 +190,7 @@ func (s *Service) DeleteDBInstance(w http.ResponseWriter, r *http.Request) {
 // DescribeDBInstances handles the DescribeDBInstances action.
 func (s *Service) DescribeDBInstances(w http.ResponseWriter, r *http.Request) {
 	var req DescribeDBInstancesInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -226,23 +226,6 @@ func extractAction(r *http.Request) string {
 	}
 
 	return r.URL.Query().Get("Action")
-}
-
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 func writeXMLResponse(w http.ResponseWriter, v any) {

--- a/internal/service/pinpointsmsvoicev2/handlers.go
+++ b/internal/service/pinpointsmsvoicev2/handlers.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // DispatchAction routes requests based on the X-Amz-Target header.
@@ -40,7 +41,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // SendTextMessage handles the SendTextMessage operation.
 func (s *Service) SendTextMessage(w http.ResponseWriter, r *http.Request) {
 	var req SendTextMessageInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -80,24 +81,6 @@ func (s *Service) GetSentTextMessages(w http.ResponseWriter, r *http.Request) {
 }
 
 // Helper functions.
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
-}
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {

--- a/internal/service/rds/handlers.go
+++ b/internal/service/rds/handlers.go
@@ -2,15 +2,15 @@
 package rds
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const rdsXMLNS = "http://rds.amazonaws.com/doc/2014-10-31/"
@@ -52,7 +52,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateDBInstance handles the CreateDBInstance action.
 func (s *Service) CreateDBInstance(w http.ResponseWriter, r *http.Request) {
 	var req CreateDBInstanceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -93,7 +93,7 @@ func (s *Service) CreateDBInstance(w http.ResponseWriter, r *http.Request) {
 // DeleteDBInstance handles the DeleteDBInstance action.
 func (s *Service) DeleteDBInstance(w http.ResponseWriter, r *http.Request) {
 	var req DeleteDBInstanceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -122,7 +122,7 @@ func (s *Service) DeleteDBInstance(w http.ResponseWriter, r *http.Request) {
 // DescribeDBInstances handles the DescribeDBInstances action.
 func (s *Service) DescribeDBInstances(w http.ResponseWriter, r *http.Request) {
 	var req DescribeDBInstancesInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -150,7 +150,7 @@ func (s *Service) DescribeDBInstances(w http.ResponseWriter, r *http.Request) {
 // ModifyDBInstance handles the ModifyDBInstance action.
 func (s *Service) ModifyDBInstance(w http.ResponseWriter, r *http.Request) {
 	var req ModifyDBInstanceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -179,7 +179,7 @@ func (s *Service) ModifyDBInstance(w http.ResponseWriter, r *http.Request) {
 // StartDBInstance handles the StartDBInstance action.
 func (s *Service) StartDBInstance(w http.ResponseWriter, r *http.Request) {
 	var req StartDBInstanceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -208,7 +208,7 @@ func (s *Service) StartDBInstance(w http.ResponseWriter, r *http.Request) {
 // StopDBInstance handles the StopDBInstance action.
 func (s *Service) StopDBInstance(w http.ResponseWriter, r *http.Request) {
 	var req StopDBInstanceInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -237,7 +237,7 @@ func (s *Service) StopDBInstance(w http.ResponseWriter, r *http.Request) {
 // CreateDBCluster handles the CreateDBCluster action.
 func (s *Service) CreateDBCluster(w http.ResponseWriter, r *http.Request) {
 	var req CreateDBClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -272,7 +272,7 @@ func (s *Service) CreateDBCluster(w http.ResponseWriter, r *http.Request) {
 // DeleteDBCluster handles the DeleteDBCluster action.
 func (s *Service) DeleteDBCluster(w http.ResponseWriter, r *http.Request) {
 	var req DeleteDBClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -301,7 +301,7 @@ func (s *Service) DeleteDBCluster(w http.ResponseWriter, r *http.Request) {
 // DescribeDBClusters handles the DescribeDBClusters action.
 func (s *Service) DescribeDBClusters(w http.ResponseWriter, r *http.Request) {
 	var req DescribeDBClustersInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -329,7 +329,7 @@ func (s *Service) DescribeDBClusters(w http.ResponseWriter, r *http.Request) {
 // ModifyDBCluster handles the ModifyDBCluster action.
 func (s *Service) ModifyDBCluster(w http.ResponseWriter, r *http.Request) {
 	var req ModifyDBClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -358,7 +358,7 @@ func (s *Service) ModifyDBCluster(w http.ResponseWriter, r *http.Request) {
 // CreateDBSnapshot handles the CreateDBSnapshot action.
 func (s *Service) CreateDBSnapshot(w http.ResponseWriter, r *http.Request) {
 	var req CreateDBSnapshotInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -393,7 +393,7 @@ func (s *Service) CreateDBSnapshot(w http.ResponseWriter, r *http.Request) {
 // DeleteDBSnapshot handles the DeleteDBSnapshot action.
 func (s *Service) DeleteDBSnapshot(w http.ResponseWriter, r *http.Request) {
 	var req DeleteDBSnapshotInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -430,23 +430,6 @@ func extractAction(r *http.Request) string {
 	}
 
 	return r.URL.Query().Get("Action")
-}
-
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 func writeXMLResponse(w http.ResponseWriter, v any) {

--- a/internal/service/redshift/handlers.go
+++ b/internal/service/redshift/handlers.go
@@ -2,15 +2,15 @@
 package redshift
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const redshiftXMLNS = "http://redshift.amazonaws.com/doc/2012-12-01/"
@@ -42,7 +42,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateCluster handles the CreateCluster action.
 func (s *Service) CreateCluster(w http.ResponseWriter, r *http.Request) {
 	var req CreateClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -71,7 +71,7 @@ func (s *Service) CreateCluster(w http.ResponseWriter, r *http.Request) {
 // DeleteCluster handles the DeleteCluster action.
 func (s *Service) DeleteCluster(w http.ResponseWriter, r *http.Request) {
 	var req DeleteClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -100,7 +100,7 @@ func (s *Service) DeleteCluster(w http.ResponseWriter, r *http.Request) {
 // DescribeClusters handles the DescribeClusters action.
 func (s *Service) DescribeClusters(w http.ResponseWriter, r *http.Request) {
 	var req DescribeClustersInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -129,7 +129,7 @@ func (s *Service) DescribeClusters(w http.ResponseWriter, r *http.Request) {
 // ModifyCluster handles the ModifyCluster action.
 func (s *Service) ModifyCluster(w http.ResponseWriter, r *http.Request) {
 	var req ModifyClusterInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -158,7 +158,7 @@ func (s *Service) ModifyCluster(w http.ResponseWriter, r *http.Request) {
 // CreateClusterSnapshot handles the CreateClusterSnapshot action.
 func (s *Service) CreateClusterSnapshot(w http.ResponseWriter, r *http.Request) {
 	var req CreateClusterSnapshotInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -193,7 +193,7 @@ func (s *Service) CreateClusterSnapshot(w http.ResponseWriter, r *http.Request) 
 // DeleteClusterSnapshot handles the DeleteClusterSnapshot action.
 func (s *Service) DeleteClusterSnapshot(w http.ResponseWriter, r *http.Request) {
 	var req DeleteClusterSnapshotInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -222,7 +222,7 @@ func (s *Service) DeleteClusterSnapshot(w http.ResponseWriter, r *http.Request) 
 // DescribeClusterSnapshots handles the DescribeClusterSnapshots action.
 func (s *Service) DescribeClusterSnapshots(w http.ResponseWriter, r *http.Request) {
 	var req DescribeClusterSnapshotsInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -259,23 +259,6 @@ func extractAction(r *http.Request) string {
 	}
 
 	return r.URL.Query().Get("Action")
-}
-
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 func writeXMLResponse(w http.ResponseWriter, v any) {

--- a/internal/service/request.go
+++ b/internal/service/request.go
@@ -1,0 +1,28 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ReadJSONRequest reads the HTTP request body and decodes it as JSON into v.
+// An empty body is treated as a no-op (v is left unchanged), matching the
+// behavior shared across the JSON-protocol service handlers.
+func ReadJSONRequest(r *http.Request, v any) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return nil
+}

--- a/internal/service/request_test.go
+++ b/internal/service/request_test.go
@@ -1,0 +1,47 @@
+package service_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sivchari/kumo/internal/service"
+)
+
+func TestReadJSONRequest(t *testing.T) {
+	t.Parallel()
+
+	type payload struct {
+		Name string `json:"name"`
+	}
+
+	tests := []struct {
+		name    string
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{name: "valid JSON decodes into v", body: `{"name":"alice"}`, want: "alice"},
+		{name: "empty body is a no-op", body: "", want: ""},
+		{name: "invalid JSON returns an error", body: `{not json`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequestWithContext(t.Context(), "POST", "/", strings.NewReader(tt.body))
+
+			var p payload
+
+			err := service.ReadJSONRequest(req, &p)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ReadJSONRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr && p.Name != tt.want {
+				t.Errorf("ReadJSONRequest() decoded name = %q, want %q", p.Name, tt.want)
+			}
+		})
+	}
+}

--- a/internal/service/route53resolver/handlers.go
+++ b/internal/service/route53resolver/handlers.go
@@ -3,12 +3,12 @@ package route53resolver
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const (
@@ -19,7 +19,7 @@ const (
 // CreateResolverEndpoint handles the CreateResolverEndpoint action.
 func (s *Service) CreateResolverEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req CreateResolverEndpointRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -52,7 +52,7 @@ func (s *Service) CreateResolverEndpoint(w http.ResponseWriter, r *http.Request)
 // GetResolverEndpoint handles the GetResolverEndpoint action.
 func (s *Service) GetResolverEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req GetResolverEndpointRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -79,7 +79,7 @@ func (s *Service) GetResolverEndpoint(w http.ResponseWriter, r *http.Request) {
 // DeleteResolverEndpoint handles the DeleteResolverEndpoint action.
 func (s *Service) DeleteResolverEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req DeleteResolverEndpointRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -106,7 +106,7 @@ func (s *Service) DeleteResolverEndpoint(w http.ResponseWriter, r *http.Request)
 // ListResolverEndpoints handles the ListResolverEndpoints action.
 func (s *Service) ListResolverEndpoints(w http.ResponseWriter, r *http.Request) {
 	var req ListResolverEndpointsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -134,7 +134,7 @@ func (s *Service) ListResolverEndpoints(w http.ResponseWriter, r *http.Request) 
 // CreateResolverRule handles the CreateResolverRule action.
 func (s *Service) CreateResolverRule(w http.ResponseWriter, r *http.Request) {
 	var req CreateResolverRuleRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -173,7 +173,7 @@ func (s *Service) CreateResolverRule(w http.ResponseWriter, r *http.Request) {
 // GetResolverRule handles the GetResolverRule action.
 func (s *Service) GetResolverRule(w http.ResponseWriter, r *http.Request) {
 	var req GetResolverRuleRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -200,7 +200,7 @@ func (s *Service) GetResolverRule(w http.ResponseWriter, r *http.Request) {
 // DeleteResolverRule handles the DeleteResolverRule action.
 func (s *Service) DeleteResolverRule(w http.ResponseWriter, r *http.Request) {
 	var req DeleteResolverRuleRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -227,7 +227,7 @@ func (s *Service) DeleteResolverRule(w http.ResponseWriter, r *http.Request) {
 // ListResolverRules handles the ListResolverRules action.
 func (s *Service) ListResolverRules(w http.ResponseWriter, r *http.Request) {
 	var req ListResolverRulesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -255,7 +255,7 @@ func (s *Service) ListResolverRules(w http.ResponseWriter, r *http.Request) {
 // AssociateResolverRule handles the AssociateResolverRule action.
 func (s *Service) AssociateResolverRule(w http.ResponseWriter, r *http.Request) {
 	var req AssociateResolverRuleRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -288,7 +288,7 @@ func (s *Service) AssociateResolverRule(w http.ResponseWriter, r *http.Request) 
 // DisassociateResolverRule handles the DisassociateResolverRule action.
 func (s *Service) DisassociateResolverRule(w http.ResponseWriter, r *http.Request) {
 	var req DisassociateResolverRuleRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -321,7 +321,7 @@ func (s *Service) DisassociateResolverRule(w http.ResponseWriter, r *http.Reques
 // ListResolverRuleAssociations handles the ListResolverRuleAssociations action.
 func (s *Service) ListResolverRuleAssociations(w http.ResponseWriter, r *http.Request) {
 	var req ListResolverRuleAssociationsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeResolverError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -458,24 +458,6 @@ func handleResolverError(w http.ResponseWriter, err error) {
 	}
 
 	writeResolverError(w, errInternalServiceError, "Internal server error", http.StatusInternalServerError)
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.

--- a/internal/service/sagemaker/handlers.go
+++ b/internal/service/sagemaker/handlers.go
@@ -3,12 +3,12 @@ package sagemaker
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // Error codes for SageMaker handlers.
@@ -52,7 +52,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateNotebookInstance handles the CreateNotebookInstance action.
 func (s *Service) CreateNotebookInstance(w http.ResponseWriter, r *http.Request) {
 	var req CreateNotebookInstanceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -91,7 +91,7 @@ func (s *Service) CreateNotebookInstance(w http.ResponseWriter, r *http.Request)
 // DeleteNotebookInstance handles the DeleteNotebookInstance action.
 func (s *Service) DeleteNotebookInstance(w http.ResponseWriter, r *http.Request) {
 	var req DeleteNotebookInstanceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -115,7 +115,7 @@ func (s *Service) DeleteNotebookInstance(w http.ResponseWriter, r *http.Request)
 // DescribeNotebookInstance handles the DescribeNotebookInstance action.
 func (s *Service) DescribeNotebookInstance(w http.ResponseWriter, r *http.Request) {
 	var req DescribeNotebookInstanceRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -155,7 +155,7 @@ func (s *Service) DescribeNotebookInstance(w http.ResponseWriter, r *http.Reques
 // ListNotebookInstances handles the ListNotebookInstances action.
 func (s *Service) ListNotebookInstances(w http.ResponseWriter, r *http.Request) {
 	var req ListNotebookInstancesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -191,7 +191,7 @@ func (s *Service) ListNotebookInstances(w http.ResponseWriter, r *http.Request) 
 // CreateTrainingJob handles the CreateTrainingJob action.
 func (s *Service) CreateTrainingJob(w http.ResponseWriter, r *http.Request) {
 	var req CreateTrainingJobRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -224,7 +224,7 @@ func (s *Service) CreateTrainingJob(w http.ResponseWriter, r *http.Request) {
 // DescribeTrainingJob handles the DescribeTrainingJob action.
 func (s *Service) DescribeTrainingJob(w http.ResponseWriter, r *http.Request) {
 	var req DescribeTrainingJobRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -274,7 +274,7 @@ func (s *Service) DescribeTrainingJob(w http.ResponseWriter, r *http.Request) {
 // CreateModel handles the CreateModel action.
 func (s *Service) CreateModel(w http.ResponseWriter, r *http.Request) {
 	var req CreateModelRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -307,7 +307,7 @@ func (s *Service) CreateModel(w http.ResponseWriter, r *http.Request) {
 // DeleteModel handles the DeleteModel action.
 func (s *Service) DeleteModel(w http.ResponseWriter, r *http.Request) {
 	var req DeleteModelRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -331,7 +331,7 @@ func (s *Service) DeleteModel(w http.ResponseWriter, r *http.Request) {
 // CreateEndpoint handles the CreateEndpoint action.
 func (s *Service) CreateEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req CreateEndpointRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -364,7 +364,7 @@ func (s *Service) CreateEndpoint(w http.ResponseWriter, r *http.Request) {
 // DeleteEndpoint handles the DeleteEndpoint action.
 func (s *Service) DeleteEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req DeleteEndpointRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -388,7 +388,7 @@ func (s *Service) DeleteEndpoint(w http.ResponseWriter, r *http.Request) {
 // DescribeEndpoint handles the DescribeEndpoint action.
 func (s *Service) DescribeEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req DescribeEndpointRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errValidationException, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -416,24 +416,6 @@ func (s *Service) DescribeEndpoint(w http.ResponseWriter, r *http.Request) {
 		LastModifiedTime:   float64(endpoint.LastModifiedTime.Unix()),
 		FailureReason:      endpoint.FailureReason,
 	})
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.

--- a/internal/service/secretsmanager/handlers.go
+++ b/internal/service/secretsmanager/handlers.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"math/big"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const (
@@ -30,7 +31,7 @@ const (
 // CreateSecret handles the CreateSecret action.
 func (s *Service) CreateSecret(w http.ResponseWriter, r *http.Request) {
 	var req CreateSecretRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -66,7 +67,7 @@ func (s *Service) CreateSecret(w http.ResponseWriter, r *http.Request) {
 // GetSecretValue handles the GetSecretValue action.
 func (s *Service) GetSecretValue(w http.ResponseWriter, r *http.Request) {
 	var req GetSecretValueRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -111,7 +112,7 @@ func (s *Service) GetSecretValue(w http.ResponseWriter, r *http.Request) {
 // PutSecretValue handles the PutSecretValue action.
 func (s *Service) PutSecretValue(w http.ResponseWriter, r *http.Request) {
 	var req PutSecretValueRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -159,7 +160,7 @@ func (s *Service) PutSecretValue(w http.ResponseWriter, r *http.Request) {
 // DeleteSecret handles the DeleteSecret action.
 func (s *Service) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 	var req DeleteSecretRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -209,7 +210,7 @@ func (s *Service) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 // ListSecrets handles the ListSecrets action.
 func (s *Service) ListSecrets(w http.ResponseWriter, r *http.Request) {
 	var req ListSecretsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -291,7 +292,7 @@ func convertSecretsToListEntries(secrets []*Secret) []SecretListEntry {
 // DescribeSecret handles the DescribeSecret action.
 func (s *Service) DescribeSecret(w http.ResponseWriter, r *http.Request) {
 	var req DescribeSecretRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -381,7 +382,7 @@ func buildDescribeSecretResponse(secret *Secret) DescribeSecretResponse {
 // UpdateSecret handles the UpdateSecret action.
 func (s *Service) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 	var req UpdateSecretRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -424,24 +425,6 @@ func (s *Service) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 	writeJSONResponse(w, resp)
 }
 
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
-}
-
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
@@ -464,7 +447,7 @@ func writeSecretsManagerError(w http.ResponseWriter, code, message string, statu
 // GetResourcePolicy returns the resource policy for an existing secret.
 func (s *Service) GetResourcePolicy(w http.ResponseWriter, r *http.Request) {
 	var req GetResourcePolicyRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -505,7 +488,7 @@ func (s *Service) GetResourcePolicy(w http.ResponseWriter, r *http.Request) {
 // PutResourcePolicy attaches a resource policy to a secret.
 func (s *Service) PutResourcePolicy(w http.ResponseWriter, r *http.Request) {
 	var req PutResourcePolicyRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -545,7 +528,7 @@ func (s *Service) PutResourcePolicy(w http.ResponseWriter, r *http.Request) {
 // DeleteResourcePolicy removes the resource policy from a secret.
 func (s *Service) DeleteResourcePolicy(w http.ResponseWriter, r *http.Request) {
 	var req DeleteResourcePolicyRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -619,7 +602,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // GetRandomPassword handles the GetRandomPassword action.
 func (s *Service) GetRandomPassword(w http.ResponseWriter, r *http.Request) {
 	var req GetRandomPasswordRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSecretsManagerError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return

--- a/internal/service/ses/handlers.go
+++ b/internal/service/ses/handlers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
-	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -14,6 +13,8 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const sesXMLNS = "http://ses.amazonaws.com/doc/2010-12-01/"
@@ -28,7 +29,7 @@ const (
 // VerifyEmailIdentity handles the VerifyEmailIdentity action.
 func (s *Service) VerifyEmailIdentity(w http.ResponseWriter, r *http.Request) {
 	var req VerifyEmailIdentityRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -57,7 +58,7 @@ func (s *Service) VerifyEmailIdentity(w http.ResponseWriter, r *http.Request) {
 // SendEmail handles the SendEmail action.
 func (s *Service) SendEmail(w http.ResponseWriter, r *http.Request) {
 	var req SendEmailRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -97,7 +98,7 @@ func (s *Service) SendEmail(w http.ResponseWriter, r *http.Request) {
 // SendRawEmail handles the SendRawEmail action.
 func (s *Service) SendRawEmail(w http.ResponseWriter, r *http.Request) {
 	var req SendRawEmailRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -178,7 +179,7 @@ func (s *Service) ListIdentities(w http.ResponseWriter, r *http.Request) {
 // DeleteIdentity handles the DeleteIdentity action.
 func (s *Service) DeleteIdentity(w http.ResponseWriter, r *http.Request) {
 	var req DeleteIdentityRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -201,7 +202,7 @@ func (s *Service) DeleteIdentity(w http.ResponseWriter, r *http.Request) {
 // GetIdentityVerificationAttributes handles the GetIdentityVerificationAttributes action.
 func (s *Service) GetIdentityVerificationAttributes(w http.ResponseWriter, r *http.Request) {
 	var req GetIdentityVerificationAttributesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -295,24 +296,6 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 }
 
 // Helper functions.
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
-}
 
 // writeXMLResponse writes an XML response with HTTP 200 OK.
 func writeXMLResponse(w http.ResponseWriter, v any) {

--- a/internal/service/sesv2/handlers.go
+++ b/internal/service/sesv2/handlers.go
@@ -3,19 +3,19 @@ package sesv2
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // CreateEmailIdentity handles the CreateEmailIdentity operation.
 func (s *Service) CreateEmailIdentity(w http.ResponseWriter, r *http.Request) {
 	var req CreateEmailIdentityRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -143,7 +143,7 @@ func (s *Service) DeleteEmailIdentity(w http.ResponseWriter, r *http.Request) {
 // CreateConfigurationSet handles the CreateConfigurationSet operation.
 func (s *Service) CreateConfigurationSet(w http.ResponseWriter, r *http.Request) {
 	var req CreateConfigurationSetRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -260,7 +260,7 @@ func (s *Service) DeleteConfigurationSet(w http.ResponseWriter, r *http.Request)
 // CreateEmailTemplate handles the CreateEmailTemplate operation.
 func (s *Service) CreateEmailTemplate(w http.ResponseWriter, r *http.Request) {
 	var req CreateEmailTemplateRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -332,7 +332,7 @@ func (s *Service) UpdateEmailTemplate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req UpdateEmailTemplateRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -419,7 +419,7 @@ func (s *Service) ListEmailTemplates(w http.ResponseWriter, r *http.Request) {
 // SendBulkEmail handles the SendBulkEmail operation.
 func (s *Service) SendBulkEmail(w http.ResponseWriter, r *http.Request) {
 	var req SendBulkEmailRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -450,7 +450,7 @@ func (s *Service) SendBulkEmail(w http.ResponseWriter, r *http.Request) {
 // SendEmail handles the SendEmail operation.
 func (s *Service) SendEmail(w http.ResponseWriter, r *http.Request) {
 	var req SendEmailRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -490,24 +490,6 @@ func (s *Service) GetSentEmails(w http.ResponseWriter, r *http.Request) {
 }
 
 // Helper functions.
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
-}
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {

--- a/internal/service/sns/handlers.go
+++ b/internal/service/sns/handlers.go
@@ -1,15 +1,14 @@
 package sns
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const snsXMLNS = "http://sns.amazonaws.com/doc/2010-03-31/"
@@ -25,7 +24,7 @@ const (
 // CreateTopic handles the CreateTopic action.
 func (s *Service) CreateTopic(w http.ResponseWriter, r *http.Request) {
 	var req CreateTopicRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -65,7 +64,7 @@ func (s *Service) CreateTopic(w http.ResponseWriter, r *http.Request) {
 // DeleteTopic handles the DeleteTopic action.
 func (s *Service) DeleteTopic(w http.ResponseWriter, r *http.Request) {
 	var req DeleteTopicRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -108,7 +107,7 @@ func (s *Service) DeleteTopic(w http.ResponseWriter, r *http.Request) {
 // ListTopics handles the ListTopics action.
 func (s *Service) ListTopics(w http.ResponseWriter, r *http.Request) {
 	var req ListTopicsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -145,7 +144,7 @@ func (s *Service) ListTopics(w http.ResponseWriter, r *http.Request) {
 // Subscribe handles the Subscribe action.
 func (s *Service) Subscribe(w http.ResponseWriter, r *http.Request) {
 	var req SubscribeRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -196,7 +195,7 @@ func (s *Service) Subscribe(w http.ResponseWriter, r *http.Request) {
 // Unsubscribe handles the Unsubscribe action.
 func (s *Service) Unsubscribe(w http.ResponseWriter, r *http.Request) {
 	var req UnsubscribeRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -239,7 +238,7 @@ func (s *Service) Unsubscribe(w http.ResponseWriter, r *http.Request) {
 // Publish handles the Publish action.
 func (s *Service) Publish(w http.ResponseWriter, r *http.Request) {
 	var req PublishRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -295,7 +294,7 @@ func (s *Service) Publish(w http.ResponseWriter, r *http.Request) {
 // ListSubscriptions handles the ListSubscriptions action.
 func (s *Service) ListSubscriptions(w http.ResponseWriter, r *http.Request) {
 	var req ListSubscriptionsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -327,7 +326,7 @@ func (s *Service) ListSubscriptions(w http.ResponseWriter, r *http.Request) {
 // ListSubscriptionsByTopic handles the ListSubscriptionsByTopic action.
 func (s *Service) ListSubscriptionsByTopic(w http.ResponseWriter, r *http.Request) {
 	var req ListSubscriptionsByTopicRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -389,24 +388,6 @@ func convertSubscriptionsToXMLMembers(subscriptions []*Subscription) []XMLSubscr
 	}
 
 	return members
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeXMLResponse writes an XML response with HTTP 200 OK.

--- a/internal/service/sns/subscription_attributes.go
+++ b/internal/service/sns/subscription_attributes.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // GetSubscriptionAttributes returns attributes for a subscription.
@@ -14,7 +16,7 @@ import (
 // aws_sns_topic_subscription resources.
 func (s *Service) GetSubscriptionAttributes(w http.ResponseWriter, r *http.Request) {
 	var req getSubscriptionAttributesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -55,7 +57,7 @@ func (s *Service) GetSubscriptionAttributes(w http.ResponseWriter, r *http.Reque
 // like RawMessageDelivery, FilterPolicy, etc.
 func (s *Service) SetSubscriptionAttributes(w http.ResponseWriter, r *http.Request) {
 	var req setSubscriptionAttributesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return

--- a/internal/service/sns/topic_attributes.go
+++ b/internal/service/sns/topic_attributes.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // flexString accepts a JSON string, number, or boolean and stores its
@@ -70,7 +72,7 @@ const defaultTopicPolicy = `{"Version":"2012-10-17","Id":"__default_policy_ID","
 // subsequent SetTopicAttributes is even tried.
 func (s *Service) SetTopicAttributes(w http.ResponseWriter, r *http.Request) {
 	var req setTopicAttributesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -106,7 +108,7 @@ func (s *Service) SetTopicAttributes(w http.ResponseWriter, r *http.Request) {
 // reads on every refresh.
 func (s *Service) GetTopicAttributes(w http.ResponseWriter, r *http.Request) {
 	var req getTopicAttributesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return

--- a/internal/service/sqs/handlers.go
+++ b/internal/service/sqs/handlers.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // CreateQueue handles the CreateQueue action.
 func (s *Service) CreateQueue(w http.ResponseWriter, r *http.Request) {
 	var req CreateQueueRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -49,7 +49,7 @@ func (s *Service) CreateQueue(w http.ResponseWriter, r *http.Request) {
 // ListQueueTags handles the ListQueueTags action.
 func (s *Service) ListQueueTags(w http.ResponseWriter, r *http.Request) {
 	var req ListQueueTagsRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -83,7 +83,7 @@ func (s *Service) ListQueueTags(w http.ResponseWriter, r *http.Request) {
 // TagQueue handles the TagQueue action.
 func (s *Service) TagQueue(w http.ResponseWriter, r *http.Request) {
 	var req TagQueueRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -114,7 +114,7 @@ func (s *Service) TagQueue(w http.ResponseWriter, r *http.Request) {
 // UntagQueue handles the UntagQueue action.
 func (s *Service) UntagQueue(w http.ResponseWriter, r *http.Request) {
 	var req UntagQueueRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -145,7 +145,7 @@ func (s *Service) UntagQueue(w http.ResponseWriter, r *http.Request) {
 // DeleteQueue handles the DeleteQueue action.
 func (s *Service) DeleteQueue(w http.ResponseWriter, r *http.Request) {
 	var req DeleteQueueRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -176,7 +176,7 @@ func (s *Service) DeleteQueue(w http.ResponseWriter, r *http.Request) {
 // ListQueues handles the ListQueues action.
 func (s *Service) ListQueues(w http.ResponseWriter, r *http.Request) {
 	var req ListQueuesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -197,7 +197,7 @@ func (s *Service) ListQueues(w http.ResponseWriter, r *http.Request) {
 // GetQueueURL handles the GetQueueURL action.
 func (s *Service) GetQueueURL(w http.ResponseWriter, r *http.Request) {
 	var req GetQueueURLRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -231,7 +231,7 @@ func (s *Service) GetQueueURL(w http.ResponseWriter, r *http.Request) {
 // SendMessage handles the SendMessage action.
 func (s *Service) SendMessage(w http.ResponseWriter, r *http.Request) {
 	var req SendMessageRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -273,7 +273,7 @@ func (s *Service) SendMessage(w http.ResponseWriter, r *http.Request) {
 // SendMessageBatch handles the SendMessageBatch action.
 func (s *Service) SendMessageBatch(w http.ResponseWriter, r *http.Request) {
 	var req SendMessageBatchRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -371,7 +371,7 @@ func (s *Service) batchEntryError(id string, err error) BatchResultErrorEntry {
 // ReceiveMessage handles the ReceiveMessage action.
 func (s *Service) ReceiveMessage(w http.ResponseWriter, r *http.Request) {
 	var req ReceiveMessageRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -433,7 +433,7 @@ func convertMessagesToResponse(messages []*Message) []MessageResponse {
 // DeleteMessage handles the DeleteMessage action.
 func (s *Service) DeleteMessage(w http.ResponseWriter, r *http.Request) {
 	var req DeleteMessageRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -470,7 +470,7 @@ func (s *Service) DeleteMessage(w http.ResponseWriter, r *http.Request) {
 // DeleteMessageBatch handles the DeleteMessageBatch action.
 func (s *Service) DeleteMessageBatch(w http.ResponseWriter, r *http.Request) {
 	var req DeleteMessageBatchRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -544,7 +544,7 @@ func (s *Service) processDeleteBatchEntries(ctx context.Context, queueURL string
 // ChangeMessageVisibility handles the ChangeMessageVisibility action.
 func (s *Service) ChangeMessageVisibility(w http.ResponseWriter, r *http.Request) {
 	var req ChangeMessageVisibilityRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -581,7 +581,7 @@ func (s *Service) ChangeMessageVisibility(w http.ResponseWriter, r *http.Request
 // ChangeMessageVisibilityBatch handles the ChangeMessageVisibilityBatch action.
 func (s *Service) ChangeMessageVisibilityBatch(w http.ResponseWriter, r *http.Request) {
 	var req ChangeMessageVisibilityBatchRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -619,7 +619,7 @@ func (s *Service) ChangeMessageVisibilityBatch(w http.ResponseWriter, r *http.Re
 // PurgeQueue handles the PurgeQueue action.
 func (s *Service) PurgeQueue(w http.ResponseWriter, r *http.Request) {
 	var req PurgeQueueRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -650,7 +650,7 @@ func (s *Service) PurgeQueue(w http.ResponseWriter, r *http.Request) {
 // GetQueueAttributes handles the GetQueueAttributes action.
 func (s *Service) GetQueueAttributes(w http.ResponseWriter, r *http.Request) {
 	var req GetQueueAttributesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -684,7 +684,7 @@ func (s *Service) GetQueueAttributes(w http.ResponseWriter, r *http.Request) {
 // SetQueueAttributes handles the SetQueueAttributes action.
 func (s *Service) SetQueueAttributes(w http.ResponseWriter, r *http.Request) {
 	var req SetQueueAttributesRequest
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -710,24 +710,6 @@ func (s *Service) SetQueueAttributes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSONResponse(w, struct{}{})
-}
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.

--- a/internal/service/sts/handlers.go
+++ b/internal/service/sts/handlers.go
@@ -2,14 +2,14 @@
 package sts
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const (
@@ -43,7 +43,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // handleAssumeRole handles the AssumeRole action.
 func (s *Service) handleAssumeRole(w http.ResponseWriter, r *http.Request) {
 	var req AssumeRoleInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParam, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -80,7 +80,7 @@ func (s *Service) handleAssumeRole(w http.ResponseWriter, r *http.Request) {
 // handleAssumeRoleWithSAML handles the AssumeRoleWithSAML action.
 func (s *Service) handleAssumeRoleWithSAML(w http.ResponseWriter, r *http.Request) {
 	var req AssumeRoleWithSAMLInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParam, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -123,7 +123,7 @@ func (s *Service) handleAssumeRoleWithSAML(w http.ResponseWriter, r *http.Reques
 // handleAssumeRoleWithWebIdentity handles the AssumeRoleWithWebIdentity action.
 func (s *Service) handleAssumeRoleWithWebIdentity(w http.ResponseWriter, r *http.Request) {
 	var req AssumeRoleWithWebIdentityInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParam, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -185,7 +185,7 @@ func (s *Service) handleGetCallerIdentity(w http.ResponseWriter, r *http.Request
 func (s *Service) handleGetSessionToken(w http.ResponseWriter, r *http.Request) {
 	var req GetSessionTokenInput
 
-	_ = readJSONRequest(r, &req)
+	_ = service.ReadJSONRequest(r, &req)
 
 	creds, err := s.storage.GetSessionToken(r.Context(), &req)
 	if err != nil {
@@ -204,7 +204,7 @@ func (s *Service) handleGetSessionToken(w http.ResponseWriter, r *http.Request) 
 // handleGetFederationToken handles the GetFederationToken action.
 func (s *Service) handleGetFederationToken(w http.ResponseWriter, r *http.Request) {
 	var req GetFederationTokenInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidParam, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -243,23 +243,6 @@ func extractAction(r *http.Request) string {
 	}
 
 	return r.URL.Query().Get("Action")
-}
-
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
 }
 
 func writeXMLResponse(w http.ResponseWriter, v any) {

--- a/internal/service/xray/handlers.go
+++ b/internal/service/xray/handlers.go
@@ -3,17 +3,17 @@ package xray
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // PutTraceSegments handles the PutTraceSegments operation.
 func (s *Service) PutTraceSegments(w http.ResponseWriter, r *http.Request) {
 	var req PutTraceSegmentsInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -40,7 +40,7 @@ func (s *Service) PutTraceSegments(w http.ResponseWriter, r *http.Request) {
 // GetTraceSummaries handles the GetTraceSummaries operation.
 func (s *Service) GetTraceSummaries(w http.ResponseWriter, r *http.Request) {
 	var req GetTraceSummariesInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -94,7 +94,7 @@ func (s *Service) GetTraceSummaries(w http.ResponseWriter, r *http.Request) {
 // BatchGetTraces handles the BatchGetTraces operation.
 func (s *Service) BatchGetTraces(w http.ResponseWriter, r *http.Request) {
 	var req BatchGetTracesInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -142,7 +142,7 @@ func (s *Service) BatchGetTraces(w http.ResponseWriter, r *http.Request) {
 // GetServiceGraph handles the GetServiceGraph operation.
 func (s *Service) GetServiceGraph(w http.ResponseWriter, r *http.Request) {
 	var req GetServiceGraphInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -171,7 +171,7 @@ func (s *Service) GetServiceGraph(w http.ResponseWriter, r *http.Request) {
 // CreateGroup handles the CreateGroup operation.
 func (s *Service) CreateGroup(w http.ResponseWriter, r *http.Request) {
 	var req CreateGroupInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -203,7 +203,7 @@ func (s *Service) CreateGroup(w http.ResponseWriter, r *http.Request) {
 // DeleteGroup handles the DeleteGroup operation.
 func (s *Service) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 	var req DeleteGroupInput
-	if err := readJSONRequest(r, &req); err != nil {
+	if err := service.ReadJSONRequest(r, &req); err != nil {
 		writeError(w, errInvalidRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -225,24 +225,6 @@ func (s *Service) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 }
 
 // Helper functions.
-
-// readJSONRequest reads and decodes JSON request body.
-func readJSONRequest(r *http.Request, v any) error {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read request body: %w", err)
-	}
-
-	if len(body) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(body, v); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return nil
-}
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {


### PR DESCRIPTION
## Summary

First Tier 2 cleanup (cross-cutting boilerplate). The identical 13-line `readJSONRequest` helper was copy-pasted **byte-for-byte across 26 JSON-protocol service packages**. This moves the single implementation to `service.ReadJSONRequest` and replaces the 26 local copies and their ~244 call sites with it.

- Adds `internal/service/request.go` with `ReadJSONRequest` (body unchanged) plus a unit test (valid / empty / invalid JSON).
- Deletes the 26 duplicate definitions and rewrites call sites to `service.ReadJSONRequest`.
- Net ~377 fewer lines.

No behavior change — the function body is identical, only its location changed.

## Test plan

- [x] `make lint` (0 issues)
- [x] `go test -race -shuffle=on ./...` (incl. the new helper test)
- [x] Full integration suite in **compare mode** (no `GOLDEN_UPDATE`): all golden files for every affected service unchanged