### PR TITLE
fix(eventbridge): cap DeliveredEvents and exclude it from the snapshot

### DIFF
--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -21,6 +21,10 @@ import (
 // Default event bus name.
 const defaultEventBusName = "default"
 
+// maxDeliveredEvents bounds the kumo-specific delivery-verification log so a
+// long-running emulator session cannot grow it (and its allocations) forever.
+const maxDeliveredEvents = 1000
+
 // Error codes.
 const (
 	errEventBusNotFound      = "ResourceNotFoundException"
@@ -103,7 +107,7 @@ type MemoryStorage struct {
 	Connections     map[string]*Connection          `json:"connections"`
 	APIDestinations map[string]*APIDestination      `json:"apiDestinations"`
 	Tags            map[string][]Tag                `json:"tags"`
-	DeliveredEvents []DeliveredEvent                `json:"deliveredEvents"`
+	DeliveredEvents []DeliveredEvent                `json:"-"`
 	region          string
 	accountID       string
 	dataDir         string
@@ -681,6 +685,16 @@ func (s *MemoryStorage) matchAndDeliver(eventID, eventBusName string, entry *Put
 				go s.deliverToLambda(target, payload)
 			}
 		}
+
+		s.trimDeliveredEventsLocked()
+	}
+}
+
+// trimDeliveredEventsLocked drops the oldest entries beyond the cap.
+// Caller must hold s.mu.
+func (s *MemoryStorage) trimDeliveredEventsLocked() {
+	if excess := len(s.DeliveredEvents) - maxDeliveredEvents; excess > 0 {
+		s.DeliveredEvents = append([]DeliveredEvent(nil), s.DeliveredEvents[excess:]...)
 	}
 }
 

--- a/internal/service/eventbridge/storage_test.go
+++ b/internal/service/eventbridge/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -580,5 +581,101 @@ func TestPutEvents_APIDestinationPathParameters(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not receive dispatched event within timeout")
+	}
+}
+
+// TestDeliveredEventsCapped verifies that DeliveredEvents never grows past
+// maxDeliveredEvents and that the oldest entries are the ones dropped.
+func TestDeliveredEventsCapped(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage()
+	ctx := context.Background()
+
+	if _, err := s.PutRule(ctx, &PutRuleRequest{
+		Name:         "cap-test-rule",
+		EventPattern: `{"source":["cap.test"]}`,
+		State:        "ENABLED",
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	// A target ARN that matches none of the SQS/Lambda/API-destination
+	// dispatch paths, so PutEvents only records the delivery without
+	// spawning any goroutine delivery.
+	if _, err := s.PutTargets(ctx, "", "cap-test-rule", []TargetInput{
+		{ID: "target-1", Arn: "arn:aws:events:us-east-1:000000000000:target/cap-test"},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	const totalEvents = maxDeliveredEvents + 50
+
+	var firstEventID string
+
+	for i := range totalEvents {
+		result, err := s.PutEvents(ctx, []PutEventsRequestEntry{
+			{Source: "cap.test", DetailType: "CapEvent", Detail: `{"i":` + strconv.Itoa(i) + `}`},
+		})
+		if err != nil {
+			t.Fatalf("PutEvents[%d]: %v", i, err)
+		}
+
+		if i == 0 {
+			firstEventID = result[0].EventID
+		}
+	}
+
+	got := s.GetDeliveredEvents(ctx)
+	if len(got) != maxDeliveredEvents {
+		t.Fatalf("len(DeliveredEvents) = %d, want %d", len(got), maxDeliveredEvents)
+	}
+
+	// The first surviving entry should not be the very first published event
+	// (EventID differs), since the oldest 50 entries must have been dropped.
+	if len(got) > 0 && got[0].EventID == firstEventID {
+		t.Fatalf("expected oldest entries to be dropped, but first entry still matches the very first published event")
+	}
+}
+
+// TestDeliveredEventsNotPersisted verifies that DeliveredEvents is excluded
+// from the storage snapshot.
+func TestDeliveredEventsNotPersisted(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage()
+	ctx := context.Background()
+
+	if _, err := s.PutRule(ctx, &PutRuleRequest{
+		Name:         "persist-test-rule",
+		EventPattern: `{"source":["persist.test"]}`,
+		State:        "ENABLED",
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := s.PutTargets(ctx, "", "persist-test-rule", []TargetInput{
+		{ID: "target-1", Arn: "arn:aws:events:us-east-1:000000000000:target/persist-test"},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	if _, err := s.PutEvents(ctx, []PutEventsRequestEntry{
+		{Source: "persist.test", DetailType: "PersistEvent", Detail: `{}`},
+	}); err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	if len(s.GetDeliveredEvents(ctx)) == 0 {
+		t.Fatal("precondition failed: expected at least one delivered event")
+	}
+
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	if strings.Contains(string(data), `"deliveredEvents"`) {
+		t.Fatalf("snapshot must not contain deliveredEvents key, got: %s", string(data))
 	}
 }


### PR DESCRIPTION
## Summary

- `DeliveredEvents` (the verification log behind
  `/kumo/eventbridge/delivered-events`) grew by one entry per matched target
  per event and was never trimmed, and its struct tag serialized it so every
  debounced snapshot flush rewrote the whole growing blob — the same
  unbounded-memory class #799 and #823 addressed, from test-only state.
- Tag it `json:"-"` (it needs no durability) and cap it to the most recent
  1000 entries via a small `trimDeliveredEventsLocked` helper called under
  the existing `PutEvents` lock.

## Test plan

- [x] `make lint` (0 issues), `go test -race ./...`
- [x] New unit tests: after 1000+ recorded deliveries the log holds exactly
      the cap and the oldest entries are dropped; `json.Marshal` of the
      storage contains no `deliveredEvents` key

Closes #834
