### PR TITLE
fix(s3): initialize MultipartUploads map for restored buckets

### DIFF
--- a/internal/service/s3/multipart_restore_test.go
+++ b/internal/service/s3/multipart_restore_test.go
@@ -1,0 +1,58 @@
+package s3
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestCreateMultipartUpload_AfterSnapshotRestore reproduces the regression
+// where CreateMultipartUpload panicked with "assignment to entry in nil map"
+// against a bucket restored from a persistence snapshot.
+//
+// MemoryBucket.MultipartUploads is tagged json:"-", so it is absent from the
+// snapshot and comes back nil after UnmarshalJSON. CreateBucket is the only
+// place that make()s the map, so a restored bucket (never re-created in the
+// running process) had a nil map and panicked on the first multipart upload.
+// UnmarshalJSON must re-initialize the map for every restored bucket.
+func TestCreateMultipartUpload_AfterSnapshotRestore(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// Build a snapshot from a store that owns one bucket, exactly as the
+	// persistence layer does on shutdown.
+	src := NewMemoryStorage()
+	if err := src.CreateBucket(ctx, "restore-test"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	snapshot, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+
+	// Restore into a fresh store, simulating a process restart.
+	restored := NewMemoryStorage()
+	if err := json.Unmarshal(snapshot, restored); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+
+	b, ok := restored.Buckets["restore-test"]
+	if !ok {
+		t.Fatalf("restored store is missing bucket %q", "restore-test")
+	}
+
+	if b.MultipartUploads == nil {
+		t.Fatalf("MultipartUploads was not re-initialized on restore (nil map)")
+	}
+
+	// This is the call that previously panicked on a restored bucket.
+	upload, err := restored.CreateMultipartUpload(ctx, "restore-test", "path/to/object", nil)
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload on restored bucket: %v", err)
+	}
+
+	if upload == nil || upload.UploadID == "" {
+		t.Fatalf("CreateMultipartUpload returned no upload: %+v", upload)
+	}
+}

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -233,6 +233,16 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 		s.Buckets = make(map[string]*MemoryBucket)
 	}
 
+	// MultipartUploads is tagged json:"-", so it is never present in the
+	// snapshot and comes back nil for every restored bucket. Re-initialize it
+	// here; otherwise the first CreateMultipartUpload against a restored bucket
+	// panics with "assignment to entry in nil map".
+	for _, b := range s.Buckets {
+		if b.MultipartUploads == nil {
+			b.MultipartUploads = make(map[string]*MultipartUpload)
+		}
+	}
+
 	if s.dataDir != "" {
 		if err := s.loadBodiesLocked(); err != nil {
 			return err


### PR DESCRIPTION
## Problem

`CreateMultipartUpload` panics with `assignment to entry in nil map` for any bucket that was restored from a persistence snapshot, and the client sees the connection closed with no response (`Empty reply from server` / EOF / `ECONNRESET`).

Root cause:

- `MemoryBucket.MultipartUploads` is tagged `json:"-"` (`internal/service/s3/storage.go`), so it is never written to the snapshot and comes back **nil** after `UnmarshalJSON`.
- The map is only `make()`d in `CreateBucket`. `UnmarshalJSON` re-initializes `s.Buckets` but not each bucket's `MultipartUploads`.
- So a bucket that exists only via restore (i.e. after a restart with `KUMO_DATA_DIR` persistence) has a nil map, and `b.MultipartUploads[uploadID] = upload` panics. `net/http` recovers per-connection and drops the socket, so the failure surfaces to clients as an empty reply rather than a 5xx.

`PutObject` and multipart against a bucket created *in the current process* work fine — the failure is specific to restored buckets, which is why it easily goes unnoticed until a restart.

## Fix

Re-initialize `MultipartUploads` for every restored bucket in `UnmarshalJSON` when it is nil.

## Test

Added `internal/service/s3/multipart_restore_test.go`: snapshots a store with one bucket, restores it into a fresh store, and asserts the map is non-nil and `CreateMultipartUpload` succeeds. The test fails (nil map) without the fix and passes with it.

- `make test` — pass (`go test -race ./...`)
- `make lint` — 0 issues

Also verified end-to-end against a real persisted volume: on the pre-fix image the restored bucket returns an empty reply and logs the nil-map panic; with this fix the same restored bucket returns `200` + `InitiateMultipartUploadResult` and no panic.