### PR TITLE
feat(logs): persist log group tags

### DIFF
--- a/internal/service/cloudwatchlogs/handlers.go
+++ b/internal/service/cloudwatchlogs/handlers.go
@@ -292,6 +292,116 @@ func (s *Service) DeleteRetentionPolicy(w http.ResponseWriter, r *http.Request) 
 	writeEmptyResponse(w)
 }
 
+// ListTagsLogGroup handles the ListTagsLogGroup action.
+func (s *Service) ListTagsLogGroup(w http.ResponseWriter, r *http.Request) {
+	var req ListTagsLogGroupRequest
+	if err := service.ReadJSONRequest(r, &req); err != nil {
+		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	tags, err := s.storage.ListTags(r.Context(), req.LogGroupName)
+	if err != nil {
+		handleLogsError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, TagsResponse{Tags: tags})
+}
+
+// ListTagsForResource handles the ListTagsForResource action.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
+	var req ListTagsForResourceRequest
+	if err := service.ReadJSONRequest(r, &req); err != nil {
+		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	tags, err := s.storage.ListTags(r.Context(), req.ResourceARN)
+	if err != nil {
+		handleLogsError(w, err)
+
+		return
+	}
+
+	writeJSONResponse(w, TagsResponse{Tags: tags})
+}
+
+// TagLogGroup handles the TagLogGroup action.
+func (s *Service) TagLogGroup(w http.ResponseWriter, r *http.Request) {
+	var req TagLogGroupRequest
+	if err := service.ReadJSONRequest(r, &req); err != nil {
+		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.Tag(r.Context(), req.LogGroupName, req.Tags); err != nil {
+		handleLogsError(w, err)
+
+		return
+	}
+
+	writeEmptyResponse(w)
+}
+
+// TagResource handles the TagResource action.
+func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
+	var req TagResourceRequest
+	if err := service.ReadJSONRequest(r, &req); err != nil {
+		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.Tag(r.Context(), req.ResourceARN, req.Tags); err != nil {
+		handleLogsError(w, err)
+
+		return
+	}
+
+	writeEmptyResponse(w)
+}
+
+// UntagLogGroup handles the UntagLogGroup action.
+func (s *Service) UntagLogGroup(w http.ResponseWriter, r *http.Request) {
+	var req UntagLogGroupRequest
+	if err := service.ReadJSONRequest(r, &req); err != nil {
+		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.Untag(r.Context(), req.LogGroupName, req.Tags); err != nil {
+		handleLogsError(w, err)
+
+		return
+	}
+
+	writeEmptyResponse(w)
+}
+
+// UntagResource handles the UntagResource action.
+func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
+	var req UntagResourceRequest
+	if err := service.ReadJSONRequest(r, &req); err != nil {
+		writeLogsError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.Untag(r.Context(), req.ResourceARN, req.TagKeys); err != nil {
+		handleLogsError(w, err)
+
+		return
+	}
+
+	writeEmptyResponse(w)
+}
+
 // DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.
 // This method implements the JSONProtocolService interface.
 func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
@@ -321,12 +431,18 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 		s.PutRetentionPolicy(w, r)
 	case "DeleteRetentionPolicy":
 		s.DeleteRetentionPolicy(w, r)
-	case "ListTagsForResource", "ListTagsLogGroup",
-		"TagResource", "UntagResource",
-		"TagLogGroup", "UntagLogGroup":
-		// Tags are not modeled; respond as no-op so AWS SDK clients
-		// reading state after CreateLogGroup do not see InvalidAction.
-		writeEmptyResponse(w)
+	case "ListTagsForResource":
+		s.ListTagsForResource(w, r)
+	case "ListTagsLogGroup":
+		s.ListTagsLogGroup(w, r)
+	case "TagResource":
+		s.TagResource(w, r)
+	case "UntagResource":
+		s.UntagResource(w, r)
+	case "TagLogGroup":
+		s.TagLogGroup(w, r)
+	case "UntagLogGroup":
+		s.UntagLogGroup(w, r)
 	default:
 		writeLogsError(w, errInvalidAction, "The action "+action+" is not valid for this web service", http.StatusBadRequest)
 	}

--- a/internal/service/cloudwatchlogs/handlers.go
+++ b/internal/service/cloudwatchlogs/handlers.go
@@ -408,43 +408,35 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 	target := r.Header.Get("X-Amz-Target")
 	action := strings.TrimPrefix(target, "Logs_20140328.")
 
-	switch action {
-	case "CreateLogGroup":
-		s.CreateLogGroup(w, r)
-	case "DeleteLogGroup":
-		s.DeleteLogGroup(w, r)
-	case "CreateLogStream":
-		s.CreateLogStream(w, r)
-	case "DeleteLogStream":
-		s.DeleteLogStream(w, r)
-	case "PutLogEvents":
-		s.PutLogEvents(w, r)
-	case "GetLogEvents":
-		s.GetLogEvents(w, r)
-	case "FilterLogEvents":
-		s.FilterLogEvents(w, r)
-	case "DescribeLogGroups":
-		s.DescribeLogGroups(w, r)
-	case "DescribeLogStreams":
-		s.DescribeLogStreams(w, r)
-	case "PutRetentionPolicy":
-		s.PutRetentionPolicy(w, r)
-	case "DeleteRetentionPolicy":
-		s.DeleteRetentionPolicy(w, r)
-	case "ListTagsForResource":
-		s.ListTagsForResource(w, r)
-	case "ListTagsLogGroup":
-		s.ListTagsLogGroup(w, r)
-	case "TagResource":
-		s.TagResource(w, r)
-	case "UntagResource":
-		s.UntagResource(w, r)
-	case "TagLogGroup":
-		s.TagLogGroup(w, r)
-	case "UntagLogGroup":
-		s.UntagLogGroup(w, r)
-	default:
+	handler, ok := s.actionHandlers()[action]
+	if !ok {
 		writeLogsError(w, errInvalidAction, "The action "+action+" is not valid for this web service", http.StatusBadRequest)
+
+		return
+	}
+
+	handler(w, r)
+}
+
+func (s *Service) actionHandlers() map[string]func(http.ResponseWriter, *http.Request) {
+	return map[string]func(http.ResponseWriter, *http.Request){
+		"CreateLogGroup":        s.CreateLogGroup,
+		"DeleteLogGroup":        s.DeleteLogGroup,
+		"CreateLogStream":       s.CreateLogStream,
+		"DeleteLogStream":       s.DeleteLogStream,
+		"PutLogEvents":          s.PutLogEvents,
+		"GetLogEvents":          s.GetLogEvents,
+		"FilterLogEvents":       s.FilterLogEvents,
+		"DescribeLogGroups":     s.DescribeLogGroups,
+		"DescribeLogStreams":    s.DescribeLogStreams,
+		"PutRetentionPolicy":    s.PutRetentionPolicy,
+		"DeleteRetentionPolicy": s.DeleteRetentionPolicy,
+		"ListTagsForResource":   s.ListTagsForResource,
+		"ListTagsLogGroup":      s.ListTagsLogGroup,
+		"TagResource":           s.TagResource,
+		"UntagResource":         s.UntagResource,
+		"TagLogGroup":           s.TagLogGroup,
+		"UntagLogGroup":         s.UntagLogGroup,
 	}
 }
 

--- a/internal/service/cloudwatchlogs/storage.go
+++ b/internal/service/cloudwatchlogs/storage.go
@@ -36,6 +36,9 @@ type Storage interface {
 	DescribeLogStreams(ctx context.Context, req *DescribeLogStreamsRequest) (*DescribeLogStreamsResponse, error)
 	PutRetentionPolicy(ctx context.Context, groupName string, retentionInDays int32) error
 	DeleteRetentionPolicy(ctx context.Context, groupName string) error
+	ListTags(ctx context.Context, groupNameOrArn string) (map[string]string, error)
+	Tag(ctx context.Context, groupNameOrArn string, tags map[string]string) error
+	Untag(ctx context.Context, groupNameOrArn string, keys []string) error
 }
 
 // LogStreamData holds log stream data with events.
@@ -174,6 +177,7 @@ func (m *MemoryStorage) CreateLogGroup(_ context.Context, req *CreateLogGroupReq
 		CreationTime:  now,
 		KmsKeyID:      req.KmsKeyID,
 		LogGroupClass: req.LogGroupClass,
+		Tags:          copyStringMap(req.Tags),
 	}
 
 	m.LogGroups[req.LogGroupName] = &LogGroupData{
@@ -182,6 +186,57 @@ func (m *MemoryStorage) CreateLogGroup(_ context.Context, req *CreateLogGroupReq
 	}
 
 	m.saveLocked()
+
+	return nil
+}
+
+// ListTags returns the tags for a log group.
+func (m *MemoryStorage) ListTags(_ context.Context, groupNameOrArn string) (map[string]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	group, err := m.lookupLogGroupByNameOrArn(groupNameOrArn)
+	if err != nil {
+		return nil, err
+	}
+
+	return copyStringMap(group.Tags), nil
+}
+
+// Tag adds or updates tags on a log group.
+func (m *MemoryStorage) Tag(_ context.Context, groupNameOrArn string, tags map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	group, err := m.lookupLogGroupByNameOrArn(groupNameOrArn)
+	if err != nil {
+		return err
+	}
+
+	if group.Tags == nil {
+		group.Tags = make(map[string]string)
+	}
+
+	for key, value := range tags {
+		group.Tags[key] = value
+	}
+
+	return nil
+}
+
+// Untag removes tags from a log group.
+func (m *MemoryStorage) Untag(_ context.Context, groupNameOrArn string, keys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	group, err := m.lookupLogGroupByNameOrArn(groupNameOrArn)
+	if err != nil {
+		return err
+	}
+
+	for _, key := range keys {
+		delete(group.Tags, key)
+	}
 
 	return nil
 }
@@ -574,6 +629,32 @@ func buildLogGroupResponse(group *LogGroup) LogGroupResponse {
 		KmsKeyID:          group.KmsKeyID,
 		LogGroupClass:     group.LogGroupClass,
 	}
+}
+
+func (m *MemoryStorage) lookupLogGroupByNameOrArn(groupNameOrArn string) (*LogGroup, error) {
+	if groupData, exists := m.LogGroups[groupNameOrArn]; exists {
+		return groupData.Group, nil
+	}
+
+	for _, groupData := range m.LogGroups {
+		if groupData.Group.LogGroupARN == groupNameOrArn {
+			return groupData.Group, nil
+		}
+	}
+
+	return nil, &LogsError{
+		Code:    "ResourceNotFoundException",
+		Message: fmt.Sprintf("The specified log group does not exist: %s", groupNameOrArn),
+	}
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+
+	return out
 }
 
 // paginateLogGroups applies pagination to log groups.

--- a/internal/service/cloudwatchlogs/tags_test.go
+++ b/internal/service/cloudwatchlogs/tags_test.go
@@ -1,0 +1,48 @@
+package cloudwatchlogs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLogGroupTagsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage(defaultBaseURL)
+	service := New(storage, defaultBaseURL)
+	ctx := context.Background()
+
+	if err := storage.CreateLogGroup(ctx, &CreateLogGroupRequest{
+		LogGroupName: "/ecs/kumo-local/kumo",
+		Tags: map[string]string{
+			"Project":   "kumo-local",
+			"Component": "kumo",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"logGroupName":"/ecs/kumo-local/kumo"}`))
+	req.Header.Set("X-Amz-Target", "Logs_20140328.ListTagsLogGroup")
+	rec := httptest.NewRecorder()
+
+	service.DispatchAction(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		`"tags"`,
+		`"Project":"kumo-local"`,
+		`"Component":"kumo"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected response to contain %q, got %s", want, body)
+		}
+	}
+}

