### PR TITLE
fix(sfn): lowercase execution ARN segment and report States.Runtime for engine failures

### DIFF
--- a/internal/service/sfn/execution_error_test.go
+++ b/internal/service/sfn/execution_error_test.go
@@ -1,0 +1,131 @@
+package sfn
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+const executionTestDefinition = `{
+	"StartAt": "Done",
+	"States": {
+		"Done": {"Type": "Pass", "End": true}
+	}
+}`
+
+func TestStartExecutionARNUsesLowercaseExecutionSegment(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "arn-casing", executionTestDefinition)
+
+	exec, err := store.StartExecution(context.Background(), sm.StateMachineArn, "run1", "{}", "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	if !strings.Contains(exec.ExecutionArn, ":execution:") {
+		t.Fatalf("execution ARN %q must use the lowercase :execution: segment", exec.ExecutionArn)
+	}
+}
+
+func TestFailedExecutionReportsRuntimeErrorForUnsupportedState(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Decide",
+		"States": {
+			"Decide": {
+				"Type": "Choice",
+				"Choices": [{"Variable": "$.mode", "StringEquals": "fast", "Next": "Done"}],
+				"Default": "Done"
+			},
+			"Done": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "runtime-error", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn)
+
+	if exec.Error != errorStatesRuntime {
+		t.Fatalf("engine failure error code: got %q, want %q (cause: %s)", exec.Error, errorStatesRuntime, exec.Cause)
+	}
+}
+
+func TestFailedExecutionReportsTaskFailedForTaskInvocationError(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "CallLambda",
+		"States": {
+			"CallLambda": {
+				"Type": "Task",
+				"Resource": "arn:aws:states:::lambda:invoke",
+				"Parameters": {"FunctionName": "missing-function"},
+				"End": true
+			}
+		}
+	}`
+
+	// The engine's base URL points at a closed port, so the task invocation
+	// itself fails and must surface as States.TaskFailed.
+	store := NewMemoryStorage(WithBaseURL("http://127.0.0.1:1"))
+	sm := createExecutionTestStateMachine(t, store, "task-error", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn)
+
+	if exec.Error != errorStatesTaskFailed {
+		t.Fatalf("task failure error code: got %q, want %q (cause: %s)", exec.Error, errorStatesTaskFailed, exec.Cause)
+	}
+}
+
+func createExecutionTestStateMachine(t *testing.T, store *MemoryStorage, name, definition string) *StateMachine {
+	t.Helper()
+
+	sm, err := store.CreateStateMachine(context.Background(), &CreateStateMachineRequest{
+		Name:       name,
+		Definition: definition,
+		RoleArn:    "arn:aws:iam::000000000000:role/sfn-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateStateMachine: %v", err)
+	}
+
+	return sm
+}
+
+func startAndAwaitFailure(t *testing.T, store *MemoryStorage, stateMachineArn string) *Execution {
+	t.Helper()
+
+	ctx := context.Background()
+
+	started, err := store.StartExecution(ctx, stateMachineArn, "", "{}", "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		exec, err := store.DescribeExecution(ctx, started.ExecutionArn)
+		if err != nil {
+			t.Fatalf("DescribeExecution: %v", err)
+		}
+
+		if exec.Status == ExecutionStatusFailed {
+			return exec
+		}
+
+		if exec.Status != ExecutionStatusRunning {
+			t.Fatalf("execution ended with status %q, want FAILED", exec.Status)
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("execution did not fail within the deadline")
+
+	return nil
+}

--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -35,6 +36,35 @@ type stateDefinition struct {
 	InputPath  *string        `json:"InputPath"`
 	OutputPath *string        `json:"OutputPath"`
 	Comment    string         `json:"Comment"`
+}
+
+// Execution error codes surfaced via DescribeExecution. States.TaskFailed is
+// reserved for failures of a Task state's work itself; every engine-level
+// failure (unsupported state, bad definition wiring) is States.Runtime.
+const (
+	errorStatesRuntime    = "States.Runtime"
+	errorStatesTaskFailed = "States.TaskFailed"
+)
+
+// taskFailedError marks a failure of the task invocation itself so the
+// execution reports States.TaskFailed instead of States.Runtime.
+type taskFailedError struct {
+	err error
+}
+
+func (e *taskFailedError) Error() string { return e.err.Error() }
+
+func (e *taskFailedError) Unwrap() error { return e.err }
+
+// executionErrorCode maps an engine error to the Step Functions error code
+// reported on the failed execution.
+func executionErrorCode(err error) string {
+	var taskErr *taskFailedError
+	if errors.As(err, &taskErr) {
+		return errorStatesTaskFailed
+	}
+
+	return errorStatesRuntime
 }
 
 // executionEngine executes a state machine definition.
@@ -141,12 +171,22 @@ func (e *executionEngine) executeTaskState(ctx context.Context, name string, sta
 
 	switch resource {
 	case "arn:aws:states:::sqs:sendMessage":
-		return e.executeSQSSendMessage(ctx, params)
+		return wrapTaskResult(e.executeSQSSendMessage(ctx, params))
 	case "arn:aws:states:::lambda:invoke":
-		return e.executeLambdaInvoke(ctx, params)
+		return wrapTaskResult(e.executeLambdaInvoke(ctx, params))
 	default:
 		return "", fmt.Errorf("unsupported task resource %q", resource)
 	}
+}
+
+// wrapTaskResult wraps a task invocation failure in taskFailedError so it is
+// reported as States.TaskFailed.
+func wrapTaskResult(output string, err error) (string, error) {
+	if err != nil {
+		return "", &taskFailedError{err: err}
+	}
+
+	return output, nil
 }
 
 // resolveParameters resolves parameter values, handling JSONPath references

--- a/internal/service/sfn/storage.go
+++ b/internal/service/sfn/storage.go
@@ -301,7 +301,7 @@ func (s *MemoryStorage) StartExecution(_ context.Context, stateMachineArn, name,
 		execName = uuid.New().String()
 	}
 
-	executionArn := fmt.Sprintf("arn:aws:states:%s:%s:Execution:%s:%s", s.region, s.accountID, sm.Name, execName)
+	executionArn := fmt.Sprintf("arn:aws:states:%s:%s:execution:%s:%s", s.region, s.accountID, sm.Name, execName)
 
 	if _, exists := s.Executions[executionArn]; exists {
 		return nil, &ServiceError{Code: errExecutionAlreadyExists, Message: "Execution already exists"}
@@ -330,7 +330,7 @@ func (s *MemoryStorage) StartExecution(_ context.Context, stateMachineArn, name,
 
 	go s.runExecution(ed, definition, input, startID)
 
-	return exec, nil
+	return copyExecution(exec), nil
 }
 
 // runExecution executes the state machine in a background goroutine.
@@ -340,14 +340,14 @@ func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string
 
 	def, err := parseDefinition(definition)
 	if err != nil {
-		s.failExecution(ed, lastEventID, "States.Runtime", fmt.Sprintf("Failed to parse definition: %v", err))
+		s.failExecution(ed, lastEventID, errorStatesRuntime, fmt.Sprintf("Failed to parse definition: %v", err))
 
 		return
 	}
 
 	output, err := s.engine.execute(ctx, def, input)
 	if err != nil {
-		s.failExecution(ed, lastEventID, "States.TaskFailed", err.Error())
+		s.failExecution(ed, lastEventID, executionErrorCode(err), err.Error())
 
 		return
 	}
@@ -413,6 +413,15 @@ func (s *MemoryStorage) createExecution(arn, smArn, name, input, traceHeader str
 	}
 }
 
+// copyExecution returns a shallow copy of an execution so callers never hold
+// a pointer that the background execution goroutine keeps mutating. Writers
+// only assign whole field values, so a shallow copy is race-free.
+func copyExecution(e *Execution) *Execution {
+	c := *e
+
+	return &c
+}
+
 // StopExecution stops an execution.
 func (s *MemoryStorage) StopExecution(_ context.Context, executionArn, errorCode, cause string) (*Execution, error) {
 	s.mu.Lock()
@@ -425,7 +434,7 @@ func (s *MemoryStorage) StopExecution(_ context.Context, executionArn, errorCode
 
 	if ed.Execution.Status != ExecutionStatusRunning {
 		// Already stopped.
-		return ed.Execution, nil
+		return copyExecution(ed.Execution), nil
 	}
 
 	now := time.Now()
@@ -451,7 +460,7 @@ func (s *MemoryStorage) StopExecution(_ context.Context, executionArn, errorCode
 
 	s.saveLocked()
 
-	return ed.Execution, nil
+	return copyExecution(ed.Execution), nil
 }
 
 // DescribeExecution describes an execution.
@@ -464,7 +473,7 @@ func (s *MemoryStorage) DescribeExecution(_ context.Context, executionArn string
 		return nil, &ServiceError{Code: errExecutionDoesNotExist, Message: "Execution does not exist"}
 	}
 
-	return ed.Execution, nil
+	return copyExecution(ed.Execution), nil
 }
 
 // ListExecutions lists executions for a state machine.
@@ -487,7 +496,7 @@ func (s *MemoryStorage) ListExecutions(_ context.Context, stateMachineArn, statu
 			continue
 		}
 
-		executions = append(executions, ed.Execution)
+		executions = append(executions, copyExecution(ed.Execution))
 	}
 
 	// Sort by start date (most recent first).


### PR DESCRIPTION
## Summary
Two Step Functions fidelity fixes reported in #862, plus a data race the new tests exposed.

- Execution ARNs now use the lowercase `:execution:` segment like real Step Functions
- Engine-level failures (e.g. unsupported state types) surface as `States.Runtime`; `States.TaskFailed` is reserved for failures of the task invocation itself
- Execution accessors (Describe/List/Stop/Start) now return copies — the background execution goroutine mutates the stored Execution, so returning the live pointer raced with readers

Fixes #862

## Test plan
- [ ] Unit tests cover the ARN casing and both error-code paths (race detector clean)