### PR TITLE
fix(apigateway): inject stage variables into Lambda proxy events

### DIFF
--- a/internal/service/apigateway/executeapi.go
+++ b/internal/service/apigateway/executeapi.go
@@ -51,6 +51,7 @@ func (s *Service) HandleExecuteAPI(w http.ResponseWriter, r *http.Request, apiID
 			Stage:          stage,
 			ResourcePath:   resolved.resource.Path,
 			PathParameters: resolved.pathParams,
+			StageVariables: resolved.stage.Variables,
 		},
 	)
 
@@ -62,13 +63,15 @@ func (s *Service) HandleExecuteAPI(w http.ResponseWriter, r *http.Request, apiID
 type resolvedTarget struct {
 	resource   *Resource
 	method     Method
+	stage      *Stage
 	pathParams map[string]string
 }
 
 // resolveExecuteTarget validates the stage and resolves the resource, method,
 // and path parameters. A non-zero status is the HTTP error to return.
 func (s *Service) resolveExecuteTarget(r *http.Request, apiID, stage, reqPath string) (resolvedTarget, int) {
-	if _, err := s.storage.GetStage(r.Context(), apiID, stage); err != nil {
+	stageObj, err := s.storage.GetStage(r.Context(), apiID, stage)
+	if err != nil {
 		return resolvedTarget{}, http.StatusNotFound
 	}
 
@@ -91,7 +94,7 @@ func (s *Service) resolveExecuteTarget(r *http.Request, apiID, stage, reqPath st
 		return resolvedTarget{}, http.StatusInternalServerError
 	}
 
-	return resolvedTarget{resource: resource, method: method, pathParams: pathParams}, 0
+	return resolvedTarget{resource: resource, method: method, stage: stageObj, pathParams: pathParams}, 0
 }
 
 // executeErrorMessage maps an execute-api error status to its AWS message.

--- a/internal/service/apigateway/handlers.go
+++ b/internal/service/apigateway/handlers.go
@@ -489,6 +489,7 @@ func toStageResponse(s *Stage) *StageResponse {
 		CreatedDate:         float64(s.CreatedDate.Unix()),
 		LastUpdatedDate:     float64(s.LastUpdatedDate.Unix()),
 		Tags:                s.Tags,
+		Variables:           s.Variables,
 	}
 }
 

--- a/internal/service/apigateway/storage.go
+++ b/internal/service/apigateway/storage.go
@@ -630,6 +630,7 @@ func (s *MemoryStorage) CreateStage(_ context.Context, restAPIID string, req *Cr
 		CreatedDate:         now,
 		LastUpdatedDate:     now,
 		Tags:                req.Tags,
+		Variables:           req.Variables,
 	}
 
 	data.Stages[req.StageName] = stage

--- a/internal/service/apigateway/storage_stage_variables_test.go
+++ b/internal/service/apigateway/storage_stage_variables_test.go
@@ -1,0 +1,74 @@
+package apigateway
+
+import "testing"
+
+func TestMemoryStorage_CreateStage_Variables(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		variables map[string]string
+	}{
+		{name: "populated variables round-trip", variables: map[string]string{"env": "dev"}},
+		{name: "nil variables round-trip", variables: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			storage := NewMemoryStorage()
+
+			api, err := storage.CreateRestAPI(t.Context(), &CreateRestAPIRequest{Name: "test-api"})
+			if err != nil {
+				t.Fatalf("CreateRestAPI() error = %v", err)
+			}
+
+			deployment, err := storage.CreateDeployment(t.Context(), api.ID, &CreateDeploymentRequest{})
+			if err != nil {
+				t.Fatalf("CreateDeployment() error = %v", err)
+			}
+
+			created, err := storage.CreateStage(t.Context(), api.ID, &CreateStageRequest{
+				StageName:    "dev",
+				DeploymentID: deployment.ID,
+				Variables:    tt.variables,
+			})
+			if err != nil {
+				t.Fatalf("CreateStage() error = %v", err)
+			}
+
+			if !mapsEqualV1(created.Variables, tt.variables) {
+				t.Errorf("CreateStage() Variables = %v, want %v", created.Variables, tt.variables)
+			}
+
+			got, err := storage.GetStage(t.Context(), api.ID, "dev")
+			if err != nil {
+				t.Fatalf("GetStage() error = %v", err)
+			}
+
+			if !mapsEqualV1(got.Variables, tt.variables) {
+				t.Errorf("GetStage() Variables = %v, want %v", got.Variables, tt.variables)
+			}
+
+			resp := toStageResponse(got)
+			if !mapsEqualV1(resp.Variables, tt.variables) {
+				t.Errorf("toStageResponse() Variables = %v, want %v", resp.Variables, tt.variables)
+			}
+		})
+	}
+}
+
+func mapsEqualV1(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/service/apigateway/types.go
+++ b/internal/service/apigateway/types.go
@@ -78,6 +78,7 @@ type Stage struct {
 	CreatedDate         time.Time         `json:"createdDate"`
 	LastUpdatedDate     time.Time         `json:"lastUpdatedDate"`
 	Tags                map[string]string `json:"tags,omitempty"`
+	Variables           map[string]string `json:"variables,omitempty"`
 }
 
 // CreateRestAPIRequest represents a CreateRestApi request.
@@ -206,6 +207,7 @@ type CreateStageRequest struct {
 	CacheClusterEnabled bool              `json:"cacheClusterEnabled,omitempty"`
 	CacheClusterSize    string            `json:"cacheClusterSize,omitempty"`
 	Tags                map[string]string `json:"tags,omitempty"`
+	Variables           map[string]string `json:"variables,omitempty"`
 }
 
 // StageResponse represents a Stage response.
@@ -218,6 +220,7 @@ type StageResponse struct {
 	CreatedDate         float64           `json:"createdDate"`
 	LastUpdatedDate     float64           `json:"lastUpdatedDate"`
 	Tags                map[string]string `json:"tags,omitempty"`
+	Variables           map[string]string `json:"variables,omitempty"`
 }
 
 // GetStagesResponse represents a GetStages response.

--- a/internal/service/apigatewayv2/executeapi.go
+++ b/internal/service/apigatewayv2/executeapi.go
@@ -24,7 +24,7 @@ func (s *Service) HandleExecuteAPI(w http.ResponseWriter, r *http.Request, apiID
 		return false
 	}
 
-	stage, routePath := s.resolveStage(r, apiID, invokePath)
+	stage, stageObj, routePath := s.resolveStage(r, apiID, invokePath)
 	if stage == "" {
 		writeExecuteErrorV2(w, http.StatusNotFound, "Not Found")
 
@@ -70,28 +70,30 @@ func (s *Service) HandleExecuteAPI(w http.ResponseWriter, r *http.Request, apiID
 			ResourcePath:   routePath,
 			RouteKey:       route.RouteKey,
 			PathParameters: pathParams,
+			StageVariables: stageObj.StageVariables,
 		},
 	)
 
 	return true
 }
 
