### PR TITLE
fix(dynamodb): always include requested tables in BatchGetItem Responses

### DIFF
--- a/internal/service/dynamodb/batch_get_item_response_test.go
+++ b/internal/service/dynamodb/batch_get_item_response_test.go
@@ -1,0 +1,152 @@
+package dynamodb
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// DynamoDB always includes every requested table in Responses (as an empty
+// list when no keys matched) and always includes UnprocessedKeys, even when
+// empty. Verified against amazon/dynamodb-local:
+//
+//	{"Responses":{"table":[]},"UnprocessedKeys":{}}
+//
+// These tests assert on the raw JSON body because SDK-side unmarshalling
+// masks omitted fields.
+//
+//nolint:funlen // Exercises the response shape across all hit/miss combinations.
+func TestBatchGetItemResponseShape(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage("http://localhost:4566")
+	svc := New(store)
+
+	for _, tableName := range []string{"batch-get-hit", "batch-get-miss"} {
+		if _, err := store.CreateTable(t.Context(), &CreateTableRequest{
+			TableName: tableName,
+			KeySchema: []KeySchemaElement{
+				{AttributeName: "pk", KeyType: "HASH"},
+			},
+			AttributeDefinitions: []AttributeDefinition{
+				{AttributeName: "pk", AttributeType: "S"},
+			},
+		}); err != nil {
+			t.Fatalf("CreateTable: %v", err)
+		}
+	}
+
+	if _, err := store.PutItem(t.Context(), "batch-get-hit", Item{
+		"pk":   {S: ptr("existing")},
+		"name": {S: ptr("value")},
+	}, false, ConditionInput{}); err != nil {
+		t.Fatalf("PutItem: %v", err)
+	}
+
+	t.Run("all keys miss", func(t *testing.T) {
+		t.Parallel()
+
+		req := `{
+			"RequestItems":{
+				"batch-get-miss":{"Keys":[{"pk":{"S":"nope-1"}},{"pk":{"S":"nope-2"}}]}
+			}
+		}`
+
+		responses, unprocessed := dispatchBatchGetItemRaw(t, svc, req)
+
+		items, ok := responses["batch-get-miss"]
+		if !ok {
+			t.Fatalf("Responses must include the requested table even with zero matches, got keys: %v", responseKeys(responses))
+		}
+
+		if len(items) != 0 {
+			t.Fatalf("Responses[batch-get-miss] length: got %d, want 0", len(items))
+		}
+
+		if unprocessed == nil {
+			t.Fatal("UnprocessedKeys must be present (as {}) even when empty")
+		}
+	})
+
+	t.Run("hit and miss mixed", func(t *testing.T) {
+		t.Parallel()
+
+		req := `{
+			"RequestItems":{
+				"batch-get-hit":{"Keys":[{"pk":{"S":"existing"}},{"pk":{"S":"nope"}}]}
+			}
+		}`
+
+		responses, _ := dispatchBatchGetItemRaw(t, svc, req)
+
+		if got, want := len(responses["batch-get-hit"]), 1; got != want {
+			t.Fatalf("Responses[batch-get-hit] length: got %d, want %d", got, want)
+		}
+	})
+
+	t.Run("multiple tables with one empty", func(t *testing.T) {
+		t.Parallel()
+
+		req := `{
+			"RequestItems":{
+				"batch-get-hit":{"Keys":[{"pk":{"S":"existing"}}]},
+				"batch-get-miss":{"Keys":[{"pk":{"S":"nope"}}]}
+			}
+		}`
+
+		responses, _ := dispatchBatchGetItemRaw(t, svc, req)
+
+		if got, want := len(responses["batch-get-hit"]), 1; got != want {
+			t.Fatalf("Responses[batch-get-hit] length: got %d, want %d", got, want)
+		}
+
+		items, ok := responses["batch-get-miss"]
+		if !ok {
+			t.Fatalf("Responses must include all requested tables, got keys: %v", responseKeys(responses))
+		}
+
+		if len(items) != 0 {
+			t.Fatalf("Responses[batch-get-miss] length: got %d, want 0", len(items))
+		}
+	})
+}
+
+func dispatchBatchGetItemRaw(t *testing.T, svc *Service, body string) (map[string][]json.RawMessage, map[string]json.RawMessage) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.BatchGetItem")
+
+	w := httptest.NewRecorder()
+	svc.DispatchAction(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("BatchGetItem status: got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var raw struct {
+		Responses       map[string][]json.RawMessage `json:"Responses"`       //nolint:tagliatelle // DynamoDB wire format uses PascalCase.
+		UnprocessedKeys map[string]json.RawMessage   `json:"UnprocessedKeys"` //nolint:tagliatelle // DynamoDB wire format uses PascalCase.
+	}
+
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, w.Body.String())
+	}
+
+	if raw.Responses == nil {
+		t.Fatalf("Responses field is missing from response body: %s", w.Body.String())
+	}
+
+	return raw.Responses, raw.UnprocessedKeys
+}
+
+func responseKeys(responses map[string][]json.RawMessage) []string {
+	keys := make([]string, 0, len(responses))
+	for k := range responses {
+		keys = append(keys, k)
+	}
+
+	return keys
+}

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -841,7 +841,10 @@ func (s *Service) BatchGetItem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writeJSONResponse(w, BatchGetItemResponse{Responses: responses})
+	writeJSONResponse(w, BatchGetItemResponse{
+		Responses:       responses,
+		UnprocessedKeys: map[string]KeysAndAttributes{},
+	})
 }
 
 // DispatchAction routes the request to the appropriate handler based on X-Amz-Target header.

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -2154,7 +2154,9 @@ func (m *MemoryStorage) BatchGetItem(_ context.Context, requestItems map[string]
 			}
 		}
 
