### PR TITLE
fix: persist create-time tags for DynamoDB, EventBridge, and SNS

### DIFF
--- a/internal/server/awsquery.go
+++ b/internal/server/awsquery.go
@@ -239,6 +239,9 @@ func formToJSON(form map[string][]string) []byte {
 		result[keyName] = arr
 	}
 
+	// Handle struct-list patterns like Tags.member.N.Key/Value.
+	result = flattenMemberStructs(result)
+
 	// Handle nested attributes (like Attributes.entry.N.key/value).
 	result = flattenAttributes(result)
 
@@ -265,6 +268,91 @@ func parseFormValue(s string) any {
 
 	// Return as string.
 	return s
+}
+
+// flattenMemberStructs converts "<Base>.member.<N>.<Field>" form keys into an
+// array of objects, e.g. Tags.member.1.Key / Tags.member.1.Value becomes
+// {"Tags": [{"Key": "...", "Value": "..."}]}.
+//
+// Plain scalar member lists (e.g. Subnets.member.1) are already consumed by
+// the numeric indexed-array pass in formToJSON and never reach this
+// function. Entry-based patterns (Attributes.entry.N, MessageAttributes.entry.N)
+// use ".entry." rather than ".member." and are handled by their own flatten
+// functions, so there is no overlap.
+func flattenMemberStructs(data map[string]any) map[string]any {
+	result := make(map[string]any)
+	groups := make(map[string]map[int]map[string]any) // base -> index -> field -> value
+
+	for key, value := range data {
+		base, idx, field, ok := parseMemberStructKey(key)
+		if !ok {
+			result[key] = value
+
+			continue
+		}
+
+		if groups[base] == nil {
+			groups[base] = make(map[int]map[string]any)
+		}
+
+		if groups[base][idx] == nil {
+			groups[base][idx] = make(map[string]any)
+		}
+
+		groups[base][idx][field] = value
+	}
+
+	for base, byIndex := range groups {
+		indices := make([]int, 0, len(byIndex))
+		for i := range byIndex {
+			indices = append(indices, i)
+		}
+
+		sort.Ints(indices)
+
+		arr := make([]map[string]any, 0, len(indices))
+		for _, i := range indices {
+			arr = append(arr, byIndex[i])
+		}
+
+		result[base] = arr
+	}
+
+	return result
+}
+
+// parseMemberStructKey parses a "<Base>.member.<N>.<Field>" key, where Field
+// is a single path segment with no further dots. ok is false for any other
+// shape of key.
+func parseMemberStructKey(key string) (base string, index int, field string, ok bool) {
+	const marker = ".member."
+
+	memberIdx := strings.Index(key, marker)
+	if memberIdx < 0 {
+		return "", 0, "", false
+	}
+
+	base = key[:memberIdx]
+	rest := key[memberIdx+len(marker):] // "<N>.<Field>"
+
+	dotIdx := strings.Index(rest, ".")
+	if dotIdx < 0 {
+		return "", 0, "", false
+	}
+
+	idxStr := rest[:dotIdx]
+	field = rest[dotIdx+1:]
+
+	if strings.Contains(field, ".") {
+		return "", 0, "", false
+	}
+
+	n, err := strconv.Atoi(idxStr)
+	if err != nil {
+		return "", 0, "", false
+	}
+
+	return base, n, field, true
 }
 
 // flattenAttributes converts nested Query protocol attributes to JSON format.

