### PR TITLE
fix(s3): externalize object bodies from snapshot to bound persistence memory

### DIFF
--- a/internal/service/s3/blob.go
+++ b/internal/service/s3/blob.go
@@ -1,0 +1,99 @@
+package s3
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// objectsDir is the sub-directory under the data directory that holds object
+// bodies as individual content-addressed blob files. Separating bodies from the
+// metadata snapshot (s3.json) keeps the snapshot small: persisting the whole
+// store no longer marshals every body into one JSON document (which spiked RSS
+// to 2-3x the data size via base64 expansion and transient buffers, driving the
+// process into the OOM killer). Bodies are written as plain bytes, one file per
+// distinct content.
+const objectsDir = "s3-objects"
+
+// bodyRefOf returns the content-address (sha256 hex) used as the blob filename
+// for the given body. Content addressing means identical bodies (object
+// versions, server-side copies) share a single blob file on disk.
+func bodyRefOf(data []byte) string {
+	sum := sha256.Sum256(data)
+
+	return hex.EncodeToString(sum[:])
+}
+
+// blobPath returns the on-disk path of the blob identified by ref.
+func blobPath(dataDir, ref string) string {
+	return filepath.Join(dataDir, objectsDir, ref)
+}
+
+// writeBlob persists data as the blob identified by ref, creating the objects
+// directory if needed. It is idempotent: because ref is the content hash, an
+// existing file already holds identical bytes, so the write is skipped. The
+// write is atomic (tmp + rename) so a crash mid-write never leaves a partial
+// blob that a later load would read as a corrupt body.
+func writeBlob(dataDir, ref string, data []byte) error {
+	path := blobPath(dataDir, ref)
+
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+
+	dir := filepath.Join(dataDir, objectsDir)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("failed to create objects directory %s: %w", dir, err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write temporary blob %s: %w", tmp, err)
+	}
+
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("failed to rename blob %s to %s: %w", tmp, path, err)
+	}
+
+	return nil
+}
+
+// readBlob loads the body identified by ref from disk.
+func readBlob(dataDir, ref string) ([]byte, error) {
+	path := blobPath(dataDir, ref)
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read blob %s: %w", path, err)
+	}
+
+	return data, nil
+}
+
+// gcBlobs removes blob files no longer referenced by any object. It is
+// best-effort: a removal failure is ignored so a transient FS error never fails
+// a snapshot. referenced holds every live bodyRef; any other file in the objects
+// directory is an orphan from an overwritten or deleted object.
+func gcBlobs(dataDir string, referenced map[string]struct{}) {
+	dir := filepath.Join(dataDir, objectsDir)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+
+		name := e.Name()
+		if _, ok := referenced[name]; ok {
+			continue
+		}
+
+		_ = os.Remove(filepath.Join(dir, name))
+	}
+}

