### PR TITLE
feat(s3): invoke Lambda on ObjectCreated events via LambdaFunctionConfiguration

### DIFF
--- a/internal/server/s3_lambda_wiring_test.go
+++ b/internal/server/s3_lambda_wiring_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestS3ToLambdaInvoker_InvokeAsync_StatusHandling regression-tests a bug
+// where InvokeAsync ignored the HTTP response status from the Lambda invoke
+// endpoint: a 404 (function not found) or 500 returned nil, so the S3 event
+// notification silently vanished instead of surfacing an error the caller
+// could log. Any status >= 300 must now produce a non-nil error that
+// includes the status code; success statuses (e.g. 202 Accepted, which is
+// what the real Lambda invoke endpoint returns for async invocations) must
+// still return nil.
+func TestS3ToLambdaInvoker_InvokeAsync_StatusHandling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+		wantSubstr string
+	}{
+		{
+			name:       "server error surfaces as an error",
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+			wantSubstr: "500",
+		},
+		{
+			name:       "accepted returns no error",
+			statusCode: http.StatusAccepted,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer srv.Close()
+
+			inv := &s3ToLambdaInvoker{
+				baseURL:    srv.URL,
+				httpClient: &http.Client{Timeout: 5 * time.Second},
+			}
+
+			err := inv.InvokeAsync(context.Background(), "arn:aws:lambda:us-east-1:123456789012:function:my-func", []byte(`{}`))
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("InvokeAsync() error = nil, want error containing %q", tt.wantSubstr)
+				}
+
+				if !strings.Contains(err.Error(), tt.wantSubstr) {
+					t.Fatalf("InvokeAsync() error = %q, want it to contain %q", err.Error(), tt.wantSubstr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("InvokeAsync() error = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -113,6 +113,7 @@ func New(config Config) *Server {
 	// Cross-service wiring (must happen after all services are registered).
 	wireSNStoSQS(registry)
 	wireS3toSQS(registry)
+	wireS3toLambda(registry)
 	wireCloudWatchToSNS(registry)
 
 	// Register unified protocol dispatcher for POST /

--- a/internal/server/sns_sqs_wiring.go
+++ b/internal/server/sns_sqs_wiring.go
@@ -1,11 +1,16 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/sivchari/kumo/internal/service"
+	"github.com/sivchari/kumo/internal/service/lambda"
 	"github.com/sivchari/kumo/internal/service/s3"
 	"github.com/sivchari/kumo/internal/service/sns"
 	"github.com/sivchari/kumo/internal/service/sqs"
@@ -187,6 +192,98 @@ func (p *s3ToSQSPublisher) arnToQueueURL(arn string) string {
 	name := parts[5]
 
 	return p.baseURL + "/" + account + "/" + name
+}
+
+// wireS3toLambda connects the S3 service to the Lambda service so that
+// S3 bucket notification configurations with LambdaFunctionConfigurations
+// actually invoke the target Lambda function.
+//
+// Without this wiring, PutObject/CopyObject/CompleteMultipartUpload
+// silently ignore LambdaFunctionConfiguration entries because
+// s3.Service.lambdaInvoker is nil. The pattern mirrors wireS3toSQS.
+func wireS3toLambda(registry *service.Registry) {
+	s3Svc, ok := registry.Get("s3")
+	if !ok {
+		return
+	}
+
+	lambdaSvc, ok := registry.Get("lambda")
+	if !ok {
+		return
+	}
+
+	s3Typed, ok := s3Svc.(*s3.Service)
+	if !ok {
+		return
+	}
+
+	lambdaTyped, ok := lambdaSvc.(*lambda.Service)
+	if !ok {
+		return
+	}
+
+	s3Typed.SetLambdaInvoker(&s3ToLambdaInvoker{
+		baseURL:    lambdaTyped.BaseURL(),
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	})
+}
+
+// s3ToLambdaInvoker adapts the Lambda service's HTTP invoke endpoint to
+// the S3 LambdaInvoker interface. It POSTs the S3 event notification
+// payload to the Lambda invoke endpoint with the async invocation-type
+// header so the request rides Lambda's async dispatch queue instead of
+// blocking for a response.
+type s3ToLambdaInvoker struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// InvokeAsync invokes the Lambda function identified by functionArn,
+// asynchronously delivering the S3 event notification payload.
+func (inv *s3ToLambdaInvoker) InvokeAsync(ctx context.Context, functionArn string, payload []byte) error {
+	functionName := lambdaFunctionNameFromArn(functionArn)
+
+	endpoint := fmt.Sprintf("%s/lambda/2015-03-31/functions/%s/invocations", inv.baseURL, functionName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create Lambda invoke request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Amz-Invocation-Type", "Event")
+
+	resp, err := inv.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to invoke Lambda function %s: %w", functionName, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+		return fmt.Errorf("invoke lambda %s returned %d: %s", functionName, resp.StatusCode, body)
+	}
+
+	return nil
+}
+
+// lambdaFunctionNameFromArn extracts the bare function name from a Lambda
+// function ARN (arn:aws:lambda:region:account:function:name[:qualifier]),
+// dropping any qualifier. If the input has no ":" it is assumed to
+// already be a bare function name and is returned unchanged.
+func lambdaFunctionNameFromArn(arn string) string {
+	if !strings.Contains(arn, ":") {
+		return arn
+	}
+
+	parts := strings.Split(arn, ":")
+	if len(parts) >= 7 && parts[5] == "function" {
+		return parts[6]
+	}
+
+	return arn
 }
 
 // wireCloudWatchToSNS connects the CloudWatch service to the SNS service

--- a/internal/service/lambda/service.go
+++ b/internal/service/lambda/service.go
@@ -45,6 +45,9 @@ func (s *Service) Name() string {
 	return "lambda"
 }
 
+// BaseURL returns the kumo server base URL the service self-calls against.
+func (s *Service) BaseURL() string { return s.baseURL }
+
 // RegisterRoutes registers the Lambda routes.
 // Routes are registered under both /lambda/... (for SDK BaseEndpoint) and /2015-03-31/... (for CLI).
 func (s *Service) RegisterRoutes(r service.Router) {

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -775,6 +775,9 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 
 	// Deliver S3 event notification to configured SQS queues.
 	go s.emitSQSNotifications(context.Background(), bucket, key, "s3:ObjectCreated:Put", obj.Size, obj.ETag)
+
+	// Invoke configured Lambda functions.
+	go s.emitLambdaNotifications(context.Background(), bucket, key, "s3:ObjectCreated:Put", obj.Size, obj.ETag)
 }
 
 // CopyObject handles PUT /{bucket}/{key} with X-Amz-Copy-Source header.
@@ -851,6 +854,7 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 
 	go s.emitObjectCreatedEvent(context.Background(), dstBucket, dstKey, dstObj.Size, dstObj.ETag)
 	go s.emitSQSNotifications(context.Background(), dstBucket, dstKey, "s3:ObjectCreated:Copy", dstObj.Size, dstObj.ETag)
+	go s.emitLambdaNotifications(context.Background(), dstBucket, dstKey, "s3:ObjectCreated:Copy", dstObj.Size, dstObj.ETag)
 }
 
 // getCopySource retrieves the source object for a copy operation,
@@ -2255,6 +2259,15 @@ func (s *Service) CompleteMultipartUpload(w http.ResponseWriter, r *http.Request
 	}
 
 	writeXMLResponse(w, result)
+
+	// Emit EventBridge notification if enabled.
+	go s.emitObjectCreatedEvent(context.Background(), bucket, key, obj.Size, obj.ETag)
+
+	// Deliver S3 event notification to configured SQS queues.
+	go s.emitSQSNotifications(context.Background(), bucket, key, "s3:ObjectCreated:CompleteMultipartUpload", obj.Size, obj.ETag)
+
+	// Invoke configured Lambda functions.
+	go s.emitLambdaNotifications(context.Background(), bucket, key, "s3:ObjectCreated:CompleteMultipartUpload", obj.Size, obj.ETag)
 }
 
 // AbortMultipartUpload handles DELETE /{bucket}/{key}?uploadId={uploadId} - abort a multipart upload.
@@ -2420,6 +2433,7 @@ func (s *Service) PutBucketNotificationConfiguration(w http.ResponseWriter, r *h
 	enabled := config.EventBridgeConfig != nil
 	s.storage.SetEventBridgeNotification(r.Context(), bucket, enabled)
 	s.storage.SetQueueConfigurations(r.Context(), bucket, config.QueueConfigurations)
+	s.storage.SetLambdaConfigurations(r.Context(), bucket, config.LambdaFunctionConfigurations)
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/service/s3/lambda_notification_test.go
+++ b/internal/service/s3/lambda_notification_test.go
@@ -1,0 +1,308 @@
+package s3
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeLambdaInvoker is a test double for LambdaInvoker that captures every
+// invocation on a buffered channel so tests can wait for the async
+// emitLambdaNotifications goroutine without a blind time.Sleep, mirroring
+// the channel-based wait pattern used by the eventbridge delivery tests.
+type fakeLambdaInvoker struct {
+	invocations chan lambdaInvocation
+}
+
+type lambdaInvocation struct {
+	functionArn string
+	payload     []byte
+}
+
+func newFakeLambdaInvoker() *fakeLambdaInvoker {
+	return &fakeLambdaInvoker{invocations: make(chan lambdaInvocation, 10)}
+}
+
+func (f *fakeLambdaInvoker) InvokeAsync(_ context.Context, functionArn string, payload []byte) error {
+	f.invocations <- lambdaInvocation{functionArn: functionArn, payload: payload}
+
+	return nil
+}
+
+// waitForInvocation waits up to 2 seconds for an invocation to arrive.
+func waitForInvocation(t *testing.T, f *fakeLambdaInvoker) lambdaInvocation {
+	t.Helper()
+
+	select {
+	case inv := <-f.invocations:
+		return inv
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive Lambda invocation within timeout")
+
+		return lambdaInvocation{}
+	}
+}
+
+// assertNoInvocation fails the test if an invocation arrives within a short
+// grace period, used to confirm a filter mismatch or missing invoker
+// correctly suppresses delivery.
+func assertNoInvocation(t *testing.T, f *fakeLambdaInvoker) {
+	t.Helper()
+
+	select {
+	case inv := <-f.invocations:
+		t.Fatalf("unexpected Lambda invocation: functionArn=%s payload=%s", inv.functionArn, inv.payload)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+const testLambdaArn = "arn:aws:lambda:us-east-1:000000000000:function:test-fn"
+
+func newLambdaNotificationTestService(t *testing.T, bucket string) (*MemoryStorage, *Service) {
+	t.Helper()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	if err := store.CreateBucket(context.Background(), bucket); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	return store, svc
+}
+
+func putLambdaNotificationConfig(t *testing.T, svc *Service, bucket string, events []string) {
+	t.Helper()
+
+	body := `<NotificationConfiguration>` +
+		`<CloudFunctionConfiguration>` +
+		`<Id>test-config</Id>` +
+		`<CloudFunction>` + testLambdaArn + `</CloudFunction>`
+	for _, e := range events {
+		body += `<Event>` + e + `</Event>`
+	}
+
+	body += `</CloudFunctionConfiguration></NotificationConfiguration>`
+
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?notification", strings.NewReader(body))
+	req.SetPathValue("bucket", bucket)
+
+	w := httptest.NewRecorder()
+	svc.PutBucketNotificationConfiguration(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutBucketNotificationConfiguration status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+}
+
+func putObjectRequest(bucket, key, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"/"+key, strings.NewReader(body))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", key)
+
+	return req
+}
+
+// TestLambdaNotification_PutObjectInvokesLambda covers Step 6 test 1: a
+// LambdaFunctionConfiguration matching s3:ObjectCreated:* fires exactly once
+// on PutObject, with the right bucket/key/eventName/configuration id.
+func TestLambdaNotification_PutObjectInvokesLambda(t *testing.T) {
+	t.Parallel()
+
+	const bucket = "lambda-notify-put"
+
+	_, svc := newLambdaNotificationTestService(t, bucket)
+	putLambdaNotificationConfig(t, svc, bucket, []string{"s3:ObjectCreated:*"})
+
+	invoker := newFakeLambdaInvoker()
+	svc.SetLambdaInvoker(invoker)
+
+	w := httptest.NewRecorder()
+	svc.PutObject(w, putObjectRequest(bucket, "hello.txt", "hello world"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	inv := waitForInvocation(t, invoker)
+
+	if inv.functionArn != testLambdaArn {
+		t.Fatalf("functionArn = %q, want %q", inv.functionArn, testLambdaArn)
+	}
+
+	var notification EventNotification
+	if err := json.Unmarshal(inv.payload, &notification); err != nil {
+		t.Fatalf("payload not valid EventNotification JSON: %v", err)
+	}
+
+	if len(notification.Records) != 1 {
+		t.Fatalf("Records length = %d, want 1", len(notification.Records))
+	}
+
+	rec := notification.Records[0]
+	if rec.EventName != "s3:ObjectCreated:Put" {
+		t.Errorf("EventName = %q, want s3:ObjectCreated:Put", rec.EventName)
+	}
+
+	if rec.S3.Bucket.Name != bucket {
+		t.Errorf("Bucket.Name = %q, want %q", rec.S3.Bucket.Name, bucket)
+	}
+
+	if rec.S3.Object.Key != "hello.txt" {
+		t.Errorf("Object.Key = %q, want hello.txt", rec.S3.Object.Key)
+	}
+
+	if rec.S3.ConfigurationID != "test-config" {
+		t.Errorf("ConfigurationID = %q, want test-config", rec.S3.ConfigurationID)
+	}
+
+	assertNoInvocation(t, invoker)
+}
+
+// TestLambdaNotification_EventFilterMismatch covers Step 6 test 2: a config
+// scoped to s3:ObjectCreated:Put must not fire for a CopyObject.
+func TestLambdaNotification_EventFilterMismatch(t *testing.T) {
+	t.Parallel()
+
+	const bucket = "lambda-notify-filter"
+
+	store, svc := newLambdaNotificationTestService(t, bucket)
+	putLambdaNotificationConfig(t, svc, bucket, []string{"s3:ObjectCreated:Put"})
+
+	invoker := newFakeLambdaInvoker()
+	svc.SetLambdaInvoker(invoker)
+
+	if _, err := store.PutObject(context.Background(), bucket, "src.txt", strings.NewReader("copy me"), nil); err != nil {
+		t.Fatalf("PutObject (seed src): %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"/dst.txt", http.NoBody)
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", "dst.txt")
+	req.Header.Set("X-Amz-Copy-Source", "/"+bucket+"/src.txt")
+
+	svc.CopyObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CopyObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	assertNoInvocation(t, invoker)
+}
+
+// TestLambdaNotification_NoInvokerInstalled covers Step 6 test 3: with no
+// invoker wired up, PutObject must still succeed and must not panic even
+// though a LambdaFunctionConfiguration is present.
+func TestLambdaNotification_NoInvokerInstalled(t *testing.T) {
+	t.Parallel()
+
+	const bucket = "lambda-notify-noinvoker"
+
+	_, svc := newLambdaNotificationTestService(t, bucket)
+	putLambdaNotificationConfig(t, svc, bucket, []string{"s3:ObjectCreated:*"})
+
+	w := httptest.NewRecorder()
+	svc.PutObject(w, putObjectRequest(bucket, "hello.txt", "hello world"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	// Give the goroutine a moment to run; it must nil-guard and return
+	// without panicking. There is nothing to observe beyond "no panic" and
+	// "handler already returned 200 above" since Go test would already
+	// have failed loudly if PutObject itself panicked.
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestLambdaNotification_XMLRoundTrip covers Step 6 test 4: a PUT
+// notification body shaped exactly as the AWS SDK serializes it
+// (<CloudFunctionConfiguration> wrapping <CloudFunction>/<Event>/<Id>)
+// round-trips through storage.
+func TestLambdaNotification_XMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const bucket = "lambda-notify-roundtrip"
+
+	store, svc := newLambdaNotificationTestService(t, bucket)
+	putLambdaNotificationConfig(t, svc, bucket, []string{"s3:ObjectCreated:Put", "s3:ObjectCreated:Copy"})
+
+	configs := store.GetLambdaConfigurations(context.Background(), bucket)
+	if len(configs) != 1 {
+		t.Fatalf("GetLambdaConfigurations length = %d, want 1", len(configs))
+	}
+
+	cfg := configs[0]
+	if cfg.ID != "test-config" {
+		t.Errorf("ID = %q, want test-config", cfg.ID)
+	}
+
+	if cfg.LambdaFunctionArn != testLambdaArn {
+		t.Errorf("LambdaFunctionArn = %q, want %q", cfg.LambdaFunctionArn, testLambdaArn)
+	}
+
+	if len(cfg.Events) != 2 || cfg.Events[0] != "s3:ObjectCreated:Put" || cfg.Events[1] != "s3:ObjectCreated:Copy" {
+		t.Errorf("Events = %v, want [s3:ObjectCreated:Put s3:ObjectCreated:Copy]", cfg.Events)
+	}
+}
+
+// TestLambdaNotification_CompleteMultipartUploadFiresAllEmitters covers Step
+// 6 test 5: CompleteMultipartUpload's success path must fire all three
+// notification emitters (EventBridge, SQS, Lambda). This asserts at least
+// that the Lambda fake receives the CompleteMultipartUpload event name.
+func TestLambdaNotification_CompleteMultipartUploadFiresAllEmitters(t *testing.T) {
+	t.Parallel()
+
+	const bucket = "lambda-notify-mpu"
+
+	store, svc := newLambdaNotificationTestService(t, bucket)
+	putLambdaNotificationConfig(t, svc, bucket, []string{"s3:ObjectCreated:*"})
+
+	invoker := newFakeLambdaInvoker()
+	svc.SetLambdaInvoker(invoker)
+
+	ctx := context.Background()
+
+	upload, err := store.CreateMultipartUpload(ctx, bucket, "big.bin")
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	part, err := store.UploadPart(ctx, bucket, "big.bin", upload.UploadID, 1, strings.NewReader("all the bytes"))
+	if err != nil {
+		t.Fatalf("UploadPart: %v", err)
+	}
+
+	completeBody := `<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>` + part.ETag + `</ETag></Part></CompleteMultipartUpload>`
+
+	req := httptest.NewRequest(http.MethodPost, "/"+bucket+"/big.bin?uploadId="+upload.UploadID, strings.NewReader(completeBody))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", "big.bin")
+
+	w := httptest.NewRecorder()
+	svc.CompleteMultipartUpload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CompleteMultipartUpload status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	inv := waitForInvocation(t, invoker)
+
+	var notification EventNotification
+	if err := json.Unmarshal(inv.payload, &notification); err != nil {
+		t.Fatalf("payload not valid EventNotification JSON: %v", err)
+	}
+
+	if len(notification.Records) != 1 {
+		t.Fatalf("Records length = %d, want 1", len(notification.Records))
+	}
+
+	if got := notification.Records[0].EventName; got != "s3:ObjectCreated:CompleteMultipartUpload" {
+		t.Errorf("EventName = %q, want s3:ObjectCreated:CompleteMultipartUpload", got)
+	}
+}

--- a/internal/service/s3/object_post.go
+++ b/internal/service/s3/object_post.go
@@ -84,6 +84,7 @@ func (s *Service) PostObject(w http.ResponseWriter, r *http.Request) {
 
 	go s.emitObjectCreatedEvent(context.Background(), bucket, upload.key, obj.Size, obj.ETag)
 	go s.emitSQSNotifications(context.Background(), bucket, upload.key, "s3:ObjectCreated:Post", obj.Size, obj.ETag)
+	go s.emitLambdaNotifications(context.Background(), bucket, upload.key, "s3:ObjectCreated:Post", obj.Size, obj.ETag)
 
 	writePostObjectResponse(w, r, bucket, upload.key, obj)
 }

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -27,6 +27,13 @@ type SQSPublisher interface {
 	PublishToSQS(ctx context.Context, queueARN, body string) error
 }
 
+// LambdaInvoker is the interface the S3 service uses to invoke Lambda
+// functions for bucket notifications. Implemented by the server wiring so
+// the s3 package does not import the lambda service.
+type LambdaInvoker interface {
+	InvokeAsync(ctx context.Context, functionArn string, payload []byte) error
+}
+
 const defaultBaseURL = "http://localhost:4566"
 
 // Compile-time check that Service implements io.Closer.
@@ -49,10 +56,11 @@ func init() {
 
 // Service implements the S3 service.
 type Service struct {
-	storage      Storage
-	baseURL      string
-	logger       *slog.Logger
-	sqsPublisher SQSPublisher
+	storage       Storage
+	baseURL       string
+	logger        *slog.Logger
+	sqsPublisher  SQSPublisher
+	lambdaInvoker LambdaInvoker
 }
 
 // New creates a new S3 service.
@@ -118,6 +126,41 @@ func (s *Service) SetSQSPublisher(p SQSPublisher) {
 	s.sqsPublisher = p
 }
 
+// SetLambdaInvoker installs the adapter that invokes Lambda functions for
+// S3 bucket notifications. Called by the server wiring layer after all
+// services have been registered.
+func (s *Service) SetLambdaInvoker(inv LambdaInvoker) {
+	s.lambdaInvoker = inv
+}
+
+// buildEventNotification constructs the S3 event notification message
+// body shared by every notification destination (SQS, Lambda, ...).
+func buildEventNotification(bucket, key, eventName string, size int64, etag, configID string) EventNotification {
+	return EventNotification{
+		Records: []EventRecord{{
+			EventVersion: "2.1",
+			EventSource:  "aws:s3",
+			AWSRegion:    "us-east-1",
+			EventTime:    time.Now().UTC().Format(time.RFC3339),
+			EventName:    eventName,
+			UserIdentity: map[string]string{"principalId": "EXAMPLE"},
+			S3: EventRecordS3Detail{
+				SchemaVersion:   "1.0",
+				ConfigurationID: configID,
+				Bucket: EventRecordBucket{
+					Name: bucket,
+					Arn:  "arn:aws:s3:::" + bucket,
+				},
+				Object: EventRecordObject{
+					Key:  url.QueryEscape(key),
+					Size: size,
+					ETag: strings.Trim(etag, "\""),
+				},
+			},
+		}},
+	}
+}
+
 // emitSQSNotifications delivers S3 event notification messages to
 // every SQS queue configured in the bucket's notification configuration
 // whose event filter matches the given eventName.
@@ -136,29 +179,7 @@ func (s *Service) emitSQSNotifications(ctx context.Context, bucket, key, eventNa
 			continue
 		}
 
-		record := EventNotification{
-			Records: []EventRecord{{
-				EventVersion: "2.1",
-				EventSource:  "aws:s3",
-				AWSRegion:    "us-east-1",
-				EventTime:    time.Now().UTC().Format(time.RFC3339),
-				EventName:    eventName,
-				UserIdentity: map[string]string{"principalId": "EXAMPLE"},
-				S3: EventRecordS3Detail{
-					SchemaVersion:   "1.0",
-					ConfigurationID: cfg.ID,
-					Bucket: EventRecordBucket{
-						Name: bucket,
-						Arn:  "arn:aws:s3:::" + bucket,
-					},
-					Object: EventRecordObject{
-						Key:  url.QueryEscape(key),
-						Size: size,
-						ETag: strings.Trim(etag, "\""),
-					},
-				},
-			}},
-		}
+		record := buildEventNotification(bucket, key, eventName, size, etag, cfg.ID)
 
 		body, err := json.Marshal(record)
 		if err != nil {
@@ -170,6 +191,41 @@ func (s *Service) emitSQSNotifications(ctx context.Context, bucket, key, eventNa
 		if err := s.sqsPublisher.PublishToSQS(ctx, cfg.QueueArn, string(body)); err != nil {
 			s.logger.Error("failed to deliver S3 notification to SQS",
 				"bucket", bucket, "key", key, "queueArn", cfg.QueueArn, "error", err)
+		}
+	}
+}
+
+// emitLambdaNotifications invokes every Lambda function configured in the
+// bucket's notification configuration whose event filter matches the
+// given eventName, asynchronously delivering the S3 event notification
+// payload.
+func (s *Service) emitLambdaNotifications(ctx context.Context, bucket, key, eventName string, size int64, etag string) {
+	if s.lambdaInvoker == nil {
+		return
+	}
+
+	configs := s.storage.GetLambdaConfigurations(ctx, bucket)
+	if len(configs) == 0 {
+		return
+	}
+
+	for _, cfg := range configs {
+		if !matchesEventFilter(cfg.Events, eventName) {
+			continue
+		}
+
+		record := buildEventNotification(bucket, key, eventName, size, etag, cfg.ID)
+
+		body, err := json.Marshal(record)
+		if err != nil {
+			s.logger.Error("failed to marshal S3 event notification", "error", err)
+
+			continue
+		}
+
+		if err := s.lambdaInvoker.InvokeAsync(ctx, cfg.LambdaFunctionArn, body); err != nil {
+			s.logger.Error("failed to invoke Lambda for S3 notification",
+				"bucket", bucket, "key", key, "functionArn", cfg.LambdaFunctionArn, "error", err)
 		}
 	}
 }

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -66,6 +66,8 @@ type Storage interface {
 	IsEventBridgeEnabled(ctx context.Context, bucket string) bool
 	SetQueueConfigurations(ctx context.Context, bucket string, configs []QueueConfiguration)
 	GetQueueConfigurations(ctx context.Context, bucket string) []QueueConfiguration
+	SetLambdaConfigurations(ctx context.Context, bucket string, configs []LambdaFunctionConfiguration)
+	GetLambdaConfigurations(ctx context.Context, bucket string) []LambdaFunctionConfiguration
 	SetCORSConfiguration(ctx context.Context, bucket string, rules []CORSRule)
 	GetCORSRules(ctx context.Context, bucket string) []CORSRule
 
@@ -120,24 +122,25 @@ type MemoryStorage struct {
 
 // MemoryBucket holds the data for a single S3 bucket.
 type MemoryBucket struct {
-	Name                string                      `json:"name"`
-	CreationDate        time.Time                   `json:"creationDate"`
-	Objects             map[string]*Object          `json:"objects"`                       // current/latest version per key
-	Versions            map[string][]*Object        `json:"versions"`                      // all versions per key (newest first)
-	VersioningStatus    string                      `json:"versioningStatus"`              // "", "Enabled", "Suspended"
-	VersionIDCounter    uint64                      `json:"versionIdcounter"`              // counter for generating version IDs
-	MultipartUploads    map[string]*MultipartUpload `json:"-"`                             // uploadID -> MultipartUpload
-	EventBridgeEnabled  bool                        `json:"eventBridgeEnabled"`            // EventBridge notification
-	QueueConfigurations []QueueConfiguration        `json:"queueConfigurations,omitempty"` // SQS queue notification destinations
-	CORSRules           []CORSRule                  `json:"corsRules,omitempty"`           // CORS configuration
-	PublicAccessBlock   *PublicAccessBlockConfig    `json:"publicAccessBlock,omitempty"`   // public access block configuration
-	Encryption          *ServerSideEncryptionConfig `json:"encryption,omitempty"`          // server-side encryption configuration
-	Policy              string                      `json:"policy,omitempty"`              // bucket policy JSON document (empty == not configured)
-	Logging             *BucketLoggingConfig        `json:"logging,omitempty"`             // server access logging target (nil == disabled)
-	ObjectACLs          map[string]*ObjectACL       `json:"objectAcls,omitempty"`          // per-object ACL (key -> ACL)
-	Website             *WebsiteConfiguration       `json:"website,omitempty"`             // static-site-hosting configuration
-	Lifecycle           *LifecycleConfiguration     `json:"lifecycle,omitempty"`           // expiration / transition rules
-	ObjectRestores      map[string]*RestoreState    `json:"objectRestores,omitempty"`      // per-object restore state (key -> state)
+	Name                 string                        `json:"name"`
+	CreationDate         time.Time                     `json:"creationDate"`
+	Objects              map[string]*Object            `json:"objects"`                        // current/latest version per key
+	Versions             map[string][]*Object          `json:"versions"`                       // all versions per key (newest first)
+	VersioningStatus     string                        `json:"versioningStatus"`               // "", "Enabled", "Suspended"
+	VersionIDCounter     uint64                        `json:"versionIdcounter"`               // counter for generating version IDs
+	MultipartUploads     map[string]*MultipartUpload   `json:"-"`                              // uploadID -> MultipartUpload
+	EventBridgeEnabled   bool                          `json:"eventBridgeEnabled"`             // EventBridge notification
+	QueueConfigurations  []QueueConfiguration          `json:"queueConfigurations,omitempty"`  // SQS queue notification destinations
+	LambdaConfigurations []LambdaFunctionConfiguration `json:"lambdaConfigurations,omitempty"` // Lambda notification destinations
+	CORSRules            []CORSRule                    `json:"corsRules,omitempty"`            // CORS configuration
+	PublicAccessBlock    *PublicAccessBlockConfig      `json:"publicAccessBlock,omitempty"`    // public access block configuration
+	Encryption           *ServerSideEncryptionConfig   `json:"encryption,omitempty"`           // server-side encryption configuration
+	Policy               string                        `json:"policy,omitempty"`               // bucket policy JSON document (empty == not configured)
+	Logging              *BucketLoggingConfig          `json:"logging,omitempty"`              // server access logging target (nil == disabled)
+	ObjectACLs           map[string]*ObjectACL         `json:"objectAcls,omitempty"`           // per-object ACL (key -> ACL)
+	Website              *WebsiteConfiguration         `json:"website,omitempty"`              // static-site-hosting configuration
+	Lifecycle            *LifecycleConfiguration       `json:"lifecycle,omitempty"`            // expiration / transition rules
+	ObjectRestores       map[string]*RestoreState      `json:"objectRestores,omitempty"`       // per-object restore state (key -> state)
 }
 
 // BucketLoggingConfig stores the destination for server access logs.
@@ -1413,6 +1416,30 @@ func (s *MemoryStorage) GetQueueConfigurations(_ context.Context, bucket string)
 
 	if b, exists := s.Buckets[bucket]; exists {
 		return b.QueueConfigurations
+	}
+
+	return nil
+}
+
+// SetLambdaConfigurations stores the Lambda notification destinations for a bucket.
+func (s *MemoryStorage) SetLambdaConfigurations(_ context.Context, bucket string, configs []LambdaFunctionConfiguration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if b, exists := s.Buckets[bucket]; exists {
+		b.LambdaConfigurations = configs
+	}
+
+	s.saveLocked()
+}
+
+// GetLambdaConfigurations returns the Lambda notification destinations for a bucket.
+func (s *MemoryStorage) GetLambdaConfigurations(_ context.Context, bucket string) []LambdaFunctionConfiguration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if b, exists := s.Buckets[bucket]; exists {
+		return append([]LambdaFunctionConfiguration(nil), b.LambdaConfigurations...)
 	}
 
 	return nil

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -439,9 +439,10 @@ type CopyRange struct {
 
 // NotificationConfiguration represents S3 bucket notification configuration.
 type NotificationConfiguration struct {
-	XMLName             xml.Name             `xml:"NotificationConfiguration"`
-	EventBridgeConfig   *EventBridgeConfig   `xml:"EventBridgeConfiguration,omitempty"`
-	QueueConfigurations []QueueConfiguration `xml:"QueueConfiguration,omitempty"`
+	XMLName                      xml.Name                      `xml:"NotificationConfiguration"`
+	EventBridgeConfig            *EventBridgeConfig            `xml:"EventBridgeConfiguration,omitempty"`
+	QueueConfigurations          []QueueConfiguration          `xml:"QueueConfiguration,omitempty"`
+	LambdaFunctionConfigurations []LambdaFunctionConfiguration `xml:"CloudFunctionConfiguration,omitempty"`
 }
 
 // EventBridgeConfig represents EventBridge notification configuration.
@@ -453,6 +454,14 @@ type QueueConfiguration struct {
 	ID       string   `xml:"Id,omitempty"       json:"id,omitempty"`
 	QueueArn string   `xml:"Queue"              json:"queue"`
 	Events   []string `xml:"Event"              json:"events"`
+}
+
+// LambdaFunctionConfiguration represents a Lambda destination in the bucket
+// notification configuration.
+type LambdaFunctionConfiguration struct {
+	ID                string   `xml:"Id,omitempty" json:"id,omitempty"`
+	LambdaFunctionArn string   `xml:"CloudFunction" json:"lambdaFunctionArn"`
+	Events            []string `xml:"Event"         json:"events"`
 }
 
 // EventNotification is the top-level wrapper sent to SQS when an S3


### PR DESCRIPTION
## Summary

- S3 bucket notifications delivered to SQS (#703) and EventBridge, but
  `LambdaFunctionConfigurations` were silently dropped on
  `PutBucketNotificationConfiguration` and never invoked — the most common
  serverless trigger (upload -> Lambda).
- Parse and store `LambdaFunctionConfigurations` (RestXML
  `CloudFunctionConfiguration` / `CloudFunction`) and invoke the configured
  function asynchronously from PutObject, CopyObject, POST Object, and
  CompleteMultipartUpload, reusing the S3 event-notification payload shared
  with the SQS/EventBridge emitters. Delivery is a self-call to kumo's own
  Lambda invoke endpoint with `X-Amz-Invocation-Type: Event` (the same
  in-process pattern eventbridge -> lambda and execute-api -> lambda use),
  so it rides the Lambda async queue.
- CompleteMultipartUpload previously emitted no notifications to any
  destination; it now fires the SQS/EventBridge/Lambda emitters like the
  other object-created paths.

## Notes

- Async delivery to a Runtime API-backed function relies on the Runtime API
  async queue; see the related fix in #835.
- The GET `?notification` response and key prefix/suffix filter rules are out
  of scope here (existing separate items).

## Test plan

- [x] `make lint` (0 issues), `go test -race ./...`
- [x] New tests: PutObject invokes the configured function with the S3 event
      payload; event-filter mismatch does not invoke; a nil invoker is a
      no-op; the config XML round-trips through storage;
      CompleteMultipartUpload fires all three emitters; the invoke adapter
      surfaces a non-2xx Lambda response as an error

Closes #713
