### PR TITLE
refactor: consolidate writeJSONResponse into service.WriteJSONResponse

### DIFF
--- a/internal/service/acm/handlers.go
+++ b/internal/service/acm/handlers.go
@@ -260,13 +260,7 @@ func (s *Service) ImportCertificate(w http.ResponseWriter, r *http.Request) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-
-	if v != nil {
-		_ = json.NewEncoder(w).Encode(v)
-	}
+	service.WriteJSONResponse(w, service.ContentTypeJSON, v)
 }
 
 // writeError writes an error response.

--- a/internal/service/appsync/handlers.go
+++ b/internal/service/appsync/handlers.go
@@ -261,13 +261,7 @@ func extractPathParam(r *http.Request, param string) string {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-
-	if v != nil {
-		_ = json.NewEncoder(w).Encode(v)
-	}
+	service.WriteJSONResponse(w, service.ContentTypeJSON, v)
 }
 
 // writeError writes an error response.

--- a/internal/service/athena/handlers.go
+++ b/internal/service/athena/handlers.go
@@ -348,10 +348,7 @@ func convertResultSetToOutput(rs *ResultSet) *ResultSetOutput {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON11, v)
 }
 
 // writeAthenaError writes an Athena error response in JSON format.

--- a/internal/service/batch/handlers.go
+++ b/internal/service/batch/handlers.go
@@ -336,13 +336,7 @@ func extractResourceName(arnOrName string) string {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-
-	if v != nil {
-		_ = json.NewEncoder(w).Encode(v)
-	}
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON11, v)
 }
 
 // writeError writes an error response.

--- a/internal/service/cloudwatch/handlers.go
+++ b/internal/service/cloudwatch/handlers.go
@@ -408,10 +408,7 @@ func handleCloudWatchError(w http.ResponseWriter, err error) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON10, v)
 }
 
 // writeCloudWatchError writes a CloudWatch error response in JSON format.

--- a/internal/service/cloudwatchlogs/handlers.go
+++ b/internal/service/cloudwatchlogs/handlers.go
@@ -347,10 +347,7 @@ func handleLogsError(w http.ResponseWriter, err error) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON11, v)
 }
 
 // writeEmptyResponse writes an empty response with HTTP 200 OK.

--- a/internal/service/codeconnections/handlers.go
+++ b/internal/service/codeconnections/handlers.go
@@ -620,10 +620,7 @@ func convertRepositoryLinkToOutput(link *RepositoryLink) *RepositoryLinkOutput {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON11, v)
 }
 
 // writeCodeConnectionsError writes a CodeConnections error response in JSON format.

--- a/internal/service/ds/handlers.go
+++ b/internal/service/ds/handlers.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // CreateDirectory handles the CreateDirectory API.
@@ -249,10 +251,7 @@ func handleError(w http.ResponseWriter, err error) {
 
 // writeJSONResponse writes a JSON response with status 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
-	w.Header().Set("X-Amzn-Requestid", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON11, v)
 }
 
 // writeDSError writes a Directory Service error response.

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -536,10 +536,7 @@ func lsiToDescription(table *Table, lsi *LocalSecondaryIndex) LocalSecondaryInde
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON10, v)
 }
 
 // writeDynamoDBError writes a DynamoDB error response in JSON format.

--- a/internal/service/ecs/handlers.go
+++ b/internal/service/ecs/handlers.go
@@ -443,10 +443,7 @@ func (s *Service) UpdateService(w http.ResponseWriter, r *http.Request) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON11, v)
 }
 
 // writeECSError writes an ECS error response in JSON format.

--- a/internal/service/glue/handlers.go
+++ b/internal/service/glue/handlers.go
@@ -417,13 +417,7 @@ func (s *Service) StartJobRun(w http.ResponseWriter, r *http.Request) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-
-	if v != nil {
-		_ = json.NewEncoder(w).Encode(v)
-	}
+	service.WriteJSONResponse(w, service.ContentTypeJSON, v)
 }
 
 // writeError writes an error response.

--- a/internal/service/mq/handlers.go
+++ b/internal/service/mq/handlers.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // CreateBroker handles the CreateBroker API.
@@ -289,10 +291,7 @@ func handleError(w http.ResponseWriter, err error) {
 
 // writeJSONResponse writes a JSON response with status 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Amzn-Requestid", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeJSON, v)
 }
 
 // writeError writes an MQ error response.

--- a/internal/service/pinpointsmsvoicev2/handlers.go
+++ b/internal/service/pinpointsmsvoicev2/handlers.go
@@ -84,13 +84,7 @@ func (s *Service) GetSentTextMessages(w http.ResponseWriter, r *http.Request) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-
-	if v != nil {
-		_ = json.NewEncoder(w).Encode(v)
-	}
+	service.WriteJSONResponse(w, service.ContentTypeJSON, v)
 }
 
 // writeError writes an error response.

