### PR TITLE
fix(sts): derive AssumedRoleUser ARN from the requested RoleArn

### DIFF
--- a/internal/service/sts/storage.go
+++ b/internal/service/sts/storage.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -117,10 +119,11 @@ func (m *MemoryStorage) AssumeRole(_ context.Context, input *AssumeRoleInput) (*
 	creds := generateCredentials(duration)
 	roleSessionName := input.RoleSessionName
 	assumedRoleID := generateAssumedRoleID(roleSessionName)
+	partition, accountID, roleName := roleArnParts(input.RoleArn)
 
 	return &AssumeRoleResult{
 		AssumedRoleUser: &AssumedRoleUser{
-			Arn:           fmt.Sprintf("arn:aws:sts::%s:assumed-role/emulated-role/%s", defaultAccountID, roleSessionName),
+			Arn:           fmt.Sprintf("arn:%s:sts::%s:assumed-role/%s/%s", partition, accountID, roleName, roleSessionName),
 			AssumedRoleID: assumedRoleID,
 		},
 		Credentials:      creds,
@@ -133,10 +136,11 @@ func (m *MemoryStorage) AssumeRoleWithSAML(_ context.Context, input *AssumeRoleW
 	duration := resolveDuration(input.DurationSeconds)
 	creds := generateCredentials(duration)
 	assumedRoleID := generateAssumedRoleID("SAMLSession")
+	partition, accountID, roleName := roleArnParts(input.RoleArn)
 
 	return &AssumeRoleResult{
 		AssumedRoleUser: &AssumedRoleUser{
-			Arn:           fmt.Sprintf("arn:aws:sts::%s:assumed-role/emulated-role/SAMLSession", defaultAccountID),
+			Arn:           fmt.Sprintf("arn:%s:sts::%s:assumed-role/%s/SAMLSession", partition, accountID, roleName),
 			AssumedRoleID: assumedRoleID,
 		},
 		Credentials:      creds,
@@ -150,10 +154,11 @@ func (m *MemoryStorage) AssumeRoleWithWebIdentity(_ context.Context, input *Assu
 	creds := generateCredentials(duration)
 	roleSessionName := input.RoleSessionName
 	assumedRoleID := generateAssumedRoleID(roleSessionName)
+	partition, accountID, roleName := roleArnParts(input.RoleArn)
 
 	return &AssumeRoleResult{
 		AssumedRoleUser: &AssumedRoleUser{
-			Arn:           fmt.Sprintf("arn:aws:sts::%s:assumed-role/emulated-role/%s", defaultAccountID, roleSessionName),
+			Arn:           fmt.Sprintf("arn:%s:sts::%s:assumed-role/%s/%s", partition, accountID, roleName, roleSessionName),
 			AssumedRoleID: assumedRoleID,
 		},
 		Credentials:      creds,
@@ -193,6 +198,38 @@ func (m *MemoryStorage) GetFederationToken(_ context.Context, input *GetFederati
 }
 
 // Helper functions.
+
+// roleArnParts extracts the partition, account ID, and role name from an IAM
+// role ARN (arn:<partition>:iam::<account>:role/<path...>/<name>). Fallbacks
+// keep AssumeRole permissive: unparseable input yields "aws" / defaultAccountID
+// / "emulated-role", and an empty partition segment also defaults to "aws".
+func roleArnParts(roleArn string) (string, string, string) {
+	partition, accountID, roleName := "aws", defaultAccountID, "emulated-role"
+
+	parts := strings.SplitN(roleArn, ":", 6)
+	if len(parts) != 6 || parts[2] != "iam" {
+		return partition, accountID, roleName
+	}
+
+	if parts[1] != "" {
+		partition = parts[1]
+	}
+
+	if parts[4] != "" {
+		accountID = parts[4]
+	}
+
+	res, ok := strings.CutPrefix(parts[5], "role/")
+	if !ok || res == "" {
+		return partition, accountID, roleName
+	}
+
+	if name := path.Base(res); name != "." && name != "/" {
+		roleName = name
+	}
+
+	return partition, accountID, roleName
+}
 
 func resolveDuration(durationSeconds int32) int32 {
 	if durationSeconds <= 0 {

--- a/internal/service/sts/storage_test.go
+++ b/internal/service/sts/storage_test.go
@@ -1,0 +1,133 @@
+package sts
+
+import (
+	"testing"
+)
+
+type roleArnPartsCase struct {
+	name          string
+	roleArn       string
+	wantPartition string
+	wantAccount   string
+	wantName      string
+}
+
+func roleArnPartsTestCases() []roleArnPartsCase {
+	return []roleArnPartsCase{
+		{
+			name:          "simple role",
+			roleArn:       "arn:aws:iam::123456789012:role/my-role",
+			wantPartition: "aws",
+			wantAccount:   "123456789012",
+			wantName:      "my-role",
+		},
+		{
+			name:          "role with path",
+			roleArn:       "arn:aws:iam::123456789012:role/path/to/my-role",
+			wantPartition: "aws",
+			wantAccount:   "123456789012",
+			wantName:      "my-role",
+		},
+		{
+			name:          "role with trailing slash",
+			roleArn:       "arn:aws:iam::123456789012:role/",
+			wantPartition: "aws",
+			wantAccount:   "123456789012",
+			wantName:      "emulated-role",
+		},
+		{
+			name:          "not an arn",
+			roleArn:       "not-an-arn",
+			wantPartition: "aws",
+			wantAccount:   defaultAccountID,
+			wantName:      "emulated-role",
+		},
+		{
+			name:          "empty",
+			roleArn:       "",
+			wantPartition: "aws",
+			wantAccount:   defaultAccountID,
+			wantName:      "emulated-role",
+		},
+		{
+			name:          "govcloud partition",
+			roleArn:       "arn:aws-us-gov:iam::123456789012:role/gov-role",
+			wantPartition: "aws-us-gov",
+			wantAccount:   "123456789012",
+			wantName:      "gov-role",
+		},
+		{
+			name:          "china partition",
+			roleArn:       "arn:aws-cn:iam::123456789012:role/cn-role",
+			wantPartition: "aws-cn",
+			wantAccount:   "123456789012",
+			wantName:      "cn-role",
+		},
+	}
+}
+
+func assertRoleArnParts(t *testing.T, tt *roleArnPartsCase) {
+	t.Helper()
+
+	gotPartition, gotAccount, gotName := roleArnParts(tt.roleArn)
+	if gotPartition != tt.wantPartition {
+		t.Errorf("roleArnParts(%q) partition = %q, want %q", tt.roleArn, gotPartition, tt.wantPartition)
+	}
+
+	if gotAccount != tt.wantAccount {
+		t.Errorf("roleArnParts(%q) account = %q, want %q", tt.roleArn, gotAccount, tt.wantAccount)
+	}
+
+	if gotName != tt.wantName {
+		t.Errorf("roleArnParts(%q) name = %q, want %q", tt.roleArn, gotName, tt.wantName)
+	}
+}
+
+func TestRoleArnParts(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range roleArnPartsTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assertRoleArnParts(t, &tt)
+		})
+	}
+}
+
+func TestAssumeRoleReflectsRoleArn(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+
+	result, err := storage.AssumeRole(t.Context(), &AssumeRoleInput{
+		RoleArn:         "arn:aws:iam::123456789012:role/deploy-role",
+		RoleSessionName: "ci",
+	})
+	if err != nil {
+		t.Fatalf("AssumeRole() error = %v", err)
+	}
+
+	want := "arn:aws:sts::123456789012:assumed-role/deploy-role/ci"
+	if result.AssumedRoleUser.Arn != want {
+		t.Errorf("AssumedRoleUser.Arn = %q, want %q", result.AssumedRoleUser.Arn, want)
+	}
+}
+
+func TestAssumeRoleReflectsGovCloudPartition(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+
+	result, err := storage.AssumeRole(t.Context(), &AssumeRoleInput{
+		RoleArn:         "arn:aws-us-gov:iam::123456789012:role/gov-role",
+		RoleSessionName: "ci",
+	})
+	if err != nil {
+		t.Fatalf("AssumeRole() error = %v", err)
+	}
+
+	want := "arn:aws-us-gov:sts::123456789012:assumed-role/gov-role/ci"
+	if result.AssumedRoleUser.Arn != want {
+		t.Errorf("AssumedRoleUser.Arn = %q, want %q", result.AssumedRoleUser.Arn, want)
+	}
+}

--- a/test/integration/testdata/sts_test_TestSTS_AssumeRoleWithWebIdentity_TestSTS_AssumeRoleWithWebIdentity.golden.go
+++ b/test/integration/testdata/sts_test_TestSTS_AssumeRoleWithWebIdentity_TestSTS_AssumeRoleWithWebIdentity.golden.go
@@ -1,6 +1,6 @@
 {
   "AssumedRoleUser": {
-    "Arn": "arn:aws:sts::000000000000:assumed-role/emulated-role/web-session",
+    "Arn": "arn:aws:sts::000000000000:assumed-role/web-identity-role/web-session",
     "AssumedRoleId": "AROAfeee8289-c58:web-session"
   },
   "Audience": null,

--- a/test/integration/testdata/sts_test_TestSTS_AssumeRole_TestSTS_AssumeRole.golden.go
+++ b/test/integration/testdata/sts_test_TestSTS_AssumeRole_TestSTS_AssumeRole.golden.go
@@ -1,6 +1,6 @@
 {
   "AssumedRoleUser": {
-    "Arn": "arn:aws:sts::000000000000:assumed-role/emulated-role/test-session",
+    "Arn": "arn:aws:sts::000000000000:assumed-role/test-role/test-session",
     "AssumedRoleId": "AROA612aa82d-8cf:test-session"
   },
   "Credentials": {


### PR DESCRIPTION
## Summary

- `AssumeRole` (and `AssumeRoleWithSAML`/`AssumeRoleWithWebIdentity`) built
  the assumed-role ARN as `.../assumed-role/emulated-role/<session>`,
  discarding the requested `RoleArn`, so the role name could never be
  recovered from the response and distinct roles were indistinguishable.
- Derive the partition, account ID, and role name from the input `RoleArn`
  and interpolate them, so
  `arn:aws:iam::123456789012:role/deploy-role` + session `ci` yields
  `arn:aws:sts::123456789012:assumed-role/deploy-role/ci`. The role path is
  dropped (AWS returns the role name only); unparseable input falls back to
  the previous `aws` / default-account / `emulated-role` values.

## Test plan

- [x] `make lint` (0 issues), `go test -race ./...`
- [x] New unit tests: `roleArnParts` table (incl. paths, aws-us-gov/aws-cn
      partitions, and unparseable fallbacks) and an AssumeRole round-trip
      assertion
- [x] Integration `TestSTS` (6 tests) run against a branch-built kumo binary;
      the two STS golden files updated to the role name from each test's
      `RoleArn`

Closes #832
