### PR TITLE
fix(sns): use slog.Error instead of slog.Default().Error()

### DIFF
--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -437,7 +437,7 @@ func (m *MemoryStorage) Publish(ctx context.Context, topicARN, message, subject,
 	// Deliver to all subscriptions.
 	for _, sub := range subscriptions {
 		if err := m.deliverMessage(ctx, sub, message, subject, messageID, messageGroupID, messageDeduplicationID, attributes); err != nil {
-			slog.Default().Error("sns: failed to deliver to subscription",
+			slog.Error("sns: failed to deliver to subscription",
 				"endpoint", sub.Endpoint,
 				"protocol", sub.Protocol,
 				"topicArn", sub.TopicARN,


### PR DESCRIPTION
## Summary
Follow-up from the #838 review: `Publish`'s delivery-failure logging called `slog.Default().Error(...)`, which matches neither of the codebase's two existing logging conventions (package-level `slog.Error`, used by execapi/lambda/sfn, or a `Service`-held `*slog.Logger` field, used by s3/eventbridge). This switches to the more common package-level form.

## Test plan
- [x] `go test -race -shuffle=on ./internal/service/sns/...`
- [x] `make lint`