### PR TITLE
fix: IaC read-back fixes (S3 object lock, CloudTrail, Firehose, CloudFront)

### DIFF
--- a/internal/service/cloudfront/handlers.go
+++ b/internal/service/cloudfront/handlers.go
@@ -460,6 +460,11 @@ func buildDistributionConfigXML(config *DistributionConfig) *DistributionConfigX
 	result.Aliases = buildAliasesConfigXML(config.Aliases)
 	result.ViewerCertificate = buildViewerCertificateConfigXML(config.ViewerCertificate)
 
+	// kumo does not store origin groups, but real CloudFront always returns an
+	// (empty) OriginGroups element. Emitting it keeps the Terraform AWS provider's
+	// resourceDistributionRead from nil-dereferencing distributionConfig.OriginGroups.Quantity.
+	result.OriginGroups = &OriginGroupsXML{Quantity: 0}
+
 	return result
 }
 
@@ -561,6 +566,13 @@ func buildDefaultCacheBehaviorXML(dcb *DefaultCacheBehavior) *DefaultCacheBehavi
 	buildForwardedValuesXML(dcb.ForwardedValues, result)
 	buildTrustedSignersXML(dcb.TrustedSigners, result)
 	buildTrustedKeyGroupsXML(dcb.TrustedKeyGroups, result)
+
+	// kumo does not store function/Lambda associations, but real CloudFront
+	// always returns both elements (empty, Quantity=0). Emitting them keeps the
+	// Terraform AWS provider's flattenDefaultCacheBehavior from nil-dereferencing
+	// apiObject.FunctionAssociations.Items / apiObject.LambdaFunctionAssociations.Items.
+	result.FunctionAssociations = &FunctionAssociationsXML{Quantity: 0}
+	result.LambdaFunctionAssociations = &LambdaFunctionAssociationsXML{Quantity: 0}
 
 	return result
 }