--- a/internal/service/s3/blob_test.go
+++ b/internal/service/s3/blob_test.go
@@ -1,0 +1,191 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// saveAndReload closes the storage (a synchronous, authoritative save) and
+// returns a fresh storage loaded from the same directory.
+func saveAndReload(t *testing.T, s *MemoryStorage, dir string) *MemoryStorage {
+	t.Helper()
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	return NewMemoryStorage(WithDataDir(dir))
+}
+
+func TestMemoryStorage_BodyBlobRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	body := []byte("hello world")
+
+	s := NewMemoryStorage(WithDataDir(dir))
+	if err := s.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	if _, err := s.PutObject(ctx, "b", "k", bytes.NewReader(body), nil); err != nil {
+		t.Fatalf("put object: %v", err)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// The snapshot must not carry the body inline; only a content reference.
+	snapshot, err := os.ReadFile(filepath.Join(dir, "s3.json")) //nolint:gosec // fixed name under t.TempDir
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+
+	if bytes.Contains(snapshot, body) {
+		t.Errorf("snapshot contains raw body; body was not externalized")
+	}
+
+	if !bytes.Contains(snapshot, []byte("bodyRef")) {
+		t.Errorf("snapshot missing bodyRef reference")
+	}
+
+	// The body lives in its own blob file, addressed by content hash.
+	ref := bodyRefOf(body)
+	if _, err := os.Stat(blobPath(dir, ref)); err != nil {
+		t.Errorf("blob file missing for ref %s: %v", ref, err)
+	}
+
+	// A fresh load reconstructs the body from the blob.
+	s2 := NewMemoryStorage(WithDataDir(dir))
+
+	obj, err := s2.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("get object after reload: %v", err)
+	}
+
+	if !bytes.Equal(obj.Body, body) {
+		t.Errorf("body after reload = %q, want %q", obj.Body, body)
+	}
+}
+
+func TestMemoryStorage_VersionedBodiesRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	s := NewMemoryStorage(WithDataDir(dir))
+	if err := s.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	if err := s.PutBucketVersioning(ctx, "b", VersioningEnabled); err != nil {
+		t.Fatalf("enable versioning: %v", err)
+	}
+
+	if _, err := s.PutObject(ctx, "b", "k", bytes.NewReader([]byte("v1-body")), nil); err != nil {
+		t.Fatalf("put v1: %v", err)
+	}
+
+	if _, err := s.PutObject(ctx, "b", "k", bytes.NewReader([]byte("v2-body")), nil); err != nil {
+		t.Fatalf("put v2: %v", err)
+	}
+
+	s2 := saveAndReload(t, s, dir)
+
+	current, err := s2.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("get current: %v", err)
+	}
+
+	if got := string(current.Body); got != "v2-body" {
+		t.Errorf("current body = %q, want %q", got, "v2-body")
+	}
+
+	v1, err := s2.GetObjectVersion(ctx, "b", "k", "v1")
+	if err != nil {
+		t.Fatalf("get v1: %v", err)
+	}
+
+	if got := string(v1.Body); got != "v1-body" {
+		t.Errorf("v1 body = %q, want %q", got, "v1-body")
+	}
+}
+
+func TestMemoryStorage_LegacyInlineBodyMigrates(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// A snapshot written by an older kumo: the body is inline base64 ("hello"
+	// == aGVsbG8=) and there is no bodyRef and no blob directory.
+	legacy := `{"buckets":{"b":{"name":"b","creationDate":"2020-01-01T00:00:00Z",` +
+		`"objects":{"k":{"Key":"k","Body":"aGVsbG8=","ETag":"\"x\"","Size":5}},"versions":{}}}}`
+	if err := os.WriteFile(filepath.Join(dir, "s3.json"), []byte(legacy), 0o600); err != nil {
+		t.Fatalf("write legacy snapshot: %v", err)
+	}
+
+	s := NewMemoryStorage(WithDataDir(dir))
+
+	obj, err := s.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("get object from legacy snapshot: %v", err)
+	}
+
+	if got := string(obj.Body); got != "hello" {
+		t.Fatalf("legacy body = %q, want %q", got, "hello")
+	}
+
+	// On the next save the inline body is migrated to a blob.
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if _, err := os.Stat(blobPath(dir, bodyRefOf([]byte("hello")))); err != nil {
+		t.Errorf("body not migrated to blob: %v", err)
+	}
+}
+
+func TestMemoryStorage_OrphanBlobGarbageCollected(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	s := NewMemoryStorage(WithDataDir(dir))
+	if err := s.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	// First body, persisted.
+	old := []byte("old-body")
+	if _, err := s.PutObject(ctx, "b", "k", bytes.NewReader(old), nil); err != nil {
+		t.Fatalf("put old: %v", err)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("close after old: %v", err)
+	}
+
+	if _, err := os.Stat(blobPath(dir, bodyRefOf(old))); err != nil {
+		t.Fatalf("old blob missing before overwrite: %v", err)
+	}
+
+	// Overwrite the key (no versioning): the old body becomes unreferenced.
+	s2 := NewMemoryStorage(WithDataDir(dir))
+
+	newBody := []byte("new-body")
+	if _, err := s2.PutObject(ctx, "b", "k", bytes.NewReader(newBody), nil); err != nil {
+		t.Fatalf("put new: %v", err)
+	}
+
+	if err := s2.Close(); err != nil {
+		t.Fatalf("close after new: %v", err)
+	}
+
+	if _, err := os.Stat(blobPath(dir, bodyRefOf(old))); !os.IsNotExist(err) {
+		t.Errorf("orphan blob not garbage collected (err=%v)", err)
+	}
+
+	if _, err := os.Stat(blobPath(dir, bodyRefOf(newBody))); err != nil {
+		t.Errorf("new blob missing after overwrite: %v", err)
+	}
+}

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -186,10 +186,21 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	return s
 }
 