--- a/internal/service/cloudwatchlogs/tags_test.go
+++ b/internal/service/cloudwatchlogs/tags_test.go
@@ -27,6 +27,7 @@ func TestLogGroupTagsRoundTrip(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"logGroupName":"/ecs/kumo-local/kumo"}`))
 	req.Header.Set("X-Amz-Target", "Logs_20140328.ListTagsLogGroup")
+
 	rec := httptest.NewRecorder()
 
 	service.DispatchAction(rec, req)

--- a/internal/service/cloudwatchlogs/types.go
+++ b/internal/service/cloudwatchlogs/types.go
@@ -12,6 +12,7 @@ type LogGroup struct {
 	KmsKeyID          string
 	DataProtection    string
 	LogGroupClass     string
+	Tags              map[string]string
 }
 
 // LogStream represents a log stream in CloudWatch Logs.
@@ -45,6 +46,45 @@ type CreateLogGroupRequest struct {
 	KmsKeyID      string            `json:"kmsKeyId,omitempty"`
 	Tags          map[string]string `json:"tags,omitempty"`
 	LogGroupClass string            `json:"logGroupClass,omitempty"`
+}
+
+// ListTagsLogGroupRequest is the request for ListTagsLogGroup.
+type ListTagsLogGroupRequest struct {
+	LogGroupName string `json:"logGroupName"`
+}
+
+// ListTagsForResourceRequest is the request for ListTagsForResource.
+type ListTagsForResourceRequest struct {
+	ResourceARN string `json:"resourceArn"`
+}
+
+// TagsResponse is the response for tag listing.
+type TagsResponse struct {
+	Tags map[string]string `json:"tags"`
+}
+
+// TagLogGroupRequest is the request for TagLogGroup.
+type TagLogGroupRequest struct {
+	LogGroupName string            `json:"logGroupName"`
+	Tags         map[string]string `json:"tags"`
+}
+
+// TagResourceRequest is the request for TagResource.
+type TagResourceRequest struct {
+	ResourceARN string            `json:"resourceArn"`
+	Tags        map[string]string `json:"tags"`
+}
+
+// UntagLogGroupRequest is the request for UntagLogGroup.
+type UntagLogGroupRequest struct {
+	LogGroupName string   `json:"logGroupName"`
+	Tags         []string `json:"tags"`
+}
+
+// UntagResourceRequest is the request for UntagResource.
+type UntagResourceRequest struct {
+	ResourceARN string   `json:"resourceArn"`
+	TagKeys     []string `json:"tagKeys"`
 }
 
 // DeleteLogGroupRequest is the request for DeleteLogGroup.


### PR DESCRIPTION
## Summary

Persists CloudWatch Logs log group tags so Terraform refresh can round-trip tag state.

## Changes

- Stores tags passed to `CreateLogGroup`.
- Implements `ListTagsLogGroup`, `ListTagsForResource`, `TagLogGroup`, `TagResource`, `UntagLogGroup`, and `UntagResource` against storage.
- Adds a focused tag round-trip test through the CloudWatch Logs JSON dispatcher.

## Validation

- `go test ./internal/service/cloudwatchlogs`