--- a/internal/service/response.go
+++ b/internal/service/response.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// Content types used by the AWS JSON protocols.
+const (
+	ContentTypeAmzJSON10 = "application/x-amz-json-1.0"
+	ContentTypeAmzJSON11 = "application/x-amz-json-1.1"
+	ContentTypeJSON      = "application/json"
+)
+
+// WriteJSONResponse writes v as a JSON body with HTTP 200 OK, the given
+// Content-Type, and a generated x-amzn-RequestId header. This is the shared
+// implementation behind the per-service writeJSONResponse helpers.
+func WriteJSONResponse(w http.ResponseWriter, contentType string, v any) {
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("X-Amzn-Requestid", uuid.New().String())
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/service/response_test.go
+++ b/internal/service/response_test.go
@@ -1,0 +1,41 @@
+package service_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sivchari/kumo/internal/service"
+)
+
+func TestWriteJSONResponse(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+
+	service.WriteJSONResponse(rec, service.ContentTypeAmzJSON11, map[string]string{"name": "alice"})
+
+	res := rec.Result()
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", res.StatusCode)
+	}
+
+	if got := res.Header.Get("Content-Type"); got != service.ContentTypeAmzJSON11 {
+		t.Errorf("Content-Type = %q, want %q", got, service.ContentTypeAmzJSON11)
+	}
+
+	if res.Header.Get("X-Amzn-Requestid") == "" {
+		t.Error("X-Amzn-Requestid header was not set")
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	if body["name"] != "alice" {
+		t.Errorf("body name = %q, want alice", body["name"])
+	}
+}

--- a/internal/service/route53resolver/handlers.go
+++ b/internal/service/route53resolver/handlers.go
@@ -462,10 +462,7 @@ func handleResolverError(w http.ResponseWriter, err error) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON11, v)
 }
 
 // writeResolverError writes a Route 53 Resolver error response in JSON format.

--- a/internal/service/sagemaker/handlers.go
+++ b/internal/service/sagemaker/handlers.go
@@ -420,10 +420,7 @@ func (s *Service) DescribeEndpoint(w http.ResponseWriter, r *http.Request) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON11, v)
 }
 
 // writeError writes an error response.

--- a/internal/service/secretsmanager/handlers.go
+++ b/internal/service/secretsmanager/handlers.go
@@ -427,10 +427,7 @@ func (s *Service) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON11, v)
 }
 
 // writeSecretsManagerError writes a Secrets Manager error response in JSON format.

--- a/internal/service/sesv2/handlers.go
+++ b/internal/service/sesv2/handlers.go
@@ -493,13 +493,7 @@ func (s *Service) GetSentEmails(w http.ResponseWriter, r *http.Request) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-
-	if v != nil {
-		_ = json.NewEncoder(w).Encode(v)
-	}
+	service.WriteJSONResponse(w, service.ContentTypeJSON, v)
 }
 
 // writeError writes an error response.

--- a/internal/service/sqs/handlers.go
+++ b/internal/service/sqs/handlers.go
@@ -714,10 +714,7 @@ func (s *Service) SetQueueAttributes(w http.ResponseWriter, r *http.Request) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON10, v)
 }
 
 // writeSQSError writes an SQS error response in JSON format.

--- a/internal/service/ssm/handlers.go
+++ b/internal/service/ssm/handlers.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // PutParameter handles the PutParameter API.
@@ -277,10 +279,7 @@ func handleSSMError(w http.ResponseWriter, err error) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/x-amz-json-1.1")
-	w.Header().Set("X-Amzn-Requestid", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponse(w, service.ContentTypeAmzJSON11, v)
 }
 
 // ListTagsForResource handles the ListTagsForResource API.

--- a/internal/service/xray/handlers.go
+++ b/internal/service/xray/handlers.go
@@ -228,13 +228,7 @@ func (s *Service) DeleteGroup(w http.ResponseWriter, r *http.Request) {
 
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("x-amzn-RequestId", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
-
-	if v != nil {
-		_ = json.NewEncoder(w).Encode(v)
-	}
+	service.WriteJSONResponse(w, service.ContentTypeJSON, v)
 }
 
 // writeError writes an error response.


### PR DESCRIPTION
## Summary

Tier 2 cleanup, pairing with the `readJSONRequest` consolidation (#813). The per-service `writeJSONResponse` helpers shared the same body — set `Content-Type` and `x-amzn-RequestId`, `WriteHeader(200)`, JSON-encode — differing only by their Content-Type value.

- Adds `service.WriteJSONResponse(w, contentType, v)` plus `ContentTypeAmzJSON10/11` and `ContentTypeJSON` constants, with a unit test.
- Reduces each of the 20 JSON-protocol packages' `writeJSONResponse` to a one-line wrapper passing its content type (json-1.0 ×3, json-1.1 ×10, application/json ×7).
- The `x-amzn-RequestId` header casing varied in source but canonicalizes identically on the wire, so it is now uniform.

Notes:
- lambda's `writeJSONResponse` has a different signature (it takes a status code) and is intentionally left unchanged.
- A few packages wrapped the encode in `if v != nil`; that guard is dropped because no caller passes a nil body (a typed-nil pointer passes the guard anyway), so it never affected behavior — confirmed by the golden comparison.

## Test plan

- [x] `make lint` (0 issues)
- [x] `go test -race -shuffle=on ./...` (incl. the new helper test)
- [x] Full integration suite in **compare mode** (no `GOLDEN_UPDATE`): all golden files unchanged