### PR TITLE
fix(lambda): queue async Event invocations for Runtime API functions

### DIFF
--- a/internal/service/lambda/async.go
+++ b/internal/service/lambda/async.go
@@ -31,18 +31,26 @@ const (
 	asyncMaxFunctionErrorRetries = 2
 )
 
-// asyncEvent is one queued asynchronous (InvocationType: Event) invocation.
-type asyncEvent struct {
-	endpoint string
-	payload  []byte
-	deadline time.Time
+// asyncDeliverer delivers one queued event to its execution target. It
+// reports whether the attempt succeeded, failed as a function error (limited
+// retries), or failed as a system error (retried until the event's
+// deadline), mirroring AWS async invocation semantics. Implementations:
+// endpointDeliverer (InvokeEndpoint) and runtimeDeliverer (Runtime API).
+type asyncDeliverer interface {
+	deliver(ctx context.Context, functionName string, payload []byte) deliveryResult
 }
 
-// asyncDispatcher queues Event invocations per function and delivers them to
-// the function's InvokeEndpoint in FIFO order. Delivery is retried with
-// exponential backoff, so a 202 from Invoke means "accepted for delivery"
-// rather than "attempted once" (issue #803). Counterpart of runtimeBroker for
-// the InvokeEndpoint execution path.
+// asyncEvent is one queued asynchronous (InvocationType: Event) invocation.
+type asyncEvent struct {
+	deliverer asyncDeliverer
+	payload   []byte
+	deadline  time.Time
+}
+
+// asyncDispatcher queues Event invocations per function and delivers them in
+// FIFO order via each event's asyncDeliverer (InvokeEndpoint or Runtime API).
+// Delivery is retried with exponential backoff, so a 202 from Invoke means
+// "accepted for delivery" rather than "attempted once" (issue #803).
 type asyncDispatcher struct {
 	client *http.Client
 	done   chan struct{}
@@ -69,14 +77,14 @@ func newAsyncDispatcher() *asyncDispatcher {
 
 // enqueue places an event on the function's FIFO queue without blocking the
 // caller. The drain goroutine for the function is started on first use.
-func (d *asyncDispatcher) enqueue(functionName, endpoint string, payload []byte) {
+func (d *asyncDispatcher) enqueue(functionName string, deliverer asyncDeliverer, payload []byte) {
 	payloadCopy := make([]byte, len(payload))
 	copy(payloadCopy, payload)
 
 	ev := &asyncEvent{
-		endpoint: endpoint,
-		payload:  payloadCopy,
-		deadline: time.Now().Add(d.maxEventAge),
+		deliverer: deliverer,
+		payload:   payloadCopy,
+		deadline:  time.Now().Add(d.maxEventAge),
 	}
 
 	d.mu.Lock()
@@ -139,24 +147,24 @@ func (d *asyncDispatcher) drain(functionName string, q chan *asyncEvent) {
 type deliveryResult int
 
 const (
-	// asyncDelivered: the endpoint accepted the event.
+	// asyncDelivered: the deliverer accepted the event.
 	asyncDelivered deliveryResult = iota
-	// asyncFunctionError: the endpoint responded with an error status.
+	// asyncFunctionError: the target responded with an error.
 	asyncFunctionError
-	// asyncSystemError: the endpoint could not be reached.
+	// asyncSystemError: the target could not be reached.
 	asyncSystemError
-	// asyncPermanentFailure: the event can never be delivered (bad endpoint).
+	// asyncPermanentFailure: the event can never be delivered (e.g. bad endpoint URL).
 	asyncPermanentFailure
 )
 
-// deliver posts the event to its endpoint, retrying failures until the event
+// deliver hands the event to its deliverer, retrying failures until the event
 // is delivered, exhausts its function-error retries, or expires.
 func (d *asyncDispatcher) deliver(ctx context.Context, functionName string, ev *asyncEvent) {
 	backoff := d.initialBackoff
 	functionErrorRetries := 0
 
 	for {
-		switch d.post(ctx, functionName, ev) {
+		switch ev.deliverer.deliver(ctx, functionName, ev.payload) {
 		case asyncDelivered, asyncPermanentFailure:
 			return
 		case asyncFunctionError:
@@ -186,9 +194,17 @@ func (d *asyncDispatcher) deliver(ctx context.Context, functionName string, ev *
 	}
 }
 
-// post performs a single delivery attempt.
-func (d *asyncDispatcher) post(ctx context.Context, functionName string, ev *asyncEvent) deliveryResult {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ev.endpoint, bytes.NewReader(ev.payload))
+// endpointDeliverer delivers an event by POSTing it to a function's
+// InvokeEndpoint. Counterpart of runtimeDeliverer (runtime.go) for functions
+// backed by a Runtime API handler.
+type endpointDeliverer struct {
+	client   *http.Client
+	endpoint string
+}
+
+// deliver performs a single delivery attempt.
+func (e *endpointDeliverer) deliver(ctx context.Context, functionName string, payload []byte) deliveryResult {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint, bytes.NewReader(payload))
 	if err != nil {
 		slog.Error("async invoke failed to create request", "function", functionName, "error", err)
 
@@ -197,7 +213,7 @@ func (d *asyncDispatcher) post(ctx context.Context, functionName string, ev *asy
 
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := d.client.Do(req)
+	resp, err := e.client.Do(req)
 	if err != nil {
 		slog.Warn("async invoke attempt failed, will retry", "function", functionName, "error", err)
 

--- a/internal/service/lambda/async_test.go
+++ b/internal/service/lambda/async_test.go
@@ -109,8 +109,10 @@ func TestAsyncDispatcher_DeliversAfterEndpointRecovers(t *testing.T) {
 	addr := reserveAddr(t)
 
 	endpoint := "http://" + addr + "/invoke"
+	deliverer := &endpointDeliverer{client: d.client, endpoint: endpoint}
+
 	for i := 1; i <= 3; i++ {
-		d.enqueue("fn", endpoint, fmt.Appendf(nil, `{"seq":%d}`, i))
+		d.enqueue("fn", deliverer, fmt.Appendf(nil, `{"seq":%d}`, i))
 	}
 
 	// Give the dispatcher time to fail at least one attempt.
@@ -167,7 +169,7 @@ func TestAsyncDispatcher_FunctionErrorRetries(t *testing.T) {
 		return attempts
 	}
 
-	d.enqueue("fn", srv.URL, []byte(`{}`))
+	d.enqueue("fn", &endpointDeliverer{client: d.client, endpoint: srv.URL}, []byte(`{}`))
 
 	wantAttempts := 1 + asyncMaxFunctionErrorRetries
 	if !waitFor(t, 5*time.Second, func() bool { return count() == wantAttempts }) {
@@ -190,7 +192,7 @@ func TestAsyncDispatcher_ExpiredEventDropped(t *testing.T) {
 
 	addr := reserveAddr(t)
 
-	d.enqueue("fn", "http://"+addr+"/invoke", []byte(`{}`))
+	d.enqueue("fn", &endpointDeliverer{client: d.client, endpoint: "http://" + addr + "/invoke"}, []byte(`{}`))
 
 	// Wait until the event is past its deadline and has been dropped.
 	time.Sleep(200 * time.Millisecond)
@@ -200,5 +202,226 @@ func TestAsyncDispatcher_ExpiredEventDropped(t *testing.T) {
 
 	if waitFor(t, 300*time.Millisecond, func() bool { return len(rec.snapshot()) > 0 }) {
 		t.Fatalf("expected expired event to be dropped, got deliveries %v", rec.snapshot())
+	}
+}
+
+// runHandler simulates a Runtime API handler (lambda.Start) that repeatedly
+// polls broker.next and answers with respond, until the test ends.
+func runHandler(t *testing.T, broker *runtimeBroker, fn string, respond func(inv *runtimeInvocation) (payload []byte, errored bool)) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	go func() {
+		for {
+			inv, err := broker.next(ctx, fn)
+			if err != nil {
+				return
+			}
+
+			payload, errored := respond(inv)
+			broker.respond(fn, inv.id, payload, errored)
+		}
+	}()
+}
+
+// TestAsyncDispatcher_RuntimeDeliveredWhileHandlerBusy reproduces the drop
+// the unbuffered channel used to cause: two async Invokes sent back-to-back
+// while the handler is slow on the first must both eventually be delivered,
+// in FIFO order, instead of the second vanishing.
+func TestAsyncDispatcher_RuntimeDeliveredWhileHandlerBusy(t *testing.T) {
+	d := newTestDispatcher(t)
+	broker := newRuntimeBroker()
+
+	var (
+		mu    sync.Mutex
+		got   []string
+		first = true
+	)
+
+	runHandler(t, broker, "fn", func(inv *runtimeInvocation) ([]byte, bool) {
+		if first {
+			first = false
+
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		mu.Lock()
+		got = append(got, string(inv.payload))
+		mu.Unlock()
+
+		return inv.payload, false
+	})
+
+	deliverer := &runtimeDeliverer{broker: broker, fn: "fn"}
+	d.enqueue("fn", deliverer, []byte(`{"seq":1}`))
+	d.enqueue("fn", deliverer, []byte(`{"seq":2}`))
+
+	if !waitFor(t, 5*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return len(got) == 2
+	}) {
+		mu.Lock()
+		defer mu.Unlock()
+		t.Fatalf("expected 2 deliveries, got %v", got)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	want := []string{`{"seq":1}`, `{"seq":2}`}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("delivery %d = %s, want %s (order must be preserved)", i, got[i], want[i])
+		}
+	}
+}
+
+// TestAsyncDispatcher_RuntimeDeliveredAfterHandlerPollsLate reproduces the
+// case the unbuffered channel dropped silently: the function is registered
+// (so Invoke routes to the runtime path) but no handler is blocked in next
+// when the event is queued. The event must survive the deliverer's timed-out
+// first attempt (a system error) and be delivered once the handler resumes
+// polling, instead of vanishing.
+func TestAsyncDispatcher_RuntimeDeliveredAfterHandlerPollsLate(t *testing.T) {
+	d := newTestDispatcher(t)
+	broker := newRuntimeBroker()
+
+	// Register the function (as broker.registered would report it) without
+	// any goroutine blocked in next — mirrors a handler that polled once
+	// before and is briefly not polling now.
+	broker.get("fn")
+
+	if !broker.registered("fn") {
+		t.Fatal("expected function to be registered")
+	}
+
+	received := make(chan []byte, 1)
+
+	deliverer := &runtimeDeliverer{broker: broker, fn: "fn", waitTimeout: 20 * time.Millisecond}
+	d.enqueue("fn", deliverer, []byte(`{"late":true}`))
+
+	// Let the deliverer's first wait (and at least one retry) time out
+	// before the handler starts polling.
+	time.Sleep(80 * time.Millisecond)
+
+	go func() {
+		inv, err := broker.next(t.Context(), "fn")
+		if err != nil {
+			return
+		}
+
+		received <- inv.payload
+		broker.respond("fn", inv.id, inv.payload, false)
+	}()
+
+	select {
+	case got := <-received:
+		if string(got) != `{"late":true}` {
+			t.Fatalf("got payload %s, want %s", got, `{"late":true}`)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("event was never delivered after handler resumed polling")
+	}
+}
+
+// TestAsyncDispatcher_RuntimeFunctionErrorRetries verifies that a handler
+// responding with an error result is retried exactly
+// asyncMaxFunctionErrorRetries times before the event is dropped, matching
+// the endpoint path's retry semantics.
+func TestAsyncDispatcher_RuntimeFunctionErrorRetries(t *testing.T) {
+	d := newTestDispatcher(t)
+	broker := newRuntimeBroker()
+
+	var (
+		mu       sync.Mutex
+		attempts int
+	)
+
+	runHandler(t, broker, "fn", func(inv *runtimeInvocation) ([]byte, bool) {
+		mu.Lock()
+		attempts++
+		mu.Unlock()
+
+		return inv.payload, true
+	})
+
+	count := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return attempts
+	}
+
+	d.enqueue("fn", &runtimeDeliverer{broker: broker, fn: "fn"}, []byte(`{}`))
+
+	wantAttempts := 1 + asyncMaxFunctionErrorRetries
+	if !waitFor(t, 5*time.Second, func() bool { return count() == wantAttempts }) {
+		t.Fatalf("expected %d attempts, got %d", wantAttempts, count())
+	}
+
+	// The event must be dropped after the final retry, not retried forever.
+	time.Sleep(100 * time.Millisecond)
+
+	if got := count(); got != wantAttempts {
+		t.Fatalf("expected exactly %d attempts, got %d", wantAttempts, got)
+	}
+}
+
+// TestAsyncDispatcher_RuntimeFunctionErrorOnResponseTimeout verifies that a
+// handler that polls and takes an invocation but never responds (its
+// function timed out) is treated as a function error with limited retries —
+// not a system error retried for up to asyncMaxEventAge — matching AWS
+// async invocation semantics for a function timeout.
+func TestAsyncDispatcher_RuntimeFunctionErrorOnResponseTimeout(t *testing.T) {
+	d := newTestDispatcher(t)
+	broker := newRuntimeBroker()
+
+	var (
+		mu       sync.Mutex
+		attempts int
+	)
+
+	ctx := t.Context()
+
+	go func() {
+		for {
+			// Poll and take the invocation, then never respond —
+			// simulates a handler whose function timed out after
+			// picking up the work.
+			_, err := broker.next(ctx, "fn")
+			if err != nil {
+				return
+			}
+
+			mu.Lock()
+			attempts++
+			mu.Unlock()
+		}
+	}()
+
+	count := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return attempts
+	}
+
+	deliverer := &runtimeDeliverer{broker: broker, fn: "fn", waitTimeout: 20 * time.Millisecond}
+	d.enqueue("fn", deliverer, []byte(`{}`))
+
+	wantAttempts := 1 + asyncMaxFunctionErrorRetries
+	if !waitFor(t, 5*time.Second, func() bool { return count() == wantAttempts }) {
+		t.Fatalf("expected %d attempts, got %d", wantAttempts, count())
+	}
+
+	// The event must be dropped after the final retry (function-error
+	// semantics), not retried for up to asyncMaxEventAge as a system error.
+	time.Sleep(200 * time.Millisecond)
+
+	if got := count(); got != wantAttempts {
+		t.Fatalf("expected exactly %d attempts, got %d", wantAttempts, got)
 	}
 }

--- a/internal/service/lambda/handlers.go
+++ b/internal/service/lambda/handlers.go
@@ -315,14 +315,13 @@ func (s *Service) Invoke(w http.ResponseWriter, r *http.Request) {
 // invokeViaRuntime dispatches to a handler connected through the Runtime API.
 func (s *Service) invokeViaRuntime(w http.ResponseWriter, r *http.Request, fn string, payload []byte, async bool) {
 	if async {
-		_, _ = s.broker.invoke(r.Context(), fn, payload, true)
-
+		s.async.enqueue(fn, &runtimeDeliverer{broker: s.broker, fn: fn}, payload)
 		writeInvokeAccepted(w)
 
 		return
 	}
 
-	res, err := s.broker.invoke(r.Context(), fn, payload, false)
+	res, err := s.broker.invoke(r.Context(), fn, payload, runtimeInvokeTimeout)
 	if err != nil {
 		writeFunctionError(w, ErrServiceException, "runtime invocation failed: "+err.Error(), http.StatusBadGateway)
 
@@ -344,7 +343,7 @@ func (s *Service) invokeViaRuntime(w http.ResponseWriter, r *http.Request, fn st
 // for delivery": failed deliveries are retried instead of dropped.
 func (s *Service) invokeViaEndpoint(w http.ResponseWriter, r *http.Request, fn, endpoint string, payload []byte, async bool) {
 	if async {
-		s.async.enqueue(fn, endpoint, payload)
+		s.async.enqueue(fn, &endpointDeliverer{client: s.async.client, endpoint: endpoint}, payload)
 		writeInvokeAccepted(w)
 
 		return

--- a/internal/service/lambda/runtime.go
+++ b/internal/service/lambda/runtime.go
@@ -18,9 +18,16 @@ import (
 // a polling handler and to receive its response.
 const runtimeInvokeTimeout = 30 * time.Second
 
-// errRuntimeTimeout is returned when no polling handler services an
-// invocation within runtimeInvokeTimeout.
-var errRuntimeTimeout = errors.New("no runtime handler available")
+// errRuntimeNoPoller is returned when no handler polls next and picks up an
+// invocation within the wait timeout — nobody ever started the work, which
+// AWS treats as a system-level delivery failure (retried with backoff).
+var errRuntimeNoPoller = errors.New("no runtime handler available to poll the invocation")
+
+// errRuntimeResponseTimeout is returned when a handler polled next and took
+// the invocation but never posted a response or error within the wait
+// timeout — the handler picked up the work but its function timed out,
+// which AWS treats as a function error (limited retries).
+var errRuntimeResponseTimeout = errors.New("runtime handler did not respond before the timeout")
 
 // runtimeBroker bridges kumo invocations to handlers that speak the AWS
 // Lambda Runtime API (lambda.Start). A handler polls next for its function;
@@ -79,22 +86,15 @@ func (b *runtimeBroker) get(fn string) *funcRuntime {
 	return fr
 }
 
-// invoke hands an invocation to a polling handler. For async it returns once
-// queued; for sync it waits for the handler's response.
-func (b *runtimeBroker) invoke(ctx context.Context, fn string, payload []byte, async bool) (runtimeResult, error) {
+// invoke hands an invocation to a polling handler and waits for its
+// response, up to timeout for each of the two phases (waiting to be picked
+// up by next, then waiting for a response/error). Callers that want async
+// (fire-and-forget-but-not-really) semantics should queue a runtimeDeliverer
+// on the asyncDispatcher instead of calling invoke directly — see
+// invokeViaRuntime.
+func (b *runtimeBroker) invoke(ctx context.Context, fn string, payload []byte, timeout time.Duration) (runtimeResult, error) {
 	fr := b.get(fn)
 	inv := &runtimeInvocation{id: uuid.New().String(), payload: payload}
-
-	if async {
-		go func() {
-			select {
-			case fr.invocations <- inv:
-			case <-time.After(runtimeInvokeTimeout):
-			}
-		}()
-
-		return runtimeResult{}, nil
-	}
 
 	resCh := make(chan runtimeResult, 1)
 
@@ -112,8 +112,8 @@ func (b *runtimeBroker) invoke(ctx context.Context, fn string, payload []byte, a
 	case fr.invocations <- inv:
 	case <-ctx.Done():
 		return runtimeResult{}, fmt.Errorf("invocation canceled: %w", ctx.Err())
-	case <-time.After(runtimeInvokeTimeout):
-		return runtimeResult{}, errRuntimeTimeout
+	case <-time.After(timeout):
+		return runtimeResult{}, errRuntimeNoPoller
 	}
 
 	select {
@@ -121,9 +121,54 @@ func (b *runtimeBroker) invoke(ctx context.Context, fn string, payload []byte, a
 		return res, nil
 	case <-ctx.Done():
 		return runtimeResult{}, fmt.Errorf("invocation canceled: %w", ctx.Err())
-	case <-time.After(runtimeInvokeTimeout):
-		return runtimeResult{}, errRuntimeTimeout
+	case <-time.After(timeout):
+		return runtimeResult{}, errRuntimeResponseTimeout
 	}
+}
+
+// runtimeDeliverer delivers an event by handing it to a Runtime API handler
+// through runtimeBroker's synchronous path — the async queue itself now
+// provides the asynchrony, so the deliverer only ever waits for one poll/
+// response round trip per attempt. Counterpart of endpointDeliverer
+// (async.go) for functions backed by an InvokeEndpoint.
+type runtimeDeliverer struct {
+	broker *runtimeBroker
+	fn     string
+
+	// waitTimeout bounds how long one delivery attempt waits for a handler
+	// to pick up and respond to the invocation. Zero means
+	// runtimeInvokeTimeout; tests inject a short value so retry scenarios
+	// don't need to wait out the real 30s default.
+	waitTimeout time.Duration
+}
+
+// deliver hands the event to a polling handler and waits for its response.
+// errRuntimeResponseTimeout means a handler took the invocation but never
+// responded — the function itself timed out, so this is a function error
+// with limited retries, matching AWS async semantics. Any other failure
+// (nobody polled, context canceled, ...) means the work was never picked up,
+// so it is a system error retried with backoff until the event's deadline. A
+// handler-reported error is likewise a function error.
+func (r *runtimeDeliverer) deliver(ctx context.Context, _ string, payload []byte) deliveryResult {
+	timeout := r.waitTimeout
+	if timeout == 0 {
+		timeout = runtimeInvokeTimeout
+	}
+
+	res, err := r.broker.invoke(ctx, r.fn, payload, timeout)
+	if err != nil {
+		if errors.Is(err, errRuntimeResponseTimeout) {
+			return asyncFunctionError
+		}
+
+		return asyncSystemError
+	}
+
+	if res.errored {
+		return asyncFunctionError
+	}
+
+	return asyncDelivered
 }
 
 // next blocks until an invocation is queued for the function or ctx is done.


### PR DESCRIPTION
## Summary

- #804 gave `InvocationType: Event` "accepted for delivery" semantics via an
  `asyncDispatcher` with retry — but only for the `InvokeEndpoint` path. For
  functions backed by the kumo-native Runtime API (#776), an async invoke
  was still sent on an unbuffered channel from a bare goroutine with a 30s
  timeout, so the event was silently dropped when no handler was polling at
  that instant (handler busy with the previous event, or restarting).
- Generalize `asyncDispatcher` to an `asyncDeliverer` interface with two
  implementations — `endpointDeliverer` (existing HTTP POST, unchanged
  behavior) and `runtimeDeliverer` (Runtime API) — and route the Runtime API
  async path through the same per-function FIFO queue with backoff/retry.
  The drop-prone async branch of `runtimeBroker.invoke` is removed.
- Delivery-failure classification mirrors AWS async semantics: "no handler
  polled the invocation" is a system error (retried with backoff until the
  event's 6h deadline), while "a handler took the invocation but never
  responded" is a function timeout (retried the default 2 times). The sync
  RequestResponse path is unchanged (still 502 on either timeout).

## Test plan

- [x] `make lint` (0 issues), `go test -race ./...`
- [x] New unit tests: an event enqueued while the handler is busy is
      delivered in FIFO order once polling resumes; a no-poller event is
      retried as a system error and eventually delivered; a handler that
      takes the event but never responds is retried the function-error count
      then dropped

Closes #835
