### PR TITLE
fix(json): emit lowercase "message" in error responses for 4 services

### DIFF
--- a/internal/service/athena/types.go
+++ b/internal/service/athena/types.go
@@ -397,7 +397,7 @@ type DeleteWorkGroupResponse struct{}
 // ErrorResponse represents an Athena error response.
 type ErrorResponse struct {
 	Type    string `json:"__type"`
-	Message string `json:"Message"`
+	Message string `json:"message"`
 }
 
 // ServiceError represents an Athena service error.

--- a/internal/service/codeconnections/types.go
+++ b/internal/service/codeconnections/types.go
@@ -320,7 +320,7 @@ type UntagResourceResponse struct{}
 // ErrorResponse represents a CodeConnections error response.
 type ErrorResponse struct {
 	Type    string `json:"__type"`
-	Message string `json:"Message"`
+	Message string `json:"message"`
 }
 
 // ServiceError represents a CodeConnections service error.

--- a/internal/service/route53resolver/types.go
+++ b/internal/service/route53resolver/types.go
@@ -280,7 +280,7 @@ type ListResolverRuleAssociationsResponse struct {
 // ErrorResponse represents a Route 53 Resolver error response.
 type ErrorResponse struct {
 	Type    string `json:"__type"`
-	Message string `json:"Message"`
+	Message string `json:"message"`
 }
 
 // ResolverError represents a Route 53 Resolver error.

--- a/internal/service/secretsmanager/types.go
+++ b/internal/service/secretsmanager/types.go
@@ -252,7 +252,7 @@ type GetRandomPasswordResponse struct {
 // ErrorResponse represents a Secrets Manager error response.
 type ErrorResponse struct {
 	Type    string `json:"__type"`
-	Message string `json:"Message"`
+	Message string `json:"message"`
 }
 
 // SecretError represents a Secrets Manager error.


### PR DESCRIPTION
## Summary

Found while consolidating the JSON error writers (#818): athena, codeconnections, route53resolver, and secretsmanager serialized their JSON-protocol error body with a capitalized `"Message"` key, diverging from the AWS convention (lowercase `"message"`) that the other 25 JSON-protocol services in kumo already use.

This corrects the json tag from `"Message"` to `"message"` in those four `ErrorResponse` types.

## Impact

- The AWS SDKs accept both casings, so SDK-based clients and the integration golden files are unaffected (golden compare is unchanged).
- The fix matters for raw HTTP clients that read the error body directly and expect the AWS-standard lowercase `message` key.

## Test plan

- [x] `make lint` (0 issues)
- [x] `go test -race -shuffle=on ./...`
- [x] Integration suite for the four services in compare mode (`-count=1`): golden files unchanged (confirming SDK clients are unaffected)