-// resolveStage determines the stage and the route path from the invoke path.
-// The path is /{stage}/{route} for a named stage, or /{route} for $default.
-func (s *Service) resolveStage(r *http.Request, apiID, invokePath string) (stage, routePath string) {
+// resolveStage determines the stage, the resolved stage object, and the
+// route path from the invoke path. The path is /{stage}/{route} for a named
+// stage, or /{route} for $default.
+func (s *Service) resolveStage(r *http.Request, apiID, invokePath string) (stage string, stageObj *Stage, routePath string) {
 	segs := execapi.SplitPath(invokePath)
 
 	if len(segs) > 0 {
-		if _, err := s.storage.GetStage(r.Context(), apiID, segs[0]); err == nil {
-			return segs[0], normalizeRoutePath(segs[1:])
+		if st, err := s.storage.GetStage(r.Context(), apiID, segs[0]); err == nil {
+			return segs[0], st, normalizeRoutePath(segs[1:])
 		}
 	}
 
-	if _, err := s.storage.GetStage(r.Context(), apiID, defaultStageName); err == nil {
-		return defaultStageName, normalizeRoutePath(segs)
+	if st, err := s.storage.GetStage(r.Context(), apiID, defaultStageName); err == nil {
+		return defaultStageName, st, normalizeRoutePath(segs)
 	}
 
-	return "", ""
+	return "", nil, ""
 }
 
 // integrationForRoute resolves the integration referenced by a route's target

--- a/internal/service/apigatewayv2/executeapi_stage_variables_test.go
+++ b/internal/service/apigatewayv2/executeapi_stage_variables_test.go
@@ -1,0 +1,114 @@
+package apigatewayv2
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResolveStage_ReturnsStageVariables(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		stageName  string
+		invokePath string
+		wantStage  string
+		wantVars   map[string]string
+	}{
+		{
+			name:       "named stage carries its variables",
+			stageName:  "dev",
+			invokePath: "/dev/items",
+			wantStage:  "dev",
+			wantVars:   map[string]string{"env": "dev"},
+		},
+		{
+			name:       "$default fallback carries its variables",
+			stageName:  defaultStageName,
+			invokePath: "/items",
+			wantStage:  defaultStageName,
+			wantVars:   map[string]string{"env": "prod"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checkResolveStageReturnsVariables(t, tt.stageName, tt.invokePath, tt.wantStage, tt.wantVars)
+		})
+	}
+}
+
+func checkResolveStageReturnsVariables(t *testing.T, stageName, invokePath, wantStage string, wantVars map[string]string) {
+	t.Helper()
+
+	storage := NewMemoryStorage()
+	svc := New(storage)
+
+	api, err := storage.CreateAPI(t.Context(), &CreateAPIRequest{Name: "test-api", ProtocolType: "HTTP"})
+	if err != nil {
+		t.Fatalf("CreateAPI() error = %v", err)
+	}
+
+	_, err = storage.CreateStage(t.Context(), api.APIID, &CreateStageRequest{
+		StageName:      stageName,
+		StageVariables: wantVars,
+	})
+	if err != nil {
+		t.Fatalf("CreateStage() error = %v", err)
+	}
+
+	r := httptest.NewRequestWithContext(t.Context(), "GET", invokePath, nil)
+
+	stage, stageObj, routePath := svc.resolveStage(r, api.APIID, invokePath)
+
+	if stage != wantStage {
+		t.Errorf("resolveStage() stage = %q, want %q", stage, wantStage)
+	}
+
+	if routePath == "" {
+		t.Error("resolveStage() routePath is empty, want a resolved path")
+	}
+
+	if stageObj == nil {
+		t.Fatal("resolveStage() stageObj is nil, want a resolved *Stage")
+	}
+
+	if !mapsEqualV2(stageObj.StageVariables, wantVars) {
+		t.Errorf("resolveStage() stageObj.StageVariables = %v, want %v", stageObj.StageVariables, wantVars)
+	}
+}
+
+func TestResolveStage_UnknownStage(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+	svc := New(storage)
+
+	api, err := storage.CreateAPI(t.Context(), &CreateAPIRequest{Name: "test-api", ProtocolType: "HTTP"})
+	if err != nil {
+		t.Fatalf("CreateAPI() error = %v", err)
+	}
+
+	r := httptest.NewRequestWithContext(t.Context(), "GET", "/missing/items", nil)
+
+	stage, stageObj, routePath := svc.resolveStage(r, api.APIID, "/missing/items")
+
+	if stage != "" || stageObj != nil || routePath != "" {
+		t.Errorf("resolveStage() = (%q, %v, %q), want (\"\", nil, \"\")", stage, stageObj, routePath)
+	}
+}
+
+func mapsEqualV2(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/service/execapi/event.go
+++ b/internal/service/execapi/event.go
@@ -48,6 +48,7 @@ func buildEventV1(r *http.Request, req *Request, body []byte) ([]byte, error) {
 		QueryStringParameters:           emptyToNil(query),
 		MultiValueQueryStringParameters: emptyMultiToNil(multiQuery),
 		PathParameters:                  emptyToNil(req.PathParameters),
+		StageVariables:                  emptyToNil(req.StageVariables),
 		Body:                            string(body),
 		RequestContext: requestContextV1{
 			ResourcePath: req.ResourcePath,
@@ -112,6 +113,7 @@ func buildEventV2(r *http.Request, req *Request, body []byte) ([]byte, error) {
 		Headers:               headers,
 		QueryStringParameters: emptyToNil(query),
 		PathParameters:        emptyToNil(req.PathParameters),
+		StageVariables:        emptyToNil(req.StageVariables),
 		Body:                  string(body),
 		RequestContext: requestContextV2{
 			APIID:     req.APIID,

--- a/internal/service/execapi/event_test.go
+++ b/internal/service/execapi/event_test.go
@@ -1,0 +1,171 @@
+package execapi
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildEventV1_StageVariables(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		stageVariables map[string]string
+		wantVars       map[string]string
+	}{
+		{
+			name:           "populated stage variables are included",
+			stageVariables: map[string]string{"env": "dev"},
+			wantVars:       map[string]string{"env": "dev"},
+		},
+		{
+			name:           "nil stage variables encode as null",
+			stageVariables: nil,
+			wantVars:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checkBuildEventV1StageVariables(t, tt.stageVariables, tt.wantVars)
+		})
+	}
+}
+
+func checkBuildEventV1StageVariables(t *testing.T, stageVariables, wantVars map[string]string) {
+	t.Helper()
+
+	r := httptest.NewRequestWithContext(t.Context(), "GET", "/dev/items", nil)
+	req := &Request{
+		APIID:          "api1",
+		Stage:          "dev",
+		ResourcePath:   "/items",
+		StageVariables: stageVariables,
+	}
+
+	data, err := buildEventV1(r, req, nil)
+	if err != nil {
+		t.Fatalf("buildEventV1() error = %v", err)
+	}
+
+	var decoded struct {
+		StageVariables map[string]string `json:"stageVariables"`
+	}
+
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+
+	if !mapsEqual(decoded.StageVariables, wantVars) {
+		t.Errorf("stageVariables = %v, want %v", decoded.StageVariables, wantVars)
+	}
+
+	if stageVariables == nil && !hasNullField(data, "stageVariables") {
+		t.Error("expected stageVariables to be present as null in the v1 event")
+	}
+}
+
+func TestBuildEventV2_StageVariables(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		stageVariables map[string]string
+		wantVars       map[string]string
+		wantOmitted    bool
+	}{
+		{
+			name:           "populated stage variables are included",
+			stageVariables: map[string]string{"env": "dev"},
+			wantVars:       map[string]string{"env": "dev"},
+		},
+		{
+			name:           "nil stage variables are omitted",
+			stageVariables: nil,
+			wantVars:       nil,
+			wantOmitted:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checkBuildEventV2StageVariables(t, tt.stageVariables, tt.wantVars, tt.wantOmitted)
+		})
+	}
+}
+
+func checkBuildEventV2StageVariables(t *testing.T, stageVariables, wantVars map[string]string, wantOmitted bool) {
+	t.Helper()
+
+	r := httptest.NewRequestWithContext(t.Context(), "GET", "/items", nil)
+	req := &Request{
+		APIID:          "api1",
+		Stage:          "$default",
+		ResourcePath:   "/items",
+		RouteKey:       "GET /items",
+		StageVariables: stageVariables,
+	}
+
+	data, err := buildEventV2(r, req, nil)
+	if err != nil {
+		t.Fatalf("buildEventV2() error = %v", err)
+	}
+
+	var decoded map[string]any
+
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+
+	_, present := decoded["stageVariables"]
+	if wantOmitted && present {
+		t.Error("expected stageVariables to be omitted from the v2 event")
+	}
+
+	if wantOmitted {
+		return
+	}
+
+	var typed struct {
+		StageVariables map[string]string `json:"stageVariables"`
+	}
+
+	if err := json.Unmarshal(data, &typed); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+
+	if !mapsEqual(typed.StageVariables, wantVars) {
+		t.Errorf("stageVariables = %v, want %v", typed.StageVariables, wantVars)
+	}
+}
+
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+// hasNullField reports whether the given top-level JSON field is present and
+// set to null in the raw payload.
+func hasNullField(data []byte, field string) bool {
+	var raw map[string]json.RawMessage
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+
+	v, ok := raw[field]
+
+	return ok && string(v) == "null"
+}

--- a/internal/service/execapi/execapi.go
+++ b/internal/service/execapi/execapi.go
@@ -46,6 +46,7 @@ type Request struct {
 	ResourcePath   string // matched resource path template (v1) or route path
 	RouteKey       string // v2 route key, e.g. "GET /items" or "$default"
 	PathParameters map[string]string
+	StageVariables map[string]string
 }
 
 // Dispatch resolves the integration target and writes the HTTP response. It is


### PR DESCRIPTION
## Summary

- A deployed API invoked through execute-api built the Lambda proxy event
  with `stageVariables` always `null`, even when the stage was created with
  variables — `buildEventV1`/`buildEventV2` never set the field. A Lambda
  reading `event.stageVariables` saw nothing locally while working on AWS.
- Thread the stage's variables into the proxy event for both REST (v1) and
  HTTP API (v2): the v1 `Stage` gains a `Variables` field (accepted in
  CreateStage), the resolved stage is carried into `execapi.Request`, and
  both builders set `stageVariables`.
- `emptyToNil` semantics are preserved: v1 emits `stageVariables: null` when
  empty, v2 omits the key (`omitempty`), matching the existing field tags.

## Test plan

- [x] `make lint` (0 issues), `go test -race ./...`
- [x] New unit tests: v1/v2 event builders populate `stageVariables` (and
      emit null/omit when empty); v1 CreateStage -> GetStage round-trips the
      variables; v2 `resolveStage` returns them for a named stage and the
      `$default` fallback

Closes #831
