### PR TITLE
test(lambda): cover event source mapping UUID path prefixes

### DIFF
--- a/internal/service/lambda/handlers_test.go
+++ b/internal/service/lambda/handlers_test.go
@@ -2,17 +2,21 @@ package lambda
 
 import "testing"
 
-func TestExtractEventSourceMappingUUID(t *testing.T) {
+func TestExtractEventSourceMappingUUIDWithEndpointPrefixes(t *testing.T) {
 	t.Parallel()
 
 	const mappingUUID = "12345678-1234-1234-1234-123456789012"
 
-	for _, path := range []string{
-		"/lambda/2015-03-31/event-source-mappings/" + mappingUUID,
-		"/2015-03-31/event-source-mappings/" + mappingUUID,
+	for name, path := range map[string]string{
+		"SDK BaseEndpoint":       "/lambda/2015-03-31/event-source-mappings/" + mappingUUID,
+		"terraform AWS provider": "/2015-03-31/event-source-mappings/" + mappingUUID,
 	} {
-		if got := extractEventSourceMappingUUID(path); got != mappingUUID {
-			t.Errorf("extractEventSourceMappingUUID(%q) = %q, want %q", path, got, mappingUUID)
-		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := extractEventSourceMappingUUID(path); got != mappingUUID {
+				t.Errorf("extractEventSourceMappingUUID(%q) = %q, want %q", path, got, mappingUUID)
+			}
+		})
 	}
 }

--- a/internal/service/lambda/handlers_test.go
+++ b/internal/service/lambda/handlers_test.go
@@ -1,0 +1,18 @@
+package lambda
+
+import "testing"
+
+func TestExtractEventSourceMappingUUID(t *testing.T) {
+	t.Parallel()
+
+	const mappingUUID = "12345678-1234-1234-1234-123456789012"
+
+	for _, path := range []string{
+		"/lambda/2015-03-31/event-source-mappings/" + mappingUUID,
+		"/2015-03-31/event-source-mappings/" + mappingUUID,
+	} {
+		if got := extractEventSourceMappingUUID(path); got != mappingUUID {
+			t.Errorf("extractEventSourceMappingUUID(%q) = %q, want %q", path, got, mappingUUID)
+		}
+	}
+}


### PR DESCRIPTION
Closes #708.

## Summary

- add regression coverage for the event source mapping UUID extraction fix already present in `08dede8`
- cover both the SDK `BaseEndpoint` path and the Terraform AWS provider path
- make no production-code changes

## Context

`08dede8` replaced the fixed path index with a search for the `event-source-mappings` segment, which fixed the prefix-less request path reported in #708. This PR adds the missing regression test so that behavior remains protected.

## Validation

- Unit tests: passed
- Integration tests: passed
- Lint: passed

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->