### PR TITLE
test: add SNS to SQS raw-delivery attribute-forwarding integration test

### DIFF
--- a/test/integration/sns_test.go
+++ b/test/integration/sns_test.go
@@ -5,11 +5,14 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
+	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/sivchari/golden"
 )
 
@@ -399,4 +402,119 @@ func TestSNS_SetSubscriptionAttributes(t *testing.T) {
 	golden.New(t, golden.WithIgnoreFields(
 		"SubscriptionArn", "TopicArn", "ResultMetadata",
 	)).Assert(t.Name(), getOutput)
+}
+
+// TestSNS_RawMessageDeliveryForwardsAttributes verifies that, with
+// RawMessageDelivery enabled, a message published with MessageAttributes
+// arrives at the subscribed SQS queue as native SQS MessageAttributes
+// (not wrapped in the SNS notification envelope).
+func TestSNS_RawMessageDeliveryForwardsAttributes(t *testing.T) {
+	snsClient := newSNSClient(t)
+	sqsClient := newSQSClient(t)
+	ctx := t.Context()
+
+	topicName := "test-raw-delivery-topic"
+	queueName := "test-raw-delivery-queue"
+
+	topicOutput, err := snsClient.CreateTopic(ctx, &sns.CreateTopicInput{
+		Name: aws.String(topicName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = snsClient.DeleteTopic(context.Background(), &sns.DeleteTopicInput{
+			TopicArn: topicOutput.TopicArn,
+		})
+	})
+
+	createQueueOutput, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queueURL := *createQueueOutput.QueueUrl
+
+	t.Cleanup(func() {
+		_, _ = sqsClient.DeleteQueue(context.Background(), &sqs.DeleteQueueInput{
+			QueueUrl: aws.String(queueURL),
+		})
+	})
+
+	queueARN := "arn:aws:sqs:us-east-1:000000000000:" + queueName
+
+	subOutput, err := snsClient.Subscribe(ctx, &sns.SubscribeInput{
+		TopicArn: topicOutput.TopicArn,
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String(queueARN),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = snsClient.Unsubscribe(context.Background(), &sns.UnsubscribeInput{
+			SubscriptionArn: subOutput.SubscriptionArn,
+		})
+	})
+
+	if _, err := snsClient.SetSubscriptionAttributes(ctx, &sns.SetSubscriptionAttributesInput{
+		SubscriptionArn: subOutput.SubscriptionArn,
+		AttributeName:   aws.String("RawMessageDelivery"),
+		AttributeValue:  aws.String("true"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = snsClient.Publish(ctx, &sns.PublishInput{
+		TopicArn: topicOutput.TopicArn,
+		Message:  aws.String("raw delivery test"),
+		MessageAttributes: map[string]snstypes.MessageAttributeValue{
+			"team": {DataType: aws.String("String"), StringValue: aws.String("infra")},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var recvOutput *sqs.ReceiveMessageOutput
+
+	for range 10 {
+		recvOutput, err = sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:              aws.String(queueURL),
+			WaitTimeSeconds:       1,
+			MessageAttributeNames: []string{"All"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(recvOutput.Messages) > 0 {
+			break
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if len(recvOutput.Messages) == 0 {
+		t.Fatal("expected raw-delivered message on the SQS queue, but no message received")
+	}
+
+	msg := recvOutput.Messages[0]
+
+	if aws.ToString(msg.Body) != "raw delivery test" {
+		t.Errorf("Body = %q, want the raw message body (no SNS envelope), got %q", "raw delivery test", aws.ToString(msg.Body))
+	}
+
+	attr, ok := msg.MessageAttributes["team"]
+	if !ok {
+		t.Fatalf("expected MessageAttributes[team] to be forwarded, got %v", msg.MessageAttributes)
+	}
+
+	if aws.ToString(attr.StringValue) != "infra" {
+		t.Errorf("MessageAttributes[team].StringValue = %q, want %q", aws.ToString(attr.StringValue), "infra")
+	}
 }


### PR DESCRIPTION
## Summary
Follow-up from the #838 review: attribute forwarding on `RawMessageDelivery` had only unit tests, no end-to-end check that a real SQS `ReceiveMessage` sees the forwarded `MessageAttributes`. Adds `TestSNS_RawMessageDeliveryForwardsAttributes`.

## Test plan
- [x] `cd test/integration && go test -tags=integration -run TestSNS_RawMessageDeliveryForwardsAttributes -v .` against a locally built server