--- a/internal/server/awsquery_test.go
+++ b/internal/server/awsquery_test.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -249,5 +252,72 @@ func TestQueryDispatcher_UnknownAction(t *testing.T) {
 
 	if !strings.Contains(rec.Body.String(), "UnknownAction") {
 		t.Errorf("expected UnknownAction error, got %s", rec.Body.String())
+	}
+}
+
+// formToJSONTests covers the form-to-JSON conversions that
+// QueryProtocolDispatcher relies on before dispatching to a JSON protocol
+// handler.
+var formToJSONTests = []struct {
+	name string
+	form url.Values
+	want map[string]any
+}{
+	{
+		name: "scalar member list",
+		form: url.Values{
+			"Subnets.member.1": {"subnet-1"},
+			"Subnets.member.2": {"subnet-2"},
+		},
+		want: map[string]any{
+			"Subnets": []any{"subnet-1", "subnet-2"},
+		},
+	},
+	{
+		name: "struct member list (Tags)",
+		form: url.Values{
+			"Action":              {"CreateTopic"},
+			"Tags.member.1.Key":   {"env"},
+			"Tags.member.1.Value": {"terraform"},
+			"Tags.member.2.Key":   {"team"},
+			"Tags.member.2.Value": {"platform"},
+		},
+		want: map[string]any{
+			"Tags": []any{
+				map[string]any{"Key": "env", "Value": "terraform"},
+				map[string]any{"Key": "team", "Value": "platform"},
+			},
+		},
+	},
+	{
+		name: "Attributes.entry still works",
+		form: url.Values{
+			"Attributes.entry.1.key":   {"VisibilityTimeout"},
+			"Attributes.entry.1.value": {"30"},
+		},
+		want: map[string]any{
+			"Attributes": map[string]any{"VisibilityTimeout": "30"},
+		},
+	},
+}
+
+func TestFormToJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range formToJSONTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := formToJSON(tt.form)
+
+			var gotMap map[string]any
+			if err := json.Unmarshal(got, &gotMap); err != nil {
+				t.Fatalf("failed to unmarshal formToJSON output %s: %v", got, err)
+			}
+
+			if !reflect.DeepEqual(gotMap, tt.want) {
+				t.Errorf("formToJSON(%v) = %v, want %v", tt.form, gotMap, tt.want)
+			}
+		})
 	}
 }

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -268,6 +268,10 @@ func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) 
 		Items: make(map[string]Item),
 	}
 
