### PR TITLE
fix(sns): forward message attributes on RawMessageDelivery and log delivery failures

### DIFF
--- a/internal/server/sns_sqs_wiring.go
+++ b/internal/server/sns_sqs_wiring.go
@@ -73,14 +73,20 @@ type snsToSQSPublisher struct {
 }
 
 // PublishToSQS hands a single message to the SQS storage layer. The
-// MessageId / Subject attributes the SNS layer attaches are forwarded as
-// SQS message attributes (String type) so subscribers can read them.
-func (p *snsToSQSPublisher) PublishToSQS(ctx context.Context, endpoint, body, messageGroupID, messageDeduplicationID string, attrs map[string]string) error {
+// MessageId / Subject attributes the SNS layer attaches, along with any
+// publisher-supplied message attributes forwarded for RawMessageDelivery,
+// are mapped field-for-field into SQS message attributes so subscribers
+// can read them.
+func (p *snsToSQSPublisher) PublishToSQS(ctx context.Context, endpoint, body, messageGroupID, messageDeduplicationID string, attrs map[string]sns.MessageAttribute) error {
 	queueURL := p.endpointToQueueURL(endpoint)
 
 	mAttrs := make(map[string]sqs.MessageAttributeValue, len(attrs))
 	for k, v := range attrs {
-		mAttrs[k] = sqs.MessageAttributeValue{DataType: "String", StringValue: v}
+		mAttrs[k] = sqs.MessageAttributeValue{
+			DataType:    v.DataType,
+			StringValue: v.StringValue,
+			BinaryValue: v.BinaryValue,
+		}
 	}
 
 	_, err := p.storage.SendMessage(ctx, queueURL, body, 0, mAttrs, messageGroupID, messageDeduplicationID)

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -21,7 +21,7 @@ const (
 
 // SQSPublisher is an interface for publishing messages to SQS.
 type SQSPublisher interface {
-	PublishToSQS(ctx context.Context, queueURL, messageBody, messageGroupID, messageDeduplicationID string, attributes map[string]string) error
+	PublishToSQS(ctx context.Context, queueURL, messageBody, messageGroupID, messageDeduplicationID string, attributes map[string]MessageAttribute) error
 }
 
 // Storage defines the SNS storage interface.
@@ -624,26 +624,7 @@ func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, m
 
 	switch sub.Protocol {
 	case "sqs":
-		if m.SqsPublisher != nil {
-			// Build the message body based on RawMessageDelivery setting.
-			body := message
-			if !isRawMessageDelivery(sub) {
-				body = buildSNSNotificationEnvelope(sub.TopicARN, message, subject, messageID, attributes)
-			}
-
-			attrs := map[string]string{
-				"MessageId": messageID,
-			}
-			if subject != "" {
-				attrs["Subject"] = subject
-			}
-
-			if err := m.SqsPublisher.PublishToSQS(ctx, sub.Endpoint, body, messageGroupID, messageDeduplicationID, attrs); err != nil {
-				return fmt.Errorf("failed to publish to SQS: %w", err)
-			}
-
-			return nil
-		}
+		return m.deliverToSQS(ctx, sub, message, subject, messageID, messageGroupID, messageDeduplicationID, attributes)
 	case "http", "https":
 		// HTTP delivery not implemented in emulator.
 		return nil
@@ -651,8 +632,67 @@ func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, m
 		// Other protocols not implemented.
 		return nil
 	}
+}
+
+// deliverToSQS delivers a message to an sqs-protocol subscription. It
+// builds the message body (raw or enveloped, depending on the
+// subscription's RawMessageDelivery attribute) and the SQS message
+// attributes, then hands both to the configured SQSPublisher.
+func (m *MemoryStorage) deliverToSQS(ctx context.Context, sub *Subscription, message, subject, messageID, messageGroupID, messageDeduplicationID string, attributes map[string]MessageAttribute) error {
+	if m.SqsPublisher == nil {
+		return nil
+	}
+
+	raw := isRawMessageDelivery(sub)
+
+	// Build the message body based on RawMessageDelivery setting.
+	body := message
+	if !raw {
+		body = buildSNSNotificationEnvelope(sub.TopicARN, message, subject, messageID, attributes)
+	}
+
+	attrs := sqsDeliveryAttributes(messageID, subject, attributes, raw)
+
+	if err := m.SqsPublisher.PublishToSQS(ctx, sub.Endpoint, body, messageGroupID, messageDeduplicationID, attrs); err != nil {
+		return fmt.Errorf("failed to publish to SQS: %w", err)
+	}
 
 	return nil
+}
+
+// sqsDeliveryAttributes builds the SQS message attributes for a delivery.
+// MessageId (and Subject, when non-empty) are always included for
+// backward compatibility with kumo's existing behavior. When raw is true,
+// the publisher-supplied attributes are merged in by presence (not by
+// value) so that Number/Binary attributes and empty StringValues are
+// still forwarded; a missing DataType defaults to "String". Envelope-mode
+// deliveries already carry attributes inside the JSON body, so they are
+// not duplicated as SQS attributes.
+func sqsDeliveryAttributes(messageID, subject string, attributes map[string]MessageAttribute, raw bool) map[string]MessageAttribute {
+	attrs := map[string]MessageAttribute{
+		"MessageId": {DataType: "String", StringValue: messageID},
+	}
+	if subject != "" {
+		attrs["Subject"] = MessageAttribute{DataType: "String", StringValue: subject}
+	}
+
+	if !raw {
+		return attrs
+	}
+
+	for name, attr := range attributes {
+		if _, exists := attrs[name]; exists {
+			continue
+		}
+
+		if attr.DataType == "" {
+			attr.DataType = "String"
+		}
+
+		attrs[name] = attr
+	}
+
+	return attrs
 }
 
 // isRawMessageDelivery checks whether the subscription has RawMessageDelivery enabled.

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -436,7 +437,13 @@ func (m *MemoryStorage) Publish(ctx context.Context, topicARN, message, subject,
 	// Deliver to all subscriptions.
 	for _, sub := range subscriptions {
 		if err := m.deliverMessage(ctx, sub, message, subject, messageID, messageGroupID, messageDeduplicationID, attributes); err != nil {
-			// Log error but continue delivering to other subscriptions.
+			slog.Default().Error("sns: failed to deliver to subscription",
+				"endpoint", sub.Endpoint,
+				"protocol", sub.Protocol,
+				"topicArn", sub.TopicARN,
+				"error", err,
+			)
+
 			continue
 		}
 	}

--- a/internal/service/sns/storage_delivery_test.go
+++ b/internal/service/sns/storage_delivery_test.go
@@ -1,0 +1,163 @@
+package sns
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// capturingPublisher is a fake SQSPublisher that records the arguments of
+// the most recent PublishToSQS call, optionally returning an error.
+type capturingPublisher struct {
+	endpoint string
+	body     string
+	attrs    map[string]MessageAttribute
+	err      error
+}
+
+func (c *capturingPublisher) PublishToSQS(_ context.Context, endpoint, body, _, _ string, attrs map[string]MessageAttribute) error {
+	c.endpoint = endpoint
+	c.body = body
+	c.attrs = attrs
+
+	return c.err
+}
+
+// newTopicWithSQSSubscription creates a topic with a single sqs
+// subscription, wires up the given publisher, and returns the topic ARN.
+func newTopicWithSQSSubscription(t *testing.T, publisher SQSPublisher, subAttrs map[string]string) (*MemoryStorage, string) {
+	t.Helper()
+
+	storage := NewMemoryStorage("http://localhost:4566")
+	storage.SetSQSPublisher(publisher)
+
+	ctx := context.Background()
+
+	topic, err := storage.CreateTopic(ctx, "test-topic", nil)
+	if err != nil {
+		t.Fatalf("CreateTopic() error = %v", err)
+	}
+
+	sub, err := storage.Subscribe(ctx, topic.ARN, "sqs", "arn:aws:sqs:us-east-1:000000000000:test-queue", nil)
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	if subAttrs != nil {
+		sub.SubscriptionAttributes = subAttrs
+	}
+
+	return storage, topic.ARN
+}
+
+func TestPublish_RawDeliveryForwardsAttributes(t *testing.T) {
+	t.Parallel()
+
+	publisher := &capturingPublisher{}
+	storage, topicARN := newTopicWithSQSSubscription(t, publisher, map[string]string{"RawMessageDelivery": "true"})
+
+	attributes := map[string]MessageAttribute{
+		"traceId": {DataType: "String", StringValue: "abc"},
+	}
+
+	messageID, err := storage.Publish(context.Background(), topicARN, "hello", "", "", "", attributes)
+	if err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	traceID, ok := publisher.attrs["traceId"]
+	if !ok {
+		t.Fatalf("expected captured attrs to contain traceId, got %v", publisher.attrs)
+	}
+
+	if traceID.DataType != "String" || traceID.StringValue != "abc" {
+		t.Errorf("traceId attribute = %+v, want DataType=String StringValue=abc", traceID)
+	}
+
+	msgIDAttr, ok := publisher.attrs["MessageId"]
+	if !ok {
+		t.Fatalf("expected captured attrs to contain MessageId, got %v", publisher.attrs)
+	}
+
+	if msgIDAttr.StringValue != messageID {
+		t.Errorf("MessageId attribute StringValue = %q, want %q", msgIDAttr.StringValue, messageID)
+	}
+}
+
+func TestPublish_RawDeliveryPreservesTypedAttributes(t *testing.T) {
+	t.Parallel()
+
+	publisher := &capturingPublisher{}
+	storage, topicARN := newTopicWithSQSSubscription(t, publisher, map[string]string{"RawMessageDelivery": "true"})
+
+	attributes := map[string]MessageAttribute{
+		"count": {DataType: "Number", StringValue: "42"},
+		"blob":  {DataType: "Binary", BinaryValue: []byte{1, 2}},
+	}
+
+	_, err := storage.Publish(context.Background(), topicARN, "hello", "", "", "", attributes)
+	if err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	count, ok := publisher.attrs["count"]
+	if !ok {
+		t.Fatalf("expected captured attrs to contain count, got %v", publisher.attrs)
+	}
+
+	if count.DataType != "Number" || count.StringValue != "42" {
+		t.Errorf("count attribute = %+v, want DataType=Number StringValue=42", count)
+	}
+
+	blob, ok := publisher.attrs["blob"]
+	if !ok {
+		t.Fatalf("expected captured attrs to contain blob, got %v", publisher.attrs)
+	}
+
+	if blob.DataType != "Binary" || !bytes.Equal(blob.BinaryValue, []byte{1, 2}) {
+		t.Errorf("blob attribute = %+v, want DataType=Binary BinaryValue=[1 2]", blob)
+	}
+}
+
+func TestPublish_EnvelopeDeliveryDoesNotDuplicateAttributes(t *testing.T) {
+	t.Parallel()
+
+	publisher := &capturingPublisher{}
+	// No RawMessageDelivery attribute set -> defaults to envelope mode.
+	storage, topicARN := newTopicWithSQSSubscription(t, publisher, nil)
+
+	attributes := map[string]MessageAttribute{
+		"traceId": {DataType: "String", StringValue: "abc"},
+	}
+
+	_, err := storage.Publish(context.Background(), topicARN, "hello", "", "", "", attributes)
+	if err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	if _, ok := publisher.attrs["traceId"]; ok {
+		t.Errorf("expected captured attrs to NOT contain traceId in envelope mode, got %v", publisher.attrs)
+	}
+
+	if !strings.Contains(publisher.body, `"traceId"`) {
+		t.Errorf("expected envelope body to contain traceId, got %q", publisher.body)
+	}
+}
+
+func TestPublish_SubscriberErrorDoesNotFailPublish(t *testing.T) {
+	t.Parallel()
+
+	publisher := &capturingPublisher{err: errors.New("boom")}
+	storage, topicARN := newTopicWithSQSSubscription(t, publisher, map[string]string{"RawMessageDelivery": "true"})
+
+	messageID, err := storage.Publish(context.Background(), topicARN, "hello", "", "", "", nil)
+	if err != nil {
+		t.Fatalf("Publish() error = %v, want nil (fire-and-forget contract)", err)
+	}
+
+	if messageID == "" {
+		t.Errorf("Publish() messageID = %q, want non-empty", messageID)
+	}
+}


### PR DESCRIPTION
## Summary

- On `RawMessageDelivery=true` SQS subscriptions, `Publish` forwarded only
  `MessageId`/`Subject` and dropped the publisher's message attributes — on
  AWS those arrive as SQS message attributes, so consumers filtering on them
  saw nothing locally. The SQS-publisher seam is widened from
  `map[string]string` to typed attributes (`map[string]MessageAttribute`),
  and the publisher attributes are merged into the raw-delivery path
  preserving `String`/`Number`/`Binary`. Envelope mode is unchanged (the
  attributes already ride inside the JSON body, so they are not duplicated).
- `Publish` previously swallowed per-subscription delivery errors with a
  bare `continue`; it now logs the failure (endpoint, protocol, topic ARN,
  error) before continuing, keeping the fire-and-forget-per-subscriber
  contract.

## Notes

- kumo's existing behavior of surfacing `MessageId`/`Subject` as SQS message
  attributes is kept for backward compatibility; real AWS does not add these
  on raw delivery. Happy to gate them off if you'd prefer strict fidelity.
- AWS's 10-attribute limit for raw delivery is not enforced here (left as a
  follow-up).

## Test plan

- [x] `make lint` (0 issues), `go test -race ./...`
- [x] New unit tests with a capturing publisher: raw delivery forwards
      publisher attributes (incl. Number/Binary type fidelity) plus
      MessageId; envelope mode does not duplicate them into SQS attributes;
      a delivery error keeps `Publish` returning a MessageId

Closes #833
