### PR TITLE
refactor: share identical ServiceError via service.CodedError alias

### DIFF
--- a/internal/service/apigateway/types.go
+++ b/internal/service/apigateway/types.go
@@ -1,6 +1,10 @@
 package apigateway
 
-import "time"
+import (
+	"time"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // RestAPI represents an API Gateway REST API.
 type RestAPI struct {
@@ -228,12 +232,4 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError

--- a/internal/service/apigatewayv2/types.go
+++ b/internal/service/apigatewayv2/types.go
@@ -1,6 +1,10 @@
 package apigatewayv2
 
-import "time"
+import (
+	"time"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // API represents an API Gateway v2 API (HTTP or WebSocket).
 type API struct {
@@ -308,12 +312,4 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a service error with an AWS error code.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError

--- a/internal/service/athena/types.go
+++ b/internal/service/athena/types.go
@@ -2,6 +2,8 @@ package athena
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // QueryExecutionState represents the state of a query execution.
@@ -399,12 +401,4 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents an Athena service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError

--- a/internal/service/ce/types.go
+++ b/internal/service/ce/types.go
@@ -1,5 +1,7 @@
 package ce
 
+import "github.com/sivchari/kumo/internal/service"
+
 // DateInterval represents a time period.
 type DateInterval struct {
 	Start string `json:"Start"`
@@ -281,15 +283,7 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError
 
 // Error codes.
 const (

--- a/internal/service/codeconnections/types.go
+++ b/internal/service/codeconnections/types.go
@@ -2,6 +2,8 @@ package codeconnections
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // ConnectionStatus represents the status of a connection.
@@ -322,12 +324,4 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a CodeConnections service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError

--- a/internal/service/cognito/types.go
+++ b/internal/service/cognito/types.go
@@ -2,6 +2,8 @@ package cognito
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // UserPoolStatus represents the status of a user pool.
@@ -627,15 +629,7 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a Cognito service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError
 
 // MfaConfig represents the stored MFA configuration for a user pool.
 type MfaConfig struct {

--- a/internal/service/ebs/storage.go
+++ b/internal/service/ebs/storage.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/sivchari/kumo/internal/service"
 	"github.com/sivchari/kumo/internal/storage"
 )
 
@@ -22,14 +23,7 @@ const (
 )
 
 // ServiceError represents an EBS service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-func (e *ServiceError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Code, e.Message)
-}
+type ServiceError = service.CodedError
 
 // Storage defines the EBS storage interface.
 type Storage interface {

--- a/internal/service/ecr/types.go
+++ b/internal/service/ecr/types.go
@@ -1,6 +1,10 @@
 package ecr
 
-import "time"
+import (
+	"time"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // Repository represents an ECR repository.
 type Repository struct {
@@ -253,12 +257,4 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a service-level error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError

--- a/internal/service/elasticbeanstalk/storage.go
+++ b/internal/service/elasticbeanstalk/storage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/sivchari/kumo/internal/service"
 	"github.com/sivchari/kumo/internal/storage"
 )
 
@@ -23,14 +24,7 @@ const (
 )
 
 // ServiceError represents an Elastic Beanstalk service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-func (e *ServiceError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Code, e.Message)
-}
+type ServiceError = service.CodedError
 
 // Storage defines the Elastic Beanstalk storage interface.
 type Storage interface {

--- a/internal/service/error.go
+++ b/internal/service/error.go
@@ -1,0 +1,13 @@
+package service
+
+// CodedError is an AWS-style error carrying an error code and message. Its
+// Error string is the message. Service packages alias their local ServiceError
+// to this type to share the single definition.
+type CodedError struct {
+	Code    string
+	Message string
+}
+
+func (e *CodedError) Error() string {
+	return e.Message
+}

--- a/internal/service/error_test.go
+++ b/internal/service/error_test.go
@@ -1,0 +1,27 @@
+package service_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sivchari/kumo/internal/service"
+)
+
+func TestCodedError(t *testing.T) {
+	t.Parallel()
+
+	err := error(&service.CodedError{Code: "ValidationException", Message: "bad input"})
+
+	if err.Error() != "bad input" {
+		t.Errorf("Error() = %q, want %q", err.Error(), "bad input")
+	}
+
+	var ce *service.CodedError
+	if !errors.As(err, &ce) {
+		t.Fatal("errors.As failed to match *CodedError")
+	}
+
+	if ce.Code != "ValidationException" {
+		t.Errorf("Code = %q, want ValidationException", ce.Code)
+	}
+}

--- a/internal/service/eventbridge/types.go
+++ b/internal/service/eventbridge/types.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math"
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // EventBusState represents the state of an event bus.
@@ -530,15 +532,7 @@ type HTTPParameters struct {
 }
 
 // ServiceError represents a service-level error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError
 
 // Tag represents an EventBridge resource tag.
 type Tag struct {

--- a/internal/service/glacier/storage.go
+++ b/internal/service/glacier/storage.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sivchari/kumo/internal/service"
 	"github.com/sivchari/kumo/internal/storage"
 )
 
@@ -18,14 +19,7 @@ const (
 )
 
 // ServiceError represents a Glacier service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-func (e *ServiceError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Code, e.Message)
-}
+type ServiceError = service.CodedError
 
 // Storage defines the Glacier storage interface.
 type Storage interface {

--- a/internal/service/globalaccelerator/types.go
+++ b/internal/service/globalaccelerator/types.go
@@ -2,6 +2,8 @@ package globalaccelerator
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // AcceleratorStatus represents the status of an accelerator.
@@ -428,12 +430,4 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a Global Accelerator service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError

--- a/internal/service/kinesis/types.go
+++ b/internal/service/kinesis/types.go
@@ -1,6 +1,10 @@
 package kinesis
 
-import "time"
+import (
+	"time"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // StreamStatus represents the status of a Kinesis stream.
 type StreamStatus string
@@ -314,12 +318,4 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a service-level error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError

--- a/internal/service/kms/types.go
+++ b/internal/service/kms/types.go
@@ -2,6 +2,8 @@ package kms
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // KeyState represents the state of a KMS key.
@@ -377,15 +379,7 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a KMS service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError
 
 // GetKeyPolicyRequest is the request for GetKeyPolicy.
 type GetKeyPolicyRequest struct {

--- a/internal/service/memorydb/storage.go
+++ b/internal/service/memorydb/storage.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/sivchari/kumo/internal/service"
 	"github.com/sivchari/kumo/internal/storage"
 )
 
@@ -15,14 +16,7 @@ const (
 )
 
 // ServiceError represents a MemoryDB service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-func (e *ServiceError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Code, e.Message)
-}
+type ServiceError = service.CodedError
 
 const (
 	errClusterNotFound = "ClusterNotFoundFault"

--- a/internal/service/rekognition/types.go
+++ b/internal/service/rekognition/types.go
@@ -1,6 +1,8 @@
 // Package rekognition provides AWS Rekognition service emulation.
 package rekognition
 
+import "github.com/sivchari/kumo/internal/service"
+
 // Image represents an image for Rekognition operations.
 type Image struct {
 	Bytes    []byte    `json:"Bytes,omitempty"`
@@ -477,16 +479,9 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a service error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
+type ServiceError = service.CodedError
 
 // Error returns the error message.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
-
 // Error codes.
 const (
 	errResourceNotFound      = "ResourceNotFoundException"

--- a/internal/service/sfn/types.go
+++ b/internal/service/sfn/types.go
@@ -1,6 +1,10 @@
 package sfn
 
-import "time"
+import (
+	"time"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // StateMachineStatus represents the status of a state machine.
 type StateMachineStatus string
@@ -346,15 +350,7 @@ type ErrorResponse struct {
 }
 
 // ServiceError represents a service-level error.
-type ServiceError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ServiceError) Error() string {
-	return e.Message
-}
+type ServiceError = service.CodedError
 
 // ListTagsForResourceRequest is the request for ListTagsForResource.
 type ListTagsForResourceRequest struct {


### PR DESCRIPTION
## Summary

Tier 2 cleanup (#3). 17 of the 18 service packages defined a `ServiceError` struct with `{Code, Message string}` fields. This adds `service.CodedError` and replaces those 17 with a type alias `type ServiceError = service.CodedError`.

Because it is an alias (identical type), every existing `&ServiceError{...}` construction, `errors.As(err, &se)` check, and field access keeps compiling and behaving the same.

- **13 packages** had `Error()` returning the message verbatim — directly equivalent to `CodedError`.
- **4 packages** (ebs, elasticbeanstalk, glacier, memorydb) formatted `Error()` as `"code: message"`. That string is internal only: handlers write `svcErr.Code`/`svcErr.Message` to the response separately, so `Error()` never reaches the wire for a matched `ServiceError`. Aliasing normalizes the internal string to the message with **no change to any AWS-facing response** (verified via the integration golden files).
- **amplify is left unchanged**: its `ServiceError` carries an extra `Status int` field (used to set the HTTP status), so it is structurally different from `CodedError`.

Adds a unit test for `CodedError`.

## Test plan

- [x] `make lint` (0 issues)
- [x] `go test -race -shuffle=on ./...` (incl. the new test)
- [x] Full integration suite in **compare mode** (no `GOLDEN_UPDATE`): all golden files unchanged