+	if len(req.Tags) > 0 {
+		m.Tags[table.TableARN] = req.Tags
+	}
+
 	m.saveLocked()
 
 	return table, nil

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -263,6 +263,7 @@ type CreateTableRequest struct {
 	BillingMode               string                 `json:"BillingMode,omitempty"`
 	DeletionProtectionEnabled bool                   `json:"DeletionProtectionEnabled,omitempty"`
 	StreamSpecification       *StreamSpecification   `json:"StreamSpecification,omitempty"`
+	Tags                      []Tag                  `json:"Tags,omitempty"`
 }
 
 // CreateTableResponse is the response for CreateTable.

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -378,6 +378,10 @@ func (s *MemoryStorage) PutRule(_ context.Context, req *PutRuleRequest) (*Rule, 
 
 	s.Rules[eventBusName][req.Name] = rule
 
+	if len(req.Tags) > 0 {
+		s.Tags[rule.Arn] = req.Tags
+	}
+
 	s.saveLocked()
 
 	return rule, nil

--- a/internal/service/eventbridge/types.go
+++ b/internal/service/eventbridge/types.go
@@ -185,6 +185,7 @@ type PutRuleRequest struct {
 	State              string `json:"State,omitempty"`
 	Description        string `json:"Description,omitempty"`
 	RoleArn            string `json:"RoleArn,omitempty"`
+	Tags               []Tag  `json:"Tags,omitempty"`
 }
 
 // PutRuleResponse is the response for PutRule.

--- a/internal/service/sns/handlers.go
+++ b/internal/service/sns/handlers.go
@@ -36,7 +36,7 @@ func (s *Service) CreateTopic(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topic, err := s.storage.CreateTopic(r.Context(), req.Name, req.Attributes)
+	topic, err := s.storage.CreateTopic(r.Context(), req.Name, req.Attributes, req.Tags)
 	if err != nil {
 		var sErr *TopicError
 		if errors.As(err, &sErr) {

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -28,7 +28,7 @@ type SQSPublisher interface {
 
 // Storage defines the SNS storage interface.
 type Storage interface {
-	CreateTopic(ctx context.Context, name string, attributes map[string]string) (*Topic, error)
+	CreateTopic(ctx context.Context, name string, attributes map[string]string, tags []Tag) (*Topic, error)
 	GetTopic(ctx context.Context, topicARN string) (*Topic, error)
 	SetTopicAttribute(ctx context.Context, topicARN, name, value string) error
 	DeleteTopic(ctx context.Context, topicARN string) error
@@ -40,6 +40,9 @@ type Storage interface {
 	Publish(ctx context.Context, topicARN, message, subject, messageGroupID, messageDeduplicationID string, attributes map[string]MessageAttribute) (string, error)
 	ListSubscriptions(ctx context.Context, nextToken string) ([]*Subscription, string, error)
 	ListSubscriptionsByTopic(ctx context.Context, topicARN, nextToken string) ([]*Subscription, string, error)
+	ListTagsForResource(ctx context.Context, resourceArn string) ([]Tag, error)
+	TagResource(ctx context.Context, resourceArn string, tags []Tag) error
+	UntagResource(ctx context.Context, resourceArn string, tagKeys []string) error
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -61,8 +64,9 @@ var (
 // MemoryStorage implements Storage with in-memory data.
 type MemoryStorage struct {
 	mu            sync.RWMutex             `json:"-"`
-	Topics        map[string]*Topic        `json:"topics"`        // keyed by ARN
-	Subscriptions map[string]*Subscription `json:"subscriptions"` // keyed by ARN
+	Topics        map[string]*Topic        `json:"topics"`         // keyed by ARN
+	Subscriptions map[string]*Subscription `json:"subscriptions"`  // keyed by ARN
+	Tags          map[string][]Tag         `json:"tags,omitempty"` // keyed by resource ARN
 	baseURL       string
 	SqsPublisher  SQSPublisher `json:"-"`
 	dataDir       string
@@ -73,6 +77,7 @@ func NewMemoryStorage(baseURL string, opts ...Option) *MemoryStorage {
 	s := &MemoryStorage{
 		Topics:        make(map[string]*Topic),
 		Subscriptions: make(map[string]*Subscription),
+		Tags:          make(map[string][]Tag),
 		baseURL:       baseURL,
 	}
 	for _, o := range opts {
@@ -122,6 +127,10 @@ func (m *MemoryStorage) UnmarshalJSON(data []byte) error {
 		m.Subscriptions = make(map[string]*Subscription)
 	}
 
+	if m.Tags == nil {
+		m.Tags = make(map[string][]Tag)
+	}
+
 	return nil
 }
 
@@ -153,7 +162,7 @@ func (m *MemoryStorage) SetSQSPublisher(publisher SQSPublisher) {
 }
 
 // CreateTopic creates a new topic.
-func (m *MemoryStorage) CreateTopic(_ context.Context, name string, attributes map[string]string) (*Topic, error) {
+func (m *MemoryStorage) CreateTopic(_ context.Context, name string, attributes map[string]string, tags []Tag) (*Topic, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -177,6 +186,10 @@ func (m *MemoryStorage) CreateTopic(_ context.Context, name string, attributes m
 		CreatedTime:   time.Now(),
 		Attributes:    attributes,
 		Subscriptions: make(map[string]*Subscription),
+	}
+
+	if len(tags) > 0 {
+		m.Tags[arn] = tags
 	}
 
 	if attributes != nil {
@@ -256,6 +269,90 @@ func (m *MemoryStorage) DeleteTopic(_ context.Context, topicARN string) error {
 	}
 
 	delete(m.Topics, topicARN)
+	delete(m.Tags, topicARN)
+
+	m.saveLocked()
+
+	return nil
+}
+
+// ListTagsForResource returns the tags for a given resource ARN.
+func (m *MemoryStorage) ListTagsForResource(_ context.Context, resourceArn string) ([]Tag, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	tags, ok := m.Tags[resourceArn]
+	if !ok {
+		return []Tag{}, nil
+	}
+
+	result := make([]Tag, len(tags))
+	copy(result, tags)
+
+	return result, nil
+}
+
+// TagResource adds or overwrites tags on a resource ARN.
+func (m *MemoryStorage) TagResource(_ context.Context, resourceArn string, tags []Tag) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	existing := m.Tags[resourceArn]
+
+	for _, tag := range tags {
+		replaced := false
+
+		for i, e := range existing {
+			if e.Key == tag.Key {
+				existing[i] = tag
+				replaced = true
+
+				break
+			}
+		}
+
+		if !replaced {
+			existing = append(existing, tag)
+		}
+	}
+
+	m.Tags[resourceArn] = existing
+
+	m.saveLocked()
+
+	return nil
+}
+
+// UntagResource removes the given tag keys from a resource ARN.
+func (m *MemoryStorage) UntagResource(_ context.Context, resourceArn string, tagKeys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	existing, exists := m.Tags[resourceArn]
+	if !exists {
+		return nil
+	}
+
+	remove := make(map[string]struct{}, len(tagKeys))
+	for _, k := range tagKeys {
+		remove[k] = struct{}{}
+	}
+
+	remaining := make([]Tag, 0, len(existing))
+
+	for _, tag := range existing {
+		if _, drop := remove[tag.Key]; drop {
+			continue
+		}
+
+		remaining = append(remaining, tag)
+	}
+
+	if len(remaining) == 0 {
+		delete(m.Tags, resourceArn)
+	} else {
+		m.Tags[resourceArn] = remaining
+	}
 
 	m.saveLocked()
 

--- a/internal/service/sns/storage_delivery_test.go
+++ b/internal/service/sns/storage_delivery_test.go
@@ -35,7 +35,7 @@ func newTopicWithSQSSubscription(t *testing.T, publisher SQSPublisher, subAttrs 
 
 	ctx := context.Background()
 
-	topic, err := storage.CreateTopic(ctx, "test-topic", nil)
+	topic, err := storage.CreateTopic(ctx, "test-topic", nil, nil)
 	if err != nil {
 		t.Fatalf("CreateTopic() error = %v", err)
 	}

--- a/internal/service/sns/storage_test.go
+++ b/internal/service/sns/storage_test.go
@@ -19,7 +19,7 @@ func TestCreateTopicRejectsDelimiterNames(t *testing.T) {
 
 			store := NewMemoryStorage("http://localhost:4566")
 
-			_, err := store.CreateTopic(t.Context(), name, nil)
+			_, err := store.CreateTopic(t.Context(), name, nil, nil)
 			expectTopicErrorCode(t, err, "InvalidParameter")
 		})
 	}
@@ -31,7 +31,7 @@ func TestCreateTopicAcceptsValidNames(t *testing.T) {
 	store := NewMemoryStorage("http://localhost:4566")
 
 	for _, name := range []string{"topic_name-1", "topic-name.fifo"} {
-		topic, err := store.CreateTopic(t.Context(), name, nil)
+		topic, err := store.CreateTopic(t.Context(), name, nil, nil)
 		if err != nil {
 			t.Fatalf("CreateTopic(%q): %v", name, err)
 		}

--- a/internal/service/sns/topic_attributes.go
+++ b/internal/service/sns/topic_attributes.go
@@ -143,24 +143,90 @@ func (s *Service) GetTopicAttributes(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// ListTagsForResource returns an empty tag list for any topic.
-func (s *Service) ListTagsForResource(w http.ResponseWriter, _ *http.Request) {
+// ListTagsForResource returns the tags stored for the given resource ARN.
+func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
+	var req listTagsForResourceRequest
+	if err := service.ReadJSONRequest(r, &req); err != nil {
+		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResourceArn == "" {
+		writeTopicError(w, errInvalidParameter, "ResourceArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	tags, err := s.storage.ListTagsForResource(r.Context(), req.ResourceArn)
+	if err != nil {
+		handleTopicError(w, err)
+
+		return
+	}
+
+	members := make([]XMLTag, 0, len(tags))
+	for _, t := range tags {
+		members = append(members, XMLTag(t))
+	}
+
 	writeXMLResponse(w, XMLListTagsForResourceResponse{
-		Xmlns:            snsXMLNS,
+		Xmlns: snsXMLNS,
+		ListTagsForResourceResult: XMLListTagsForResourceResult{
+			Tags: XMLTagList{Member: members},
+		},
 		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
 	})
 }
 
-// TagResource accepts and discards tag attachments.
-func (s *Service) TagResource(w http.ResponseWriter, _ *http.Request) {
+// TagResource adds or overwrites tags on a resource ARN.
+func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
+	var req tagResourceRequest
+	if err := service.ReadJSONRequest(r, &req); err != nil {
+		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResourceArn == "" {
+		writeTopicError(w, errInvalidParameter, "ResourceArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.TagResource(r.Context(), req.ResourceArn, req.Tags); err != nil {
+		handleTopicError(w, err)
+
+		return
+	}
+
 	writeXMLResponse(w, XMLTagResourceResponse{
 		Xmlns:            snsXMLNS,
 		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},
 	})
 }
 
-// UntagResource accepts and discards tag detachments.
-func (s *Service) UntagResource(w http.ResponseWriter, _ *http.Request) {
+// UntagResource removes tags from a resource ARN.
+func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
+	var req untagResourceRequest
+	if err := service.ReadJSONRequest(r, &req); err != nil {
+		writeTopicError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.ResourceArn == "" {
+		writeTopicError(w, errInvalidParameter, "ResourceArn is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.UntagResource(r.Context(), req.ResourceArn, req.TagKeys); err != nil {
+		handleTopicError(w, err)
+
+		return
+	}
+
 	writeXMLResponse(w, XMLUntagResourceResponse{
 		Xmlns:            snsXMLNS,
 		ResponseMetadata: ResponseMetadata{RequestID: uuid.New().String()},

--- a/internal/service/sns/types.go
+++ b/internal/service/sns/types.go
@@ -332,8 +332,7 @@ type XMLAttributeEntry struct {
 	Value string `xml:"value"`
 }
 
-// XMLListTagsForResourceResponse mirrors the AWS shape; the Tags member is
-// always an empty member list because tag storage is not modeled.
+// XMLListTagsForResourceResponse is the XML response for ListTagsForResource.
 type XMLListTagsForResourceResponse struct {
 	XMLName                   struct{}                     `xml:"ListTagsForResourceResponse"`
 	Xmlns                     string                       `xml:"xmlns,attr"`
@@ -341,7 +340,7 @@ type XMLListTagsForResourceResponse struct {
 	ResponseMetadata          ResponseMetadata             `xml:"ResponseMetadata"`
 }
 
-// XMLListTagsForResourceResult contains the (always empty) tag list.
+// XMLListTagsForResourceResult contains the tag list.
 type XMLListTagsForResourceResult struct {
 	Tags XMLTagList `xml:"Tags"`
 }
@@ -421,6 +420,23 @@ type setTopicAttributesRequest struct {
 // dispatcher converts the form-encoded body to JSON.
 type getTopicAttributesRequest struct {
 	TopicArn string `json:"TopicArn"`
+}
+
+// listTagsForResourceRequest is the request for ListTagsForResource.
+type listTagsForResourceRequest struct {
+	ResourceArn string `json:"ResourceArn"`
+}
+
+// tagResourceRequest is the request for TagResource.
+type tagResourceRequest struct {
+	ResourceArn string `json:"ResourceArn"`
+	Tags        []Tag  `json:"Tags"`
+}
+
+// untagResourceRequest is the request for UntagResource.
+type untagResourceRequest struct {
+	ResourceArn string   `json:"ResourceArn"`
+	TagKeys     []string `json:"TagKeys"`
 }
 
 // snsNotificationEnvelope is the JSON envelope AWS wraps around messages


### PR DESCRIPTION
## Summary
Persist tags supplied at resource creation time so Terraform can read them back after apply. This fixes the failing terraform integration tests on main.

- DynamoDB CreateTable / EventBridge PutRule store Tags into the existing ARN-keyed tag maps
- AWS Query form parser converts Tags.member.N.Key/Value struct lists into JSON arrays
- SNS persists tags: create-time tags on CreateTopic, and TagResource/UntagResource/ListTagsForResource are now real implementations instead of stubs

## Test plan
- [ ] Unit tests for formToJSON struct lists and SNS tag storage pass
- [ ] Integration CI (terraform fixtures) is green again