### PR TITLE
fix(s3): preserve SSE and metadata through CopyObject and multipart uploads

### DIFF
--- a/internal/service/s3/copyobject_test.go
+++ b/internal/service/s3/copyobject_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+const sseAlgorithmAWSKMS = "aws:kms"
+
 func TestCopyObjectReplacesMetadataWhenDirectiveIsReplace(t *testing.T) {
 	t.Parallel()
 
@@ -77,6 +79,109 @@ func TestCopyObjectRejectsInvalidMetadataDirective(t *testing.T) {
 
 	if _, err := store.GetObject(context.Background(), "dst", "copied.txt"); err == nil {
 		t.Fatal("destination object was stored for invalid metadata directive")
+	}
+}
+
+func TestCopyObjectUsesRequestSSEHeadersRegardlessOfSource(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupCopyObjectMetadataFixture(t)
+	w := issueCopyObject(svc, map[string]string{
+		"X-Amz-Server-Side-Encryption":                sseAlgorithmAWSKMS,
+		"X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id": "request-key",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	dstObj, err := store.GetObject(context.Background(), "dst", "copied.txt")
+	if err != nil {
+		t.Fatalf("GetObject dst: %v", err)
+	}
+
+	if dstObj.ServerSideEncryption != sseAlgorithmAWSKMS {
+		t.Fatalf("ServerSideEncryption: got %q, want aws:kms", dstObj.ServerSideEncryption)
+	}
+
+	if dstObj.SSEKMSKeyID != "request-key" {
+		t.Fatalf("SSEKMSKeyID: got %q, want request-key", dstObj.SSEKMSKeyID)
+	}
+}
+
+func TestCopyObjectFallsBackToDestinationBucketDefaultEncryption(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupCopyObjectMetadataFixture(t)
+
+	if err := store.PutBucketEncryption(context.Background(), "dst", ServerSideEncryptionConfig{
+		Rules: []ServerSideEncryptionRule{
+			{SSEAlgorithm: sseAlgorithmAWSKMS, KMSMasterKeyID: "bucket-default-key"},
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketEncryption: %v", err)
+	}
+
+	w := issueCopyObject(svc, map[string]string{})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	dstObj, err := store.GetObject(context.Background(), "dst", "copied.txt")
+	if err != nil {
+		t.Fatalf("GetObject dst: %v", err)
+	}
+
+	if dstObj.ServerSideEncryption != sseAlgorithmAWSKMS {
+		t.Fatalf("ServerSideEncryption: got %q, want aws:kms", dstObj.ServerSideEncryption)
+	}
+
+	if dstObj.SSEKMSKeyID != "bucket-default-key" {
+		t.Fatalf("SSEKMSKeyID: got %q, want bucket-default-key", dstObj.SSEKMSKeyID)
+	}
+}
+
+func TestCopyObjectDoesNotInheritSourceEncryptionWithNoDefault(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	if err := store.CreateBucket(ctx, "src"); err != nil {
+		t.Fatalf("CreateBucket src: %v", err)
+	}
+
+	if err := store.CreateBucket(ctx, "dst"); err != nil {
+		t.Fatalf("CreateBucket dst: %v", err)
+	}
+
+	_, err := store.PutObject(ctx, "src", "source.txt", strings.NewReader("copy me"), map[string]string{
+		"x-amz-server-side-encryption":                sseAlgorithmAWSKMS,
+		"x-amz-server-side-encryption-aws-kms-key-id": "source-key",
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	w := issueCopyObject(svc, map[string]string{})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	dstObj, err := store.GetObject(ctx, "dst", "copied.txt")
+	if err != nil {
+		t.Fatalf("GetObject dst: %v", err)
+	}
+
+	if dstObj.ServerSideEncryption != "" {
+		t.Fatalf("ServerSideEncryption: got %q, want empty (no inheritance from source)", dstObj.ServerSideEncryption)
+	}
+
+	if dstObj.SSEKMSKeyID != "" {
+		t.Fatalf("SSEKMSKeyID: got %q, want empty (no inheritance from source)", dstObj.SSEKMSKeyID)
 	}
 }
 

--- a/internal/service/s3/copyobject_version_test.go
+++ b/internal/service/s3/copyobject_version_test.go
@@ -52,7 +52,7 @@ func TestUploadPartCopyCopiesSpecifiedSourceVersion(t *testing.T) {
 
 	v1, v2 := setupVersionedSourceObject(t, store)
 
-	upload, err := store.CreateMultipartUpload(ctx, "dst", "joined.txt")
+	upload, err := store.CreateMultipartUpload(ctx, "dst", "joined.txt", nil)
 	if err != nil {
 		t.Fatalf("CreateMultipartUpload: %v", err)
 	}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -2078,7 +2078,7 @@ func (s *Service) CreateMultipartUpload(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	upload, err := s.storage.CreateMultipartUpload(r.Context(), bucket, key)
+	upload, err := s.storage.CreateMultipartUpload(r.Context(), bucket, key, extractObjectMetadata(r.Header))
 	if err != nil {
 		var bucketErr *BucketError
 		if errors.As(err, &bucketErr) {

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -811,6 +811,8 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.applyCopyEncryption(r.Context(), r.Header, dstBucket, metadata)
+
 	tags, err := s.copyObjectTags(r.Context(), r.Header, srcBucket, srcKey)
 	if err != nil {
 		writeS3Error(w, r, "InvalidArgument", err.Error(), http.StatusBadRequest)
@@ -908,6 +910,34 @@ func copyObjectMetadata(header http.Header, src map[string]string) (map[string]s
 		return extractObjectMetadata(header), nil
 	default:
 		return nil, errors.New("invalid metadata directive")
+	}
+}
+
+// applyCopyEncryption sets the destination object's SSE following AWS
+// CopyObject semantics: request headers win, else the destination bucket's
+// default encryption. The source object's SSE is intentionally NOT
+// inherited (issue #714 asks for "preservation", but AWS does not preserve
+// SSE across copies; see the PR description).
+func (s *Service) applyCopyEncryption(ctx context.Context, header http.Header, dstBucket string, metadata map[string]string) {
+	if sse := header.Get("X-Amz-Server-Side-Encryption"); sse != "" {
+		metadata["x-amz-server-side-encryption"] = sse
+		if key := header.Get("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id"); key != "" {
+			metadata["x-amz-server-side-encryption-aws-kms-key-id"] = key
+		}
+
+		return
+	}
+
+	cfg, err := s.storage.GetBucketEncryption(ctx, dstBucket)
+	if err != nil || cfg == nil || len(cfg.Rules) == 0 {
+		return
+	}
+
+	rule := cfg.Rules[0]
+	metadata["x-amz-server-side-encryption"] = rule.SSEAlgorithm
+
+	if rule.KMSMasterKeyID != "" {
+		metadata["x-amz-server-side-encryption-aws-kms-key-id"] = rule.KMSMasterKeyID
 	}
 }
 

--- a/internal/service/s3/multipart_metadata_test.go
+++ b/internal/service/s3/multipart_metadata_test.go
@@ -1,0 +1,180 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestMultipartUploadCarriesContentTypeMetadataAndSSE drives the full
+// CreateMultipartUpload -> UploadPart -> CompleteMultipartUpload cycle
+// through the HTTP handlers with Content-Type, x-amz-meta-*, and SSE-KMS
+// headers on the initiate request, and asserts the completed object carries
+// all three groups.
+func TestMultipartUploadCarriesContentTypeMetadataAndSSE(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupMultipartMetadataFixture(t)
+
+	uploadID := issueCreateMultipartUpload(t, svc, map[string]string{
+		"Content-Type":                                "image/jpeg",
+		"X-Amz-Meta-Origin":                           "cam1",
+		"X-Amz-Server-Side-Encryption":                "aws:kms",
+		"X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id": "mpu-key",
+	})
+
+	etag := issueUploadPart(t, svc, uploadID, 1, "hello multipart")
+
+	issueCompleteMultipartUpload(t, svc, uploadID, []PartRequest{
+		{PartNumber: 1, ETag: etag},
+	})
+
+	dstObj, err := store.GetObject(context.Background(), "mpu-metadata-test", "object")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+
+	if dstObj.ContentType != "image/jpeg" {
+		t.Fatalf("ContentType: got %q, want image/jpeg", dstObj.ContentType)
+	}
+
+	if got := dstObj.Metadata["origin"]; got != "cam1" {
+		t.Fatalf("Metadata[origin]: got %q, want cam1", got)
+	}
+
+	if dstObj.ServerSideEncryption != "aws:kms" {
+		t.Fatalf("ServerSideEncryption: got %q, want aws:kms", dstObj.ServerSideEncryption)
+	}
+
+	if dstObj.SSEKMSKeyID != "mpu-key" {
+		t.Fatalf("SSEKMSKeyID: got %q, want mpu-key", dstObj.SSEKMSKeyID)
+	}
+}
+
+// TestMultipartUploadWithNoHeadersFallsBackToOctetStream is a regression
+// guard: when the initiate request carries no Content-Type, the completed
+// object still defaults to application/octet-stream.
+func TestMultipartUploadWithNoHeadersFallsBackToOctetStream(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupMultipartMetadataFixture(t)
+
+	uploadID := issueCreateMultipartUpload(t, svc, map[string]string{})
+	etag := issueUploadPart(t, svc, uploadID, 1, "plain body")
+	issueCompleteMultipartUpload(t, svc, uploadID, []PartRequest{
+		{PartNumber: 1, ETag: etag},
+	})
+
+	dstObj, err := store.GetObject(context.Background(), "mpu-metadata-test", "object")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+
+	if dstObj.ContentType != "application/octet-stream" {
+		t.Fatalf("ContentType: got %q, want application/octet-stream", dstObj.ContentType)
+	}
+
+	if len(dstObj.Metadata) != 0 {
+		t.Fatalf("Metadata: got %v, want empty", dstObj.Metadata)
+	}
+
+	if dstObj.ServerSideEncryption != "" {
+		t.Fatalf("ServerSideEncryption: got %q, want empty", dstObj.ServerSideEncryption)
+	}
+}
+
+func setupMultipartMetadataFixture(t *testing.T) (*MemoryStorage, *Service) {
+	t.Helper()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	if err := store.CreateBucket(context.Background(), "mpu-metadata-test"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	return store, svc
+}
+
+func issueCreateMultipartUpload(t *testing.T, svc *Service, headers map[string]string) string {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/mpu-metadata-test/object?uploads", http.NoBody)
+	req.SetPathValue("bucket", "mpu-metadata-test")
+	req.SetPathValue("key", "object")
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	w := httptest.NewRecorder()
+	svc.CreateMultipartUpload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateMultipartUpload status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var result InitiateMultipartUploadResult
+	if err := xml.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode InitiateMultipartUploadResult: %v", err)
+	}
+
+	if result.UploadID == "" {
+		t.Fatal("UploadID is empty")
+	}
+
+	return result.UploadID
+}
+
+func issueUploadPart(t *testing.T, svc *Service, uploadID string, partNumber int, body string) string {
+	t.Helper()
+
+	url := fmt.Sprintf("/mpu-metadata-test/object?partNumber=%d&uploadId=%s", partNumber, uploadID)
+	req := httptest.NewRequest(http.MethodPut, url, strings.NewReader(body))
+	req.SetPathValue("bucket", "mpu-metadata-test")
+	req.SetPathValue("key", "object")
+
+	w := httptest.NewRecorder()
+	svc.UploadPart(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("UploadPart status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	etag := w.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("UploadPart: missing ETag response header")
+	}
+
+	return etag
+}
+
+func issueCompleteMultipartUpload(t *testing.T, svc *Service, uploadID string, parts []PartRequest) {
+	t.Helper()
+
+	var b strings.Builder
+
+	b.WriteString("<CompleteMultipartUpload>")
+
+	for _, p := range parts {
+		fmt.Fprintf(&b, "<Part><PartNumber>%d</PartNumber><ETag>%s</ETag></Part>", p.PartNumber, p.ETag)
+	}
+
+	b.WriteString("</CompleteMultipartUpload>")
+
+	url := "/mpu-metadata-test/object?uploadId=" + uploadID
+	req := httptest.NewRequest(http.MethodPost, url, strings.NewReader(b.String()))
+	req.SetPathValue("bucket", "mpu-metadata-test")
+	req.SetPathValue("key", "object")
+
+	w := httptest.NewRecorder()
+	svc.CompleteMultipartUpload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CompleteMultipartUpload status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+}

--- a/internal/service/s3/multipart_order_test.go
+++ b/internal/service/s3/multipart_order_test.go
@@ -49,7 +49,7 @@ func createMultipartOrderTestParts(t *testing.T, store *MemoryStorage) multipart
 		t.Fatalf("CreateBucket: %v", err)
 	}
 
-	upload, err := store.CreateMultipartUpload(ctx, "mpu-order-test", "object")
+	upload, err := store.CreateMultipartUpload(ctx, "mpu-order-test", "object", nil)
 	if err != nil {
 		t.Fatalf("CreateMultipartUpload: %v", err)
 	}

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -45,7 +45,7 @@ type Storage interface {
 	ListObjectVersions(ctx context.Context, bucket, prefix, delimiter string, maxKeys int) ([]Object, []string, error)
 
 	// Multipart upload operations
-	CreateMultipartUpload(ctx context.Context, bucket, key string) (*MultipartUpload, error)
+	CreateMultipartUpload(ctx context.Context, bucket, key string, metadata map[string]string) (*MultipartUpload, error)
 	UploadPart(ctx context.Context, bucket, key, uploadID string, partNumber int, body io.Reader) (*Part, error)
 	CompleteMultipartUpload(ctx context.Context, bucket, key, uploadID string, parts []PartRequest) (*Object, error)
 	AbortMultipartUpload(ctx context.Context, bucket, key, uploadID string) error
@@ -1013,7 +1013,7 @@ func (e *MultipartError) Error() string {
 }
 
 // CreateMultipartUpload creates a new multipart upload.
-func (s *MemoryStorage) CreateMultipartUpload(_ context.Context, bucket, key string) (*MultipartUpload, error) {
+func (s *MemoryStorage) CreateMultipartUpload(_ context.Context, bucket, key string, metadata map[string]string) (*MultipartUpload, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1029,6 +1029,7 @@ func (s *MemoryStorage) CreateMultipartUpload(_ context.Context, bucket, key str
 		UploadID:  uploadID,
 		Initiated: time.Now(),
 		Parts:     make(map[int]*Part),
+		Metadata:  metadata,
 	}
 
 	b.MultipartUploads[uploadID] = upload
@@ -1179,7 +1180,37 @@ func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, 
 		return nil, &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
 	}
 
-	// Validate and assemble parts
+	combinedBody, err := assembleMultipartBody(upload, parts, uploadID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Calculate final ETag (MD5 of MD5s + "-" + number of parts)
+	etag := calculateMultipartETag(parts, upload.Parts)
+
+	obj := &Object{
+		Key:          key,
+		Body:         combinedBody,
+		bodyRef:      bodyRefOf(combinedBody),
+		ETag:         etag,
+		Size:         int64(len(combinedBody)),
+		LastModified: time.Now(),
+		ContentType:  "application/octet-stream",
+	}
+
+	applyMultipartUploadMetadata(obj, upload.Metadata)
+
+	b.Objects[key] = obj
+	delete(b.MultipartUploads, uploadID)
+
+	s.saveLocked()
+
+	return obj, nil
+}
+
+// assembleMultipartBody validates the part list (ascending order, no
+// duplicates, ETag match) and concatenates the part bodies in order.
+func assembleMultipartBody(upload *MultipartUpload, parts []PartRequest, uploadID string) ([]byte, error) {
 	var combinedBody []byte
 
 	previousPartNumber := 0
@@ -1204,25 +1235,27 @@ func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, 
 		combinedBody = append(combinedBody, part.Body...)
 	}
 
-	// Calculate final ETag (MD5 of MD5s + "-" + number of parts)
-	etag := calculateMultipartETag(parts, upload.Parts)
+	return combinedBody, nil
+}
 
-	obj := &Object{
-		Key:          key,
-		Body:         combinedBody,
-		bodyRef:      bodyRefOf(combinedBody),
-		ETag:         etag,
-		Size:         int64(len(combinedBody)),
-		LastModified: time.Now(),
-		ContentType:  "application/octet-stream",
+// applyMultipartUploadMetadata carries the Content-Type, user metadata, and
+// SSE headers captured at CreateMultipartUpload time onto the completed
+// object, mirroring PutObject's metadata/SSE handling. Operates on a clone
+// of upload.Metadata since applySSEMetadata mutates its argument and
+// CompleteMultipartUpload can in principle be retried.
+func applyMultipartUploadMetadata(obj *Object, metadata map[string]string) {
+	if metadata == nil {
+		return
 	}
 
-	b.Objects[key] = obj
-	delete(b.MultipartUploads, uploadID)
+	m := cloneStringMap(metadata)
+	obj.Metadata = m
 
-	s.saveLocked()
+	if ct, ok := m["Content-Type"]; ok {
+		obj.ContentType = ct
+	}
 
-	return obj, nil
+	applySSEMetadata(obj, m)
 }
 
 // AbortMultipartUpload aborts a multipart upload.

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -328,7 +328,8 @@ type MultipartUpload struct {
 	Key       string
 	UploadID  string
 	Initiated time.Time
-	Parts     map[int]*Part // partNumber -> Part
+	Parts     map[int]*Part     // partNumber -> Part
+	Metadata  map[string]string // Content-Type, x-amz-meta-*, and SSE headers captured at CreateMultipartUpload time
 }
 
 // Part represents a part in a multipart upload.

--- a/internal/service/s3/uploadpartcopy_test.go
+++ b/internal/service/s3/uploadpartcopy_test.go
@@ -123,7 +123,7 @@ func setupUploadPartCopyFixture(t *testing.T, srcPayload string) (*MemoryStorage
 		t.Fatalf("PutObject: %v", err)
 	}
 
-	upload, err := store.CreateMultipartUpload(ctx, "dst", "out.txt")
+	upload, err := store.CreateMultipartUpload(ctx, "dst", "out.txt", nil)
 	if err != nil {
 		t.Fatalf("CreateMultipartUpload: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestUploadPartCopy_RoundTripsThroughComplete(t *testing.T) {
 	_ = store.CreateBucket(ctx, "dst")
 	_, _ = store.PutObject(ctx, "src", "blob", strings.NewReader("ABCDEFGHIJ"), nil)
 
-	upload, err := store.CreateMultipartUpload(ctx, "dst", "joined")
+	upload, err := store.CreateMultipartUpload(ctx, "dst", "joined", nil)
 	if err != nil {
 		t.Fatalf("CreateMultipartUpload: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Completes the remaining half of #714 (tags + user metadata on CopyObject
  already landed): CopyObject lost server-side encryption, and multipart
  uploads lost Content-Type, user metadata, and SSE entirely.
- CopyObject now sets the destination SSE following AWS CopyObject
  semantics — the copy request's SSE headers win, otherwise the destination
  bucket's default encryption applies; the source object's SSE is **not**
  inherited (AWS re-encrypts per request/bucket-default rather than
  preserving across a copy).
- `CreateMultipartUpload` captures Content-Type, `x-amz-meta-*`, and SSE
  headers and carries them to the completed object, mirroring PutObject's
  metadata/SSE handling (the completed object was previously hard-coded to
  `application/octet-stream` with no metadata or SSE).

## Notes

- This intentionally diverges from #714's literal "preserve through copy"
  wording in favor of AWS's actual CopyObject encryption behavior (request
  header, else destination bucket default).
- Applying bucket default encryption on the PutObject / CreateMultipartUpload
  paths (kumo stores the config but does not yet apply it there) is left as a
  follow-up to avoid changing existing PutObject behavior in this PR.

## Test plan

- [x] `make lint` (0 issues), `go test -race ./...`
- [x] New tests: copy with request SSE headers; copy inheriting the
      destination bucket default; copy of an unencrypted object stays
      unencrypted; multipart upload round-trips Content-Type / user metadata
      / SSE-KMS; multipart with no headers falls back to octet-stream

Closes #714
