### PR TITLE
test: assert on real values in sts/s3 golden tests instead of ignoring them

### DIFF
--- a/internal/service/s3/lambda_notification_test.go
+++ b/internal/service/s3/lambda_notification_test.go
@@ -268,7 +268,7 @@ func TestLambdaNotification_CompleteMultipartUploadFiresAllEmitters(t *testing.T
 
 	ctx := context.Background()
 
-	upload, err := store.CreateMultipartUpload(ctx, bucket, "big.bin")
+	upload, err := store.CreateMultipartUpload(ctx, bucket, "big.bin", nil)
 	if err != nil {
 		t.Fatalf("CreateMultipartUpload: %v", err)
 	}

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1337,8 +1337,60 @@ func TestS3_CopyObject(t *testing.T) {
 
 	golden.New(t, golden.WithIgnoreFields(
 		"ETag", "LastModified", "ResultMetadata",
-		"ServerSideEncryption", "CopySourceVersionId",
+		"CopySourceVersionId",
 	)).Assert(t.Name(), copyOutput)
+}
+
+// TestS3_CopyObjectPreservesSSEKMS verifies that CopyObject applies the
+// SSE-KMS settings from the copy request itself to the destination object,
+// matching AWS's CopyObject SSE semantics.
+func TestS3_CopyObjectPreservesSSEKMS(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucketName := "test-copy-object-sse-bucket"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("source.txt"),
+		Body:   bytes.NewReader([]byte("copy me")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.CopyObject(ctx, &s3.CopyObjectInput{
+		Bucket:               aws.String(bucketName),
+		Key:                  aws.String("dest.txt"),
+		CopySource:           aws.String(bucketName + "/source.txt"),
+		ServerSideEncryption: types.ServerSideEncryptionAwsKms,
+		SSEKMSKeyId:          aws.String("arn:aws:kms:us-east-1:000000000000:key/test-key"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	headOutput, err := client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("dest.txt"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if headOutput.ServerSideEncryption != types.ServerSideEncryptionAwsKms {
+		t.Errorf("expected persisted SSE algorithm aws:kms, got %s", headOutput.ServerSideEncryption)
+	}
+
+	if aws.ToString(headOutput.SSEKMSKeyId) == "" {
+		t.Error("expected persisted SSEKMSKeyId to be set")
+	}
 }
 
 // TestS3_CopyObject_URLEncodedSource verifies that the URL-encoded

--- a/test/integration/sts_test.go
+++ b/test/integration/sts_test.go
@@ -52,7 +52,7 @@ func TestSTS_AssumeRole(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	golden.New(t, golden.WithIgnoreFields("AccessKeyId", "SecretAccessKey", "SessionToken", "Expiration", "AssumedRoleId", "Arn", "ResultMetadata")).Assert(t.Name(), result)
+	golden.New(t, golden.WithIgnoreFields("AccessKeyId", "SecretAccessKey", "SessionToken", "Expiration", "AssumedRoleId", "ResultMetadata")).Assert(t.Name(), result)
 }
 
 func TestSTS_AssumeRoleWithWebIdentity(t *testing.T) {
@@ -67,7 +67,7 @@ func TestSTS_AssumeRoleWithWebIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	golden.New(t, golden.WithIgnoreFields("AccessKeyId", "SecretAccessKey", "SessionToken", "Expiration", "AssumedRoleId", "Arn", "ResultMetadata")).Assert(t.Name(), result)
+	golden.New(t, golden.WithIgnoreFields("AccessKeyId", "SecretAccessKey", "SessionToken", "Expiration", "AssumedRoleId", "ResultMetadata")).Assert(t.Name(), result)
 }
 
 func TestSTS_GetSessionToken(t *testing.T) {

--- a/test/integration/testdata/s3_test_TestS3_CopyObject_TestS3_CopyObject.golden.go
+++ b/test/integration/testdata/s3_test_TestS3_CopyObject_TestS3_CopyObject.golden.go
@@ -8,7 +8,7 @@
     "ChecksumSHA256": null,
     "ChecksumType": "",
     "ETag": "\"56fe0b1409a5662d70cfedc4555d4771\"",
-    "LastModified": "2026-04-28T18:11:02.112Z"
+    "LastModified": "2026-07-10T17:39:02.78Z"
   },
   "CopySourceVersionId": null,
   "Expiration": null,

--- a/test/integration/testdata/sts_test_TestSTS_AssumeRoleWithWebIdentity_TestSTS_AssumeRoleWithWebIdentity.golden.go
+++ b/test/integration/testdata/sts_test_TestSTS_AssumeRoleWithWebIdentity_TestSTS_AssumeRoleWithWebIdentity.golden.go
@@ -1,14 +1,14 @@
 {
   "AssumedRoleUser": {
     "Arn": "arn:aws:sts::000000000000:assumed-role/web-identity-role/web-session",
-    "AssumedRoleId": "AROAfeee8289-c58:web-session"
+    "AssumedRoleId": "AROA598b80eb-99b:web-session"
   },
   "Audience": null,
   "Credentials": {
-    "AccessKeyId": "ASIA4baa795ec4cb50a5",
-    "Expiration": "2026-03-23T08:45:28Z",
-    "SecretAccessKey": "e4e80e3901e72a7cf0b1ddb237aff1d64169fef0",
-    "SessionToken": "d0d71a51041bf91638830928c092ddfb61a49ef9e79a0ab213dcf484facca73a"
+    "AccessKeyId": "ASIAf97b1ed155b7ac7a",
+    "Expiration": "2026-07-10T09:39:02Z",
+    "SecretAccessKey": "30f36ca6e95a1aef09a4ca05769526e6545f394e",
+    "SessionToken": "7ea868ac6fcb3405af52a404fd7abb2be3761d7d345643b9a98d8910a7f7ba3d"
   },
   "PackedPolicySize": 0,
   "Provider": null,

--- a/test/integration/testdata/sts_test_TestSTS_AssumeRole_TestSTS_AssumeRole.golden.go
+++ b/test/integration/testdata/sts_test_TestSTS_AssumeRole_TestSTS_AssumeRole.golden.go
@@ -1,13 +1,13 @@
 {
   "AssumedRoleUser": {
     "Arn": "arn:aws:sts::000000000000:assumed-role/test-role/test-session",
-    "AssumedRoleId": "AROA612aa82d-8cf:test-session"
+    "AssumedRoleId": "AROA67aa0a18-523:test-session"
   },
   "Credentials": {
-    "AccessKeyId": "ASIAae63a0f54cfd94a5",
-    "Expiration": "2026-03-23T08:45:28Z",
-    "SecretAccessKey": "15d78eeafd0f89d579a30f02c11c022e6ee03db7",
-    "SessionToken": "c3fb4f38877a8ebc5155c756f218ccab16fc9ff561965f419d9595a687b8f79f"
+    "AccessKeyId": "ASIA789c78da017e437a",
+    "Expiration": "2026-07-10T09:39:02Z",
+    "SecretAccessKey": "a2c98b24494d115a9918d8ec746319d9867305ef",
+    "SessionToken": "29164f4664db8db62d31fd1abf634dc6bc03aefae4ca2ab93ade09edbc486421"
   },
   "PackedPolicySize": 0,
   "SourceIdentity": null,


### PR DESCRIPTION
## Summary
Follow-up to #837 and #841: their golden tests ignored the exact fields those PRs fixed (`Arn` in AssumeRole, `ServerSideEncryption` in CopyObject), so a regression would still pass CI. This asserts on the real values instead, and adds an end-to-end CopyObject+SSE-KMS test. Also fixes a build break in `lambda_notification_test.go` left by combining #841's `CreateMultipartUpload` signature change with #842's test file.

## Test plan
- [x] `go test -race -shuffle=on ./internal/service/s3/... ./internal/service/sts/...`
- [x] `cd test/integration && go test -tags=integration .` against a locally built server
- [x] `make lint`