-// MarshalJSON serializes the storage state to JSON.
+// MarshalJSON serializes the storage metadata to JSON. Object bodies are NOT
+// inlined: when persistence is enabled they are written to the blob store first
+// and the snapshot carries only a content reference per object (see blob.go and
+// Object.MarshalJSON). This keeps the whole-store marshal small and bounds its
+// peak memory, which is what stops the snapshot path from driving the process
+// into the OOM killer as the dataset grows.
 func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+
+	if s.dataDir != "" {
+		if err := s.persistBodiesLocked(); err != nil {
+			return nil, err
+		}
+	}
 
 	type Alias MemoryStorage
 
@@ -201,7 +212,8 @@ func (s *MemoryStorage) MarshalJSON() ([]byte, error) {
 	return data, nil
 }
 
-// UnmarshalJSON restores the storage state from JSON.
+// UnmarshalJSON restores the storage metadata from JSON and, when persistence is
+// enabled, fills each object body from the blob store.
 func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -217,6 +229,103 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 	if s.Buckets == nil {
 		s.Buckets = make(map[string]*MemoryBucket)
 	}
+
+	if s.dataDir != "" {
+		if err := s.loadBodiesLocked(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// persistBodiesLocked writes every object body to the blob store and prunes
+// orphaned blobs. The caller must hold at least the read lock; bodies are only
+// read (never mutated), so snapshotting never blocks concurrent reads.
+func (s *MemoryStorage) persistBodiesLocked() error {
+	referenced := make(map[string]struct{})
+
+	for _, b := range s.Buckets {
+		for _, obj := range b.Objects {
+			if err := s.persistObjectBody(obj, referenced); err != nil {
+				return err
+			}
+		}
+
+		for _, versions := range b.Versions {
+			for _, obj := range versions {
+				if err := s.persistObjectBody(obj, referenced); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	gcBlobs(s.dataDir, referenced)
+
+	return nil
+}
+
+// persistObjectBody writes one object's body to the blob store, recording its
+// reference in referenced (the live set used to GC orphans). Empty bodies carry
+// no blob: an empty or delete-marker object round-trips with a nil body.
+func (s *MemoryStorage) persistObjectBody(obj *Object, referenced map[string]struct{}) error {
+	if len(obj.Body) == 0 {
+		return nil
+	}
+
+	ref := obj.effectiveRef()
+	referenced[ref] = struct{}{}
+
+	return writeBlob(s.dataDir, ref, obj.Body)
+}
+
+// loadBodiesLocked fills each object's body from the blob store. The caller must
+// hold the write lock.
+func (s *MemoryStorage) loadBodiesLocked() error {
+	for _, b := range s.Buckets {
+		for _, obj := range b.Objects {
+			if err := s.loadObjectBody(obj); err != nil {
+				return err
+			}
+		}
+
+		for _, versions := range b.Versions {
+			for _, obj := range versions {
+				if err := s.loadObjectBody(obj); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// loadObjectBody populates one object's body from its blob. An object carrying a
+// legacy inline body (bodyRef empty, Body already set by an older snapshot) is
+// left untouched and gets a freshly computed ref so the next save migrates it to
+// a blob. The current-version object is shared by pointer between Objects and
+// Versions, so this may be called twice on it; the second call is a no-op.
+func (s *MemoryStorage) loadObjectBody(obj *Object) error {
+	if obj.bodyRef == "" {
+		if len(obj.Body) > 0 {
+			obj.bodyRef = bodyRefOf(obj.Body)
+		}
+
+		return nil
+	}
+
+	if len(obj.Body) > 0 {
+		return nil
+	}
+
+	data, err := readBlob(s.dataDir, obj.bodyRef)
+	if err != nil {
+		return err
+	}
+
+	obj.Body = data
 
 	return nil
 }
@@ -338,6 +447,7 @@ func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io
 	obj := &Object{
 		Key:          key,
 		Body:         data,
+		bodyRef:      bodyRefOf(data),
 		ETag:         fmt.Sprintf("%q", etag),
 		Size:         int64(len(data)),
 		LastModified: time.Now(),
@@ -1100,6 +1210,7 @@ func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, 
 	obj := &Object{
 		Key:          key,
 		Body:         combinedBody,
+		bodyRef:      bodyRefOf(combinedBody),
 		ETag:         etag,
 		Size:         int64(len(combinedBody)),
 		LastModified: time.Now(),

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -2,7 +2,9 @@
 package s3
 
 import (
+	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"time"
 )
 
@@ -43,6 +45,75 @@ type Object struct {
 	IsDeleteMarker       bool
 	ServerSideEncryption string
 	SSEKMSKeyID          string
+
+	// bodyRef is the content-address of Body in the on-disk blob store. It is
+	// computed once when the object is created (or loaded) and is persistence
+	// metadata only: it is never read on the request path. Keeping it on the
+	// object lets the snapshot emit a reference instead of the raw body, so the
+	// whole-store marshal no longer carries every body inline.
+	bodyRef string
+}
+
+// effectiveRef returns the blob content-address for this object's body, falling
+// back to hashing the body if bodyRef was not pre-computed (e.g. an object
+// loaded from a legacy inline snapshot before its first re-save). It is a pure
+// read, safe to call while only holding the storage read lock.
+func (o *Object) effectiveRef() string {
+	if o.bodyRef != "" {
+		return o.bodyRef
+	}
+
+	if len(o.Body) == 0 {
+		return ""
+	}
+
+	return bodyRefOf(o.Body)
+}
+
+// MarshalJSON serializes the object for the metadata snapshot, dropping the raw
+// Body and emitting a content reference (bodyRef) instead. The body itself is
+// persisted separately as a blob file (see blob.go); excluding it here is what
+// keeps the whole-store snapshot small and bounds its peak memory.
+func (o *Object) MarshalJSON() ([]byte, error) {
+	type alias Object
+
+	data, err := json.Marshal(&struct {
+		*alias
+		Body    []byte `json:"-"`
+		BodyRef string `json:"bodyRef,omitempty"`
+	}{
+		alias:   (*alias)(o),
+		BodyRef: o.effectiveRef(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal object: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalJSON restores an object from the metadata snapshot. It reads the
+// content reference (bodyRef) into the unexported field; the body is filled
+// from the blob store afterwards by MemoryStorage.UnmarshalJSON. For backward
+// compatibility it also accepts a legacy inline Body (base64) written by older
+// snapshots, which is migrated to a blob on the next save.
+func (o *Object) UnmarshalJSON(data []byte) error {
+	type alias Object
+
+	aux := &struct {
+		*alias
+		Body    []byte `json:"Body"` //nolint:tagliatelle // legacy snapshots wrote the body under the PascalCase "Body" key
+		BodyRef string `json:"bodyRef"`
+	}{alias: (*alias)(o)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return fmt.Errorf("failed to unmarshal object: %w", err)
+	}
+
+	o.Body = aux.Body
+	o.bodyRef = aux.BodyRef
+
+	return nil
 }
 
 // Tagging represents the XML structure for S3 object tagging.


### PR DESCRIPTION
## Summary
Persisting S3 state with `KUMO_DATA_DIR` marshaled every object body into one JSON snapshot, spiking memory to 2-3x the data size (base64 + transient buffers) on every save/load and triggering the OOM killer as data grew. Object bodies now live in individual content-addressed blob files (`s3-objects/<sha256>`); the snapshot keeps only a per-object reference.

The in-memory model and request path are unchanged, so API responses and golden tests are unaffected. Legacy inline-body snapshots still load and migrate to blobs on the next save, and orphaned blobs are GC'd on save.

## Test plan
- [ ] `go test -race -shuffle=on ./internal/service/s3/...` (incl. new blob round-trip / legacy migration / versioned bodies / GC unit tests)
- [ ] S3 integration golden tests pass unchanged
- [ ] With `KUMO_DATA_DIR` set: snapshot no longer contains raw bodies; put/restart/get round-trips