### PR TITLE
fix(eventbridge): expand InvocationEndpoint path parameters on API destination delivery

### DIFF
--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -834,7 +835,7 @@ func (s *MemoryStorage) deliverToHTTP(dest *APIDestination, target *Target, payl
 		return
 	}
 
-	endpoint := dest.InvocationEndpoint
+	endpoint := expandEndpointPathParameters(dest.InvocationEndpoint, target.HTTPParameters)
 	method := dest.HTTPMethod
 
 	if method == "" {
@@ -971,6 +972,22 @@ func (s *MemoryStorage) deliverToLambda(target *Target, payload []byte) {
 		"function", functionName,
 		"status", resp.StatusCode,
 	)
+}
+
+// expandEndpointPathParameters replaces each "*" wildcard in the invocation
+// endpoint with the corresponding value from PathParameterValues, in order.
+// AWS EventBridge substitutes path parameters into the endpoint at delivery
+// time; without this, the literal "*" would be sent and the target would 404.
+func expandEndpointPathParameters(endpoint string, params *HTTPParameters) string {
+	if params == nil {
+		return endpoint
+	}
+
+	for _, value := range params.PathParameterValues {
+		endpoint = strings.Replace(endpoint, "*", url.PathEscape(value), 1)
+	}
+
+	return endpoint
 }
 
 // applyHTTPParameters applies HTTP parameters from a target to an HTTP request.

--- a/internal/service/eventbridge/storage_test.go
+++ b/internal/service/eventbridge/storage_test.go
@@ -492,3 +492,93 @@ func TestPutEvents_APIDestinationCrossRegion(t *testing.T) {
 		t.Fatal("did not receive dispatched event within timeout (silent drop)")
 	}
 }
+
+// TestPutEvents_APIDestinationPathParameters verifies that "*" wildcards in an
+// API destination's InvocationEndpoint are substituted with the target's
+// PathParameterValues, in order, at delivery time. AWS EventBridge expands
+// path parameters into the endpoint; without it the literal "*" is sent and the
+// target returns 404.
+//
+//nolint:funlen // End-to-end test with setup, dispatch, and assertion.
+func TestPutEvents_APIDestinationPathParameters(t *testing.T) {
+	t.Parallel()
+
+	received := make(chan string, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case received <- r.URL.Path:
+		default:
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	s := NewMemoryStorage()
+	ctx := context.Background()
+
+	conn, err := s.CreateConnection(ctx, &CreateConnectionRequest{
+		Name:              "test-conn",
+		AuthorizationType: "API_KEY",
+		AuthParameters: AuthParameters{
+			APIKeyAuthParameters: &APIKeyAuthParameters{
+				APIKeyName:  "X-Api-Key",
+				APIKeyValue: "secret",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateConnection: %v", err)
+	}
+
+	dest, err := s.CreateAPIDestination(ctx, &CreateAPIDestinationRequest{
+		Name:               "test-dest",
+		ConnectionArn:      conn.Arn,
+		InvocationEndpoint: server.URL + "/webhook/events/*/*",
+		HTTPMethod:         http.MethodPost,
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIDestination: %v", err)
+	}
+
+	if _, err := s.PutRule(ctx, &PutRuleRequest{
+		Name:         "test-rule",
+		EventPattern: `{"source":["my.test"]}`,
+		State:        "ENABLED",
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := s.PutTargets(ctx, "", "test-rule", []TargetInput{
+		{
+			ID:  "target-1",
+			Arn: dest.Arn,
+			HTTPParameters: &HTTPParameters{
+				PathParameterValues: []string{
+					"bpo.v1.DocumentReceiverService",
+					"SubscribeSendGridInboundParseWebhook",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := s.PutEvents(ctx, []PutEventsRequestEntry{
+		{Source: "my.test", DetailType: "TestEvent", Detail: `{"hello":"world"}`},
+	}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	const wantPath = "/webhook/events/bpo.v1.DocumentReceiverService/SubscribeSendGridInboundParseWebhook"
+
+	select {
+	case gotPath := <-received:
+		if gotPath != wantPath {
+			t.Errorf("request path = %q, want %q", gotPath, wantPath)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive dispatched event within timeout")
+	}
+}


### PR DESCRIPTION
## Summary
API Destination delivery sent the literal `InvocationEndpoint`, so `*` wildcards were never replaced by the target's `PathParameterValues` and the endpoint received a 404. Now the endpoint is expanded before the request is built, substituting each `*` in order with the URL-escaped path parameter value, matching AWS behavior.

Header and query parameters are unchanged.