### PR TITLE
feat(aws): add ECS Terraform module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ coverage.html
 
 # Dependency directories
 vendor/
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -213,6 +213,20 @@ volumes:
   kumo-data:
 ```
 
+### AWS ECS/Fargate
+
+Terraform for running kumo on AWS is available under `infra/terraform/aws`.
+It creates an ECS/Fargate service behind an ALB and mounts EFS at `KUMO_DATA_DIR=/data` for
+persistent emulator state.
+
+```bash
+terraform -chdir=infra/terraform/aws init
+terraform -chdir=infra/terraform/aws plan \
+  -var='vpc_id=vpc-...' \
+  -var='alb_subnet_ids=["subnet-private-a","subnet-private-c"]' \
+  -var='private_subnet_ids=["subnet-private-a","subnet-private-c"]'
+```
+
 ## Usage Examples
 
 ### S3

--- a/infra/terraform/aws/.terraform.lock.hcl
+++ b/infra/terraform/aws/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:7/GgVlN+KplSVCuc8qb4ct2R7gotYooPNRd0cnj9GxE=",
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:C6eM6fGJVktK2M5vH3Yhv5NnqmegcBDY0EuDHhiXoVY=",
+    "h1:C7yD4Be2zhVdjnilsKPfucYAYMG5UCJYuUSoY6FCtGQ=",
+    "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:JJ+EJQ+sIN3XRmNmrSUnUQtR8i3P22z+AbtAf8O/cRE=",
+    "h1:Wm5Ofhc15lX1OMMCt7iDV0NY5FDIouQDjX7I1iab55s=",
+    "h1:crKvBCgX6RlMcE6Ewm8o8YVuIg6mkXqKNgt/kSFYTvQ=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}

--- a/infra/terraform/aws/README.md
+++ b/infra/terraform/aws/README.md
@@ -1,0 +1,78 @@
+# sivchari/kumo AWS Terraform
+
+This deploys `sivchari/kumo` as a single ECS/Fargate service behind an Application Load Balancer.
+The task mounts EFS at `KUMO_DATA_DIR=/data` so emulator state survives task restarts.
+
+Default posture:
+
+- ECS/Fargate service running `ghcr.io/sivchari/kumo:latest`
+- ALB listener on port `4566`
+- internal ALB by default
+- ALB ingress limited to RFC1918 CIDR blocks by default
+- EFS file system, mount targets, and access point owned by UID/GID `10000`
+- CloudWatch Logs retention of 14 days
+- `/health` target-group health check
+
+kumo has no built-in authentication. Keep `alb_internal=true` unless this is an isolated throwaway
+environment, and prefer VPN, peering, or private DNS for clients.
+
+## Plan
+
+```sh
+terraform -chdir=infra/terraform/aws init
+terraform -chdir=infra/terraform/aws plan \
+  -var='vpc_id=vpc-...' \
+  -var='alb_subnet_ids=["subnet-private-a","subnet-private-c"]' \
+  -var='private_subnet_ids=["subnet-private-a","subnet-private-c"]'
+```
+
+With DNS and TLS:
+
+```sh
+terraform -chdir=infra/terraform/aws plan \
+  -var='vpc_id=vpc-...' \
+  -var='alb_subnet_ids=["subnet-private-a","subnet-private-c"]' \
+  -var='private_subnet_ids=["subnet-private-a","subnet-private-c"]' \
+  -var='route53_zone_id=Z...' \
+  -var='record_name=kumo.internal.example.com' \
+  -var='listener_port=443' \
+  -var='certificate_arn=arn:aws:acm:ap-northeast-1:123456789012:certificate/...'
+```
+
+The `endpoint_url` output can be used as `AWS_ENDPOINT_URL`:
+
+```sh
+export AWS_ENDPOINT_URL="$(terraform -chdir=infra/terraform/aws output -raw endpoint_url)"
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=us-east-1
+```
+
+## Local kumo compatibility check
+
+When applying this module to a local kumo endpoint rather than real AWS, disable the resources
+that kumo does not emulate:
+
+```sh
+AWS_ENDPOINT_URL=http://127.0.0.1:4566 \
+AWS_ACCESS_KEY_ID=test \
+AWS_SECRET_ACCESS_KEY=test \
+AWS_REGION=us-east-1 \
+AWS_EC2_METADATA_DISABLED=true \
+tofu -chdir=infra/terraform/aws plan -refresh=false \
+  -var='vpc_id=vpc-kumo' \
+  -var='alb_subnet_ids=["subnet-kumo-a","subnet-kumo-b"]' \
+  -var='private_subnet_ids=["subnet-kumo-a","subnet-kumo-b"]' \
+  -var='enable_efs=false' \
+  -var='attach_task_execution_policy=false'
+```
+
+## Operations
+
+- Keep `desired_count=1` while using shared EFS persistence. kumo persists service state as JSON
+  files on shutdown, so multiple writers can overwrite each other.
+- Private ECS tasks need NAT or an ECR mirror to pull `ghcr.io/sivchari/kumo:latest`.
+- Set `image` to an ECR image digest for reproducible production-like environments.
+- Set `enable_pprof=true` to expose the optional pprof listener inside the task. Do not route it
+  through the ALB unless you add separate network controls.
+- Set `enable_execute_command=true` only for break-glass debugging.

--- a/infra/terraform/aws/aws_terraform_test.go
+++ b/infra/terraform/aws/aws_terraform_test.go
@@ -1,0 +1,69 @@
+package aws_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestKumoAwsTerraformDefinesFargateServiceWithPersistentData(t *testing.T) {
+	main := readTerraformFile(t, "main.tf")
+	variables := readTerraformFile(t, "variables.tf")
+	outputs := readTerraformFile(t, "outputs.tf")
+	readme := readTerraformFile(t, "README.md")
+
+	assertContains(t, main, `resource "aws_ecs_cluster" "this"`)
+	assertContains(t, main, `resource "aws_ecs_task_definition" "kumo"`)
+	assertContains(t, main, `resource "aws_ecs_service" "kumo"`)
+	assertContains(t, main, `resource "aws_lb_target_group" "kumo"`)
+	assertContains(t, main, `"/health"`)
+	assertContains(t, main, `KUMO_DATA_DIR`)
+	assertContains(t, main, `containerPath = var.data_dir`)
+	assertContains(t, main, `resource "aws_efs_file_system" "data"`)
+	assertContains(t, main, `count          = var.enable_efs ? 1 : 0`)
+	assertContains(t, main, `resource "aws_efs_access_point" "data"`)
+	assertContains(t, main, `uid = 10000`)
+	assertContains(t, main, `gid = 10000`)
+	assertContains(t, main, `readonlyRootFilesystem = true`)
+	assertContains(t, main, `"SYS_PTRACE"`)
+	assertContains(t, main, `count      = var.attach_task_execution_policy ? 1 : 0`)
+	assertContains(t, main, `dynamic "volume"`)
+	assertContains(t, main, `mountPoints = var.enable_efs ?`)
+
+	assertContains(t, variables, `variable "image"`)
+	assertContains(t, variables, `default     = "ghcr.io/sivchari/kumo:latest"`)
+	assertContains(t, variables, `variable "alb_internal"`)
+	assertContains(t, variables, `default     = true`)
+	assertContains(t, variables, `variable "allowed_cidr_blocks"`)
+	assertContains(t, variables, `variable "enable_pprof"`)
+	assertContains(t, variables, `variable "enable_efs"`)
+	assertContains(t, variables, `variable "attach_task_execution_policy"`)
+	assertContains(t, variables, `default     = "/data"`)
+
+	assertContains(t, outputs, `output "endpoint_url"`)
+	assertContains(t, outputs, `aws_lb.this.dns_name`)
+	assertContains(t, outputs, `try(aws_efs_file_system.data[0].id, null)`)
+
+	assertContains(t, readme, "sivchari/kumo")
+	assertContains(t, readme, "ECS/Fargate")
+	assertContains(t, readme, "EFS")
+	assertContains(t, readme, "KUMO_DATA_DIR=/data")
+	assertContains(t, readme, "enable_efs=false")
+}
+
+func readTerraformFile(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(".", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func assertContains(t *testing.T, text string, want string) {
+	t.Helper()
+	if !strings.Contains(text, want) {
+		t.Fatalf("expected file to contain %q", want)
+	}
+}

--- a/infra/terraform/aws/aws_terraform_test.go
+++ b/infra/terraform/aws/aws_terraform_test.go
@@ -54,15 +54,18 @@ func TestKumoAwsTerraformDefinesFargateServiceWithPersistentData(t *testing.T) {
 
 func readTerraformFile(t *testing.T, name string) string {
 	t.Helper()
-	b, err := os.ReadFile(filepath.Join(".", name))
+
+	b, err := os.ReadFile(filepath.Join(".", name)) //nolint:gosec // Test fixture names are fixed by callers in this file.
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	return string(b)
 }
 
-func assertContains(t *testing.T, text string, want string) {
+func assertContains(t *testing.T, text, want string) {
 	t.Helper()
+
 	if !strings.Contains(text, want) {
 		t.Fatalf("expected file to contain %q", want)
 	}

--- a/infra/terraform/aws/main.tf
+++ b/infra/terraform/aws/main.tf
@@ -1,0 +1,374 @@
+locals {
+  tags = merge(var.tags, {
+    Project   = var.name
+    Component = "kumo"
+    ManagedBy = "terraform"
+  })
+
+  listener_protocol = var.certificate_arn == "" ? "HTTP" : "HTTPS"
+  endpoint_scheme   = var.certificate_arn == "" ? "http" : "https"
+  endpoint_host     = var.route53_zone_id != "" && var.record_name != "" ? var.record_name : aws_lb.this.dns_name
+  endpoint_port     = contains([80, 443], var.listener_port) ? "" : ":${var.listener_port}"
+
+  base_environment = [
+    { name = "KUMO_HOST", value = "0.0.0.0" },
+    { name = "KUMO_PORT", value = "4566" },
+    { name = "KUMO_LOG_LEVEL", value = var.log_level }
+  ]
+
+  data_environment = var.enable_efs ? [
+    { name = "KUMO_DATA_DIR", value = var.data_dir }
+  ] : []
+
+  optional_environment = concat(
+    var.init_dir == "" ? [] : [{ name = "KUMO_INIT_DIR", value = var.init_dir }],
+    var.enable_pprof ? [
+      { name = "KUMO_PPROF", value = "true" },
+      { name = "KUMO_PPROF_ADDR", value = var.pprof_addr }
+    ] : []
+  )
+
+  extra_environment = [
+    for key, value in var.extra_environment : {
+      name  = key
+      value = value
+    }
+  ]
+
+  environment = concat(local.base_environment, local.data_environment, local.optional_environment, local.extra_environment)
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = var.name
+  tags = local.tags
+
+  setting {
+    name  = "containerInsights"
+    value = var.enable_container_insights ? "enabled" : "disabled"
+  }
+}
+
+data "aws_iam_policy_document" "ecs_tasks_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${var.name}-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  count      = var.attach_task_execution_policy ? 1 : 0
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${var.name}-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "ecs_exec" {
+  statement {
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_exec" {
+  count  = var.enable_execute_command ? 1 : 0
+  name   = "${var.name}-ecs-exec"
+  role   = aws_iam_role.task.id
+  policy = data.aws_iam_policy_document.ecs_exec.json
+}
+
+resource "aws_cloudwatch_log_group" "kumo" {
+  name              = "/ecs/${var.name}/kumo"
+  retention_in_days = var.log_retention_days
+  tags              = local.tags
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${var.name}-alb"
+  description = "kumo ALB"
+  vpc_id      = var.vpc_id
+  tags        = local.tags
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = var.listener_port
+    to_port     = var.listener_port
+    cidr_blocks = var.allowed_cidr_blocks
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "tasks" {
+  name        = "${var.name}-tasks"
+  description = "kumo ECS tasks"
+  vpc_id      = var.vpc_id
+  tags        = local.tags
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 4566
+    to_port         = 4566
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "efs" {
+  count       = var.enable_efs ? 1 : 0
+  name        = "${var.name}-efs"
+  description = "kumo EFS"
+  vpc_id      = var.vpc_id
+  tags        = local.tags
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 2049
+    to_port         = 2049
+    security_groups = [aws_security_group.tasks.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_efs_file_system" "data" {
+  count          = var.enable_efs ? 1 : 0
+  creation_token = "${var.name}-data"
+  encrypted      = true
+  tags           = local.tags
+
+  lifecycle_policy {
+    transition_to_ia = var.efs_transition_to_ia
+  }
+}
+
+resource "aws_efs_backup_policy" "data" {
+  count          = var.enable_efs ? 1 : 0
+  file_system_id = aws_efs_file_system.data[0].id
+
+  backup_policy {
+    status = var.efs_backup_policy_enabled ? "ENABLED" : "DISABLED"
+  }
+}
+
+resource "aws_efs_mount_target" "data" {
+  for_each        = var.enable_efs ? toset(var.private_subnet_ids) : toset([])
+  file_system_id  = aws_efs_file_system.data[0].id
+  subnet_id       = each.value
+  security_groups = [aws_security_group.efs[0].id]
+}
+
+resource "aws_efs_access_point" "data" {
+  count          = var.enable_efs ? 1 : 0
+  file_system_id = aws_efs_file_system.data[0].id
+  tags           = local.tags
+
+  posix_user {
+    uid = 10000
+    gid = 10000
+  }
+
+  root_directory {
+    path = "/kumo"
+
+    creation_info {
+      owner_uid   = 10000
+      owner_gid   = 10000
+      permissions = "0750"
+    }
+  }
+}
+
+resource "aws_lb" "this" {
+  name               = var.name
+  internal           = var.alb_internal
+  load_balancer_type = "application"
+  subnets            = var.alb_subnet_ids
+  security_groups    = [aws_security_group.alb.id]
+  tags               = local.tags
+}
+
+resource "aws_lb_target_group" "kumo" {
+  name        = "${var.name}-kumo"
+  port        = 4566
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+  tags        = local.tags
+
+  health_check {
+    enabled             = true
+    path                = "/health"
+    matcher             = "200"
+    interval            = 10
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+}
+
+resource "aws_lb_listener" "kumo" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = var.listener_port
+  protocol          = local.listener_protocol
+  ssl_policy        = var.certificate_arn == "" ? null : var.ssl_policy
+  certificate_arn   = var.certificate_arn == "" ? null : var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.kumo.arn
+  }
+}
+
+resource "aws_route53_record" "kumo" {
+  count   = var.route53_zone_id != "" && var.record_name != "" ? 1 : 0
+  zone_id = var.route53_zone_id
+  name    = var.record_name
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.this.dns_name
+    zone_id                = aws_lb.this.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_ecs_task_definition" "kumo" {
+  family                   = var.name
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = tostring(var.cpu)
+  memory                   = tostring(var.memory)
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  ephemeral_storage {
+    size_in_gib = var.ephemeral_storage_gib
+  }
+
+  dynamic "volume" {
+    for_each = var.enable_efs ? [1] : []
+
+    content {
+      name = "data"
+
+      efs_volume_configuration {
+        file_system_id     = aws_efs_file_system.data[0].id
+        transit_encryption = "ENABLED"
+
+        authorization_config {
+          access_point_id = aws_efs_access_point.data[0].id
+          iam             = "DISABLED"
+        }
+      }
+    }
+  }
+
+  container_definitions = jsonencode([
+    {
+      name                   = "kumo"
+      image                  = var.image
+      essential              = true
+      user                   = "10000:10000"
+      readonlyRootFilesystem = true
+      command                = ["--host", "0.0.0.0", "--port", "4566"]
+      portMappings = [
+        {
+          containerPort = 4566
+          protocol      = "tcp"
+        }
+      ]
+      environment = local.environment
+      mountPoints = var.enable_efs ? [
+        {
+          sourceVolume  = "data"
+          containerPath = var.data_dir
+          readOnly      = false
+        }
+      ] : []
+      linuxParameters = {
+        initProcessEnabled = true
+        capabilities = {
+          drop = ["ALL"]
+          add  = var.enable_ptrace ? ["SYS_PTRACE"] : []
+        }
+      }
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.kumo.name
+          awslogs-region        = var.region
+          awslogs-stream-prefix = "kumo"
+        }
+      }
+    }
+  ])
+
+  tags = local.tags
+}
+
+resource "aws_ecs_service" "kumo" {
+  name                   = var.name
+  cluster                = aws_ecs_cluster.this.id
+  task_definition        = aws_ecs_task_definition.kumo.arn
+  desired_count          = var.desired_count
+  launch_type            = "FARGATE"
+  enable_execute_command = var.enable_execute_command
+  wait_for_steady_state  = var.wait_for_steady_state
+  propagate_tags         = "SERVICE"
+  tags                   = local.tags
+
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.tasks.id]
+    assign_public_ip = var.assign_public_ip
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.kumo.arn
+    container_name   = "kumo"
+    container_port   = 4566
+  }
+
+  depends_on = [
+    aws_lb_listener.kumo,
+    aws_efs_mount_target.data
+  ]
+}

--- a/infra/terraform/aws/outputs.tf
+++ b/infra/terraform/aws/outputs.tf
@@ -1,0 +1,39 @@
+output "endpoint_url" {
+  description = "AWS SDK endpoint URL for kumo."
+  value       = "${local.endpoint_scheme}://${local.endpoint_host}${local.endpoint_port}"
+}
+
+output "alb_dns_name" {
+  description = "ALB DNS name."
+  value       = aws_lb.this.dns_name
+}
+
+output "alb_security_group_id" {
+  description = "Security group id attached to the ALB."
+  value       = aws_security_group.alb.id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name."
+  value       = aws_ecs_cluster.this.name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name."
+  value       = aws_ecs_service.kumo.name
+}
+
+output "efs_file_system_id" {
+  description = "EFS file system id backing KUMO_DATA_DIR."
+  value       = try(aws_efs_file_system.data[0].id, null)
+}
+
+output "task_execution_role_arn" {
+  description = "ECS task execution role ARN."
+  value       = aws_iam_role.task_execution.arn
+}
+
+output "task_role_arn" {
+  description = "ECS task role ARN."
+  value       = aws_iam_role.task.arn
+}

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -1,0 +1,230 @@
+variable "name" {
+  description = "Name prefix for kumo AWS resources."
+  type        = string
+  default     = "kumo"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]+$", var.name)) && length(var.name) <= 26
+    error_message = "name must contain only letters, digits, and hyphens, and be 26 characters or fewer."
+  }
+}
+
+variable "region" {
+  description = "AWS region."
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "vpc_id" {
+  description = "VPC id that contains the ALB and ECS subnets."
+  type        = string
+}
+
+variable "alb_subnet_ids" {
+  description = "Subnet ids for the ALB. Use private subnets when alb_internal is true."
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet ids for ECS tasks and EFS mount targets."
+  type        = list(string)
+}
+
+variable "image" {
+  description = "Container image for kumo."
+  type        = string
+  default     = "ghcr.io/sivchari/kumo:latest"
+}
+
+variable "desired_count" {
+  description = "Desired ECS task count. Keep this at 1 when KUMO_DATA_DIR persists to EFS."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.desired_count >= 1
+    error_message = "desired_count must be at least 1."
+  }
+}
+
+variable "cpu" {
+  description = "Fargate task CPU units."
+  type        = number
+  default     = 512
+}
+
+variable "memory" {
+  description = "Fargate task memory in MiB."
+  type        = number
+  default     = 1024
+}
+
+variable "ephemeral_storage_gib" {
+  description = "Fargate ephemeral storage size in GiB."
+  type        = number
+  default     = 21
+
+  validation {
+    condition     = var.ephemeral_storage_gib >= 21 && var.ephemeral_storage_gib <= 200
+    error_message = "ephemeral_storage_gib must be between 21 and 200."
+  }
+}
+
+variable "listener_port" {
+  description = "ALB listener port exposed for AWS SDK endpoint URLs."
+  type        = number
+  default     = 4566
+
+  validation {
+    condition     = var.listener_port > 0 && var.listener_port <= 65535
+    error_message = "listener_port must be a valid TCP port."
+  }
+}
+
+variable "certificate_arn" {
+  description = "Optional ACM certificate ARN. When set, the ALB listener uses HTTPS."
+  type        = string
+  default     = ""
+}
+
+variable "ssl_policy" {
+  description = "ALB SSL policy used when certificate_arn is set."
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}
+
+variable "alb_internal" {
+  description = "Whether the ALB is internal. kumo has no built-in auth, so the safe default is internal."
+  type        = bool
+  default     = true
+}
+
+variable "allowed_cidr_blocks" {
+  description = "CIDR blocks allowed to reach the ALB listener."
+  type        = list(string)
+  default     = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+}
+
+variable "assign_public_ip" {
+  description = "Assign public IPs to ECS tasks. Prefer false with private subnets and NAT or an ECR mirror."
+  type        = bool
+  default     = false
+}
+
+variable "route53_zone_id" {
+  description = "Optional Route53 hosted zone id for an alias record."
+  type        = string
+  default     = ""
+}
+
+variable "record_name" {
+  description = "Optional Route53 record name, for example kumo.internal.example.com."
+  type        = string
+  default     = ""
+}
+
+variable "log_level" {
+  description = "KUMO_LOG_LEVEL value."
+  type        = string
+  default     = "info"
+
+  validation {
+    condition     = contains(["debug", "info", "warn", "error"], var.log_level)
+    error_message = "log_level must be debug, info, warn, or error."
+  }
+}
+
+variable "data_dir" {
+  description = "KUMO_DATA_DIR value mounted from EFS."
+  type        = string
+  default     = "/data"
+
+  validation {
+    condition     = can(regex("^/[A-Za-z0-9._/-]+$", var.data_dir))
+    error_message = "data_dir must be an absolute container path."
+  }
+}
+
+variable "enable_efs" {
+  description = "Create and mount EFS for persistent KUMO_DATA_DIR. Disable for local kumo compatibility tests."
+  type        = bool
+  default     = true
+}
+
+variable "init_dir" {
+  description = "Optional KUMO_INIT_DIR value. Mount/init contents must be provided by the image or another volume."
+  type        = string
+  default     = ""
+}
+
+variable "enable_pprof" {
+  description = "Enable kumo's optional pprof endpoint through KUMO_PPROF."
+  type        = bool
+  default     = false
+}
+
+variable "pprof_addr" {
+  description = "KUMO_PPROF_ADDR value when enable_pprof is true."
+  type        = string
+  default     = ":6060"
+}
+
+variable "enable_ptrace" {
+  description = "Add SYS_PTRACE to the container. Keep false unless profiling tooling requires it."
+  type        = bool
+  default     = false
+}
+
+variable "extra_environment" {
+  description = "Additional plain-text environment variables for the kumo container."
+  type        = map(string)
+  default     = {}
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch Logs retention in days."
+  type        = number
+  default     = 14
+}
+
+variable "enable_container_insights" {
+  description = "Enable ECS container insights."
+  type        = bool
+  default     = true
+}
+
+variable "enable_execute_command" {
+  description = "Enable ECS Exec for the kumo service."
+  type        = bool
+  default     = false
+}
+
+variable "attach_task_execution_policy" {
+  description = "Attach the AWS-managed ECS task execution policy. Disable when planning/applying against emulators that do not seed AWS-managed IAM policies."
+  type        = bool
+  default     = true
+}
+
+variable "wait_for_steady_state" {
+  description = "Whether Terraform waits for the ECS service to reach steady state."
+  type        = bool
+  default     = false
+}
+
+variable "efs_transition_to_ia" {
+  description = "EFS lifecycle policy transition_to_ia value."
+  type        = string
+  default     = "AFTER_30_DAYS"
+}
+
+variable "efs_backup_policy_enabled" {
+  description = "Enable automatic AWS Backup backups for the EFS file system."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Additional tags."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/aws/versions.tf
+++ b/infra/terraform/aws/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}


### PR DESCRIPTION
## Summary

Adds an AWS ECS/Fargate Terraform module for running kumo behind an ALB.

## Changes

- Adds `infra/terraform/aws` with ECS cluster, Fargate task/service, ALB, target group, listener, optional Route53/TLS, CloudWatch Logs, and optional EFS persistence.
- Adds local-emulator compatibility switches for `enable_efs=false` and `attach_task_execution_policy=false`.
- Documents the deployment flow and local kumo compatibility check.
- Ignores Terraform state and plan files.

## Validation

- `go test ./infra/terraform/aws`
- `tofu -chdir=infra/terraform/aws fmt -check`
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_REGION=us-east-1 AWS_EC2_METADATA_DISABLED=true tofu -chdir=infra/terraform/aws validate -no-color`