--- a/internal/service/cloudfront/handlers.go
+++ b/internal/service/cloudfront/handlers.go
@@ -544,10 +544,18 @@ func buildDefaultCacheBehaviorXML(dcb *DefaultCacheBehavior) *DefaultCacheBehavi
 	}
 
 	if dcb.AllowedMethods != nil {
-		result.AllowedMethods = &AllowedMethodsXML{
+		am := &AllowedMethodsXML{
 			Quantity: dcb.AllowedMethods.Quantity,
 			Items:    dcb.AllowedMethods.Items,
 		}
+		if dcb.CachedMethods != nil {
+			am.CachedMethods = &CachedMethodsXML{
+				Quantity: dcb.CachedMethods.Quantity,
+				Items:    dcb.CachedMethods.Items,
+			}
+		}
+
+		result.AllowedMethods = am
 	}
 
 	buildForwardedValuesXML(dcb.ForwardedValues, result)
@@ -582,6 +590,8 @@ func buildForwardedValuesXML(fv *ForwardedValues, result *DefaultCacheBehaviorXM
 
 func buildTrustedSignersXML(ts *TrustedSigners, result *DefaultCacheBehaviorXML) {
 	if ts == nil {
+		result.TrustedSigners = &TrustedSignersXML{Enabled: false, Quantity: 0}
+
 		return
 	}
 
@@ -594,6 +604,8 @@ func buildTrustedSignersXML(ts *TrustedSigners, result *DefaultCacheBehaviorXML)
 
 func buildTrustedKeyGroupsXML(tkg *TrustedKeyGroups, result *DefaultCacheBehaviorXML) {
 	if tkg == nil {
+		result.TrustedKeyGroups = &TrustedKeyGroupsXML{Enabled: false, Quantity: 0}
+
 		return
 	}
 

--- a/internal/service/cloudfront/handlers.go
+++ b/internal/service/cloudfront/handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
@@ -16,7 +17,10 @@ const (
 	cloudfrontXmlns = "http://cloudfront.amazonaws.com/doc/2020-05-31/"
 )
 
-// CreateDistribution handles the CreateDistribution operation.
+// CreateDistribution handles both CreateDistribution and the
+// CreateDistributionWithTags variant (POST /2020-05-31/distribution?WithTags).
+// The Terraform AWS provider uses the WithTags variant, whose body root is
+// <DistributionConfigWithTags> wrapping <DistributionConfig> and <Tags>.
 func (s *Service) CreateDistribution(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -25,8 +29,22 @@ func (s *Service) CreateDistribution(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req CreateDistributionRequest
-	if err := xml.Unmarshal(body, &req); err != nil {
+	var (
+		req  CreateDistributionRequest
+		tags *Tags
+	)
+
+	if _, withTags := r.URL.Query()["WithTags"]; withTags {
+		var wrap DistributionConfigWithTags
+		if err := xml.Unmarshal(body, &wrap); err != nil {
+			writeCloudFrontError(w, errInvalidArgument, "Invalid request body", http.StatusBadRequest)
+
+			return
+		}
+
+		req = wrap.DistributionConfig
+		tags = wrap.Tags
+	} else if err := xml.Unmarshal(body, &req); err != nil {
 		writeCloudFrontError(w, errInvalidArgument, "Invalid request body", http.StatusBadRequest)
 
 		return
@@ -37,6 +55,14 @@ func (s *Service) CreateDistribution(w http.ResponseWriter, r *http.Request) {
 		handleStorageError(w, err)
 
 		return
+	}
+
+	if tags != nil && len(tags.Items) > 0 {
+		if err := s.storage.TagResource(r.Context(), dist.ARN, tagsToMap(tags)); err != nil {
+			handleStorageError(w, err)
+
+			return
+		}
 	}
 
 	resp := buildDistributionXML(dist)
@@ -234,7 +260,117 @@ func (s *Service) GetDistributionConfig(w http.ResponseWriter, r *http.Request) 
 	writeXMLResponse(w, http.StatusOK, resp)
 }
 
+// Tagging handles TagResource and UntagResource on POST /2020-05-31/tagging,
+// dispatched by the Operation query parameter (Tag or Untag).
+func (s *Service) Tagging(w http.ResponseWriter, r *http.Request) {
+	resource := r.URL.Query().Get("Resource")
+	if resource == "" {
+		writeCloudFrontError(w, errInvalidArgument, "Resource ARN is required", http.StatusBadRequest)
+
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeCloudFrontError(w, errMissingBody, "Request body is missing", http.StatusBadRequest)
+
+		return
+	}
+
+	switch r.URL.Query().Get("Operation") {
+	case "Tag":
+		s.tagResource(w, r, resource, body)
+	case "Untag":
+		s.untagResource(w, r, resource, body)
+	default:
+		writeCloudFrontError(w, errInvalidArgument, "Invalid Operation", http.StatusBadRequest)
+	}
+}
+
+func (s *Service) tagResource(w http.ResponseWriter, r *http.Request, resource string, body []byte) {
+	var tags Tags
+	if err := xml.Unmarshal(body, &tags); err != nil {
+		writeCloudFrontError(w, errInvalidArgument, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.TagResource(r.Context(), resource, tagsToMap(&tags)); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Service) untagResource(w http.ResponseWriter, r *http.Request, resource string, body []byte) {
+	var keys TagKeysBody
+	if err := xml.Unmarshal(body, &keys); err != nil {
+		writeCloudFrontError(w, errInvalidArgument, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.UntagResource(r.Context(), resource, keys.Items); err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListTagsForResource handles GET /2020-05-31/tagging?Resource=<arn>.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
+	resource := r.URL.Query().Get("Resource")
+	if resource == "" {
+		writeCloudFrontError(w, errInvalidArgument, "Resource ARN is required", http.StatusBadRequest)
+
+		return
+	}
+
+	tags, err := s.storage.ListTags(r.Context(), resource)
+	if err != nil {
+		handleStorageError(w, err)
+
+		return
+	}
+
+	writeXMLResponse(w, http.StatusOK, buildTagsXML(tags))
+}
+
 // Helper functions.
+
+func tagsToMap(t *Tags) map[string]string {
+	if t == nil {
+		return nil
+	}
+
+	m := make(map[string]string, len(t.Items))
+	for _, tag := range t.Items {
+		m[tag.Key] = tag.Value
+	}
+
+	return m
+}
+
+func buildTagsXML(tags map[string]string) *Tags {
+	result := &Tags{Xmlns: cloudfrontXmlns}
+
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		result.Items = append(result.Items, Tag{Key: k, Value: tags[k]})
+	}
+
+	return result
+}
 
 func writeXMLResponse(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/xml")

--- a/internal/service/cloudfront/handlers_cache_behavior_test.go
+++ b/internal/service/cloudfront/handlers_cache_behavior_test.go
@@ -75,6 +75,68 @@ func assertCachedMethods(t *testing.T, dcb *DefaultCacheBehaviorXML) {
 	}
 }
 
+func assertAssociationDefaults(t *testing.T, dcb *DefaultCacheBehaviorXML) {
+	t.Helper()
+
+	if dcb == nil {
+		t.Fatal("DefaultCacheBehavior is nil")
+	}
+
+	if dcb.FunctionAssociations == nil {
+		t.Fatal("FunctionAssociations is nil, want present with Quantity=0")
+	}
+
+	if dcb.FunctionAssociations.Quantity != 0 {
+		t.Errorf("FunctionAssociations.Quantity: got %d, want 0", dcb.FunctionAssociations.Quantity)
+	}
+
+	if dcb.LambdaFunctionAssociations == nil {
+		t.Fatal("LambdaFunctionAssociations is nil, want present with Quantity=0")
+	}
+
+	if dcb.LambdaFunctionAssociations.Quantity != 0 {
+		t.Errorf("LambdaFunctionAssociations.Quantity: got %d, want 0", dcb.LambdaFunctionAssociations.Quantity)
+	}
+}
+
+// TestDefaultCacheBehavior_AssociationsAlwaysPresent verifies that a distribution
+// response always carries FunctionAssociations and LambdaFunctionAssociations
+// (empty, Quantity=0), matching real CloudFront. Omitting them leaves the SDK
+// pointers nil and crashes the Terraform provider's flattenDefaultCacheBehavior,
+// which dereferences .Items without a parent nil-check.
+func TestDefaultCacheBehavior_AssociationsAlwaysPresent(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+
+	created := createDistViaHandler(t, svc, marshalXML(minimalConfig("assoc-ref")), false)
+	assertAssociationDefaults(t, created.DistributionConfig.DefaultCacheBehavior)
+
+	got := getDistViaHandler(t, svc, created.ID)
+	assertAssociationDefaults(t, got.DistributionConfig.DefaultCacheBehavior)
+}
+
+// TestDistribution_OriginGroupsAlwaysPresent verifies that a distribution
+// response always carries an (empty) OriginGroups element. Real CloudFront
+// always returns it, and the Terraform provider's resourceDistributionRead
+// dereferences distributionConfig.OriginGroups.Quantity without a nil-check
+// (distribution.go:1000); omitting it crashes the provider.
+func TestDistribution_OriginGroupsAlwaysPresent(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+
+	created := createDistViaHandler(t, svc, marshalXML(minimalConfig("origin-groups-ref")), false)
+	if created.DistributionConfig.OriginGroups == nil || created.DistributionConfig.OriginGroups.Quantity != 0 {
+		t.Errorf("create OriginGroups: got %+v, want present with Quantity=0", created.DistributionConfig.OriginGroups)
+	}
+
+	got := getDistViaHandler(t, svc, created.ID)
+	if got.DistributionConfig.OriginGroups == nil || got.DistributionConfig.OriginGroups.Quantity != 0 {
+		t.Errorf("get OriginGroups: got %+v, want present with Quantity=0", got.DistributionConfig.OriginGroups)
+	}
+}
+
 // TestDefaultCacheBehavior_TrustedDefaultsWhenSigningAbsent verifies that a
 // CachePolicy-style distribution without TrustedSigners/TrustedKeyGroups still
 // returns both elements with Enabled=false/Quantity=0, matching real CloudFront

--- a/internal/service/cloudfront/handlers_cache_behavior_test.go
+++ b/internal/service/cloudfront/handlers_cache_behavior_test.go
@@ -1,0 +1,117 @@
+package cloudfront
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func getDistViaHandler(t *testing.T, svc *Service, id string) *GetDistributionResult {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/2020-05-31/distribution/"+id, http.NoBody)
+	req.SetPathValue("id", id)
+
+	w := httptest.NewRecorder()
+	svc.GetDistribution(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetDistribution status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	var out GetDistributionResult
+	if err := xml.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal get response: %v body=%s", err, w.Body.String())
+	}
+
+	return &out
+}
+
+func assertTrustedDefaults(t *testing.T, dcb *DefaultCacheBehaviorXML) {
+	t.Helper()
+
+	if dcb == nil {
+		t.Fatal("DefaultCacheBehavior is nil")
+	}
+
+	if dcb.TrustedSigners == nil {
+		t.Fatal("TrustedSigners is nil, want present with Enabled=false/Quantity=0")
+	}
+
+	if dcb.TrustedSigners.Enabled || dcb.TrustedSigners.Quantity != 0 {
+		t.Errorf("TrustedSigners: got Enabled=%v Quantity=%d, want false/0",
+			dcb.TrustedSigners.Enabled, dcb.TrustedSigners.Quantity)
+	}
+
+	if dcb.TrustedKeyGroups == nil {
+		t.Fatal("TrustedKeyGroups is nil, want present with Enabled=false/Quantity=0")
+	}
+
+	if dcb.TrustedKeyGroups.Enabled || dcb.TrustedKeyGroups.Quantity != 0 {
+		t.Errorf("TrustedKeyGroups: got Enabled=%v Quantity=%d, want false/0",
+			dcb.TrustedKeyGroups.Enabled, dcb.TrustedKeyGroups.Quantity)
+	}
+}
+
+func assertCachedMethods(t *testing.T, dcb *DefaultCacheBehaviorXML) {
+	t.Helper()
+
+	if dcb == nil || dcb.AllowedMethods == nil {
+		t.Fatal("AllowedMethods is nil")
+	}
+
+	cm := dcb.AllowedMethods.CachedMethods
+	if cm == nil {
+		t.Fatal("CachedMethods is nil, want preserved in response")
+	}
+
+	if cm.Quantity != 2 {
+		t.Errorf("CachedMethods.Quantity: got %d, want 2", cm.Quantity)
+	}
+
+	if len(cm.Items) != 2 || cm.Items[0] != "GET" || cm.Items[1] != "HEAD" {
+		t.Errorf("CachedMethods.Items: got %v, want [GET HEAD]", cm.Items)
+	}
+}
+
+// TestDefaultCacheBehavior_TrustedDefaultsWhenSigningAbsent verifies that a
+// CachePolicy-style distribution without TrustedSigners/TrustedKeyGroups still
+// returns both elements with Enabled=false/Quantity=0, matching real CloudFront
+// and avoiding the Terraform provider nil-pointer crash.
+func TestDefaultCacheBehavior_TrustedDefaultsWhenSigningAbsent(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+
+	created := createDistViaHandler(t, svc, marshalXML(minimalConfig("cache-policy-ref")), false)
+	assertTrustedDefaults(t, created.DistributionConfig.DefaultCacheBehavior)
+
+	got := getDistViaHandler(t, svc, created.ID)
+	assertTrustedDefaults(t, got.DistributionConfig.DefaultCacheBehavior)
+}
+
+// TestDefaultCacheBehavior_CachedMethodsRoundTrip verifies that AllowedMethods'
+// nested CachedMethods present in the request survives into both the create and
+// get responses.
+func TestDefaultCacheBehavior_CachedMethodsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+
+	config := minimalConfig("cached-methods-ref")
+	config.DefaultCacheBehavior.AllowedMethods = &AllowedMethodsXML{
+		Quantity: 2,
+		Items:    []string{"GET", "HEAD"},
+		CachedMethods: &CachedMethodsXML{
+			Quantity: 2,
+			Items:    []string{"GET", "HEAD"},
+		},
+	}
+
+	created := createDistViaHandler(t, svc, marshalXML(config), false)
+	assertCachedMethods(t, created.DistributionConfig.DefaultCacheBehavior)
+
+	got := getDistViaHandler(t, svc, created.ID)
+	assertCachedMethods(t, got.DistributionConfig.DefaultCacheBehavior)
+}

--- a/internal/service/cloudfront/handlers_tags_test.go
+++ b/internal/service/cloudfront/handlers_tags_test.go
@@ -1,0 +1,197 @@
+package cloudfront
+
+import (
+	"bytes"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func minimalConfig(callerRef string) CreateDistributionRequest {
+	return CreateDistributionRequest{
+		CallerReference: callerRef,
+		Comment:         "test",
+		Enabled:         true,
+		Origins: &OriginsXML{
+			Quantity: 1,
+			Items: &OriginList{Origin: []OriginXML{{
+				ID:             "o1",
+				DomainName:     "example.s3.amazonaws.com",
+				S3OriginConfig: &S3OriginConfigXML{OriginAccessIdentity: ""},
+			}}},
+		},
+		DefaultCacheBehavior: &DefaultCacheBehaviorXML{
+			TargetOriginID:       "o1",
+			ViewerProtocolPolicy: "allow-all",
+		},
+	}
+}
+
+func marshalXML(v any) []byte {
+	raw, _ := xml.Marshal(v)
+
+	return raw
+}
+
+func tagItemsToMap(items []Tag) map[string]string {
+	m := make(map[string]string, len(items))
+	for _, it := range items {
+		m[it.Key] = it.Value
+	}
+
+	return m
+}
+
+func createDistViaHandler(t *testing.T, svc *Service, body []byte, withTags bool) *GetDistributionResult {
+	t.Helper()
+
+	target := "/2020-05-31/distribution"
+	if withTags {
+		target += "?WithTags"
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, target, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	svc.CreateDistribution(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateDistribution status: got %d, want 201 (body=%s)", w.Code, w.Body.String())
+	}
+
+	var out GetDistributionResult
+	if err := xml.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal create response: %v body=%s", err, w.Body.String())
+	}
+
+	return &out
+}
+
+func listTagsViaHandler(t *testing.T, svc *Service, arn string) map[string]string {
+	t.Helper()
+
+	target := "/2020-05-31/tagging?Resource=" + url.QueryEscape(arn)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, http.NoBody)
+	w := httptest.NewRecorder()
+	svc.ListTagsForResource(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListTagsForResource status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	var out Tags
+	if err := xml.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal tags: %v body=%s", err, w.Body.String())
+	}
+
+	return tagItemsToMap(out.Items)
+}
+
+func taggingViaHandler(t *testing.T, svc *Service, operation, arn string, body []byte) {
+	t.Helper()
+
+	target := "/2020-05-31/tagging?Operation=" + operation + "&Resource=" + url.QueryEscape(arn)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, target, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	svc.Tagging(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("%s status: got %d, want 204 (body=%s)", operation, w.Code, w.Body.String())
+	}
+}
+
+func TestCreateDistribution_WithTags(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+
+	wrap := DistributionConfigWithTags{
+		DistributionConfig: minimalConfig("with-tags-ref"),
+		Tags: &Tags{Items: []Tag{
+			{Key: "env", Value: "local"},
+			{Key: "team", Value: "idp"},
+		}},
+	}
+
+	created := createDistViaHandler(t, svc, marshalXML(wrap), true)
+	if created.ARN == "" {
+		t.Fatal("created ARN is empty")
+	}
+
+	got := listTagsViaHandler(t, svc, created.ARN)
+	if got["env"] != "local" || got["team"] != "idp" {
+		t.Fatalf("tags: got %v, want env=local team=idp", got)
+	}
+}
+
+func TestCreateDistribution_WithoutTags_NoRegression(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+
+	created := createDistViaHandler(t, svc, marshalXML(minimalConfig("plain-ref")), false)
+	if created.Status != statusInProgress {
+		t.Fatalf("create status: got %q, want %q", created.Status, statusInProgress)
+	}
+
+	if got := listTagsViaHandler(t, svc, created.ARN); len(got) != 0 {
+		t.Fatalf("plain create should have no tags, got %v", got)
+	}
+}
+
+func TestTagging_TagListUntag(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+	created := createDistViaHandler(t, svc, marshalXML(minimalConfig("tagging-ref")), false)
+
+	taggingViaHandler(t, svc, "Tag", created.ARN,
+		marshalXML(Tags{Items: []Tag{{Key: "a", Value: "1"}, {Key: "b", Value: "2"}}}))
+
+	if got := listTagsViaHandler(t, svc, created.ARN); got["a"] != "1" || got["b"] != "2" {
+		t.Fatalf("after tag: got %v, want a=1 b=2", got)
+	}
+
+	taggingViaHandler(t, svc, "Untag", created.ARN, marshalXML(TagKeysBody{Items: []string{"a"}}))
+
+	got := listTagsViaHandler(t, svc, created.ARN)
+	if _, ok := got["a"]; ok {
+		t.Fatalf("key a should be removed, got %v", got)
+	}
+
+	if got["b"] != "2" {
+		t.Fatalf("key b should remain, got %v", got)
+	}
+}
+
+func TestGetDistribution_TransitionsToDeployed(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage())
+	created := createDistViaHandler(t, svc, marshalXML(minimalConfig("deploy-ref")), false)
+
+	if created.Status != statusInProgress {
+		t.Fatalf("create status: got %q, want %q", created.Status, statusInProgress)
+	}
+
+	target := "/2020-05-31/distribution/" + created.ID
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, http.NoBody)
+	req.SetPathValue("id", created.ID)
+
+	w := httptest.NewRecorder()
+	svc.GetDistribution(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetDistribution status: %d body=%s", w.Code, w.Body.String())
+	}
+
+	var got GetDistributionResult
+	if err := xml.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
+	}
+
+	if got.Status != statusDeployed {
+		t.Fatalf("get status: got %q, want %q", got.Status, statusDeployed)
+	}
+}

--- a/internal/service/cloudfront/service.go
+++ b/internal/service/cloudfront/service.go
@@ -53,6 +53,10 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("POST", "/2020-05-31/distribution/{id}/invalidation", s.CreateInvalidation)
 	r.Handle("GET", "/2020-05-31/distribution/{id}/invalidation/{invalidationId}", s.GetInvalidation)
 
+	// Tagging operations (TagResource/UntagResource dispatched by ?Operation).
+	r.Handle("POST", "/2020-05-31/tagging", s.Tagging)
+	r.Handle("GET", "/2020-05-31/tagging", s.ListTagsForResource)
+
 	// PublicKey + KeyGroup — building blocks for signed URL / signed cookie verification.
 	r.Handle("POST", "/2020-05-31/public-key", s.CreatePublicKey)
 	r.Handle("GET", "/2020-05-31/public-key", s.ListPublicKeys)

--- a/internal/service/cloudfront/storage.go
+++ b/internal/service/cloudfront/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -22,6 +23,11 @@ type Storage interface {
 	CreateInvalidation(ctx context.Context, distributionID string, batch *CreateInvalidationRequest) (*Invalidation, error)
 	GetInvalidation(ctx context.Context, distributionID, invalidationID string) (*Invalidation, error)
 	ListInvalidations(ctx context.Context, distributionID, marker string, maxItems int) ([]*Invalidation, string, error)
+
+	// Tagging operations, keyed by distribution ARN.
+	TagResource(ctx context.Context, arn string, tags map[string]string) error
+	UntagResource(ctx context.Context, arn string, keys []string) error
+	ListTags(ctx context.Context, arn string) (map[string]string, error)
 
 	// Signed URL building blocks.
 	CreatePublicKey(ctx context.Context, cfg *PublicKeyConfig) (*PublicKey, error)
@@ -144,6 +150,12 @@ func (s *MemoryStorage) Close() error {
 	return nil
 }
 
+// Distribution deployment statuses.
+const (
+	statusInProgress = "InProgress"
+	statusDeployed   = "Deployed"
+)
+
 // Error represents a CloudFront error.
 type Error struct {
 	Code    string
@@ -177,7 +189,7 @@ func (s *MemoryStorage) CreateDistribution(_ context.Context, config *CreateDist
 	dist := &Distribution{
 		ID:               id,
 		ARN:              fmt.Sprintf("arn:aws:cloudfront::000000000000:distribution/%s", id),
-		Status:           "InProgress",
+		Status:           statusInProgress,
 		LastModifiedTime: now,
 		DomainName:       fmt.Sprintf("%s.cloudfront.net", id),
 		ETag:             etag,
@@ -206,9 +218,13 @@ func (s *MemoryStorage) CreateDistribution(_ context.Context, config *CreateDist
 }
 
 // GetDistribution retrieves a distribution by ID.
+//
+// A newly created distribution starts as InProgress; the first read marks it
+// Deployed so that Terraform's wait_for_deployment poller completes instead of
+// timing out.
 func (s *MemoryStorage) GetDistribution(_ context.Context, id string) (*Distribution, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	dist, exists := s.Distributions[id]
 	if !exists {
@@ -216,6 +232,12 @@ func (s *MemoryStorage) GetDistribution(_ context.Context, id string) (*Distribu
 			Code:    errDistributionNotFound,
 			Message: fmt.Sprintf("The distribution with id %s does not exist", id),
 		}
+	}
+
+	if dist.Status == statusInProgress {
+		dist.Status = statusDeployed
+
+		s.saveLocked()
 	}
 
 	return dist, nil
@@ -290,7 +312,7 @@ func (s *MemoryStorage) UpdateDistribution(_ context.Context, id string, config 
 	newETag := generateETag()
 	dist.ETag = newETag
 	dist.LastModifiedTime = time.Now()
-	dist.Status = "InProgress"
+	dist.Status = statusInProgress
 	dist.DistributionConfig = &DistributionConfig{
 		CallerReference:      config.CallerReference,
 		Comment:              config.Comment,
@@ -465,6 +487,83 @@ func (s *MemoryStorage) ListInvalidations(_ context.Context, distributionID, mar
 	}
 
 	return result, nextMarker, nil
+}
+
+// findByARN returns the distribution matching the given ARN. The caller must
+// hold s.mu.
+func (s *MemoryStorage) findByARN(arn string) (*Distribution, bool) {
+	for _, d := range s.Distributions {
+		if d.ARN == arn {
+			return d, true
+		}
+	}
+
+	return nil, false
+}
+
+// TagResource adds or overwrites tags on the distribution identified by ARN.
+func (s *MemoryStorage) TagResource(_ context.Context, arn string, tags map[string]string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dist, ok := s.findByARN(arn)
+	if !ok {
+		return &Error{
+			Code:    errDistributionNotFound,
+			Message: fmt.Sprintf("The resource %s does not exist", arn),
+		}
+	}
+
+	if dist.Tags == nil {
+		dist.Tags = make(map[string]string)
+	}
+
+	maps.Copy(dist.Tags, tags)
+
+	s.saveLocked()
+
+	return nil
+}
+
+// UntagResource removes the given tag keys from the distribution identified by ARN.
+func (s *MemoryStorage) UntagResource(_ context.Context, arn string, keys []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dist, ok := s.findByARN(arn)
+	if !ok {
+		return &Error{
+			Code:    errDistributionNotFound,
+			Message: fmt.Sprintf("The resource %s does not exist", arn),
+		}
+	}
+
+	for _, k := range keys {
+		delete(dist.Tags, k)
+	}
+
+	s.saveLocked()
+
+	return nil
+}
+
+// ListTags returns a copy of the tags on the distribution identified by ARN.
+func (s *MemoryStorage) ListTags(_ context.Context, arn string) (map[string]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dist, ok := s.findByARN(arn)
+	if !ok {
+		return nil, &Error{
+			Code:    errDistributionNotFound,
+			Message: fmt.Sprintf("The resource %s does not exist", arn),
+		}
+	}
+
+	out := make(map[string]string, len(dist.Tags))
+	maps.Copy(out, dist.Tags)
+
+	return out, nil
 }
 
 // Helper functions.

--- a/internal/service/cloudfront/types.go
+++ b/internal/service/cloudfront/types.go
@@ -267,10 +267,15 @@ type ActiveTrustedKeyGroupsXML struct {
 
 // DistributionConfigXML represents distribution config in XML format.
 type DistributionConfigXML struct {
-	CallerReference      string                   `xml:"CallerReference"`
-	Aliases              *AliasesXML              `xml:"Aliases,omitempty"`
-	DefaultRootObject    string                   `xml:"DefaultRootObject,omitempty"`
-	Origins              *OriginsXML              `xml:"Origins"`
+	CallerReference   string      `xml:"CallerReference"`
+	Aliases           *AliasesXML `xml:"Aliases,omitempty"`
+	DefaultRootObject string      `xml:"DefaultRootObject,omitempty"`
+	Origins           *OriginsXML `xml:"Origins"`
+	// OriginGroups is emitted unconditionally (no omitempty). Real CloudFront
+	// always returns it even empty (Quantity=0); the Terraform AWS provider's
+	// resourceDistributionRead does aws.ToInt32(distributionConfig.OriginGroups.Quantity)
+	// without a nil-check (distribution.go:1000), so omitting it crashes the provider.
+	OriginGroups         *OriginGroupsXML         `xml:"OriginGroups"`
 	DefaultCacheBehavior *DefaultCacheBehaviorXML `xml:"DefaultCacheBehavior"`
 	CacheBehaviors       *CacheBehaviorsXML       `xml:"CacheBehaviors,omitempty"`
 	Comment              string                   `xml:"Comment"`
@@ -349,6 +354,27 @@ type DefaultCacheBehaviorXML struct {
 	CachePolicyID        string               `xml:"CachePolicyId,omitempty"`
 	TrustedSigners       *TrustedSignersXML   `xml:"TrustedSigners,omitempty"`
 	TrustedKeyGroups     *TrustedKeyGroupsXML `xml:"TrustedKeyGroups,omitempty"`
+	// FunctionAssociations and LambdaFunctionAssociations are emitted
+	// unconditionally (no omitempty). Real CloudFront always returns both
+	// elements, even empty (Quantity=0); the Terraform AWS provider's
+	// flattenDefaultCacheBehavior dereferences apiObject.FunctionAssociations.Items
+	// and apiObject.LambdaFunctionAssociations.Items without nil-checking the
+	// parent pointer, so omitting them crashes the provider.
+	FunctionAssociations       *FunctionAssociationsXML       `xml:"FunctionAssociations"`
+	LambdaFunctionAssociations *LambdaFunctionAssociationsXML `xml:"LambdaFunctionAssociations"`
+}
+
+// FunctionAssociationsXML represents CloudFront function associations in XML.
+// kumo does not store associations, so only the empty (Quantity=0) shape is
+// emitted; the parent element must always be present.
+type FunctionAssociationsXML struct {
+	Quantity int `xml:"Quantity"`
+}
+
+// LambdaFunctionAssociationsXML represents Lambda@Edge associations in XML.
+// Same rationale as FunctionAssociationsXML.
+type LambdaFunctionAssociationsXML struct {
+	Quantity int `xml:"Quantity"`
 }
 
 // AllowedMethodsXML represents allowed methods in XML format.
@@ -398,6 +424,13 @@ type TrustedKeyGroupsXML struct {
 
 // CacheBehaviorsXML represents cache behaviors in XML format.
 type CacheBehaviorsXML struct {
+	Quantity int `xml:"Quantity"`
+}
+
+// OriginGroupsXML represents origin groups in XML format. kumo does not store
+// origin groups, so only the empty (Quantity=0) shape is emitted; the parent
+// element must always be present for the provider's read.
+type OriginGroupsXML struct {
 	Quantity int `xml:"Quantity"`
 }
 

--- a/internal/service/cloudfront/types.go
+++ b/internal/service/cloudfront/types.go
@@ -17,6 +17,7 @@ type Distribution struct {
 	DistributionConfig     *DistributionConfig
 	ActiveTrustedSigners   *ActiveTrustedSigners
 	ActiveTrustedKeyGroups *ActiveTrustedKeyGroups
+	Tags                   map[string]string
 }
 
 // DistributionConfig represents CloudFront distribution configuration.
@@ -495,6 +496,36 @@ type CreateDistributionRequest struct {
 	ViewerCertificate    *ViewerCertificateXML    `xml:"ViewerCertificate,omitempty"`
 	HTTPVersion          string                   `xml:"HttpVersion,omitempty"`
 	IsIPV6Enabled        bool                     `xml:"IsIPV6Enabled,omitempty"`
+}
+
+// DistributionConfigWithTags wraps a DistributionConfig and its Tags for the
+// CreateDistributionWithTags operation (POST /2020-05-31/distribution?WithTags).
+// The inner config reuses CreateDistributionRequest so all parsing logic is shared.
+type DistributionConfigWithTags struct {
+	XMLName            xml.Name                  `xml:"DistributionConfigWithTags"`
+	DistributionConfig CreateDistributionRequest `xml:"DistributionConfig"`
+	Tags               *Tags                     `xml:"Tags,omitempty"`
+}
+
+// Tags represents a CloudFront tag set. It is reused as the nested
+// element of CreateDistributionWithTags, as the TagResource request body, and
+// as the ListTagsForResource response body (with Xmlns set).
+type Tags struct {
+	XMLName xml.Name `xml:"Tags"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty"`
+	Items   []Tag    `xml:"Items>Tag,omitempty"`
+}
+
+// Tag represents a single CloudFront tag.
+type Tag struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value,omitempty"`
+}
+
+// TagKeysBody is the UntagResource request body (root <TagKeys>).
+type TagKeysBody struct {
+	XMLName xml.Name `xml:"TagKeys"`
+	Items   []string `xml:"Items>Key"`
 }
 
 // InvalidationXML represents an invalidation in XML format.

--- a/internal/service/cloudtrail/handlers.go
+++ b/internal/service/cloudtrail/handlers.go
@@ -25,6 +25,9 @@ func (s *Service) getActionHandlers() map[string]handlerFunc {
 		"StopLogging":    s.StopLogging,
 		"LookupEvents":   s.LookupEvents,
 		"GetTrailStatus": s.GetTrailStatus,
+		"ListTags":       s.ListTags,
+		"AddTags":        s.AddTags,
+		"RemoveTags":     s.RemoveTags,
 	}
 }
 
@@ -268,6 +271,76 @@ func (s *Service) GetTrailStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeResponse(w, resp)
+}
+
+// ListTags handles the ListTags API. It returns the tags of each requested
+// resource ARN; an unknown or untagged trail yields an empty tag list so the
+// Terraform provider's read-time tag fetch stays stable.
+func (s *Service) ListTags(w http.ResponseWriter, r *http.Request) {
+	var req ListTagsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	resourceTags := make([]ResourceTag, 0, len(req.ResourceIDList))
+	for _, arn := range req.ResourceIDList {
+		resourceTags = append(resourceTags, ResourceTag{
+			ResourceID: arn,
+			TagsList:   s.storage.ListTrailTags(r.Context(), arn),
+		})
+	}
+
+	writeResponse(w, &ListTagsResponse{ResourceTagList: resourceTags})
+}
+
+// AddTags handles the AddTags API.
+func (s *Service) AddTags(w http.ResponseWriter, r *http.Request) {
+	var req AddTagsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResourceID == "" {
+		writeError(w, "ValidationException", "ResourceId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.AddTrailTags(r.Context(), req.ResourceID, req.TagsList); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &AddTagsResponse{})
+}
+
+// RemoveTags handles the RemoveTags API.
+func (s *Service) RemoveTags(w http.ResponseWriter, r *http.Request) {
+	var req RemoveTagsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResourceID == "" {
+		writeError(w, "ValidationException", "ResourceId is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.RemoveTrailTags(r.Context(), req.ResourceID, req.TagsList); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &RemoveTagsResponse{})
 }
 
 // Helper functions.

--- a/internal/service/cloudtrail/handlers_test.go
+++ b/internal/service/cloudtrail/handlers_test.go
@@ -1,0 +1,233 @@
+package cloudtrail
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ctBody marshals v to a request body. The request structs never fail to
+// marshal, so the error is ignored. It takes no *testing.T so arrange-style
+// callers stay free of the thelper requirement.
+func ctBody(v any) string {
+	data, _ := json.Marshal(v)
+
+	return string(data)
+}
+
+// dispatchCT drives an action through the JSON dispatcher exactly as the wire
+// would, setting the X-Amz-Target header the server routes on.
+func dispatchCT(t *testing.T, svc *Service, action, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("X-Amz-Target", "CloudTrail_20131101."+action)
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	return w
+}
+
+// dispatchCase is one row of the CloudTrail dispatch test table. arrange builds
+// the request body (and any prerequisite state) from ctx but not *testing.T;
+// verify takes *testing.T for assertions.
+type dispatchCase struct {
+	name       string
+	action     string
+	body       string
+	arrange    func(ctx context.Context, store *MemoryStorage) string
+	wantStatus int
+	wantType   string
+	verify     func(t *testing.T, store *MemoryStorage, w *httptest.ResponseRecorder)
+}
+
+// runDispatchCases dispatches each case on a fresh service and checks the
+// status, optional error __type, and any extra verification.
+func runDispatchCases(t *testing.T, cases []dispatchCase) {
+	t.Helper()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := NewMemoryStorage()
+			svc := New(store)
+
+			body := tc.body
+			if tc.arrange != nil {
+				body = tc.arrange(t.Context(), store)
+			}
+
+			w := dispatchCT(t, svc, tc.action, body)
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status: got %d, want %d (body=%s)", w.Code, tc.wantStatus, w.Body.String())
+			}
+
+			if tc.wantType != "" {
+				var resp ErrorResponse
+				if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+					t.Fatalf("decode error response: %v", err)
+				}
+
+				if resp.Type != tc.wantType {
+					t.Errorf("__type: got %q, want %q", resp.Type, tc.wantType)
+				}
+			}
+
+			if tc.verify != nil {
+				tc.verify(t, store, w)
+			}
+		})
+	}
+}
+
+// createTrailFixture creates a trail named tagTrailName with the given tags. It
+// takes ctx (not *testing.T) so arrange closures stay thelper-free.
+func createTrailFixture(ctx context.Context, store *MemoryStorage, tags []Tag) *Trail {
+	created, _ := store.CreateTrail(ctx, &CreateTrailRequest{
+		Name:         tagTrailName,
+		S3BucketName: tagBucket,
+		TagsList:     tags,
+	})
+
+	return created
+}
+
+func verifyListTagsEnv(t *testing.T, _ *MemoryStorage, w *httptest.ResponseRecorder) {
+	t.Helper()
+
+	var resp ListTagsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.ResourceTagList) != 1 || len(resp.ResourceTagList[0].TagsList) != 1 {
+		t.Fatalf("ResourceTagList: got %+v, want one resource with one tag", resp.ResourceTagList)
+	}
+
+	if tag := resp.ResourceTagList[0].TagsList[0]; tag.Key != tagKeyEnv || tag.Value != tagValLocal {
+		t.Errorf("tag: got %+v, want {env local}", tag)
+	}
+}
+
+func verifyListTagsEmpty(t *testing.T, _ *MemoryStorage, w *httptest.ResponseRecorder) {
+	t.Helper()
+
+	var resp ListTagsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.ResourceTagList) != 1 || len(resp.ResourceTagList[0].TagsList) != 0 {
+		t.Errorf("ResourceTagList: got %+v, want one resource with no tags", resp.ResourceTagList)
+	}
+}
+
+func verifyTagPresent(t *testing.T, store *MemoryStorage, _ *httptest.ResponseRecorder) {
+	t.Helper()
+
+	if tags := store.ListTrailTags(t.Context(), tagTrailName); len(tags) != 1 || tags[0].Key != tagKeyEnv {
+		t.Errorf("tags: got %v, want [env]", tags)
+	}
+}
+
+func verifyNoTags(t *testing.T, store *MemoryStorage, _ *httptest.ResponseRecorder) {
+	t.Helper()
+
+	if tags := store.ListTrailTags(t.Context(), tagTrailName); len(tags) != 0 {
+		t.Errorf("tags: got %v, want empty", tags)
+	}
+}
+
+// TestListTagsDispatch covers the read path: ListTags is a registered action
+// (no UnknownOperationException), returns create-time tags, and yields an empty
+// list for an unknown resource so the provider's read-time fetch stays stable.
+func TestListTagsDispatch(t *testing.T) {
+	t.Parallel()
+
+	runDispatchCases(t, []dispatchCase{
+		{
+			name:   "returns create-time tags",
+			action: "ListTags",
+			arrange: func(ctx context.Context, store *MemoryStorage) string {
+				created := createTrailFixture(ctx, store, []Tag{{Key: tagKeyEnv, Value: tagValLocal}})
+
+				return ctBody(ListTagsRequest{ResourceIDList: []string{created.TrailARN}})
+			},
+			wantStatus: http.StatusOK,
+			verify:     verifyListTagsEnv,
+		},
+		{
+			name:       "unknown resource is empty",
+			action:     "ListTags",
+			body:       ctBody(ListTagsRequest{ResourceIDList: []string{absentTrailARN}}),
+			wantStatus: http.StatusOK,
+			verify:     verifyListTagsEmpty,
+		},
+	})
+}
+
+// TestTagMutationDispatch covers AddTags / RemoveTags routing, the create-tag
+// effect, ResourceId validation, and the not-found path.
+func TestTagMutationDispatch(t *testing.T) {
+	t.Parallel()
+
+	runDispatchCases(t, []dispatchCase{
+		{
+			name:   "AddTags adds a tag",
+			action: "AddTags",
+			arrange: func(ctx context.Context, store *MemoryStorage) string {
+				created := createTrailFixture(ctx, store, nil)
+
+				return ctBody(AddTagsRequest{ResourceID: created.TrailARN, TagsList: []Tag{{Key: tagKeyEnv, Value: tagValLocal}}})
+			},
+			wantStatus: http.StatusOK,
+			verify:     verifyTagPresent,
+		},
+		{
+			name:       "AddTags requires ResourceId",
+			action:     "AddTags",
+			body:       ctBody(AddTagsRequest{TagsList: []Tag{{Key: tagKeyEnv, Value: tagValLocal}}}),
+			wantStatus: http.StatusBadRequest,
+			wantType:   errValidationError,
+		},
+		{
+			name:       "AddTags on missing trail is not found",
+			action:     "AddTags",
+			body:       ctBody(AddTagsRequest{ResourceID: absentTrailARN, TagsList: []Tag{{Key: tagKeyEnv, Value: tagValLocal}}}),
+			wantStatus: http.StatusNotFound,
+			wantType:   errTrailNotFound,
+		},
+		{
+			name:   "RemoveTags removes a tag",
+			action: "RemoveTags",
+			arrange: func(ctx context.Context, store *MemoryStorage) string {
+				created := createTrailFixture(ctx, store, []Tag{{Key: tagKeyEnv, Value: tagValLocal}})
+
+				return ctBody(RemoveTagsRequest{ResourceID: created.TrailARN, TagsList: []Tag{{Key: tagKeyEnv}}})
+			},
+			wantStatus: http.StatusOK,
+			verify:     verifyNoTags,
+		},
+	})
+}
+
+// TestUnknownActionDispatch verifies an unregistered action returns
+// UnknownOperationException, guarding the dispatch fallthrough.
+func TestUnknownActionDispatch(t *testing.T) {
+	t.Parallel()
+
+	runDispatchCases(t, []dispatchCase{
+		{
+			name:       "unknown action",
+			action:     "Frobnicate",
+			body:       `{}`,
+			wantStatus: http.StatusBadRequest,
+			wantType:   "UnknownOperationException",
+		},
+	})
+}

--- a/internal/service/cloudtrail/storage.go
+++ b/internal/service/cloudtrail/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -154,13 +155,15 @@ func (m *MemoryStorage) CreateTrail(_ context.Context, req *CreateTrailRequest) 
 		return nil, &Error{Code: errValidationError, Message: "S3 bucket name is required"}
 	}
 
-	if _, exists := m.Trails[req.Name]; exists {
+	key := normalizeTrailName(req.Name)
+
+	if _, exists := m.Trails[key]; exists {
 		return nil, &Error{Code: errTrailAlreadyExists, Message: "Trail already exists"}
 	}
 
 	trail := &Trail{
-		Name:                       req.Name,
-		TrailARN:                   generateTrailARN(m.region, m.accountID, req.Name),
+		Name:                       key,
+		TrailARN:                   generateTrailARN(m.region, m.accountID, key),
 		S3BucketName:               req.S3BucketName,
 		S3KeyPrefix:                req.S3KeyPrefix,
 		IncludeGlobalServiceEvents: true,
@@ -193,7 +196,7 @@ func (m *MemoryStorage) CreateTrail(_ context.Context, req *CreateTrailRequest) 
 		trail.IsOrganizationTrail = *req.IsOrganizationTrail
 	}
 
-	m.Trails[req.Name] = trail
+	m.Trails[key] = trail
 
 	m.saveLocked()
 
@@ -204,6 +207,8 @@ func (m *MemoryStorage) CreateTrail(_ context.Context, req *CreateTrailRequest) 
 func (m *MemoryStorage) DeleteTrail(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	name = normalizeTrailName(name)
 
 	if _, exists := m.Trails[name]; !exists {
 		return &Error{Code: errTrailNotFound, Message: "Trail not found"}
@@ -220,6 +225,8 @@ func (m *MemoryStorage) DeleteTrail(_ context.Context, name string) error {
 func (m *MemoryStorage) GetTrail(_ context.Context, name string) (*Trail, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	name = normalizeTrailName(name)
 
 	trail, exists := m.Trails[name]
 	if !exists {
@@ -248,7 +255,7 @@ func (m *MemoryStorage) DescribeTrails(_ context.Context, names []string) ([]*Tr
 	result := make([]*Trail, 0, len(names))
 
 	for _, name := range names {
-		if trail, exists := m.Trails[name]; exists {
+		if trail, exists := m.Trails[normalizeTrailName(name)]; exists {
 			result = append(result, trail)
 		}
 	}
@@ -260,6 +267,8 @@ func (m *MemoryStorage) DescribeTrails(_ context.Context, names []string) ([]*Tr
 func (m *MemoryStorage) StartLogging(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	name = normalizeTrailName(name)
 
 	trail, exists := m.Trails[name]
 	if !exists {
@@ -277,6 +286,8 @@ func (m *MemoryStorage) StartLogging(_ context.Context, name string) error {
 func (m *MemoryStorage) StopLogging(_ context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	name = normalizeTrailName(name)
 
 	trail, exists := m.Trails[name]
 	if !exists {
@@ -302,6 +313,8 @@ func (m *MemoryStorage) GetTrailStatus(_ context.Context, name string) (*Trail, 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	name = normalizeTrailName(name)
+
 	trail, exists := m.Trails[name]
 	if !exists {
 		return nil, &Error{Code: errTrailNotFound, Message: "Trail not found"}
@@ -311,6 +324,18 @@ func (m *MemoryStorage) GetTrailStatus(_ context.Context, name string) (*Trail, 
 }
 
 // Helper functions.
+
+// normalizeTrailName normalizes both a short name and an ARN to the short name.
+// If the input is in the form "arn:aws:cloudtrail:<region>:<account>:trail/<name>"
+// it returns the trailing <name>; otherwise it returns the input as-is.
+// Real CloudTrail accepts either form for Name, so kumo treats them as aliases.
+func normalizeTrailName(name string) string {
+	if i := strings.LastIndex(name, ":trail/"); i >= 0 {
+		return name[i+len(":trail/"):]
+	}
+
+	return name
+}
 
 func generateTrailARN(region, accountID, trailName string) string {
 	return "arn:aws:cloudtrail:" + region + ":" + accountID + ":trail/" + trailName

--- a/internal/service/cloudtrail/storage.go
+++ b/internal/service/cloudtrail/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -35,6 +36,9 @@ type Storage interface {
 	StopLogging(ctx context.Context, name string) error
 	LookupEvents(ctx context.Context, req *LookupEventsRequest) ([]*Event, string, error)
 	GetTrailStatus(ctx context.Context, name string) (*Trail, error)
+	ListTrailTags(ctx context.Context, name string) []Tag
+	AddTrailTags(ctx context.Context, name string, tags []Tag) error
+	RemoveTrailTags(ctx context.Context, name string, tags []Tag) error
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -178,6 +182,7 @@ func (m *MemoryStorage) CreateTrail(_ context.Context, req *CreateTrailRequest) 
 		HasInsightSelectors:        false,
 		IsOrganizationTrail:        false,
 		CreationTime:               time.Now(),
+		Tags:                       tagsToMap(req.TagsList),
 	}
 
 	if req.IncludeGlobalServiceEvents != nil {
@@ -339,4 +344,89 @@ func normalizeTrailName(name string) string {
 
 func generateTrailARN(region, accountID, trailName string) string {
 	return "arn:aws:cloudtrail:" + region + ":" + accountID + ":trail/" + trailName
+}
+
+// ListTrailTags returns the tags of the trail named by a short name or ARN.
+// A missing trail (or one without tags) yields an empty list rather than an
+// error, so the Terraform provider's read-time ListTags stays stable even when
+// no tags were ever set.
+func (m *MemoryStorage) ListTrailTags(_ context.Context, name string) []Tag {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	trail, exists := m.Trails[normalizeTrailName(name)]
+	if !exists {
+		return []Tag{}
+	}
+
+	return mapToTags(trail.Tags)
+}
+
+// AddTrailTags merges the given tags into the trail's tag set.
+func (m *MemoryStorage) AddTrailTags(_ context.Context, name string, tags []Tag) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	trail, exists := m.Trails[normalizeTrailName(name)]
+	if !exists {
+		return &Error{Code: errTrailNotFound, Message: "Trail not found"}
+	}
+
+	if trail.Tags == nil {
+		trail.Tags = make(map[string]string, len(tags))
+	}
+
+	for _, t := range tags {
+		trail.Tags[t.Key] = t.Value
+	}
+
+	m.saveLocked()
+
+	return nil
+}
+
+// RemoveTrailTags deletes the given tags (matched by key) from the trail.
+func (m *MemoryStorage) RemoveTrailTags(_ context.Context, name string, tags []Tag) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	trail, exists := m.Trails[normalizeTrailName(name)]
+	if !exists {
+		return &Error{Code: errTrailNotFound, Message: "Trail not found"}
+	}
+
+	for _, t := range tags {
+		delete(trail.Tags, t.Key)
+	}
+
+	m.saveLocked()
+
+	return nil
+}
+
+// tagsToMap folds a tag list into a map, returning nil for an empty list so the
+// trail's Tags field stays absent until tags are actually set.
+func tagsToMap(list []Tag) map[string]string {
+	if len(list) == 0 {
+		return nil
+	}
+
+	m := make(map[string]string, len(list))
+	for _, t := range list {
+		m[t.Key] = t.Value
+	}
+
+	return m
+}
+
+// mapToTags renders a tag map as a key-sorted list for deterministic responses.
+func mapToTags(m map[string]string) []Tag {
+	tags := make([]Tag, 0, len(m))
+	for k, v := range m {
+		tags = append(tags, Tag{Key: k, Value: v})
+	}
+
+	sort.Slice(tags, func(i, j int) bool { return tags[i].Key < tags[j].Key })
+
+	return tags
 }

--- a/internal/service/cloudtrail/storage_test.go
+++ b/internal/service/cloudtrail/storage_test.go
@@ -1,0 +1,108 @@
+package cloudtrail
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeTrailName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"short name unchanged", "authz-trail", "authz-trail"},
+		{"full arn to short name", "arn:aws:cloudtrail:us-east-1:123456789012:trail/authz-trail", "authz-trail"},
+		{"arn with different region and account", "arn:aws:cloudtrail:ap-northeast-1:000000000000:trail/my-trail", "my-trail"},
+		{"unrelated string unchanged", "some-random-value", "some-random-value"},
+		{"empty string unchanged", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := normalizeTrailName(tc.input); got != tc.want {
+				t.Fatalf("normalizeTrailName(%q): got %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCreateTrail_ARNAlias verifies that a trail created with a short name can be
+// referenced by its ARN and vice versa, matching real CloudTrail's behaviour where
+// StartLogging/GetTrailStatus accept either identifier.
+func TestCreateTrail_ARNAlias(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	ctx := t.Context()
+
+	const trailName = "authz-trail"
+
+	created, err := store.CreateTrail(ctx, &CreateTrailRequest{
+		Name:         trailName,
+		S3BucketName: "audit-bucket",
+	})
+	if err != nil {
+		t.Fatalf("CreateTrail: unexpected error: %v", err)
+	}
+
+	// StartLogging by ARN must succeed; the migration target sends the ARN as Name.
+	if err := store.StartLogging(ctx, created.TrailARN); err != nil {
+		t.Fatalf("StartLogging by ARN: unexpected error: %v", err)
+	}
+
+	// GetTrailStatus by short name must observe the same trail.
+	status, err := store.GetTrailStatus(ctx, trailName)
+	if err != nil {
+		t.Fatalf("GetTrailStatus by short name: unexpected error: %v", err)
+	}
+
+	if !status.IsLogging {
+		t.Fatalf("IsLogging after StartLogging by ARN: got %v, want true", status.IsLogging)
+	}
+
+	// StopLogging by ARN flips it back, observable by short name.
+	if err := store.StopLogging(ctx, created.TrailARN); err != nil {
+		t.Fatalf("StopLogging by ARN: unexpected error: %v", err)
+	}
+
+	stopped, err := store.GetTrailStatus(ctx, trailName)
+	if err != nil {
+		t.Fatalf("GetTrailStatus after stop: unexpected error: %v", err)
+	}
+
+	if stopped.IsLogging {
+		t.Fatalf("IsLogging after StopLogging by ARN: got %v, want false", stopped.IsLogging)
+	}
+}
+
+// TestCreateTrail_NoDoubleARN verifies that passing an ARN to CreateTrail does not
+// produce a nested "...:trail/arn:aws:cloudtrail:..." ARN.
+func TestCreateTrail_NoDoubleARN(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	ctx := t.Context()
+
+	const arn = "arn:aws:cloudtrail:us-east-1:123456789012:trail/authz-trail"
+
+	created, err := store.CreateTrail(ctx, &CreateTrailRequest{
+		Name:         arn,
+		S3BucketName: "audit-bucket",
+	})
+	if err != nil {
+		t.Fatalf("CreateTrail with ARN name: unexpected error: %v", err)
+	}
+
+	if created.Name != "authz-trail" {
+		t.Fatalf("Trail.Name: got %q, want %q", created.Name, "authz-trail")
+	}
+
+	if strings.Count(created.TrailARN, ":trail/") != 1 {
+		t.Fatalf("TrailARN must contain exactly one \":trail/\": got %q", created.TrailARN)
+	}
+}

--- a/internal/service/cloudtrail/storage_test.go
+++ b/internal/service/cloudtrail/storage_test.go
@@ -1,8 +1,20 @@
 package cloudtrail
 
 import (
+	"context"
+	"reflect"
 	"strings"
 	"testing"
+)
+
+// Literals reused across the CloudTrail tag tests.
+const (
+	tagKeyEnv      = "env"
+	tagValLocal    = "local"
+	tagKeyTeam     = "team"
+	tagTrailName   = "authz-trail"
+	tagBucket      = "audit-bucket"
+	absentTrailARN = "arn:aws:cloudtrail:us-east-1:123456789012:trail/absent"
 )
 
 func TestNormalizeTrailName(t *testing.T) {
@@ -104,5 +116,117 @@ func TestCreateTrail_NoDoubleARN(t *testing.T) {
 
 	if strings.Count(created.TrailARN, ":trail/") != 1 {
 		t.Fatalf("TrailARN must contain exactly one \":trail/\": got %q", created.TrailARN)
+	}
+}
+
+// trailTagCase is one row of the trail-tag table: starting tags, an optional
+// add/remove mutation, and the tag list expected on read-back.
+type trailTagCase struct {
+	name       string
+	createTags []Tag
+	add        []Tag
+	remove     []Tag
+	want       []Tag
+}
+
+// runTrailTagCases creates a trail with the case's tags, applies its mutation,
+// and asserts the read-back (by short name, an alias of the ARN) on a fresh
+// store per case.
+func runTrailTagCases(t *testing.T, cases []trailTagCase) {
+	t.Helper()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := NewMemoryStorage()
+			ctx := t.Context()
+
+			created, err := store.CreateTrail(ctx, &CreateTrailRequest{
+				Name:         tagTrailName,
+				S3BucketName: tagBucket,
+				TagsList:     tc.createTags,
+			})
+			if err != nil {
+				t.Fatalf("CreateTrail: unexpected error: %v", err)
+			}
+
+			if len(tc.add) > 0 {
+				if err := store.AddTrailTags(ctx, created.TrailARN, tc.add); err != nil {
+					t.Fatalf("AddTrailTags: unexpected error: %v", err)
+				}
+			}
+
+			if len(tc.remove) > 0 {
+				if err := store.RemoveTrailTags(ctx, created.TrailARN, tc.remove); err != nil {
+					t.Fatalf("RemoveTrailTags: unexpected error: %v", err)
+				}
+			}
+
+			if got := store.ListTrailTags(ctx, tagTrailName); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("ListTrailTags: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTrailTags verifies tags read back after create / add / remove, including
+// that an untagged trail reads back empty.
+func TestTrailTags(t *testing.T) {
+	t.Parallel()
+
+	runTrailTagCases(t, []trailTagCase{
+		{
+			name:       "create-time tags read back",
+			createTags: []Tag{{Key: tagKeyEnv, Value: tagValLocal}},
+			want:       []Tag{{Key: tagKeyEnv, Value: tagValLocal}},
+		},
+		{name: "untagged trail reads empty", want: []Tag{}},
+		{
+			name:       "add merges and sorts by key",
+			createTags: []Tag{{Key: tagKeyEnv, Value: tagValLocal}},
+			add:        []Tag{{Key: tagKeyTeam, Value: "idp"}},
+			want:       []Tag{{Key: tagKeyEnv, Value: tagValLocal}, {Key: tagKeyTeam, Value: "idp"}},
+		},
+		{
+			name:       "remove deletes by key",
+			createTags: []Tag{{Key: tagKeyEnv, Value: tagValLocal}, {Key: tagKeyTeam, Value: "idp"}},
+			remove:     []Tag{{Key: tagKeyEnv}},
+			want:       []Tag{{Key: tagKeyTeam, Value: "idp"}},
+		},
+	})
+}
+
+// TestTrailTags_MissingTrail verifies the mutating tag ops report not-found for
+// an unknown trail (ListTrailTags-on-unknown is covered at the dispatch layer).
+func TestTrailTags_MissingTrail(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		op   func(ctx context.Context, s *MemoryStorage) error
+	}{
+		{
+			name: "AddTrailTags reports not found",
+			op: func(ctx context.Context, s *MemoryStorage) error {
+				return s.AddTrailTags(ctx, absentTrailARN, []Tag{{Key: "k", Value: "v"}})
+			},
+		},
+		{
+			name: "RemoveTrailTags reports not found",
+			op: func(ctx context.Context, s *MemoryStorage) error {
+				return s.RemoveTrailTags(ctx, absentTrailARN, []Tag{{Key: "k"}})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := tc.op(t.Context(), NewMemoryStorage()); err == nil {
+				t.Fatalf("%s: expected error for a missing trail, got nil", tc.name)
+			}
+		})
 	}
 }

--- a/internal/service/cloudtrail/types.go
+++ b/internal/service/cloudtrail/types.go
@@ -20,6 +20,14 @@ type Trail struct {
 	HasInsightSelectors        bool
 	IsOrganizationTrail        bool
 	CreationTime               time.Time
+	Tags                       map[string]string
+}
+
+// Tag is a single CloudTrail resource tag. CloudTrail represents tags as a list
+// of key/value pairs (unlike Verified Permissions, which uses a map).
+type Tag struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value,omitempty"`
 }
 
 // Event represents a CloudTrail event for LookupEvents.
@@ -55,6 +63,7 @@ type CreateTrailRequest struct {
 	CloudWatchLogsRoleArn      string `json:"CloudWatchLogsRoleArn,omitempty"`
 	KMSKeyID                   string `json:"KmsKeyId,omitempty"`
 	IsOrganizationTrail        *bool  `json:"IsOrganizationTrail,omitempty"`
+	TagsList                   []Tag  `json:"TagsList,omitempty"`
 }
 
 // CreateTrailResponse represents the CreateTrail API response.
@@ -185,6 +194,42 @@ type GetTrailStatusResponse struct {
 	LatestNotificationError           string  `json:"LatestNotificationError,omitempty"`
 	LatestCloudWatchLogsDeliveryError string  `json:"LatestCloudWatchLogsDeliveryError,omitempty"`
 }
+
+// ListTagsRequest represents the ListTags API request.
+type ListTagsRequest struct {
+	ResourceIDList []string `json:"ResourceIdList"`
+	NextToken      string   `json:"NextToken,omitempty"`
+}
+
+// ListTagsResponse represents the ListTags API response.
+type ListTagsResponse struct {
+	ResourceTagList []ResourceTag `json:"ResourceTagList"`
+	NextToken       string        `json:"NextToken,omitempty"`
+}
+
+// ResourceTag pairs a resource ARN with its tag list in the ListTags response.
+type ResourceTag struct {
+	ResourceID string `json:"ResourceId"`
+	TagsList   []Tag  `json:"TagsList"`
+}
+
+// AddTagsRequest represents the AddTags API request.
+type AddTagsRequest struct {
+	ResourceID string `json:"ResourceId"`
+	TagsList   []Tag  `json:"TagsList"`
+}
+
+// AddTagsResponse represents the AddTags API response.
+type AddTagsResponse struct{}
+
+// RemoveTagsRequest represents the RemoveTags API request.
+type RemoveTagsRequest struct {
+	ResourceID string `json:"ResourceId"`
+	TagsList   []Tag  `json:"TagsList"`
+}
+
+// RemoveTagsResponse represents the RemoveTags API response.
+type RemoveTagsResponse struct{}
 
 // ErrorResponse represents an error response.
 type ErrorResponse struct {

--- a/internal/service/firehose/handlers.go
+++ b/internal/service/firehose/handlers.go
@@ -17,13 +17,16 @@ type handlerFunc func(http.ResponseWriter, *http.Request)
 // getActionHandlers returns a map of action names to handler functions.
 func (s *Service) getActionHandlers() map[string]handlerFunc {
 	return map[string]handlerFunc{
-		"CreateDeliveryStream":   s.CreateDeliveryStream,
-		"DeleteDeliveryStream":   s.DeleteDeliveryStream,
-		"DescribeDeliveryStream": s.DescribeDeliveryStream,
-		"ListDeliveryStreams":    s.ListDeliveryStreams,
-		"PutRecord":              s.PutRecord,
-		"PutRecordBatch":         s.PutRecordBatch,
-		"UpdateDestination":      s.UpdateDestination,
+		"CreateDeliveryStream":      s.CreateDeliveryStream,
+		"DeleteDeliveryStream":      s.DeleteDeliveryStream,
+		"DescribeDeliveryStream":    s.DescribeDeliveryStream,
+		"ListDeliveryStreams":       s.ListDeliveryStreams,
+		"PutRecord":                 s.PutRecord,
+		"PutRecordBatch":            s.PutRecordBatch,
+		"UpdateDestination":         s.UpdateDestination,
+		"ListTagsForDeliveryStream": s.ListTagsForDeliveryStream,
+		"TagDeliveryStream":         s.TagDeliveryStream,
+		"UntagDeliveryStream":       s.UntagDeliveryStream,
 	}
 }
 
@@ -256,6 +259,94 @@ func (s *Service) UpdateDestination(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeResponse(w, &UpdateDestinationOutput{})
+}
+
+// ListTagsForDeliveryStream handles the ListTagsForDeliveryStream API.
+func (s *Service) ListTagsForDeliveryStream(w http.ResponseWriter, r *http.Request) {
+	var req ListTagsForDeliveryStreamInput
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DeliveryStreamName == "" {
+		writeError(w, "ValidationException", "DeliveryStreamName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	tags, err := s.storage.ListTagsForDeliveryStream(r.Context(), req.DeliveryStreamName)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &ListTagsForDeliveryStreamOutput{
+		Tags:        tags,
+		HasMoreTags: false,
+	})
+}
+
+// TagDeliveryStream handles the TagDeliveryStream API.
+func (s *Service) TagDeliveryStream(w http.ResponseWriter, r *http.Request) {
+	var req TagDeliveryStreamInput
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DeliveryStreamName == "" {
+		writeError(w, "ValidationException", "DeliveryStreamName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if len(req.Tags) == 0 {
+		writeError(w, "ValidationException", "Tags is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.TagDeliveryStream(r.Context(), req.DeliveryStreamName, req.Tags); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &TagDeliveryStreamOutput{})
+}
+
+// UntagDeliveryStream handles the UntagDeliveryStream API.
+func (s *Service) UntagDeliveryStream(w http.ResponseWriter, r *http.Request) {
+	var req UntagDeliveryStreamInput
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.DeliveryStreamName == "" {
+		writeError(w, "ValidationException", "DeliveryStreamName is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if len(req.TagKeys) == 0 {
+		writeError(w, "ValidationException", "TagKeys is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.UntagDeliveryStream(r.Context(), req.DeliveryStreamName, req.TagKeys); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &UntagDeliveryStreamOutput{})
 }
 
 // writeResponse writes a JSON response.

--- a/internal/service/firehose/handlers_tags_test.go
+++ b/internal/service/firehose/handlers_tags_test.go
@@ -1,0 +1,186 @@
+package firehose
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const tagTargetPrefix = "Firehose_20150804."
+
+// newTagTestService builds a Firehose service backed by in-memory storage.
+func newTagTestService(t *testing.T) *Service {
+	t.Helper()
+
+	return New(NewMemoryStorage())
+}
+
+// dispatchTag sends a JSON request to the given action and returns the recorder.
+func dispatchTag(t *testing.T, svc *Service, action, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("X-Amz-Target", tagTargetPrefix+action)
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	return w
+}
+
+// createStreamWithTags creates a delivery stream, optionally with the given tags JSON array.
+func createStreamWithTags(t *testing.T, svc *Service, name, tagsJSON string) {
+	t.Helper()
+
+	body := `{"DeliveryStreamName":"` + name + `","DeliveryStreamType":"DirectPut"`
+	if tagsJSON != "" {
+		body += `,"Tags":` + tagsJSON
+	}
+
+	body += `}`
+
+	w := dispatchTag(t, svc, "CreateDeliveryStream", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateDeliveryStream: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+// listTags reads the tags of a delivery stream and returns them as a slice.
+func listTags(t *testing.T, svc *Service, name string) []Tag {
+	t.Helper()
+
+	w := dispatchTag(t, svc, "ListTagsForDeliveryStream", `{"DeliveryStreamName":"`+name+`"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListTagsForDeliveryStream: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	var out ListTagsForDeliveryStreamOutput
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	return out.Tags
+}
+
+// tagsToMapForTest converts a tag slice to a key-value map for comparison.
+func tagsToMapForTest(tags []Tag) map[string]string {
+	m := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		m[tag.Key] = tag.Value
+	}
+
+	return m
+}
+
+func TestFirehose_TagDeliveryStreamLifecycle(t *testing.T) {
+	t.Parallel()
+
+	svc := newTagTestService(t)
+
+	const name = "audit-to-s3"
+
+	// Tags supplied at creation are readable back, sorted by key.
+	createStreamWithTags(t, svc, name, `[{"Key":"env","Value":"local"},{"Key":"app","Value":"idp"}]`)
+
+	gotSorted := listTags(t, svc, name)
+	wantSorted := []Tag{{Key: "app", Value: "idp"}, {Key: "env", Value: "local"}}
+
+	if !reflect.DeepEqual(gotSorted, wantSorted) {
+		t.Fatalf("ListTags after create: got %v, want %v", gotSorted, wantSorted)
+	}
+
+	// TagDeliveryStream adds a new key and overwrites an existing one.
+	w := dispatchTag(t, svc, "TagDeliveryStream",
+		`{"DeliveryStreamName":"`+name+`","Tags":[{"Key":"env","Value":"prod"},{"Key":"team","Value":"sec"}]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("TagDeliveryStream: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	got := tagsToMapForTest(listTags(t, svc, name))
+	want := map[string]string{"app": "idp", "env": "prod", "team": "sec"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListTags after tag: got %v, want %v", got, want)
+	}
+
+	// UntagDeliveryStream removes only the specified keys.
+	w = dispatchTag(t, svc, "UntagDeliveryStream",
+		`{"DeliveryStreamName":"`+name+`","TagKeys":["app","team"]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UntagDeliveryStream: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	got = tagsToMapForTest(listTags(t, svc, name))
+	want = map[string]string{"env": "prod"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListTags after untag: got %v, want %v", got, want)
+	}
+}
+
+func TestFirehose_TagActionsResourceNotFound(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		action string
+		body   string
+	}{
+		{"list", "ListTagsForDeliveryStream", `{"DeliveryStreamName":"missing"}`},
+		{"tag", "TagDeliveryStream", `{"DeliveryStreamName":"missing","Tags":[{"Key":"k","Value":"v"}]}`},
+		{"untag", "UntagDeliveryStream", `{"DeliveryStreamName":"missing","TagKeys":["k"]}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := newTagTestService(t)
+
+			w := dispatchTag(t, svc, tc.action, tc.body)
+			if w.Code != http.StatusNotFound {
+				t.Fatalf("%s: got %d, want 404 (body=%s)", tc.action, w.Code, w.Body.String())
+			}
+
+			var errResp ErrorResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+				t.Fatalf("failed to unmarshal error: %v", err)
+			}
+
+			if errResp.Type != errResourceNotFound {
+				t.Errorf("error type: got %q, want %q", errResp.Type, errResourceNotFound)
+			}
+		})
+	}
+}
+
+func TestFirehose_TagActionsValidation(t *testing.T) {
+	t.Parallel()
+
+	svc := newTagTestService(t)
+	createStreamWithTags(t, svc, "validate-stream", "")
+
+	cases := []struct {
+		name   string
+		action string
+		body   string
+	}{
+		{"tag without tags", "TagDeliveryStream", `{"DeliveryStreamName":"validate-stream"}`},
+		{"untag without keys", "UntagDeliveryStream", `{"DeliveryStreamName":"validate-stream"}`},
+		{"list without name", "ListTagsForDeliveryStream", `{}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := dispatchTag(t, svc, tc.action, tc.body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("%s: got %d, want 400 (body=%s)", tc.action, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/service/firehose/storage.go
+++ b/internal/service/firehose/storage.go
@@ -23,6 +23,9 @@ type Storage interface {
 	PutRecord(ctx context.Context, streamName string, record Record) (string, error)
 	PutRecordBatch(ctx context.Context, streamName string, records []Record) ([]PutRecordBatchResponseEntry, int32, error)
 	UpdateDestination(ctx context.Context, input *UpdateDestinationInput) error
+	ListTagsForDeliveryStream(ctx context.Context, name string) ([]Tag, error)
+	TagDeliveryStream(ctx context.Context, name string, tags []Tag) error
+	UntagDeliveryStream(ctx context.Context, name string, tagKeys []string) error
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -50,8 +53,9 @@ type MemoryStorage struct {
 
 // StreamData holds a delivery stream and its records.
 type StreamData struct {
-	Stream  *DeliveryStream `json:"stream"`
-	Records []StoredRecord  `json:"records"`
+	Stream  *DeliveryStream   `json:"stream"`
+	Records []StoredRecord    `json:"records"`
+	Tags    map[string]string `json:"tags,omitempty"`
 }
 
 // StoredRecord holds a stored record.
@@ -150,11 +154,26 @@ func (s *MemoryStorage) CreateDeliveryStream(_ context.Context, input *CreateDel
 	s.Streams[input.DeliveryStreamName] = &StreamData{
 		Stream:  stream,
 		Records: make([]StoredRecord, 0),
+		Tags:    tagsToMap(input.Tags),
 	}
 
 	s.saveLocked()
 
 	return stream, nil
+}
+
+// tagsToMap converts a slice of tags to a key-value map.
+func tagsToMap(tags []Tag) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	m := make(map[string]string, len(tags))
+	for _, t := range tags {
+		m[t.Key] = t.Value
+	}
+
+	return m
 }
 
 func (s *MemoryStorage) buildDeliveryStream(input *CreateDeliveryStreamInput) *DeliveryStream {
@@ -535,4 +554,80 @@ func (s *MemoryStorage) applyExtendedS3Update(desc *ExtendedS3DestinationDescrip
 	if update.S3BackupMode != "" {
 		desc.S3BackupMode = update.S3BackupMode
 	}
+}
+
+// ListTagsForDeliveryStream returns the tags of a delivery stream, sorted by key.
+func (s *MemoryStorage) ListTagsForDeliveryStream(_ context.Context, name string) ([]Tag, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, exists := s.Streams[name]
+	if !exists {
+		return nil, &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Delivery stream %s not found", name),
+		}
+	}
+
+	keys := make([]string, 0, len(data.Tags))
+	for k := range data.Tags {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	tags := make([]Tag, 0, len(keys))
+	for _, k := range keys {
+		tags = append(tags, Tag{Key: k, Value: data.Tags[k]})
+	}
+
+	return tags, nil
+}
+
+// TagDeliveryStream adds or overwrites tags on a delivery stream by key.
+func (s *MemoryStorage) TagDeliveryStream(_ context.Context, name string, tags []Tag) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, exists := s.Streams[name]
+	if !exists {
+		return &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Delivery stream %s not found", name),
+		}
+	}
+
+	if data.Tags == nil {
+		data.Tags = make(map[string]string, len(tags))
+	}
+
+	for _, t := range tags {
+		data.Tags[t.Key] = t.Value
+	}
+
+	s.saveLocked()
+
+	return nil
+}
+
+// UntagDeliveryStream removes tags from a delivery stream by key.
+func (s *MemoryStorage) UntagDeliveryStream(_ context.Context, name string, tagKeys []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, exists := s.Streams[name]
+	if !exists {
+		return &Error{
+			Code:    errResourceNotFound,
+			Message: fmt.Sprintf("Delivery stream %s not found", name),
+		}
+	}
+
+	for _, k := range tagKeys {
+		delete(data.Tags, k)
+	}
+
+	s.saveLocked()
+
+	return nil
 }

--- a/internal/service/firehose/types.go
+++ b/internal/service/firehose/types.go
@@ -303,6 +303,37 @@ type ExtendedS3DestinationUpdate struct {
 // UpdateDestinationOutput is the output for UpdateDestination.
 type UpdateDestinationOutput struct{}
 
+// ListTagsForDeliveryStreamInput is the input for ListTagsForDeliveryStream.
+type ListTagsForDeliveryStreamInput struct {
+	DeliveryStreamName   string `json:"DeliveryStreamName"`
+	ExclusiveStartTagKey string `json:"ExclusiveStartTagKey,omitempty"`
+	Limit                int32  `json:"Limit,omitempty"`
+}
+
+// ListTagsForDeliveryStreamOutput is the output for ListTagsForDeliveryStream.
+type ListTagsForDeliveryStreamOutput struct {
+	Tags        []Tag `json:"Tags"`
+	HasMoreTags bool  `json:"HasMoreTags"`
+}
+
+// TagDeliveryStreamInput is the input for TagDeliveryStream.
+type TagDeliveryStreamInput struct {
+	DeliveryStreamName string `json:"DeliveryStreamName"`
+	Tags               []Tag  `json:"Tags"`
+}
+
+// TagDeliveryStreamOutput is the output for TagDeliveryStream.
+type TagDeliveryStreamOutput struct{}
+
+// UntagDeliveryStreamInput is the input for UntagDeliveryStream.
+type UntagDeliveryStreamInput struct {
+	DeliveryStreamName string   `json:"DeliveryStreamName"`
+	TagKeys            []string `json:"TagKeys"`
+}
+
+// UntagDeliveryStreamOutput is the output for UntagDeliveryStream.
+type UntagDeliveryStreamOutput struct{}
+
 // ErrorResponse represents an error response.
 type ErrorResponse struct {
 	Type    string `json:"__type"`

--- a/internal/service/s3/bucket_objectlock.go
+++ b/internal/service/s3/bucket_objectlock.go
@@ -1,0 +1,122 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ObjectLockConfiguration is the XML body of PUT/GET /{bucket}?object-lock,
+// matching S3's `ObjectLockConfiguration` schema.
+//
+// kumo doesn't actually enforce WORM retention at object-write/delete time —
+// it just roundtrips the bucket's default-retention configuration so terraform
+// resources like `aws_s3_bucket_object_lock_configuration` see consistent
+// state. Object-level retention (PutObjectRetention) and legal hold
+// (PutObjectLegalHold) are out of scope.
+type ObjectLockConfiguration struct {
+	XMLName           xml.Name        `xml:"ObjectLockConfiguration"`
+	Xmlns             string          `xml:"xmlns,attr,omitempty"`
+	ObjectLockEnabled string          `xml:"ObjectLockEnabled,omitempty"`
+	Rule              *ObjectLockRule `xml:"Rule,omitempty"`
+}
+
+// ObjectLockRule wraps the bucket default retention rule.
+type ObjectLockRule struct {
+	DefaultRetention *DefaultRetention `xml:"DefaultRetention,omitempty"`
+}
+
+// DefaultRetention is the bucket's default retention period. Days and Years
+// are mutually exclusive, so both are pointers — only the one supplied by the
+// caller is serialized back.
+type DefaultRetention struct {
+	Mode  string `xml:"Mode,omitempty"`
+	Days  *int   `xml:"Days,omitempty"`
+	Years *int   `xml:"Years,omitempty"`
+}
+
+// PutObjectLockConfiguration handles PUT /{bucket}?object-lock.
+//
+// kumo does not require the bucket to have been created with object lock
+// enabled (real S3 returns InvalidBucketState otherwise); the emulator stays
+// permissive so terraform apply succeeds against an already-versioned bucket.
+func (s *Service) PutObjectLockConfiguration(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeS3Error(w, r, "InvalidRequest", "Failed to read request body", http.StatusBadRequest)
+
+		return
+	}
+
+	var cfg ObjectLockConfiguration
+	if err = xml.Unmarshal(body, &cfg); err != nil {
+		writeS3Error(w, r, "MalformedXML", fmt.Sprintf("ObjectLockConfiguration XML: %v", err), http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.PutBucketObjectLockConfiguration(r.Context(), bucket, &cfg); err != nil {
+		handleBucketLevelError(w, r, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetObjectLockConfiguration handles GET /{bucket}?object-lock.
+func (s *Service) GetObjectLockConfiguration(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+
+	cfg, err := s.storage.GetBucketObjectLockConfiguration(r.Context(), bucket)
+	if err != nil {
+		handleBucketLevelError(w, r, err)
+
+		return
+	}
+
+	cfg.Xmlns = s3Namespace
+	writeXMLResponse(w, cfg)
+}
+
+// MemoryStorage hooks for bucket object lock configuration.
+
+// PutBucketObjectLockConfiguration stores the object lock configuration on the
+// bucket.
+func (s *MemoryStorage) PutBucketObjectLockConfiguration(_ context.Context, bucket string, cfg *ObjectLockConfiguration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	b.ObjectLockConfiguration = cfg
+
+	s.saveLocked()
+
+	return nil
+}
+
+// GetBucketObjectLockConfiguration returns the stored object lock
+// configuration, or ObjectLockConfigurationNotFoundError if none has been set.
+func (s *MemoryStorage) GetBucketObjectLockConfiguration(_ context.Context, bucket string) (*ObjectLockConfiguration, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, ok := s.Buckets[bucket]
+	if !ok {
+		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if b.ObjectLockConfiguration == nil {
+		return nil, &BucketError{Code: "ObjectLockConfigurationNotFoundError", Message: "Object Lock configuration does not exist for this bucket", BucketName: bucket}
+	}
+
+	return b.ObjectLockConfiguration, nil
+}

--- a/internal/service/s3/bucket_objectlock_test.go
+++ b/internal/service/s3/bucket_objectlock_test.go
@@ -1,0 +1,141 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- BucketObjectLock ------------------------------------------------
+
+func TestBucketObjectLock_PutAndGet(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage(), "")
+	ctx := context.Background()
+
+	store, ok := svc.storage.(*MemoryStorage)
+	if !ok {
+		t.Fatalf("storage is not *MemoryStorage")
+	}
+
+	_ = store.CreateBucket(ctx, "olb")
+
+	putObjectLockFixture(t, svc, "olb")
+	verifyObjectLockRoundTrip(t, svc, "olb")
+}
+
+// TestBucketObjectLock_PutDoesNotFallThroughToCreateBucket guards the original
+// regression: ?object-lock PUT used to fall through to CreateBucket and return
+// 409 BucketAlreadyOwnedByYou on an existing bucket.
+func TestBucketObjectLock_PutDoesNotFallThroughToCreateBucket(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage(), "")
+	ctx := context.Background()
+
+	store, ok := svc.storage.(*MemoryStorage)
+	if !ok {
+		t.Fatalf("storage is not *MemoryStorage")
+	}
+
+	_ = store.CreateBucket(ctx, "olb-regression")
+
+	putObjectLockFixture(t, svc, "olb-regression")
+}
+
+// TestBucketObjectLock_GetUnconfigured verifies an unset bucket returns 404
+// ObjectLockConfigurationNotFoundError rather than the generic stub.
+func TestBucketObjectLock_GetUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	svc := New(NewMemoryStorage(), "")
+	ctx := context.Background()
+
+	store, ok := svc.storage.(*MemoryStorage)
+	if !ok {
+		t.Fatalf("storage is not *MemoryStorage")
+	}
+
+	_ = store.CreateBucket(ctx, "olb-empty")
+
+	req := httptest.NewRequest(http.MethodGet, "/olb-empty?object-lock", http.NoBody)
+	req.SetPathValue("bucket", "olb-empty")
+
+	w := httptest.NewRecorder()
+	svc.handleBucketGet(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("GET status: got %d, want 404 (body=%s)", w.Code, w.Body.String())
+	}
+
+	if !strings.Contains(w.Body.String(), "ObjectLockConfigurationNotFoundError") {
+		t.Fatalf("error code: got body=%s", w.Body.String())
+	}
+}
+
+func objectLockFixtureBody() []byte {
+	days := 365
+	cfg := ObjectLockConfiguration{
+		ObjectLockEnabled: "Enabled",
+		Rule: &ObjectLockRule{
+			DefaultRetention: &DefaultRetention{Mode: "COMPLIANCE", Days: &days},
+		},
+	}
+	body, _ := xml.Marshal(cfg)
+
+	return body
+}
+
+func putObjectLockFixture(t *testing.T, svc *Service, bucket string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?object-lock", strings.NewReader(string(objectLockFixtureBody())))
+	req.SetPathValue("bucket", bucket)
+
+	w := httptest.NewRecorder()
+	svc.handleBucketPut(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func verifyObjectLockRoundTrip(t *testing.T, svc *Service, bucket string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/"+bucket+"?object-lock", http.NoBody)
+	req.SetPathValue("bucket", bucket)
+
+	w := httptest.NewRecorder()
+	svc.handleBucketGet(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET status: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+
+	var got ObjectLockConfiguration
+	if err := xml.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
+	}
+
+	if got.ObjectLockEnabled != "Enabled" {
+		t.Fatalf("ObjectLockEnabled: got %q, want Enabled", got.ObjectLockEnabled)
+	}
+
+	if got.Rule == nil || got.Rule.DefaultRetention == nil {
+		t.Fatalf("Rule.DefaultRetention: got %+v, want non-nil", got.Rule)
+	}
+
+	dr := got.Rule.DefaultRetention
+	if dr.Mode != "COMPLIANCE" {
+		t.Fatalf("Mode: got %q, want COMPLIANCE", dr.Mode)
+	}
+
+	if dr.Days == nil || *dr.Days != 365 {
+		t.Fatalf("Days: got %v, want 365", dr.Days)
+	}
+}

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -146,6 +146,12 @@ func (s *Service) handleBucketGet(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if _, ok := r.URL.Query()["object-lock"]; ok {
+		s.GetObjectLockConfiguration(w, r)
+
+		return
+	}
+
 	if handled := s.serveBucketSubresourceStub(w, r); handled {
 		return
 	}
@@ -206,7 +212,6 @@ func bucketSubresourceErrorCode(q map[string][]string) (string, bool) {
 		"cors":              "NoSuchCORSConfiguration",
 		"replication":       "ReplicationConfigurationNotFoundError",
 		"tagging":           "NoSuchTagSet",
-		"object-lock":       "ObjectLockConfigurationNotFoundError",
 		"ownershipControls": "OwnershipControlsNotFoundError",
 	}
 
@@ -1584,6 +1589,8 @@ func toCommonPrefixes(prefixes []string) []CommonPrefix {
 }
 
 // handleBucketPut routes PUT /{bucket} requests based on query parameters.
+//
+//nolint:funlen // It's a straightforward dispatch, and splitting it up would just add indirection.
 func (s *Service) handleBucketPut(w http.ResponseWriter, r *http.Request) {
 	if _, ok := r.URL.Query()["versioning"]; ok {
 		s.PutBucketVersioning(w, r)
@@ -1635,6 +1642,12 @@ func (s *Service) handleBucketPut(w http.ResponseWriter, r *http.Request) {
 
 	if _, ok := r.URL.Query()["lifecycle"]; ok {
 		s.PutBucketLifecycleConfiguration(w, r)
+
+		return
+	}
+
+	if _, ok := r.URL.Query()["object-lock"]; ok {
+		s.PutObjectLockConfiguration(w, r)
 
 		return
 	}

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -94,6 +94,9 @@ type Storage interface {
 	GetBucketLifecycle(ctx context.Context, bucket string) (*LifecycleConfiguration, error)
 	DeleteBucketLifecycle(ctx context.Context, bucket string) error
 
+	PutBucketObjectLockConfiguration(ctx context.Context, bucket string, cfg *ObjectLockConfiguration) error
+	GetBucketObjectLockConfiguration(ctx context.Context, bucket string) (*ObjectLockConfiguration, error)
+
 	PutObjectRestore(ctx context.Context, bucket, key string, state *RestoreState) (bool, error)
 }
 
@@ -122,25 +125,26 @@ type MemoryStorage struct {
 
 // MemoryBucket holds the data for a single S3 bucket.
 type MemoryBucket struct {
-	Name                 string                        `json:"name"`
-	CreationDate         time.Time                     `json:"creationDate"`
-	Objects              map[string]*Object            `json:"objects"`                        // current/latest version per key
-	Versions             map[string][]*Object          `json:"versions"`                       // all versions per key (newest first)
-	VersioningStatus     string                        `json:"versioningStatus"`               // "", "Enabled", "Suspended"
-	VersionIDCounter     uint64                        `json:"versionIdcounter"`               // counter for generating version IDs
-	MultipartUploads     map[string]*MultipartUpload   `json:"-"`                              // uploadID -> MultipartUpload
-	EventBridgeEnabled   bool                          `json:"eventBridgeEnabled"`             // EventBridge notification
-	QueueConfigurations  []QueueConfiguration          `json:"queueConfigurations,omitempty"`  // SQS queue notification destinations
-	LambdaConfigurations []LambdaFunctionConfiguration `json:"lambdaConfigurations,omitempty"` // Lambda notification destinations
-	CORSRules            []CORSRule                    `json:"corsRules,omitempty"`            // CORS configuration
-	PublicAccessBlock    *PublicAccessBlockConfig      `json:"publicAccessBlock,omitempty"`    // public access block configuration
-	Encryption           *ServerSideEncryptionConfig   `json:"encryption,omitempty"`           // server-side encryption configuration
-	Policy               string                        `json:"policy,omitempty"`               // bucket policy JSON document (empty == not configured)
-	Logging              *BucketLoggingConfig          `json:"logging,omitempty"`              // server access logging target (nil == disabled)
-	ObjectACLs           map[string]*ObjectACL         `json:"objectAcls,omitempty"`           // per-object ACL (key -> ACL)
-	Website              *WebsiteConfiguration         `json:"website,omitempty"`              // static-site-hosting configuration
-	Lifecycle            *LifecycleConfiguration       `json:"lifecycle,omitempty"`            // expiration / transition rules
-	ObjectRestores       map[string]*RestoreState      `json:"objectRestores,omitempty"`       // per-object restore state (key -> state)
+	Name                    string                        `json:"name"`
+	CreationDate            time.Time                     `json:"creationDate"`
+	Objects                 map[string]*Object            `json:"objects"`                           // current/latest version per key
+	Versions                map[string][]*Object          `json:"versions"`                          // all versions per key (newest first)
+	VersioningStatus        string                        `json:"versioningStatus"`                  // "", "Enabled", "Suspended"
+	VersionIDCounter        uint64                        `json:"versionIdcounter"`                  // counter for generating version IDs
+	MultipartUploads        map[string]*MultipartUpload   `json:"-"`                                 // uploadID -> MultipartUpload
+	EventBridgeEnabled      bool                          `json:"eventBridgeEnabled"`                // EventBridge notification
+	QueueConfigurations     []QueueConfiguration          `json:"queueConfigurations,omitempty"`     // SQS queue notification destinations
+	LambdaConfigurations    []LambdaFunctionConfiguration `json:"lambdaConfigurations,omitempty"`    // Lambda notification destinations
+	CORSRules               []CORSRule                    `json:"corsRules,omitempty"`               // CORS configuration
+	PublicAccessBlock       *PublicAccessBlockConfig      `json:"publicAccessBlock,omitempty"`       // public access block configuration
+	Encryption              *ServerSideEncryptionConfig   `json:"encryption,omitempty"`              // server-side encryption configuration
+	Policy                  string                        `json:"policy,omitempty"`                  // bucket policy JSON document (empty == not configured)
+	Logging                 *BucketLoggingConfig          `json:"logging,omitempty"`                 // server access logging target (nil == disabled)
+	ObjectACLs              map[string]*ObjectACL         `json:"objectAcls,omitempty"`              // per-object ACL (key -> ACL)
+	Website                 *WebsiteConfiguration         `json:"website,omitempty"`                 // static-site-hosting configuration
+	Lifecycle               *LifecycleConfiguration       `json:"lifecycle,omitempty"`               // expiration / transition rules
+	ObjectRestores          map[string]*RestoreState      `json:"objectRestores,omitempty"`          // per-object restore state (key -> state)
+	ObjectLockConfiguration *ObjectLockConfiguration      `json:"objectLockConfiguration,omitempty"` // bucket default-retention configuration
 }
 
 // BucketLoggingConfig stores the destination for server access logs.

--- a/test/integration/cloudfront_test.go
+++ b/test/integration/cloudfront_test.go
@@ -86,6 +86,78 @@ func TestCloudFront_CreateDistribution(t *testing.T) {
 	}
 }
 
+func TestCloudFront_CreateDistributionWithTags(t *testing.T) {
+	t.Parallel()
+
+	client := newCloudFrontClient(t)
+	ctx := t.Context()
+
+	result, err := client.CreateDistributionWithTags(ctx, &cloudfront.CreateDistributionWithTagsInput{
+		DistributionConfigWithTags: &types.DistributionConfigWithTags{
+			DistributionConfig: &types.DistributionConfig{
+				CallerReference: aws.String("test-create-distribution-with-tags"),
+				Origins: &types.Origins{
+					Quantity: aws.Int32(1),
+					Items: []types.Origin{
+						{
+							Id:         aws.String("myS3Origin"),
+							DomainName: aws.String("mybucket.s3.amazonaws.com"),
+							S3OriginConfig: &types.S3OriginConfig{
+								OriginAccessIdentity: aws.String(""),
+							},
+						},
+					},
+				},
+				DefaultCacheBehavior: &types.DefaultCacheBehavior{
+					TargetOriginId:       aws.String("myS3Origin"),
+					ViewerProtocolPolicy: types.ViewerProtocolPolicyAllowAll,
+					CachePolicyId:        aws.String("658327ea-f89d-4fab-a63d-7e88639e58f6"),
+				},
+				Comment: aws.String("Test distribution with tags"),
+				Enabled: aws.Bool(true),
+			},
+			Tags: &types.Tags{
+				Items: []types.Tag{
+					{Key: aws.String("env"), Value: aws.String("local")},
+					{Key: aws.String("team"), Value: aws.String("idp")},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteDistribution(context.Background(), &cloudfront.DeleteDistributionInput{
+			Id:      result.Distribution.Id,
+			IfMatch: result.ETag,
+		})
+	})
+
+	golden.New(t, golden.WithIgnoreFields(
+		"Id",
+		"ARN",
+		"DomainName",
+		"LastModifiedTime",
+		"ETag",
+		"Location",
+		"ResultMetadata",
+	)).Assert(t.Name()+"_create", result)
+
+	// Tags applied at creation must be readable back via ListTagsForResource.
+	tagsResult, err := client.ListTagsForResource(ctx, &cloudfront.ListTagsForResourceInput{
+		Resource: result.Distribution.ARN,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"ResultMetadata",
+	)).Assert(t.Name()+"_tags", tagsResult)
+}
+
 func TestCloudFront_GetDistribution(t *testing.T) {
 	t.Parallel()
 

--- a/test/integration/cloudfront_test.go
+++ b/test/integration/cloudfront_test.go
@@ -510,3 +510,71 @@ func TestCloudFront_GetInvalidation(t *testing.T) {
 		"ResultMetadata",
 	)).Assert(t.Name(), getResult)
 }
+
+// TestCloudFront_CreateDistribution_CachePolicyNoSigning provisions a
+// CachePolicy-based distribution without trusted signers/key groups but with
+// CachedMethods, a common shape for an SPA frontend distribution. It guards
+// the DefaultCacheBehavior response shape the Terraform AWS provider flattens:
+// the response must always carry TrustedSigners and
+// TrustedKeyGroups (Enabled=false), and must preserve CachedMethods.
+func TestCloudFront_CreateDistribution_CachePolicyNoSigning(t *testing.T) {
+	t.Parallel()
+
+	client := newCloudFrontClient(t)
+	ctx := t.Context()
+
+	result, err := client.CreateDistribution(ctx, &cloudfront.CreateDistributionInput{
+		DistributionConfig: &types.DistributionConfig{
+			CallerReference: aws.String("test-cache-policy-no-signing"),
+			Origins: &types.Origins{
+				Quantity: aws.Int32(1),
+				Items: []types.Origin{
+					{
+						Id:         aws.String("myS3Origin"),
+						DomainName: aws.String("mybucket.s3.amazonaws.com"),
+						S3OriginConfig: &types.S3OriginConfig{
+							OriginAccessIdentity: aws.String(""),
+						},
+					},
+				},
+			},
+			DefaultCacheBehavior: &types.DefaultCacheBehavior{
+				TargetOriginId:       aws.String("myS3Origin"),
+				ViewerProtocolPolicy: types.ViewerProtocolPolicyRedirectToHttps,
+				CachePolicyId:        aws.String("658327ea-f89d-4fab-a63d-7e88639e58f6"),
+				AllowedMethods: &types.AllowedMethods{
+					Quantity: aws.Int32(2),
+					Items:    []types.Method{types.MethodGet, types.MethodHead},
+					CachedMethods: &types.CachedMethods{
+						Quantity: aws.Int32(2),
+						Items:    []types.Method{types.MethodGet, types.MethodHead},
+					},
+				},
+			},
+			Comment: aws.String("Test distribution cache policy no signing"),
+			Enabled: aws.Bool(true),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"Id",
+		"ARN",
+		"DomainName",
+		"LastModifiedTime",
+		"ETag",
+		"Location",
+		"ResultMetadata",
+	)).Assert(t.Name(), result)
+
+	// Clean up.
+	_, err = client.DeleteDistribution(ctx, &cloudfront.DeleteDistributionInput{
+		Id:      result.Distribution.Id,
+		IfMatch: result.ETag,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/integration/cloudtrail_test.go
+++ b/test/integration/cloudtrail_test.go
@@ -235,6 +235,47 @@ func TestCloudTrail_StartAndStopLogging(t *testing.T) {
 	golden.New(t, golden.WithIgnoreFields("StartLoggingTime", "StopLoggingTime", "LatestDeliveryTime", "LatestNotificationTime", "LatestCloudWatchLogsDeliveryTime", "LatestDigestDeliveryTime", "ResultMetadata")).Assert(t.Name()+"_stopped", statusOutput)
 }
 
+func TestCloudTrail_StartLoggingByARN(t *testing.T) {
+	client := newCloudTrailClient(t)
+	ctx := t.Context()
+
+	trailName := "test-trail-arn-alias"
+	bucketName := "test-bucket"
+
+	// Create trail with the short name, as Terraform's CreateTrail does.
+	createOutput, err := client.CreateTrail(ctx, &cloudtrail.CreateTrailInput{
+		Name:         aws.String(trailName),
+		S3BucketName: aws.String(bucketName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTrail(context.Background(), &cloudtrail.DeleteTrailInput{
+			Name: aws.String(trailName),
+		})
+	})
+
+	// Start logging using the ARN, as Terraform does (it holds the ARN as resource ID).
+	_, err = client.StartLogging(ctx, &cloudtrail.StartLoggingInput{
+		Name: createOutput.TrailARN,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify logging started, referenced by the short name.
+	statusOutput, err := client.GetTrailStatus(ctx, &cloudtrail.GetTrailStatusInput{
+		Name: aws.String(trailName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("StartLoggingTime", "LatestDeliveryTime", "LatestNotificationTime", "LatestCloudWatchLogsDeliveryTime", "LatestDigestDeliveryTime", "ResultMetadata")).Assert(t.Name(), statusOutput)
+}
+
 func TestCloudTrail_LookupEvents(t *testing.T) {
 	client := newCloudTrailClient(t)
 	ctx := t.Context()

--- a/test/integration/firehose_test.go
+++ b/test/integration/firehose_test.go
@@ -266,6 +266,140 @@ func TestFirehose_UpdateDestination(t *testing.T) {
 	}
 }
 
+func TestFirehose_ListTagsForDeliveryStream(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	client := createFirehoseClient(t)
+
+	streamName := "list-tags-test-stream"
+
+	// Create delivery stream with tags (Terraform supplies them on create).
+	_, err := client.CreateDeliveryStream(ctx, &firehose.CreateDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+		DeliveryStreamType: types.DeliveryStreamTypeDirectPut,
+		Tags: []types.Tag{
+			{Key: aws.String("env"), Value: aws.String("local")},
+			{Key: aws.String("app"), Value: aws.String("idp")},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// List tags (this is what Terraform calls right after create).
+	result, err := client.ListTagsForDeliveryStream(ctx, &firehose.ListTagsForDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), result)
+
+	// Clean up.
+	_, err = client.DeleteDeliveryStream(ctx, &firehose.DeleteDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFirehose_TagDeliveryStream(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	client := createFirehoseClient(t)
+
+	streamName := "tag-test-stream"
+
+	// Create delivery stream.
+	_, err := client.CreateDeliveryStream(ctx, &firehose.CreateDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+		DeliveryStreamType: types.DeliveryStreamTypeDirectPut,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tag the delivery stream.
+	_, err = client.TagDeliveryStream(ctx, &firehose.TagDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+		Tags: []types.Tag{
+			{Key: aws.String("env"), Value: aws.String("local")},
+			{Key: aws.String("team"), Value: aws.String("sec")},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the tags are readable back.
+	result, err := client.ListTagsForDeliveryStream(ctx, &firehose.ListTagsForDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), result)
+
+	// Clean up.
+	_, err = client.DeleteDeliveryStream(ctx, &firehose.DeleteDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFirehose_UntagDeliveryStream(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	client := createFirehoseClient(t)
+
+	streamName := "untag-test-stream"
+
+	// Create delivery stream with tags.
+	_, err := client.CreateDeliveryStream(ctx, &firehose.CreateDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+		DeliveryStreamType: types.DeliveryStreamTypeDirectPut,
+		Tags: []types.Tag{
+			{Key: aws.String("env"), Value: aws.String("local")},
+			{Key: aws.String("team"), Value: aws.String("sec")},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove one tag.
+	_, err = client.UntagDeliveryStream(ctx, &firehose.UntagDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+		TagKeys:            []string{"team"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify only the remaining tag is returned.
+	result, err := client.ListTagsForDeliveryStream(ctx, &firehose.ListTagsForDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name(), result)
+
+	// Clean up.
+	_, err = client.DeleteDeliveryStream(ctx, &firehose.DeleteDeliveryStreamInput{
+		DeliveryStreamName: aws.String(streamName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func createFirehoseClient(t *testing.T) *firehose.Client {
 	t.Helper()
 

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -767,6 +767,72 @@ func TestS3_Versioning_PutAndGetBucketVersioning(t *testing.T) {
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_suspended", result)
 }
 
+// Object Lock Tests
+
+func TestS3_ObjectLock_PutAndGetConfiguration(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucketName := "test-object-lock-config"
+
+	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		t.Fatalf("failed to create bucket: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{
+			Bucket: aws.String(bucketName),
+		})
+	})
+
+	// Object Lock requires versioning to be enabled on the bucket.
+	_, err = client.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{
+		Bucket: aws.String(bucketName),
+		VersioningConfiguration: &types.VersioningConfiguration{
+			Status: types.BucketVersioningStatusEnabled,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to enable versioning: %v", err)
+	}
+
+	// GET before configuring should fail with ObjectLockConfigurationNotFoundError.
+	_, err = client.GetObjectLockConfiguration(ctx, &s3.GetObjectLockConfigurationInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err == nil {
+		t.Fatal("expected error for unconfigured object lock, got nil")
+	}
+
+	// Set the bucket default-retention configuration.
+	_, err = client.PutObjectLockConfiguration(ctx, &s3.PutObjectLockConfigurationInput{
+		Bucket: aws.String(bucketName),
+		ObjectLockConfiguration: &types.ObjectLockConfiguration{
+			ObjectLockEnabled: types.ObjectLockEnabledEnabled,
+			Rule: &types.ObjectLockRule{
+				DefaultRetention: &types.DefaultRetention{
+					Mode: types.ObjectLockRetentionModeCompliance,
+					Days: aws.Int32(365),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to put object lock configuration: %v", err)
+	}
+
+	// Verify the configuration roundtrips.
+	result, err := client.GetObjectLockConfiguration(ctx, &s3.GetObjectLockConfigurationInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		t.Fatalf("failed to get object lock configuration: %v", err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_configured", result)
+}
+
 func TestS3_Versioning_PutObjectWithVersioning(t *testing.T) {
 	client := newS3Client(t)
 	ctx := t.Context()

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistributionWithTags_TestCloudFront_CreateDistributionWithTags_create.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistributionWithTags_TestCloudFront_CreateDistributionWithTags_create.golden.go
@@ -1,6 +1,6 @@
 {
   "Distribution": {
-    "ARN": "arn:aws:cloudfront::000000000000:distribution/E31b371ac-8c12",
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/E27e453bc-eb3d",
     "DistributionConfig": {
       "CallerReference": "test-create-distribution-with-tags",
       "Comment": "Test distribution with tags",
@@ -13,9 +13,15 @@
         "DefaultTTL": null,
         "FieldLevelEncryptionId": null,
         "ForwardedValues": null,
-        "FunctionAssociations": null,
+        "FunctionAssociations": {
+          "Quantity": 0,
+          "Items": null
+        },
         "GrpcConfig": null,
-        "LambdaFunctionAssociations": null,
+        "LambdaFunctionAssociations": {
+          "Quantity": 0,
+          "Items": null
+        },
         "MaxTTL": null,
         "MinTTL": null,
         "OriginRequestPolicyId": null,
@@ -67,7 +73,10 @@
       "HttpVersion": "http2",
       "IsIPV6Enabled": null,
       "Logging": null,
-      "OriginGroups": null,
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": null
+      },
       "PriceClass": "PriceClass_All",
       "Restrictions": null,
       "Staging": null,
@@ -84,10 +93,10 @@
       "ViewerMtlsConfig": null,
       "WebACLId": null
     },
-    "DomainName": "E31b371ac-8c12.cloudfront.net",
-    "Id": "E31b371ac-8c12",
+    "DomainName": "E27e453bc-eb3d.cloudfront.net",
+    "Id": "E27e453bc-eb3d",
     "InProgressInvalidationBatches": null,
-    "LastModifiedTime": "2026-06-12T15:24:36+09:00",
+    "LastModifiedTime": "2026-06-12T16:37:13+09:00",
     "Status": "InProgress",
     "ActiveTrustedKeyGroups": {
       "Enabled": false,
@@ -101,7 +110,7 @@
     },
     "AliasICPRecordals": null
   },
-  "ETag": "E345d7b81-38b9-4f1e-a9f9-4142f901",
-  "Location": "/2020-05-31/distribution/E31b371ac-8c12",
+  "ETag": "E93852bee-6ef9-4633-9981-94c1339d",
+  "Location": "/2020-05-31/distribution/E27e453bc-eb3d",
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistributionWithTags_TestCloudFront_CreateDistributionWithTags_create.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistributionWithTags_TestCloudFront_CreateDistributionWithTags_create.golden.go
@@ -1,6 +1,6 @@
 {
   "Distribution": {
-    "ARN": "arn:aws:cloudfront::000000000000:distribution/E3becc0a8-b813",
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/E31b371ac-8c12",
     "DistributionConfig": {
       "CallerReference": "test-create-distribution-with-tags",
       "Comment": "Test distribution with tags",
@@ -22,8 +22,16 @@
         "RealtimeLogConfigArn": null,
         "ResponseHeadersPolicyId": null,
         "SmoothStreaming": null,
-        "TrustedKeyGroups": null,
-        "TrustedSigners": null
+        "TrustedKeyGroups": {
+          "Enabled": false,
+          "Quantity": 0,
+          "Items": []
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Quantity": 0,
+          "Items": []
+        }
       },
       "Enabled": true,
       "Origins": {
@@ -76,10 +84,10 @@
       "ViewerMtlsConfig": null,
       "WebACLId": null
     },
-    "DomainName": "E3becc0a8-b813.cloudfront.net",
-    "Id": "E3becc0a8-b813",
+    "DomainName": "E31b371ac-8c12.cloudfront.net",
+    "Id": "E31b371ac-8c12",
     "InProgressInvalidationBatches": null,
-    "LastModifiedTime": "2026-06-12T14:07:59+09:00",
+    "LastModifiedTime": "2026-06-12T15:24:36+09:00",
     "Status": "InProgress",
     "ActiveTrustedKeyGroups": {
       "Enabled": false,
@@ -93,7 +101,7 @@
     },
     "AliasICPRecordals": null
   },
-  "ETag": "Eb48ea4b0-6724-49ad-9ca5-71b78b0b",
-  "Location": "/2020-05-31/distribution/E3becc0a8-b813",
+  "ETag": "E345d7b81-38b9-4f1e-a9f9-4142f901",
+  "Location": "/2020-05-31/distribution/E31b371ac-8c12",
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistributionWithTags_TestCloudFront_CreateDistributionWithTags_create.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistributionWithTags_TestCloudFront_CreateDistributionWithTags_create.golden.go
@@ -1,9 +1,9 @@
 {
   "Distribution": {
-    "ARN": "arn:aws:cloudfront::000000000000:distribution/E311fa72c-72ec",
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/E3becc0a8-b813",
     "DistributionConfig": {
-      "CallerReference": "test-get-distribution",
-      "Comment": "Test distribution",
+      "CallerReference": "test-create-distribution-with-tags",
+      "Comment": "Test distribution with tags",
       "DefaultCacheBehavior": {
         "TargetOriginId": "myS3Origin",
         "ViewerProtocolPolicy": "allow-all",
@@ -76,11 +76,11 @@
       "ViewerMtlsConfig": null,
       "WebACLId": null
     },
-    "DomainName": "E311fa72c-72ec.cloudfront.net",
-    "Id": "E311fa72c-72ec",
+    "DomainName": "E3becc0a8-b813.cloudfront.net",
+    "Id": "E3becc0a8-b813",
     "InProgressInvalidationBatches": null,
     "LastModifiedTime": "2026-06-12T14:07:59+09:00",
-    "Status": "Deployed",
+    "Status": "InProgress",
     "ActiveTrustedKeyGroups": {
       "Enabled": false,
       "Quantity": 0,
@@ -93,6 +93,7 @@
     },
     "AliasICPRecordals": null
   },
-  "ETag": "E8cb994bd-394f-43ea-8bb7-ceacf079",
+  "ETag": "Eb48ea4b0-6724-49ad-9ca5-71b78b0b",
+  "Location": "/2020-05-31/distribution/E3becc0a8-b813",
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistributionWithTags_TestCloudFront_CreateDistributionWithTags_tags.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistributionWithTags_TestCloudFront_CreateDistributionWithTags_tags.golden.go
@@ -1,0 +1,15 @@
+{
+  "Tags": {
+    "Items": [
+      {
+        "Key": "env",
+        "Value": "local"
+      },
+      {
+        "Key": "team",
+        "Value": "idp"
+      }
+    ]
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistribution_CachePolicyNoSigning_TestCloudFront_CreateDistribution_CachePolicyNoSigning.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistribution_CachePolicyNoSigning_TestCloudFront_CreateDistribution_CachePolicyNoSigning.golden.go
@@ -1,13 +1,26 @@
 {
   "Distribution": {
-    "ARN": "arn:aws:cloudfront::000000000000:distribution/E83995c30-bffb",
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/E22a9ded2-8524",
     "DistributionConfig": {
-      "CallerReference": "test-create-distribution",
-      "Comment": "Test distribution",
+      "CallerReference": "test-cache-policy-no-signing",
+      "Comment": "Test distribution cache policy no signing",
       "DefaultCacheBehavior": {
         "TargetOriginId": "myS3Origin",
-        "ViewerProtocolPolicy": "allow-all",
-        "AllowedMethods": null,
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "AllowedMethods": {
+          "Items": [
+            "GET",
+            "HEAD"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "GET",
+              "HEAD"
+            ],
+            "Quantity": 2
+          }
+        },
         "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
         "Compress": null,
         "DefaultTTL": null,
@@ -84,8 +97,8 @@
       "ViewerMtlsConfig": null,
       "WebACLId": null
     },
-    "DomainName": "E83995c30-bffb.cloudfront.net",
-    "Id": "E83995c30-bffb",
+    "DomainName": "E22a9ded2-8524.cloudfront.net",
+    "Id": "E22a9ded2-8524",
     "InProgressInvalidationBatches": null,
     "LastModifiedTime": "2026-06-12T15:24:36+09:00",
     "Status": "InProgress",
@@ -101,7 +114,7 @@
     },
     "AliasICPRecordals": null
   },
-  "ETag": "Eaa2213fb-5145-4942-aa21-4b518eaa",
-  "Location": "/2020-05-31/distribution/E83995c30-bffb",
+  "ETag": "E418f8ba0-a03c-40c5-95ec-e2f5f4c1",
+  "Location": "/2020-05-31/distribution/E22a9ded2-8524",
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistribution_CachePolicyNoSigning_TestCloudFront_CreateDistribution_CachePolicyNoSigning.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistribution_CachePolicyNoSigning_TestCloudFront_CreateDistribution_CachePolicyNoSigning.golden.go
@@ -1,6 +1,6 @@
 {
   "Distribution": {
-    "ARN": "arn:aws:cloudfront::000000000000:distribution/E22a9ded2-8524",
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/Eab931381-edab",
     "DistributionConfig": {
       "CallerReference": "test-cache-policy-no-signing",
       "Comment": "Test distribution cache policy no signing",
@@ -26,9 +26,15 @@
         "DefaultTTL": null,
         "FieldLevelEncryptionId": null,
         "ForwardedValues": null,
-        "FunctionAssociations": null,
+        "FunctionAssociations": {
+          "Quantity": 0,
+          "Items": null
+        },
         "GrpcConfig": null,
-        "LambdaFunctionAssociations": null,
+        "LambdaFunctionAssociations": {
+          "Quantity": 0,
+          "Items": null
+        },
         "MaxTTL": null,
         "MinTTL": null,
         "OriginRequestPolicyId": null,
@@ -80,7 +86,10 @@
       "HttpVersion": "http2",
       "IsIPV6Enabled": null,
       "Logging": null,
-      "OriginGroups": null,
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": null
+      },
       "PriceClass": "PriceClass_All",
       "Restrictions": null,
       "Staging": null,
@@ -97,10 +106,10 @@
       "ViewerMtlsConfig": null,
       "WebACLId": null
     },
-    "DomainName": "E22a9ded2-8524.cloudfront.net",
-    "Id": "E22a9ded2-8524",
+    "DomainName": "Eab931381-edab.cloudfront.net",
+    "Id": "Eab931381-edab",
     "InProgressInvalidationBatches": null,
-    "LastModifiedTime": "2026-06-12T15:24:36+09:00",
+    "LastModifiedTime": "2026-06-12T16:37:13+09:00",
     "Status": "InProgress",
     "ActiveTrustedKeyGroups": {
       "Enabled": false,
@@ -114,7 +123,7 @@
     },
     "AliasICPRecordals": null
   },
-  "ETag": "E418f8ba0-a03c-40c5-95ec-e2f5f4c1",
-  "Location": "/2020-05-31/distribution/E22a9ded2-8524",
+  "ETag": "E78e549d9-e2b9-45e5-aa1d-80fd5ca8",
+  "Location": "/2020-05-31/distribution/Eab931381-edab",
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistribution_TestCloudFront_CreateDistribution.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_CreateDistribution_TestCloudFront_CreateDistribution.golden.go
@@ -1,6 +1,6 @@
 {
   "Distribution": {
-    "ARN": "arn:aws:cloudfront::000000000000:distribution/E83995c30-bffb",
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/Ef434e2f1-4cce",
     "DistributionConfig": {
       "CallerReference": "test-create-distribution",
       "Comment": "Test distribution",
@@ -13,9 +13,15 @@
         "DefaultTTL": null,
         "FieldLevelEncryptionId": null,
         "ForwardedValues": null,
-        "FunctionAssociations": null,
+        "FunctionAssociations": {
+          "Quantity": 0,
+          "Items": null
+        },
         "GrpcConfig": null,
-        "LambdaFunctionAssociations": null,
+        "LambdaFunctionAssociations": {
+          "Quantity": 0,
+          "Items": null
+        },
         "MaxTTL": null,
         "MinTTL": null,
         "OriginRequestPolicyId": null,
@@ -67,7 +73,10 @@
       "HttpVersion": "http2",
       "IsIPV6Enabled": null,
       "Logging": null,
-      "OriginGroups": null,
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": null
+      },
       "PriceClass": "PriceClass_All",
       "Restrictions": null,
       "Staging": null,
@@ -84,10 +93,10 @@
       "ViewerMtlsConfig": null,
       "WebACLId": null
     },
-    "DomainName": "E83995c30-bffb.cloudfront.net",
-    "Id": "E83995c30-bffb",
+    "DomainName": "Ef434e2f1-4cce.cloudfront.net",
+    "Id": "Ef434e2f1-4cce",
     "InProgressInvalidationBatches": null,
-    "LastModifiedTime": "2026-06-12T15:24:36+09:00",
+    "LastModifiedTime": "2026-06-12T16:37:13+09:00",
     "Status": "InProgress",
     "ActiveTrustedKeyGroups": {
       "Enabled": false,
@@ -101,7 +110,7 @@
     },
     "AliasICPRecordals": null
   },
-  "ETag": "Eaa2213fb-5145-4942-aa21-4b518eaa",
-  "Location": "/2020-05-31/distribution/E83995c30-bffb",
+  "ETag": "E6a2f40e1-1152-498a-9f08-9c93014e",
+  "Location": "/2020-05-31/distribution/Ef434e2f1-4cce",
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_GetDistribution_TestCloudFront_GetDistribution.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_GetDistribution_TestCloudFront_GetDistribution.golden.go
@@ -1,6 +1,6 @@
 {
   "Distribution": {
-    "ARN": "arn:aws:cloudfront::000000000000:distribution/E10a06eb8-0f3d",
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/Ecf959148-482f",
     "DistributionConfig": {
       "CallerReference": "test-get-distribution",
       "Comment": "Test distribution",
@@ -13,9 +13,15 @@
         "DefaultTTL": null,
         "FieldLevelEncryptionId": null,
         "ForwardedValues": null,
-        "FunctionAssociations": null,
+        "FunctionAssociations": {
+          "Quantity": 0,
+          "Items": null
+        },
         "GrpcConfig": null,
-        "LambdaFunctionAssociations": null,
+        "LambdaFunctionAssociations": {
+          "Quantity": 0,
+          "Items": null
+        },
         "MaxTTL": null,
         "MinTTL": null,
         "OriginRequestPolicyId": null,
@@ -67,7 +73,10 @@
       "HttpVersion": "http2",
       "IsIPV6Enabled": null,
       "Logging": null,
-      "OriginGroups": null,
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": null
+      },
       "PriceClass": "PriceClass_All",
       "Restrictions": null,
       "Staging": null,
@@ -84,10 +93,10 @@
       "ViewerMtlsConfig": null,
       "WebACLId": null
     },
-    "DomainName": "E10a06eb8-0f3d.cloudfront.net",
-    "Id": "E10a06eb8-0f3d",
+    "DomainName": "Ecf959148-482f.cloudfront.net",
+    "Id": "Ecf959148-482f",
     "InProgressInvalidationBatches": null,
-    "LastModifiedTime": "2026-06-12T15:24:36+09:00",
+    "LastModifiedTime": "2026-06-12T16:37:13+09:00",
     "Status": "Deployed",
     "ActiveTrustedKeyGroups": {
       "Enabled": false,
@@ -101,6 +110,6 @@
     },
     "AliasICPRecordals": null
   },
-  "ETag": "Eee785941-8bfb-4b79-97aa-2fb28b4e",
+  "ETag": "E41fc55eb-63aa-4cb3-aa8a-2e5b7778",
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_GetDistribution_TestCloudFront_GetDistribution.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_GetDistribution_TestCloudFront_GetDistribution.golden.go
@@ -1,6 +1,6 @@
 {
   "Distribution": {
-    "ARN": "arn:aws:cloudfront::000000000000:distribution/E311fa72c-72ec",
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/E10a06eb8-0f3d",
     "DistributionConfig": {
       "CallerReference": "test-get-distribution",
       "Comment": "Test distribution",
@@ -22,8 +22,16 @@
         "RealtimeLogConfigArn": null,
         "ResponseHeadersPolicyId": null,
         "SmoothStreaming": null,
-        "TrustedKeyGroups": null,
-        "TrustedSigners": null
+        "TrustedKeyGroups": {
+          "Enabled": false,
+          "Quantity": 0,
+          "Items": []
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Quantity": 0,
+          "Items": []
+        }
       },
       "Enabled": true,
       "Origins": {
@@ -76,10 +84,10 @@
       "ViewerMtlsConfig": null,
       "WebACLId": null
     },
-    "DomainName": "E311fa72c-72ec.cloudfront.net",
-    "Id": "E311fa72c-72ec",
+    "DomainName": "E10a06eb8-0f3d.cloudfront.net",
+    "Id": "E10a06eb8-0f3d",
     "InProgressInvalidationBatches": null,
-    "LastModifiedTime": "2026-06-12T14:07:59+09:00",
+    "LastModifiedTime": "2026-06-12T15:24:36+09:00",
     "Status": "Deployed",
     "ActiveTrustedKeyGroups": {
       "Enabled": false,
@@ -93,6 +101,6 @@
     },
     "AliasICPRecordals": null
   },
-  "ETag": "E8cb994bd-394f-43ea-8bb7-ceacf079",
+  "ETag": "Eee785941-8bfb-4b79-97aa-2fb28b4e",
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_UpdateDistribution_TestCloudFront_UpdateDistribution.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_UpdateDistribution_TestCloudFront_UpdateDistribution.golden.go
@@ -1,6 +1,6 @@
 {
   "Distribution": {
-    "ARN": "arn:aws:cloudfront::000000000000:distribution/E8950c884-a8d6",
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/E1e6408bd-2ee2",
     "DistributionConfig": {
       "CallerReference": "test-update-distribution",
       "Comment": "Updated comment",
@@ -22,8 +22,16 @@
         "RealtimeLogConfigArn": null,
         "ResponseHeadersPolicyId": null,
         "SmoothStreaming": null,
-        "TrustedKeyGroups": null,
-        "TrustedSigners": null
+        "TrustedKeyGroups": {
+          "Enabled": false,
+          "Quantity": 0,
+          "Items": []
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Quantity": 0,
+          "Items": []
+        }
       },
       "Enabled": true,
       "Origins": {
@@ -76,10 +84,10 @@
       "ViewerMtlsConfig": null,
       "WebACLId": null
     },
-    "DomainName": "E8950c884-a8d6.cloudfront.net",
-    "Id": "E8950c884-a8d6",
+    "DomainName": "E1e6408bd-2ee2.cloudfront.net",
+    "Id": "E1e6408bd-2ee2",
     "InProgressInvalidationBatches": null,
-    "LastModifiedTime": "2026-03-23T07:45:28Z",
+    "LastModifiedTime": "2026-06-12T15:24:36+09:00",
     "Status": "InProgress",
     "ActiveTrustedKeyGroups": {
       "Enabled": false,
@@ -93,6 +101,6 @@
     },
     "AliasICPRecordals": null
   },
-  "ETag": "E5d92b10b-0f9f-4acd-bea0-cd6b693d",
+  "ETag": "Ee2054771-4a53-43c0-8ade-90832ff6",
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_UpdateDistribution_TestCloudFront_UpdateDistribution.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_UpdateDistribution_TestCloudFront_UpdateDistribution.golden.go
@@ -1,6 +1,6 @@
 {
   "Distribution": {
-    "ARN": "arn:aws:cloudfront::000000000000:distribution/E1e6408bd-2ee2",
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/E53f71198-7d73",
     "DistributionConfig": {
       "CallerReference": "test-update-distribution",
       "Comment": "Updated comment",
@@ -13,9 +13,15 @@
         "DefaultTTL": null,
         "FieldLevelEncryptionId": null,
         "ForwardedValues": null,
-        "FunctionAssociations": null,
+        "FunctionAssociations": {
+          "Quantity": 0,
+          "Items": null
+        },
         "GrpcConfig": null,
-        "LambdaFunctionAssociations": null,
+        "LambdaFunctionAssociations": {
+          "Quantity": 0,
+          "Items": null
+        },
         "MaxTTL": null,
         "MinTTL": null,
         "OriginRequestPolicyId": null,
@@ -67,7 +73,10 @@
       "HttpVersion": "http2",
       "IsIPV6Enabled": null,
       "Logging": null,
-      "OriginGroups": null,
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": null
+      },
       "PriceClass": "PriceClass_All",
       "Restrictions": null,
       "Staging": null,
@@ -84,10 +93,10 @@
       "ViewerMtlsConfig": null,
       "WebACLId": null
     },
-    "DomainName": "E1e6408bd-2ee2.cloudfront.net",
-    "Id": "E1e6408bd-2ee2",
+    "DomainName": "E53f71198-7d73.cloudfront.net",
+    "Id": "E53f71198-7d73",
     "InProgressInvalidationBatches": null,
-    "LastModifiedTime": "2026-06-12T15:24:36+09:00",
+    "LastModifiedTime": "2026-06-12T16:37:13+09:00",
     "Status": "InProgress",
     "ActiveTrustedKeyGroups": {
       "Enabled": false,
@@ -101,6 +110,6 @@
     },
     "AliasICPRecordals": null
   },
-  "ETag": "Ee2054771-4a53-43c0-8ade-90832ff6",
+  "ETag": "E50d50f90-9222-43b3-8e54-1034de06",
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/cloudtrail_test_TestCloudTrail_StartLoggingByARN_TestCloudTrail_StartLoggingByARN.golden.go
+++ b/test/integration/testdata/cloudtrail_test_TestCloudTrail_StartLoggingByARN_TestCloudTrail_StartLoggingByARN.golden.go
@@ -1,0 +1,20 @@
+{
+  "IsLogging": true,
+  "LatestCloudWatchLogsDeliveryError": null,
+  "LatestCloudWatchLogsDeliveryTime": null,
+  "LatestDeliveryAttemptSucceeded": null,
+  "LatestDeliveryAttemptTime": null,
+  "LatestDeliveryError": null,
+  "LatestDeliveryTime": null,
+  "LatestDigestDeliveryError": null,
+  "LatestDigestDeliveryTime": null,
+  "LatestNotificationAttemptSucceeded": null,
+  "LatestNotificationAttemptTime": null,
+  "LatestNotificationError": null,
+  "LatestNotificationTime": null,
+  "StartLoggingTime": null,
+  "StopLoggingTime": null,
+  "TimeLoggingStarted": null,
+  "TimeLoggingStopped": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/firehose_test_TestFirehose_ListTagsForDeliveryStream_TestFirehose_ListTagsForDeliveryStream.golden.go
+++ b/test/integration/testdata/firehose_test_TestFirehose_ListTagsForDeliveryStream_TestFirehose_ListTagsForDeliveryStream.golden.go
@@ -1,0 +1,14 @@
+{
+  "HasMoreTags": false,
+  "Tags": [
+    {
+      "Key": "app",
+      "Value": "idp"
+    },
+    {
+      "Key": "env",
+      "Value": "local"
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/firehose_test_TestFirehose_TagDeliveryStream_TestFirehose_TagDeliveryStream.golden.go
+++ b/test/integration/testdata/firehose_test_TestFirehose_TagDeliveryStream_TestFirehose_TagDeliveryStream.golden.go
@@ -1,0 +1,14 @@
+{
+  "HasMoreTags": false,
+  "Tags": [
+    {
+      "Key": "env",
+      "Value": "local"
+    },
+    {
+      "Key": "team",
+      "Value": "sec"
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/firehose_test_TestFirehose_UntagDeliveryStream_TestFirehose_UntagDeliveryStream.golden.go
+++ b/test/integration/testdata/firehose_test_TestFirehose_UntagDeliveryStream_TestFirehose_UntagDeliveryStream.golden.go
@@ -1,0 +1,10 @@
+{
+  "HasMoreTags": false,
+  "Tags": [
+    {
+      "Key": "env",
+      "Value": "local"
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/s3_test_TestS3_ObjectLock_PutAndGetConfiguration_TestS3_ObjectLock_PutAndGetConfiguration_configured.golden.go
+++ b/test/integration/testdata/s3_test_TestS3_ObjectLock_PutAndGetConfiguration_TestS3_ObjectLock_PutAndGetConfiguration_configured.golden.go
@@ -1,0 +1,13 @@
+{
+  "ObjectLockConfiguration": {
+    "ObjectLockEnabled": "Enabled",
+    "Rule": {
+      "DefaultRetention": {
+        "Days": 365,
+        "Mode": "COMPLIANCE",
+        "Years": null
+      }
+    }
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
Splits the read-back / tagging fixes out of #816. Each fix closes a gap that
made `terraform plan` show perpetual drift (or crash the AWS provider) after a
successful apply against kumo:

- **S3**: `PutObjectLockConfiguration` / `GetObjectLockConfiguration`
  subresource, persisted per bucket.
- **CloudTrail**: `StartLogging`/`StopLogging`/`GetTrailStatus` accept a trail
  ARN as the Name parameter (AWS-normalized lookup), and
  `AddTags`/`RemoveTags`/`ListTags` are implemented.
- **Firehose**: `TagDeliveryStream` / `UntagDeliveryStream` /
  `ListTagsForDeliveryStream`.
- **CloudFront**: `CreateDistributionWithTags` + `Tags` in `ListTagsForResource`;
  `DefaultCacheBehavior` read-back always carries `TrustedSigners` /
  `TrustedKeyGroups` / `CachedMethods`; empty `FunctionAssociations`,
  `LambdaFunctionAssociations` and `OriginGroups` blocks are always present
  (Quantity=0) as real CloudFront returns them — omitting them nil-panics
  terraform-provider-aws's flatteners.

Test plan: unit tests per service; golden-file integration tests for each new
operation (`TestS3_ObjectLock*`, `TestCloudTrail_*`, `TestFirehose_*Tag*`,
`TestCloudFront_*`).