### PR TITLE
fix(s3): apply bucket default encryption to PutObject and CreateMultipartUpload

### DIFF
--- a/internal/service/s3/copyobject_test.go
+++ b/internal/service/s3/copyobject_test.go
@@ -116,7 +116,7 @@ func TestCopyObjectFallsBackToDestinationBucketDefaultEncryption(t *testing.T) {
 
 	if err := store.PutBucketEncryption(context.Background(), "dst", ServerSideEncryptionConfig{
 		Rules: []ServerSideEncryptionRule{
-			{SSEAlgorithm: sseAlgorithmAWSKMS, KMSMasterKeyID: "bucket-default-key"},
+			{SSEAlgorithm: sseAlgorithmAWSKMS, KMSMasterKeyID: testBucketDefaultKMSKeyID},
 		},
 	}); err != nil {
 		t.Fatalf("PutBucketEncryption: %v", err)
@@ -137,8 +137,8 @@ func TestCopyObjectFallsBackToDestinationBucketDefaultEncryption(t *testing.T) {
 		t.Fatalf("ServerSideEncryption: got %q, want aws:kms", dstObj.ServerSideEncryption)
 	}
 
-	if dstObj.SSEKMSKeyID != "bucket-default-key" {
-		t.Fatalf("SSEKMSKeyID: got %q, want bucket-default-key", dstObj.SSEKMSKeyID)
+	if dstObj.SSEKMSKeyID != testBucketDefaultKMSKeyID {
+		t.Fatalf("SSEKMSKeyID: got %q, want %s", dstObj.SSEKMSKeyID, testBucketDefaultKMSKeyID)
 	}
 }
 

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -740,7 +740,10 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	obj, err := s.storage.PutObject(r.Context(), bucket, key, r.Body, extractObjectMetadata(r.Header))
+	metadata := extractObjectMetadata(r.Header)
+	s.resolveEncryptionMetadata(r.Context(), r.Header, bucket, metadata)
+
+	obj, err := s.storage.PutObject(r.Context(), bucket, key, r.Body, metadata)
 	if err != nil {
 		var bucketErr *BucketError
 		if errors.As(err, &bucketErr) {
@@ -814,7 +817,7 @@ func (s *Service) CopyObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.applyCopyEncryption(r.Context(), r.Header, dstBucket, metadata)
+	s.resolveEncryptionMetadata(r.Context(), r.Header, dstBucket, metadata)
 
 	tags, err := s.copyObjectTags(r.Context(), r.Header, srcBucket, srcKey)
 	if err != nil {
@@ -917,12 +920,12 @@ func copyObjectMetadata(header http.Header, src map[string]string) (map[string]s
 	}
 }
 
-// applyCopyEncryption sets the destination object's SSE following AWS
-// CopyObject semantics: request headers win, else the destination bucket's
-// default encryption. The source object's SSE is intentionally NOT
-// inherited (issue #714 asks for "preservation", but AWS does not preserve
-// SSE across copies; see the PR description).
-func (s *Service) applyCopyEncryption(ctx context.Context, header http.Header, dstBucket string, metadata map[string]string) {
+// resolveEncryptionMetadata sets an object's SSE following AWS semantics:
+// request headers win, else the destination bucket's default encryption.
+// Used by PutObject, CopyObject, and CreateMultipartUpload. For CopyObject,
+// the source object's SSE is intentionally NOT inherited (issue #714 asks
+// for "preservation", but AWS does not preserve SSE across copies).
+func (s *Service) resolveEncryptionMetadata(ctx context.Context, header http.Header, dstBucket string, metadata map[string]string) {
 	if sse := header.Get("X-Amz-Server-Side-Encryption"); sse != "" {
 		metadata["x-amz-server-side-encryption"] = sse
 		if key := header.Get("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id"); key != "" {
@@ -2082,7 +2085,10 @@ func (s *Service) CreateMultipartUpload(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	upload, err := s.storage.CreateMultipartUpload(r.Context(), bucket, key, extractObjectMetadata(r.Header))
+	metadata := extractObjectMetadata(r.Header)
+	s.resolveEncryptionMetadata(r.Context(), r.Header, bucket, metadata)
+
+	upload, err := s.storage.CreateMultipartUpload(r.Context(), bucket, key, metadata)
 	if err != nil {
 		var bucketErr *BucketError
 		if errors.As(err, &bucketErr) {

--- a/internal/service/s3/multipart_metadata_test.go
+++ b/internal/service/s3/multipart_metadata_test.go
@@ -23,7 +23,7 @@ func TestMultipartUploadCarriesContentTypeMetadataAndSSE(t *testing.T) {
 	uploadID := issueCreateMultipartUpload(t, svc, map[string]string{
 		"Content-Type":                                "image/jpeg",
 		"X-Amz-Meta-Origin":                           "cam1",
-		"X-Amz-Server-Side-Encryption":                "aws:kms",
+		"X-Amz-Server-Side-Encryption":                sseAlgorithmAWSKMS,
 		"X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id": "mpu-key",
 	})
 
@@ -46,8 +46,8 @@ func TestMultipartUploadCarriesContentTypeMetadataAndSSE(t *testing.T) {
 		t.Fatalf("Metadata[origin]: got %q, want cam1", got)
 	}
 
-	if dstObj.ServerSideEncryption != "aws:kms" {
-		t.Fatalf("ServerSideEncryption: got %q, want aws:kms", dstObj.ServerSideEncryption)
+	if dstObj.ServerSideEncryption != sseAlgorithmAWSKMS {
+		t.Fatalf("ServerSideEncryption: got %q, want %s", dstObj.ServerSideEncryption, sseAlgorithmAWSKMS)
 	}
 
 	if dstObj.SSEKMSKeyID != "mpu-key" {
@@ -84,6 +84,43 @@ func TestMultipartUploadWithNoHeadersFallsBackToOctetStream(t *testing.T) {
 
 	if dstObj.ServerSideEncryption != "" {
 		t.Fatalf("ServerSideEncryption: got %q, want empty", dstObj.ServerSideEncryption)
+	}
+}
+
+// TestCreateMultipartUploadFallsBackToDestinationBucketDefaultEncryption
+// verifies that, absent SSE headers on the initiate request, a multipart
+// upload picks up the destination bucket's default encryption, matching
+// AWS's CreateMultipartUpload semantics.
+func TestCreateMultipartUploadFallsBackToDestinationBucketDefaultEncryption(t *testing.T) {
+	t.Parallel()
+
+	store, svc := setupMultipartMetadataFixture(t)
+
+	if err := store.PutBucketEncryption(context.Background(), "mpu-metadata-test", ServerSideEncryptionConfig{
+		Rules: []ServerSideEncryptionRule{
+			{SSEAlgorithm: sseAlgorithmAWSKMS, KMSMasterKeyID: testBucketDefaultKMSKeyID},
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketEncryption: %v", err)
+	}
+
+	uploadID := issueCreateMultipartUpload(t, svc, map[string]string{})
+	etag := issueUploadPart(t, svc, uploadID, 1, "hello multipart")
+	issueCompleteMultipartUpload(t, svc, uploadID, []PartRequest{
+		{PartNumber: 1, ETag: etag},
+	})
+
+	dstObj, err := store.GetObject(context.Background(), "mpu-metadata-test", "object")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+
+	if dstObj.ServerSideEncryption != sseAlgorithmAWSKMS {
+		t.Fatalf("ServerSideEncryption: got %q, want %s", dstObj.ServerSideEncryption, sseAlgorithmAWSKMS)
+	}
+
+	if dstObj.SSEKMSKeyID != testBucketDefaultKMSKeyID {
+		t.Fatalf("SSEKMSKeyID: got %q, want %s", dstObj.SSEKMSKeyID, testBucketDefaultKMSKeyID)
 	}
 }
 

--- a/internal/service/s3/putobject_test.go
+++ b/internal/service/s3/putobject_test.go
@@ -1,0 +1,101 @@
+package s3
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const testBucketDefaultKMSKeyID = "bucket-default-key"
+
+// TestPutObjectFallsBackToDestinationBucketDefaultEncryption verifies that,
+// absent SSE headers on the request, PutObject picks up the destination
+// bucket's default encryption, matching AWS's PutObject semantics.
+func TestPutObjectFallsBackToDestinationBucketDefaultEncryption(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	if err := store.CreateBucket(context.Background(), "put-object-sse-test"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if err := store.PutBucketEncryption(context.Background(), "put-object-sse-test", ServerSideEncryptionConfig{
+		Rules: []ServerSideEncryptionRule{
+			{SSEAlgorithm: sseAlgorithmAWSKMS, KMSMasterKeyID: testBucketDefaultKMSKeyID},
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketEncryption: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/put-object-sse-test/object.txt", strings.NewReader("hello"))
+	req.SetPathValue("bucket", "put-object-sse-test")
+	req.SetPathValue("key", "object.txt")
+
+	w := httptest.NewRecorder()
+	svc.PutObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	dstObj, err := store.GetObject(context.Background(), "put-object-sse-test", "object.txt")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+
+	if dstObj.ServerSideEncryption != sseAlgorithmAWSKMS {
+		t.Fatalf("ServerSideEncryption: got %q, want %s", dstObj.ServerSideEncryption, sseAlgorithmAWSKMS)
+	}
+
+	if dstObj.SSEKMSKeyID != testBucketDefaultKMSKeyID {
+		t.Fatalf("SSEKMSKeyID: got %q, want %s", dstObj.SSEKMSKeyID, testBucketDefaultKMSKeyID)
+	}
+}
+
+// TestPutObjectRequestSSEHeadersWinOverBucketDefault verifies that explicit
+// SSE headers on the PutObject request take precedence over the destination
+// bucket's default encryption.
+func TestPutObjectRequestSSEHeadersWinOverBucketDefault(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+
+	if err := store.CreateBucket(context.Background(), "put-object-sse-test"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if err := store.PutBucketEncryption(context.Background(), "put-object-sse-test", ServerSideEncryptionConfig{
+		Rules: []ServerSideEncryptionRule{
+			{SSEAlgorithm: sseAlgorithmAWSKMS, KMSMasterKeyID: testBucketDefaultKMSKeyID},
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketEncryption: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/put-object-sse-test/object.txt", strings.NewReader("hello"))
+	req.SetPathValue("bucket", "put-object-sse-test")
+	req.SetPathValue("key", "object.txt")
+	req.Header.Set("X-Amz-Server-Side-Encryption", sseAlgorithmAWSKMS)
+	req.Header.Set("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id", "request-key")
+
+	w := httptest.NewRecorder()
+	svc.PutObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	dstObj, err := store.GetObject(context.Background(), "put-object-sse-test", "object.txt")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+
+	if dstObj.SSEKMSKeyID != "request-key" {
+		t.Fatalf("SSEKMSKeyID: got %q, want request-key", dstObj.SSEKMSKeyID)
+	}
+}

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -1908,6 +1908,69 @@ func TestS3_PutObjectWithSSEKMS(t *testing.T) {
 	}
 }
 
+// TestS3_PutObjectFallsBackToBucketDefaultEncryption verifies that, absent
+// SSE headers on the request, PutObject applies the destination bucket's
+// default encryption, matching AWS's PutObject semantics.
+func TestS3_PutObjectFallsBackToBucketDefaultEncryption(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-put-object-bucket-default-sse"
+	key := "encrypted.txt"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)})
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	})
+
+	if _, err := client.PutBucketEncryption(ctx, &s3.PutBucketEncryptionInput{
+		Bucket: aws.String(bucket),
+		ServerSideEncryptionConfiguration: &types.ServerSideEncryptionConfiguration{
+			Rules: []types.ServerSideEncryptionRule{
+				{
+					ApplyServerSideEncryptionByDefault: &types.ServerSideEncryptionByDefault{
+						SSEAlgorithm:   types.ServerSideEncryptionAwsKms,
+						KMSMasterKeyID: aws.String("bucket-default-key"),
+					},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("failed to put bucket encryption: %v", err)
+	}
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   strings.NewReader("secret"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	headOutput, err := client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if headOutput.ServerSideEncryption != types.ServerSideEncryptionAwsKms {
+		t.Errorf("expected SSE algorithm aws:kms, got %s", headOutput.ServerSideEncryption)
+	}
+
+	if aws.ToString(headOutput.SSEKMSKeyId) == "" {
+		t.Error("expected SSEKMSKeyId to be set")
+	}
+}
+
 // postPresignedForm builds a multipart/form-data body from the presigned POST
 // fields plus the object content (the file field is written last, as AWS
 // requires) and sends it to the presigned URL.


### PR DESCRIPTION
## Summary
Follow-up from the #841 review: `CopyObject` fell back to the destination bucket's default encryption when the request had no SSE headers, but `PutObject` and `CreateMultipartUpload` did not, unlike real AWS S3. This extracts the shared fallback into `resolveEncryptionMetadata` and wires it into all three write paths (`CompleteMultipartUpload` needs no change, since it already carries `CreateMultipartUpload`'s metadata through to completion).

Also dedupes the `"aws:kms"` literal in `multipart_metadata_test.go` into the existing `sseAlgorithmAWSKMS` const.

## Test plan
- [x] `go test -race -shuffle=on ./internal/service/s3/...`
- [x] New integration test `TestS3_PutObjectFallsBackToBucketDefaultEncryption`
- [x] `make lint`