### PR TITLE
feat(elbv2): persist tags for Terraform refresh

### DIFF
--- a/internal/service/elbv2/capacity_reservation_test.go
+++ b/internal/service/elbv2/capacity_reservation_test.go
@@ -1,0 +1,33 @@
+package elbv2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDescribeCapacityReservationReturnsEmptyResult(t *testing.T) {
+	t.Parallel()
+
+	service := New(NewMemoryStorage())
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"LoadBalancerArn":"arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/kumo-local/123"}`))
+	rec := httptest.NewRecorder()
+
+	service.DescribeCapacityReservation(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"<DescribeCapacityReservationResponse",
+		"<DescribeCapacityReservationResult>",
+		"<ResponseMetadata>",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected response to contain %q, got %s", want, body)
+		}
+	}
+}

--- a/internal/service/elbv2/handlers.go
+++ b/internal/service/elbv2/handlers.go
@@ -62,7 +62,7 @@ func (s *Service) CreateLoadBalancer(w http.ResponseWriter, r *http.Request) {
 func readCreateLoadBalancerRequest(r *http.Request, req *CreateLoadBalancerRequest) error {
 	if strings.Contains(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
 		if err := r.ParseForm(); err != nil {
-			return err
+			return fmt.Errorf("parse create load balancer form: %w", err)
 		}
 
 		req.Name = r.Form.Get("Name")
@@ -182,7 +182,7 @@ func (s *Service) CreateTargetGroup(w http.ResponseWriter, r *http.Request) {
 func readCreateTargetGroupRequest(r *http.Request, req *CreateTargetGroupRequest) error {
 	if strings.Contains(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
 		if err := r.ParseForm(); err != nil {
-			return err
+			return fmt.Errorf("parse create target group form: %w", err)
 		}
 
 		applyCreateTargetGroupForm(r.Form, req)
@@ -222,6 +222,7 @@ func applyCreateTargetGroupFormSupplement(form map[string][]string, req *CreateT
 	if req.Matcher == nil {
 		req.Matcher = matcherFromForm(form)
 	}
+
 	if len(req.Tags) == 0 {
 		req.Tags = parseELBTagPairsFromForm(form)
 	}
@@ -233,7 +234,7 @@ func matcherFromForm(form map[string][]string) *Matcher {
 		return nil
 	}
 
-	return &Matcher{HttpCode: httpCode}
+	return &Matcher{HTTPCode: httpCode}
 }
 
 func firstELBFormValue(form map[string][]string, key string) string {
@@ -465,7 +466,7 @@ func (s *Service) CreateListener(w http.ResponseWriter, r *http.Request) {
 func readCreateListenerRequest(r *http.Request, req *CreateListenerRequest) error {
 	if strings.Contains(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
 		if err := r.ParseForm(); err != nil {
-			return err
+			return fmt.Errorf("parse create listener form: %w", err)
 		}
 
 		req.LoadBalancerArn = r.Form.Get("LoadBalancerArn")
@@ -1128,6 +1129,7 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 // DescribeTags returns tag descriptions for requested ResourceArns.
 func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
 	arns := collectResourceArns(r)
+
 	tagsByARN, err := s.storage.DescribeTags(r.Context(), arns)
 	if err != nil {
 		handleELBError(w, err)
@@ -1232,6 +1234,7 @@ func readAddTagsRequest(r *http.Request) ([]string, map[string]string, error) {
 	if err := r.ParseForm(); err == nil {
 		arns := parseELBMemberListFromForm(r.Form, "ResourceArns")
 		tags := parseELBTagPairsFromForm(r.Form)
+
 		if len(arns) > 0 || len(tags) > 0 {
 			return arns, tags, nil
 		}
@@ -1249,6 +1252,7 @@ func readRemoveTagsRequest(r *http.Request) ([]string, []string, error) {
 	if err := r.ParseForm(); err == nil {
 		arns := parseELBMemberListFromForm(r.Form, "ResourceArns")
 		keys := parseELBMemberListFromForm(r.Form, "TagKeys")
+
 		if len(arns) > 0 || len(keys) > 0 {
 			return arns, keys, nil
 		}
@@ -1263,22 +1267,22 @@ func readRemoveTagsRequest(r *http.Request) ([]string, []string, error) {
 }
 
 type describeTagsJSONRequest struct {
-	ResourceArns []string `json:"ResourceArns"`
+	ResourceArns []string `json:"ResourceArns"` //nolint:tagliatelle // ELBv2 query-compatible JSON uses PascalCase names.
 }
 
 type addTagsJSONRequest struct {
-	ResourceArns []string      `json:"ResourceArns"`
-	Tags         []tagJSONPair `json:"Tags"`
+	ResourceArns []string      `json:"ResourceArns"` //nolint:tagliatelle // ELBv2 query-compatible JSON uses PascalCase names.
+	Tags         []tagJSONPair `json:"Tags"`         //nolint:tagliatelle // ELBv2 query-compatible JSON uses PascalCase names.
 }
 
 type removeTagsJSONRequest struct {
-	ResourceArns []string `json:"ResourceArns"`
-	TagKeys      []string `json:"TagKeys"`
+	ResourceArns []string `json:"ResourceArns"` //nolint:tagliatelle // ELBv2 query-compatible JSON uses PascalCase names.
+	TagKeys      []string `json:"TagKeys"`      //nolint:tagliatelle // ELBv2 query-compatible JSON uses PascalCase names.
 }
 
 type tagJSONPair struct {
-	Key   string `json:"Key"`
-	Value string `json:"Value"`
+	Key   string `json:"Key"`   //nolint:tagliatelle // ELBv2 query-compatible JSON uses PascalCase names.
+	Value string `json:"Value"` //nolint:tagliatelle // ELBv2 query-compatible JSON uses PascalCase names.
 }
 
 type tagPairAcc struct {
@@ -1294,6 +1298,7 @@ func parseELBTagPairsFromForm(form map[string][]string) map[string]string {
 	}
 
 	out := make(map[string]string)
+
 	for _, entry := range byIdx {
 		if entry.key != "" {
 			out[entry.key] = entry.value
@@ -1335,6 +1340,7 @@ func applyELBTagPairFormEntry(byIdx map[int]*tagPairAcc, key string, values []st
 
 func jsonTagsToMap(tags []tagJSONPair) map[string]string {
 	out := make(map[string]string, len(tags))
+
 	for _, tag := range tags {
 		if tag.Key != "" {
 			out[tag.Key] = tag.Value
@@ -1415,7 +1421,7 @@ func xmlMatcher(httpCode string) *XMLMatcher {
 		return nil
 	}
 
-	return &XMLMatcher{HttpCode: httpCode}
+	return &XMLMatcher{HTTPCode: httpCode}
 }
 
 // convertActionToXML serialises an Action for the wire. The legacy

--- a/internal/service/elbv2/handlers.go
+++ b/internal/service/elbv2/handlers.go
@@ -29,7 +29,7 @@ const (
 // CreateLoadBalancer handles the CreateLoadBalancer action.
 func (s *Service) CreateLoadBalancer(w http.ResponseWriter, r *http.Request) {
 	var req CreateLoadBalancerRequest
-	if err := readELBJSONRequest(r, &req); err != nil {
+	if err := readCreateLoadBalancerRequest(r, &req); err != nil {
 		writeELBError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -57,6 +57,34 @@ func (s *Service) CreateLoadBalancer(w http.ResponseWriter, r *http.Request) {
 		},
 		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
 	})
+}
+
+func readCreateLoadBalancerRequest(r *http.Request, req *CreateLoadBalancerRequest) error {
+	if strings.Contains(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+		if err := r.ParseForm(); err != nil {
+			return err
+		}
+
+		req.Name = r.Form.Get("Name")
+		req.Subnets = parseELBMemberListFromForm(r.Form, "Subnets")
+		req.SecurityGroups = parseELBMemberListFromForm(r.Form, "SecurityGroups")
+		req.Scheme = r.Form.Get("Scheme")
+		req.Type = r.Form.Get("Type")
+		req.IPAddressType = r.Form.Get("IpAddressType")
+		req.Tags = parseELBTagPairsFromForm(r.Form)
+
+		return nil
+	}
+
+	if err := readELBJSONRequest(r, req); err != nil {
+		return err
+	}
+
+	if err := r.ParseForm(); err == nil && len(req.Tags) == 0 {
+		req.Tags = parseELBTagPairsFromForm(r.Form)
+	}
+
+	return nil
 }
 
 // DeleteLoadBalancer handles the DeleteLoadBalancer action.
@@ -121,7 +149,7 @@ func (s *Service) DescribeLoadBalancers(w http.ResponseWriter, r *http.Request) 
 // CreateTargetGroup handles the CreateTargetGroup action.
 func (s *Service) CreateTargetGroup(w http.ResponseWriter, r *http.Request) {
 	var req CreateTargetGroupRequest
-	if err := readELBJSONRequest(r, &req); err != nil {
+	if err := readCreateTargetGroupRequest(r, &req); err != nil {
 		writeELBError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -149,6 +177,81 @@ func (s *Service) CreateTargetGroup(w http.ResponseWriter, r *http.Request) {
 		},
 		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
 	})
+}
+
+func readCreateTargetGroupRequest(r *http.Request, req *CreateTargetGroupRequest) error {
+	if strings.Contains(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+		if err := r.ParseForm(); err != nil {
+			return err
+		}
+
+		applyCreateTargetGroupForm(r.Form, req)
+
+		return nil
+	}
+
+	if err := readELBJSONRequest(r, req); err != nil {
+		return err
+	}
+
+	if err := r.ParseForm(); err == nil {
+		applyCreateTargetGroupFormSupplement(r.Form, req)
+	}
+
+	return nil
+}
+
+func applyCreateTargetGroupForm(form map[string][]string, req *CreateTargetGroupRequest) {
+	req.Name = firstELBFormValue(form, "Name")
+	req.Protocol = firstELBFormValue(form, "Protocol")
+	req.Port = parseELBFormInt(firstELBFormValue(form, "Port"))
+	req.VpcID = firstELBFormValue(form, "VpcId")
+	req.HealthCheckProtocol = firstELBFormValue(form, "HealthCheckProtocol")
+	req.HealthCheckPort = firstELBFormValue(form, "HealthCheckPort")
+	req.HealthCheckPath = firstELBFormValue(form, "HealthCheckPath")
+	req.HealthCheckIntervalSeconds = parseELBFormInt(firstELBFormValue(form, "HealthCheckIntervalSeconds"))
+	req.HealthCheckTimeoutSeconds = parseELBFormInt(firstELBFormValue(form, "HealthCheckTimeoutSeconds"))
+	req.HealthyThresholdCount = parseELBFormInt(firstELBFormValue(form, "HealthyThresholdCount"))
+	req.UnhealthyThresholdCount = parseELBFormInt(firstELBFormValue(form, "UnhealthyThresholdCount"))
+	req.Matcher = matcherFromForm(form)
+	req.TargetType = firstELBFormValue(form, "TargetType")
+	req.Tags = parseELBTagPairsFromForm(form)
+}
+
+func applyCreateTargetGroupFormSupplement(form map[string][]string, req *CreateTargetGroupRequest) {
+	if req.Matcher == nil {
+		req.Matcher = matcherFromForm(form)
+	}
+	if len(req.Tags) == 0 {
+		req.Tags = parseELBTagPairsFromForm(form)
+	}
+}
+
+func matcherFromForm(form map[string][]string) *Matcher {
+	httpCode := firstELBFormValue(form, "Matcher.HttpCode")
+	if httpCode == "" {
+		return nil
+	}
+
+	return &Matcher{HttpCode: httpCode}
+}
+
+func firstELBFormValue(form map[string][]string, key string) string {
+	values := form[key]
+	if len(values) == 0 {
+		return ""
+	}
+
+	return values[0]
+}
+
+func parseELBFormInt(value string) int {
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return 0
+	}
+
+	return n
 }
 
 // DeleteTargetGroup handles the DeleteTargetGroup action.
@@ -329,7 +432,7 @@ func applyELBTargetFormEntry(byIdx map[int]*Target, key string, values []string)
 // CreateListener handles the CreateListener action.
 func (s *Service) CreateListener(w http.ResponseWriter, r *http.Request) {
 	var req CreateListenerRequest
-	if err := readELBJSONRequest(r, &req); err != nil {
+	if err := readCreateListenerRequest(r, &req); err != nil {
 		writeELBError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
 
 		return
@@ -339,19 +442,6 @@ func (s *Service) CreateListener(w http.ResponseWriter, r *http.Request) {
 		writeELBError(w, errInvalidParameter, "LoadBalancerArn is required", http.StatusBadRequest)
 
 		return
-	}
-
-	// readELBJSONRequest goes through the form-to-JSON converter, which
-	// flattens nested wire keys like
-	// DefaultActions.member.N.ForwardConfig.TargetGroups.member.M.Weight
-	// into dotted top-level keys that don't unmarshal back into the
-	// CreateListenerRequest struct. Re-parse the form directly so the
-	// listener's default actions — including weighted forward configs —
-	// survive into storage.
-	if err := r.ParseForm(); err == nil {
-		if acts := parseELBActionsFromForm(r.Form, "DefaultActions"); len(acts) > 0 {
-			req.DefaultActions = acts
-		}
 	}
 
 	listener, err := s.storage.CreateListener(r.Context(), &req)
@@ -370,6 +460,40 @@ func (s *Service) CreateListener(w http.ResponseWriter, r *http.Request) {
 		},
 		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
 	})
+}
+
+func readCreateListenerRequest(r *http.Request, req *CreateListenerRequest) error {
+	if strings.Contains(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+		if err := r.ParseForm(); err != nil {
+			return err
+		}
+
+		req.LoadBalancerArn = r.Form.Get("LoadBalancerArn")
+		req.Protocol = r.Form.Get("Protocol")
+		req.Port = parseELBFormInt(r.Form.Get("Port"))
+		req.DefaultActions = parseELBActionsFromForm(r.Form, "DefaultActions")
+
+		return nil
+	}
+
+	if err := readELBJSONRequest(r, req); err != nil {
+		return err
+	}
+
+	// readELBJSONRequest goes through the form-to-JSON converter, which
+	// flattens nested wire keys like
+	// DefaultActions.member.N.ForwardConfig.TargetGroups.member.M.Weight
+	// into dotted top-level keys that don't unmarshal back into the
+	// CreateListenerRequest struct. Re-parse the form directly so the
+	// listener's default actions — including weighted forward configs —
+	// survive into storage.
+	if err := r.ParseForm(); err == nil {
+		if acts := parseELBActionsFromForm(r.Form, "DefaultActions"); len(acts) > 0 {
+			req.DefaultActions = acts
+		}
+	}
+
+	return nil
 }
 
 // DeleteListener handles the DeleteListener action.
@@ -991,8 +1115,8 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 		"ModifyListener":                 s.ModifyListener,
 		"DescribeTargetHealth":           s.DescribeTargetHealth,
 		"DescribeTags":                   s.DescribeTags,
-		"AddTags":                        s.addTagsNoOp,
-		"RemoveTags":                     s.removeTagsNoOp,
+		"AddTags":                        s.AddTags,
+		"RemoveTags":                     s.RemoveTags,
 		"DescribeCapacityReservation":    s.DescribeCapacityReservation,
 		"DescribeListenerAttributes":     s.DescribeListenerAttributes,
 		"ModifyListenerAttributes":       s.DescribeListenerAttributes,
@@ -1001,23 +1125,20 @@ func (s *Service) getActionHandler(action string) func(http.ResponseWriter, *htt
 	return handlers[action]
 }
 
-// DescribeTags returns empty tag descriptions for each ResourceArn.N. The
-// AWS provider calls this on every read to surface tags to the user; we
-// don't model them yet but must echo the requested ARNs back.
+// DescribeTags returns tag descriptions for requested ResourceArns.
 func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
-	_ = r.ParseForm()
+	arns := collectResourceArns(r)
+	tagsByARN, err := s.storage.DescribeTags(r.Context(), arns)
+	if err != nil {
+		handleELBError(w, err)
 
-	descs := make([]XMLTagDescription, 0)
+		return
+	}
 
-	for i := 1; ; i++ {
-		key := fmt.Sprintf("ResourceArns.member.%d", i)
+	descs := make([]XMLTagDescription, 0, len(arns))
 
-		arn := r.Form.Get(key)
-		if arn == "" {
-			break
-		}
-
-		descs = append(descs, XMLTagDescription{ResourceArn: arn})
+	for _, arn := range arns {
+		descs = append(descs, XMLTagDescription{ResourceArn: arn, Tags: xmlTags(tagsByARN[arn])})
 	}
 
 	writeELBXMLResponse(w, XMLDescribeTagsResponse{
@@ -1025,6 +1146,22 @@ func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
 		DescribeTagsResult: XMLDescribeTagsResult{TagDescriptions: XMLTagDescriptions{Members: descs}},
 		ResponseMetadata:   XMLResponseMetadata{RequestID: uuid.New().String()},
 	})
+}
+
+func collectResourceArns(r *http.Request) []string {
+	if err := r.ParseForm(); err == nil {
+		arns := parseELBMemberListFromForm(r.Form, "ResourceArns")
+		if len(arns) > 0 {
+			return arns
+		}
+	}
+
+	var req describeTagsJSONRequest
+	if err := readELBJSONRequest(r, &req); err == nil {
+		return req.ResourceArns
+	}
+
+	return nil
 }
 
 // DescribeCapacityReservation returns an empty capacity reservation block.
@@ -1049,20 +1186,178 @@ func (s *Service) DescribeListenerAttributes(w http.ResponseWriter, _ *http.Requ
 	})
 }
 
-// addTagsNoOp accepts AddTags as a no-op success response.
-func (s *Service) addTagsNoOp(w http.ResponseWriter, _ *http.Request) {
+// AddTags attaches or updates tags on ELBv2 resources.
+func (s *Service) AddTags(w http.ResponseWriter, r *http.Request) {
+	arns, tags, err := readAddTagsRequest(r)
+	if err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.AddTags(r.Context(), arns, tags); err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
 	writeELBXMLResponse(w, XMLAddTagsResponse{
 		Xmlns:            elbXMLNS,
 		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
 	})
 }
 
-// removeTagsNoOp accepts RemoveTags as a no-op success response.
-func (s *Service) removeTagsNoOp(w http.ResponseWriter, _ *http.Request) {
+// RemoveTags detaches tags from ELBv2 resources.
+func (s *Service) RemoveTags(w http.ResponseWriter, r *http.Request) {
+	arns, keys, err := readRemoveTagsRequest(r)
+	if err != nil {
+		writeELBError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.RemoveTags(r.Context(), arns, keys); err != nil {
+		handleELBError(w, err)
+
+		return
+	}
+
 	writeELBXMLResponse(w, XMLRemoveTagsResponse{
 		Xmlns:            elbXMLNS,
 		ResponseMetadata: XMLResponseMetadata{RequestID: uuid.New().String()},
 	})
+}
+
+func readAddTagsRequest(r *http.Request) ([]string, map[string]string, error) {
+	if err := r.ParseForm(); err == nil {
+		arns := parseELBMemberListFromForm(r.Form, "ResourceArns")
+		tags := parseELBTagPairsFromForm(r.Form)
+		if len(arns) > 0 || len(tags) > 0 {
+			return arns, tags, nil
+		}
+	}
+
+	var req addTagsJSONRequest
+	if err := readELBJSONRequest(r, &req); err != nil {
+		return nil, nil, err
+	}
+
+	return req.ResourceArns, jsonTagsToMap(req.Tags), nil
+}
+
+func readRemoveTagsRequest(r *http.Request) ([]string, []string, error) {
+	if err := r.ParseForm(); err == nil {
+		arns := parseELBMemberListFromForm(r.Form, "ResourceArns")
+		keys := parseELBMemberListFromForm(r.Form, "TagKeys")
+		if len(arns) > 0 || len(keys) > 0 {
+			return arns, keys, nil
+		}
+	}
+
+	var req removeTagsJSONRequest
+	if err := readELBJSONRequest(r, &req); err != nil {
+		return nil, nil, err
+	}
+
+	return req.ResourceArns, req.TagKeys, nil
+}
+
+type describeTagsJSONRequest struct {
+	ResourceArns []string `json:"ResourceArns"`
+}
+
+type addTagsJSONRequest struct {
+	ResourceArns []string      `json:"ResourceArns"`
+	Tags         []tagJSONPair `json:"Tags"`
+}
+
+type removeTagsJSONRequest struct {
+	ResourceArns []string `json:"ResourceArns"`
+	TagKeys      []string `json:"TagKeys"`
+}
+
+type tagJSONPair struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+type tagPairAcc struct {
+	key   string
+	value string
+}
+
+func parseELBTagPairsFromForm(form map[string][]string) map[string]string {
+	byIdx := make(map[int]*tagPairAcc)
+
+	for key, values := range form {
+		applyELBTagPairFormEntry(byIdx, key, values)
+	}
+
+	out := make(map[string]string)
+	for _, entry := range byIdx {
+		if entry.key != "" {
+			out[entry.key] = entry.value
+		}
+	}
+
+	return out
+}
+
+func applyELBTagPairFormEntry(byIdx map[int]*tagPairAcc, key string, values []string) {
+	suffix, ok := strings.CutPrefix(key, "Tags.member.")
+	if !ok || len(values) == 0 {
+		return
+	}
+
+	dot := strings.Index(suffix, ".")
+	if dot < 0 {
+		return
+	}
+
+	n, err := strconv.Atoi(suffix[:dot])
+	if err != nil {
+		return
+	}
+
+	entry, exists := byIdx[n]
+	if !exists {
+		entry = &tagPairAcc{}
+		byIdx[n] = entry
+	}
+
+	switch suffix[dot+1:] {
+	case "Key":
+		entry.key = values[0]
+	case "Value":
+		entry.value = values[0]
+	}
+}
+
+func jsonTagsToMap(tags []tagJSONPair) map[string]string {
+	out := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		if tag.Key != "" {
+			out[tag.Key] = tag.Value
+		}
+	}
+
+	return out
+}
+
+func xmlTags(tags map[string]string) XMLTagList {
+	keys := make([]string, 0, len(tags))
+	for key := range tags {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	items := make([]XMLTagMember, 0, len(keys))
+	for _, key := range keys {
+		items = append(items, XMLTagMember{Key: key, Value: tags[key]})
+	}
+
+	return XMLTagList{Items: items}
 }
 
 // Helper functions.
@@ -1109,9 +1404,18 @@ func convertToXMLTargetGroup(tg *TargetGroup) XMLTargetGroup {
 		HealthCheckTimeoutSeconds:  tg.HealthCheckTimeoutSeconds,
 		HealthyThresholdCount:      tg.HealthyThresholdCount,
 		UnhealthyThresholdCount:    tg.UnhealthyThresholdCount,
+		Matcher:                    xmlMatcher(tg.Matcher),
 		TargetType:                 tg.TargetType,
 		LoadBalancerArns:           XMLLoadBalancerArns{Members: tg.LoadBalancerArns},
 	}
+}
+
+func xmlMatcher(httpCode string) *XMLMatcher {
+	if httpCode == "" {
+		return nil
+	}
+
+	return &XMLMatcher{HttpCode: httpCode}
 }
 
 // convertActionToXML serialises an Action for the wire. The legacy

--- a/internal/service/elbv2/listener_attributes_test.go
+++ b/internal/service/elbv2/listener_attributes_test.go
@@ -1,0 +1,34 @@
+package elbv2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDescribeListenerAttributesReturnsEmptyAttributes(t *testing.T) {
+	t.Parallel()
+
+	service := New(NewMemoryStorage())
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("Action=DescribeListenerAttributes&ListenerArn=arn-listener"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	service.DescribeListenerAttributes(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"<DescribeListenerAttributesResponse",
+		"<DescribeListenerAttributesResult>",
+		"<Attributes>",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected response to contain %q, got %s", want, body)
+		}
+	}
+}

--- a/internal/service/elbv2/listener_attributes_test.go
+++ b/internal/service/elbv2/listener_attributes_test.go
@@ -13,6 +13,7 @@ func TestDescribeListenerAttributesReturnsEmptyAttributes(t *testing.T) {
 	service := New(NewMemoryStorage())
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("Action=DescribeListenerAttributes&ListenerArn=arn-listener"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 	rec := httptest.NewRecorder()
 
 	service.DescribeListenerAttributes(rec, req)

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -1,0 +1,83 @@
+package elbv2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCreateListenerParsesDefaultActionsFromQueryForm(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+	service := New(storage)
+
+	lb, err := storage.CreateLoadBalancer(nil, &CreateLoadBalancerRequest{
+		Name:           "kumo-local",
+		Type:           "application",
+		Scheme:         "internal",
+		SecurityGroups: []string{"sg-kumo"},
+		Subnets:        []string{"subnet-kumo-a"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tg, err := storage.CreateTargetGroup(nil, &CreateTargetGroupRequest{
+		Name:       "kumo-local-kumo",
+		Port:       4566,
+		Protocol:   "HTTP",
+		TargetType: "ip",
+		VpcID:      "vpc-kumo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := "Action=CreateListener" +
+		"&LoadBalancerArn=" + lb.LoadBalancerArn +
+		"&Port=4566" +
+		"&Protocol=HTTP" +
+		"&DefaultActions.member.1.Type=forward" +
+		"&DefaultActions.member.1.TargetGroupArn=" + tg.TargetGroupArn
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	service.CreateListener(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if !strings.Contains(rec.Body.String(), "<TargetGroupArn>"+tg.TargetGroupArn+"</TargetGroupArn>") {
+		t.Fatalf("expected listener response to include default target group, got %s", rec.Body.String())
+	}
+}
+
+func TestCreateTargetGroupParsesMatcherFromQueryForm(t *testing.T) {
+	t.Parallel()
+
+	service := New(NewMemoryStorage())
+	body := "Action=CreateTargetGroup" +
+		"&Name=kumo-local-kumo" +
+		"&Port=4566" +
+		"&Protocol=HTTP" +
+		"&TargetType=ip" +
+		"&VpcId=vpc-kumo" +
+		"&Matcher.HttpCode=200"
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	service.CreateTargetGroup(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if !strings.Contains(rec.Body.String(), "<Matcher><HttpCode>200</HttpCode></Matcher>") {
+		t.Fatalf("expected target group response to include matcher, got %s", rec.Body.String())
+	}
+}

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -1,6 +1,7 @@
 package elbv2
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,8 +13,9 @@ func TestCreateListenerParsesDefaultActionsFromQueryForm(t *testing.T) {
 
 	storage := NewMemoryStorage()
 	service := New(storage)
+	ctx := context.TODO()
 
-	lb, err := storage.CreateLoadBalancer(nil, &CreateLoadBalancerRequest{
+	lb, err := storage.CreateLoadBalancer(ctx, &CreateLoadBalancerRequest{
 		Name:           "kumo-local",
 		Type:           "application",
 		Scheme:         "internal",
@@ -24,7 +26,7 @@ func TestCreateListenerParsesDefaultActionsFromQueryForm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tg, err := storage.CreateTargetGroup(nil, &CreateTargetGroupRequest{
+	tg, err := storage.CreateTargetGroup(ctx, &CreateTargetGroupRequest{
 		Name:       "kumo-local-kumo",
 		Port:       4566,
 		Protocol:   "HTTP",
@@ -43,6 +45,7 @@ func TestCreateListenerParsesDefaultActionsFromQueryForm(t *testing.T) {
 		"&DefaultActions.member.1.TargetGroupArn=" + tg.TargetGroupArn
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 	rec := httptest.NewRecorder()
 
 	service.CreateListener(rec, req)
@@ -69,6 +72,7 @@ func TestCreateTargetGroupParsesMatcherFromQueryForm(t *testing.T) {
 		"&Matcher.HttpCode=200"
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 	rec := httptest.NewRecorder()
 
 	service.CreateTargetGroup(rec, req)

--- a/internal/service/elbv2/storage.go
+++ b/internal/service/elbv2/storage.go
@@ -467,7 +467,7 @@ func matcherFromRequest(req *CreateTargetGroupRequest) string {
 		return ""
 	}
 
-	return req.Matcher.HttpCode
+	return req.Matcher.HTTPCode
 }
 
 // DeleteTargetGroup deletes a target group.
@@ -969,6 +969,7 @@ func (m *MemoryStorage) DescribeTags(_ context.Context, arns []string) (map[stri
 	defer m.mu.RUnlock()
 
 	out := make(map[string]map[string]string, len(arns))
+
 	for _, arn := range arns {
 		tags, err := m.lookupTagsLocked(arn)
 		if err != nil {

--- a/internal/service/elbv2/storage.go
+++ b/internal/service/elbv2/storage.go
@@ -46,6 +46,9 @@ type Storage interface {
 	DescribeLoadBalancerAttributes(ctx context.Context, lbArn string) (map[string]string, error)
 	ModifyTargetGroupAttributes(ctx context.Context, tgArn string, attrs map[string]string) (map[string]string, error)
 	DescribeTargetGroupAttributes(ctx context.Context, tgArn string) (map[string]string, error)
+	DescribeTags(ctx context.Context, arns []string) (map[string]map[string]string, error)
+	AddTags(ctx context.Context, arns []string, tags map[string]string) error
+	RemoveTags(ctx context.Context, arns, keys []string) error
 
 	DescribeListeners(ctx context.Context, listenerArns []string, lbArn string) ([]*Listener, error)
 	ModifyListener(ctx context.Context, listenerArn string, port int, protocol string, defaultActions []Action) (*Listener, error)
@@ -263,6 +266,7 @@ func (m *MemoryStorage) buildLoadBalancer(req *CreateLoadBalancerRequest, defaul
 		AvailabilityZones:     azs,
 		SecurityGroups:        req.SecurityGroups,
 		IPAddressType:         defaults.ipAddressType,
+		Tags:                  cloneAttributes(req.Tags),
 	}
 }
 
@@ -451,9 +455,19 @@ func (m *MemoryStorage) buildTargetGroup(req *CreateTargetGroupRequest, defaults
 		HealthCheckTimeoutSeconds:  defaults.healthCheckTimeout,
 		HealthyThresholdCount:      defaults.healthyThreshold,
 		UnhealthyThresholdCount:    defaults.unhealthyThreshold,
+		Matcher:                    matcherFromRequest(req),
 		TargetType:                 defaults.targetType,
 		LoadBalancerArns:           []string{},
+		Tags:                       cloneAttributes(req.Tags),
 	}
+}
+
+func matcherFromRequest(req *CreateTargetGroupRequest) string {
+	if req.Matcher == nil {
+		return ""
+	}
+
+	return req.Matcher.HttpCode
 }
 
 // DeleteTargetGroup deletes a target group.
@@ -621,6 +635,7 @@ func (m *MemoryStorage) CreateListener(_ context.Context, req *CreateListenerReq
 		Port:            req.Port,
 		Protocol:        req.Protocol,
 		DefaultActions:  req.DefaultActions,
+		Tags:            map[string]string{},
 	}
 
 	m.Listeners[arn] = listener
@@ -946,6 +961,94 @@ func cloneAttributes(in map[string]string) map[string]string {
 	}
 
 	return out
+}
+
+// DescribeTags returns tags for the requested ELBv2 resources.
+func (m *MemoryStorage) DescribeTags(_ context.Context, arns []string) (map[string]map[string]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make(map[string]map[string]string, len(arns))
+	for _, arn := range arns {
+		tags, err := m.lookupTagsLocked(arn)
+		if err != nil {
+			return nil, err
+		}
+
+		out[arn] = cloneAttributes(tags)
+	}
+
+	return out, nil
+}
+
+// AddTags adds or updates tags for the requested ELBv2 resources.
+func (m *MemoryStorage) AddTags(_ context.Context, arns []string, tags map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, arn := range arns {
+		current, err := m.lookupTagsLocked(arn)
+		if err != nil {
+			return err
+		}
+
+		for key, value := range tags {
+			current[key] = value
+		}
+	}
+
+	m.saveLocked()
+
+	return nil
+}
+
+// RemoveTags removes tags from the requested ELBv2 resources.
+func (m *MemoryStorage) RemoveTags(_ context.Context, arns, keys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, arn := range arns {
+		current, err := m.lookupTagsLocked(arn)
+		if err != nil {
+			return err
+		}
+
+		for _, key := range keys {
+			delete(current, key)
+		}
+	}
+
+	m.saveLocked()
+
+	return nil
+}
+
+func (m *MemoryStorage) lookupTagsLocked(arn string) (map[string]string, error) {
+	if lb, ok := m.LoadBalancers[arn]; ok {
+		if lb.Tags == nil {
+			lb.Tags = make(map[string]string)
+		}
+
+		return lb.Tags, nil
+	}
+
+	if tg, ok := m.TargetGroups[arn]; ok {
+		if tg.Tags == nil {
+			tg.Tags = make(map[string]string)
+		}
+
+		return tg.Tags, nil
+	}
+
+	if listener, ok := m.Listeners[arn]; ok {
+		if listener.Tags == nil {
+			listener.Tags = make(map[string]string)
+		}
+
+		return listener.Tags, nil
+	}
+
+	return nil, &Error{Code: "ResourceNotFound", Message: "resource '" + arn + "' not found"}
 }
 
 // DescribeListeners returns listeners by ARN list or by parent load balancer.

--- a/internal/service/elbv2/tags_test.go
+++ b/internal/service/elbv2/tags_test.go
@@ -1,0 +1,135 @@
+package elbv2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAddTagsAreReturnedByDescribeTags(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+	service := New(storage)
+
+	lb, err := storage.CreateLoadBalancer(nil, &CreateLoadBalancerRequest{
+		Name:    "kumo-local",
+		Type:    "application",
+		Scheme:  "internal",
+		Subnets: []string{"subnet-kumo-a"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addBody := "Action=AddTags" +
+		"&ResourceArns.member.1=" + lb.LoadBalancerArn +
+		"&Tags.member.1.Key=Project" +
+		"&Tags.member.1.Value=kumo-local"
+	addReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(addBody))
+	addReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	addRec := httptest.NewRecorder()
+
+	service.AddTags(addRec, addReq)
+
+	if addRec.Code != http.StatusOK {
+		t.Fatalf("expected AddTags status 200, got %d: %s", addRec.Code, addRec.Body.String())
+	}
+
+	describeBody := "Action=DescribeTags&ResourceArns.member.1=" + lb.LoadBalancerArn
+	describeReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(describeBody))
+	describeReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	describeRec := httptest.NewRecorder()
+
+	service.DescribeTags(describeRec, describeReq)
+
+	if describeRec.Code != http.StatusOK {
+		t.Fatalf("expected DescribeTags status 200, got %d: %s", describeRec.Code, describeRec.Body.String())
+	}
+
+	body := describeRec.Body.String()
+	for _, want := range []string{
+		"<ResourceArn>" + lb.LoadBalancerArn + "</ResourceArn>",
+		"<Key>Project</Key>",
+		"<Value>kumo-local</Value>",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected response to contain %q, got %s", want, body)
+		}
+	}
+}
+
+func TestCreateLoadBalancerStoresQueryTags(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+	service := New(storage)
+	body := "Action=CreateLoadBalancer" +
+		"&Name=kumo-local" +
+		"&Type=application" +
+		"&Scheme=internal" +
+		"&Subnets.member.1=subnet-kumo-a" +
+		"&Tags.member.1.Key=Project" +
+		"&Tags.member.1.Value=kumo-local"
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	service.CreateLoadBalancer(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	lbs, err := storage.DescribeLoadBalancers(nil, nil, []string{"kumo-local"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertStoredTag(t, storage, lbs[0].LoadBalancerArn, "Project", "kumo-local")
+}
+
+func TestCreateTargetGroupStoresQueryTags(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+	service := New(storage)
+	body := "Action=CreateTargetGroup" +
+		"&Name=kumo-local-kumo" +
+		"&Port=4566" +
+		"&Protocol=HTTP" +
+		"&TargetType=ip" +
+		"&VpcId=vpc-kumo" +
+		"&Tags.member.1.Key=Project" +
+		"&Tags.member.1.Value=kumo-local"
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	service.CreateTargetGroup(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	tgs, err := storage.DescribeTargetGroups(nil, nil, []string{"kumo-local-kumo"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertStoredTag(t, storage, tgs[0].TargetGroupArn, "Project", "kumo-local")
+}
+
+func assertStoredTag(t *testing.T, storage *MemoryStorage, arn, key, want string) {
+	t.Helper()
+
+	tagsByARN, err := storage.DescribeTags(nil, []string{arn})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := tagsByARN[arn][key]; got != want {
+		t.Fatalf("expected tag %s=%q, got %q", key, want, got)
+	}
+}

--- a/internal/service/elbv2/tags_test.go
+++ b/internal/service/elbv2/tags_test.go
@@ -1,6 +1,7 @@
 package elbv2
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,8 +13,9 @@ func TestAddTagsAreReturnedByDescribeTags(t *testing.T) {
 
 	storage := NewMemoryStorage()
 	service := New(storage)
+	ctx := context.TODO()
 
-	lb, err := storage.CreateLoadBalancer(nil, &CreateLoadBalancerRequest{
+	lb, err := storage.CreateLoadBalancer(ctx, &CreateLoadBalancerRequest{
 		Name:    "kumo-local",
 		Type:    "application",
 		Scheme:  "internal",
@@ -29,6 +31,7 @@ func TestAddTagsAreReturnedByDescribeTags(t *testing.T) {
 		"&Tags.member.1.Value=kumo-local"
 	addReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(addBody))
 	addReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 	addRec := httptest.NewRecorder()
 
 	service.AddTags(addRec, addReq)
@@ -40,6 +43,7 @@ func TestAddTagsAreReturnedByDescribeTags(t *testing.T) {
 	describeBody := "Action=DescribeTags&ResourceArns.member.1=" + lb.LoadBalancerArn
 	describeReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(describeBody))
 	describeReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 	describeRec := httptest.NewRecorder()
 
 	service.DescribeTags(describeRec, describeReq)
@@ -65,6 +69,7 @@ func TestCreateLoadBalancerStoresQueryTags(t *testing.T) {
 
 	storage := NewMemoryStorage()
 	service := New(storage)
+	ctx := context.TODO()
 	body := "Action=CreateLoadBalancer" +
 		"&Name=kumo-local" +
 		"&Type=application" +
@@ -74,6 +79,7 @@ func TestCreateLoadBalancerStoresQueryTags(t *testing.T) {
 		"&Tags.member.1.Value=kumo-local"
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 	rec := httptest.NewRecorder()
 
 	service.CreateLoadBalancer(rec, req)
@@ -82,7 +88,7 @@ func TestCreateLoadBalancerStoresQueryTags(t *testing.T) {
 		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	lbs, err := storage.DescribeLoadBalancers(nil, nil, []string{"kumo-local"})
+	lbs, err := storage.DescribeLoadBalancers(ctx, nil, []string{"kumo-local"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,6 +101,7 @@ func TestCreateTargetGroupStoresQueryTags(t *testing.T) {
 
 	storage := NewMemoryStorage()
 	service := New(storage)
+	ctx := context.TODO()
 	body := "Action=CreateTargetGroup" +
 		"&Name=kumo-local-kumo" +
 		"&Port=4566" +
@@ -105,6 +112,7 @@ func TestCreateTargetGroupStoresQueryTags(t *testing.T) {
 		"&Tags.member.1.Value=kumo-local"
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 	rec := httptest.NewRecorder()
 
 	service.CreateTargetGroup(rec, req)
@@ -113,7 +121,7 @@ func TestCreateTargetGroupStoresQueryTags(t *testing.T) {
 		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	tgs, err := storage.DescribeTargetGroups(nil, nil, []string{"kumo-local-kumo"}, "")
+	tgs, err := storage.DescribeTargetGroups(ctx, nil, []string{"kumo-local-kumo"}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +132,7 @@ func TestCreateTargetGroupStoresQueryTags(t *testing.T) {
 func assertStoredTag(t *testing.T, storage *MemoryStorage, arn, key, want string) {
 	t.Helper()
 
-	tagsByARN, err := storage.DescribeTags(nil, []string{arn})
+	tagsByARN, err := storage.DescribeTags(context.TODO(), []string{arn})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/service/elbv2/types.go
+++ b/internal/service/elbv2/types.go
@@ -194,7 +194,7 @@ type CreateTargetGroupRequest struct {
 
 // Matcher represents target group health check matcher settings.
 type Matcher struct {
-	HttpCode string `json:"HttpCode,omitempty"`
+	HTTPCode string `json:"HttpCode,omitempty"`
 }
 
 // DeleteTargetGroupRequest represents a DeleteTargetGroup request.
@@ -380,7 +380,7 @@ type XMLTargetGroup struct {
 
 // XMLMatcher represents target group matcher settings.
 type XMLMatcher struct {
-	HttpCode string `xml:"HttpCode,omitempty"`
+	HTTPCode string `xml:"HttpCode,omitempty"`
 }
 
 // XMLLoadBalancerArns contains a list of load balancer ARNs.

--- a/internal/service/elbv2/types.go
+++ b/internal/service/elbv2/types.go
@@ -23,6 +23,7 @@ type LoadBalancer struct {
 	SecurityGroups        []string
 	IPAddressType         string
 	Attributes            map[string]string
+	Tags                  map[string]string
 }
 
 // LoadBalancerState represents the state of a load balancer.
@@ -59,9 +60,11 @@ type TargetGroup struct {
 	HealthCheckTimeoutSeconds  int
 	HealthyThresholdCount      int
 	UnhealthyThresholdCount    int
+	Matcher                    string
 	TargetType                 string // instance | ip | lambda | alb
 	LoadBalancerArns           []string
 	Attributes                 map[string]string
+	Tags                       map[string]string
 }
 
 // Listener represents an ELB listener.
@@ -72,6 +75,7 @@ type Listener struct {
 	Protocol        string
 	DefaultActions  []Action
 	Rules           []Rule
+	Tags            map[string]string
 }
 
 // Action represents a listener action. The legacy single-target form
@@ -149,12 +153,13 @@ type TargetDescription struct {
 
 // CreateLoadBalancerRequest represents a CreateLoadBalancer request.
 type CreateLoadBalancerRequest struct {
-	Name           string   `json:"Name"`
-	Subnets        []string `json:"Subnets,omitempty"`
-	SecurityGroups []string `json:"SecurityGroups,omitempty"`
-	Scheme         string   `json:"Scheme,omitempty"`
-	Type           string   `json:"Type,omitempty"`
-	IPAddressType  string   `json:"IpAddressType,omitempty"`
+	Name           string            `json:"Name"`
+	Subnets        []string          `json:"Subnets,omitempty"`
+	SecurityGroups []string          `json:"SecurityGroups,omitempty"`
+	Scheme         string            `json:"Scheme,omitempty"`
+	Type           string            `json:"Type,omitempty"`
+	IPAddressType  string            `json:"IpAddressType,omitempty"`
+	Tags           map[string]string `json:"Tags,omitempty"`
 }
 
 // DeleteLoadBalancerRequest represents a DeleteLoadBalancer request.
@@ -170,19 +175,26 @@ type DescribeLoadBalancersRequest struct {
 
 // CreateTargetGroupRequest represents a CreateTargetGroup request.
 type CreateTargetGroupRequest struct {
-	Name                       string `json:"Name"`
-	Protocol                   string `json:"Protocol,omitempty"`
-	Port                       int    `json:"Port,omitempty"`
-	VpcID                      string `json:"VpcId,omitempty"`
-	HealthCheckProtocol        string `json:"HealthCheckProtocol,omitempty"`
-	HealthCheckPort            string `json:"HealthCheckPort,omitempty"`
-	HealthCheckEnabled         bool   `json:"HealthCheckEnabled,omitempty"`
-	HealthCheckPath            string `json:"HealthCheckPath,omitempty"`
-	HealthCheckIntervalSeconds int    `json:"HealthCheckIntervalSeconds,omitempty"`
-	HealthCheckTimeoutSeconds  int    `json:"HealthCheckTimeoutSeconds,omitempty"`
-	HealthyThresholdCount      int    `json:"HealthyThresholdCount,omitempty"`
-	UnhealthyThresholdCount    int    `json:"UnhealthyThresholdCount,omitempty"`
-	TargetType                 string `json:"TargetType,omitempty"`
+	Name                       string            `json:"Name"`
+	Protocol                   string            `json:"Protocol,omitempty"`
+	Port                       int               `json:"Port,omitempty"`
+	VpcID                      string            `json:"VpcId,omitempty"`
+	HealthCheckProtocol        string            `json:"HealthCheckProtocol,omitempty"`
+	HealthCheckPort            string            `json:"HealthCheckPort,omitempty"`
+	HealthCheckEnabled         bool              `json:"HealthCheckEnabled,omitempty"`
+	HealthCheckPath            string            `json:"HealthCheckPath,omitempty"`
+	HealthCheckIntervalSeconds int               `json:"HealthCheckIntervalSeconds,omitempty"`
+	HealthCheckTimeoutSeconds  int               `json:"HealthCheckTimeoutSeconds,omitempty"`
+	HealthyThresholdCount      int               `json:"HealthyThresholdCount,omitempty"`
+	UnhealthyThresholdCount    int               `json:"UnhealthyThresholdCount,omitempty"`
+	Matcher                    *Matcher          `json:"Matcher,omitempty"`
+	TargetType                 string            `json:"TargetType,omitempty"`
+	Tags                       map[string]string `json:"Tags,omitempty"`
+}
+
+// Matcher represents target group health check matcher settings.
+type Matcher struct {
+	HttpCode string `json:"HttpCode,omitempty"`
 }
 
 // DeleteTargetGroupRequest represents a DeleteTargetGroup request.
@@ -361,8 +373,14 @@ type XMLTargetGroup struct {
 	HealthCheckTimeoutSeconds  int                 `xml:"HealthCheckTimeoutSeconds"`
 	HealthyThresholdCount      int                 `xml:"HealthyThresholdCount"`
 	UnhealthyThresholdCount    int                 `xml:"UnhealthyThresholdCount"`
+	Matcher                    *XMLMatcher         `xml:"Matcher,omitempty"`
 	TargetType                 string              `xml:"TargetType"`
 	LoadBalancerArns           XMLLoadBalancerArns `xml:"LoadBalancerArns"`
+}
+
+// XMLMatcher represents target group matcher settings.
+type XMLMatcher struct {
+	HttpCode string `xml:"HttpCode,omitempty"`
 }
 
 // XMLLoadBalancerArns contains a list of load balancer ARNs.
@@ -782,8 +800,19 @@ type XMLTagDescriptions struct {
 
 // XMLTagDescription represents tags attached to a resource.
 type XMLTagDescription struct {
-	ResourceArn string          `xml:"ResourceArn"`
-	Tags        XMLEmptyMembers `xml:"Tags"`
+	ResourceArn string     `xml:"ResourceArn"`
+	Tags        XMLTagList `xml:"Tags"`
+}
+
+// XMLTagList wraps tag members.
+type XMLTagList struct {
+	Items []XMLTagMember `xml:"member"`
+}
+
+// XMLTagMember is a single tag.
+type XMLTagMember struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
 }
 
 // XMLEmptyMembers represents an empty AWS Query member list.


### PR DESCRIPTION
## Summary

Improves ELBv2 Terraform refresh compatibility by persisting tags and returning target group/listener readback fields.

## Changes

- Persists ELBv2 tags on load balancers, target groups, and listeners.
- Implements storage-backed `DescribeTags`, `AddTags`, and `RemoveTags`.
- Parses create-time Query form tags for load balancers and target groups.
- Parses and returns target group health check matcher values.
- Keeps listener default actions from Query form requests.
- Adds coverage for capacity reservation, listener attributes, listener default actions, target group matcher, and tag round trips.

## Validation

- `go test ./internal/service/elbv2`