-		var items []Item
+		// DynamoDB includes every requested table in Responses, as an empty
+		// list when none of the keys matched.
+		items := make([]Item, 0, len(ka.Keys))
 
 		for _, key := range ka.Keys {
 			if err := validateKey(td.Table, key); err != nil {
@@ -2167,9 +2169,7 @@ func (m *MemoryStorage) BatchGetItem(_ context.Context, requestItems map[string]
 			}
 		}
 
-		if len(items) > 0 {
-			responses[tableName] = items
-		}
+		responses[tableName] = items
 	}
 
 	return responses, nil

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -597,9 +597,10 @@ type KeysAndAttributes struct {
 }
 
 // BatchGetItemResponse is the response for BatchGetItem.
+// DynamoDB always serializes both fields, even when empty.
 type BatchGetItemResponse struct {
-	Responses       map[string][]Item            `json:"Responses,omitempty"`
-	UnprocessedKeys map[string]KeysAndAttributes `json:"UnprocessedKeys,omitempty"`
+	Responses       map[string][]Item            `json:"Responses"`
+	UnprocessedKeys map[string]KeysAndAttributes `json:"UnprocessedKeys"`
 }
 
 // ErrorResponse represents a DynamoDB error response in JSON format.

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_BatchGetItem_TestDynamoDB_BatchGetItem.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_BatchGetItem_TestDynamoDB_BatchGetItem.golden.go
@@ -20,6 +20,6 @@
       }
     ]
   },
-  "UnprocessedKeys": null,
+  "UnprocessedKeys": {},
   "ResultMetadata": {}
 }


### PR DESCRIPTION
## Summary

`BatchGetItem` omits the per-table key from `Responses` when none of the requested keys matched, and drops both `Responses` and `UnprocessedKeys` entirely via `omitempty` — an all-miss request returns `{}`.

Real DynamoDB always includes every requested table (as an empty list) and always serializes `UnprocessedKeys`, even when empty.

## Actual vs. expected

All-miss `BatchGetItem` (2 non-existent keys), captured against `amazon/dynamodb-local`:

```json
{"Responses":{"golden-raw-card-transactions":[]},"UnprocessedKeys":{}}
```

Same request against kumo (v0.26.0 and current `main`):

```json
{}
```

moto's reference implementation matches dynamodb-local: it unconditionally seeds `results["Responses"][table_name] = []` before iterating keys ([moto/dynamodb/responses.py](https://github.com/getmoto/moto/blob/master/moto/dynamodb/responses.py)).

## Why it matters

SDK client code commonly distinguishes "table present with zero matches" from "table missing" via key presence:

```go
avMaps, ok := res.Responses[tableName]
if !ok {
    return nil, errors.New("unexpected response from dynamodb")
}
```

This pattern works against real DynamoDB but breaks against kumo whenever a batch lookup has zero hits — e.g. an idempotency pre-check on the first import of a dataset, which is exactly how we hit this.

## Changes

- `storage.go`: build `items` as a non-nil empty slice and always set `responses[tableName]`, so zero-match tables serialize as `[]` instead of disappearing.
- `types.go`: drop `omitempty` from `BatchGetItemResponse.Responses` / `UnprocessedKeys` — DynamoDB always serializes both.
- `handlers.go`: initialize `UnprocessedKeys` to an empty map so it serializes as `{}` rather than `null`.

## Tests

- New `TestBatchGetItemResponseShape` asserts on the raw JSON body (SDK-side unmarshalling would mask omitted fields): all-miss, hit+miss mixed, and multi-table with one empty table.
- `make test` and `make lint` pass.

## Note

`BatchWriteItemResponse.UnprocessedItems` has the same class of issue (`omitempty`, real DynamoDB returns `"UnprocessedItems":{}`). Left out to keep this change focused — happy to send a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
