### PR TITLE
fix(dynamodb): apply Limit to evaluated items before FilterExpression

### DIFF
--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -704,30 +704,21 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 		return nil, nil, 0, err
 	}
 
-	results, scannedCount, err := m.queryCollectMatches(td.Items, partitionKeyName, partitionKeyValue, resolvedKeyCondExpr, filterExpr, exprNames, exprValues)
+	candidates, err := m.queryMatchingItems(td.Items, partitionKeyName, partitionKeyValue, resolvedKeyCondExpr, exprValues)
 	if err != nil {
 		return nil, nil, 0, err
 	}
 
-	// DynamoDB Query always returns items sorted by sort key.
-	if sortKeyName := keyAttrName(keySchema, "RANGE"); sortKeyName != "" {
-		sort.Slice(results, func(i, j int) bool {
-			vi := results[i][sortKeyName]
-			vj := results[j][sortKeyName]
+	m.orderQueryCandidates(candidates, keyAttrName(keySchema, "RANGE"), scanForward)
 
-			return m.compareForSort(&vi, &vj)
-		})
+	startIdx := m.startIndexAfterKey(td.Table, candidates, exclusiveStartKey)
+
+	items, lastKey, scannedCount, err := m.evaluatePage(td.Table, candidates[startIdx:], filterExpr, exprNames, exprValues, limit)
+	if err != nil {
+		return nil, nil, 0, err
 	}
 
-	if !scanForward {
-		for i, j := 0, len(results)-1; i < j; i, j = i+1, j-1 {
-			results[i], results[j] = results[j], results[i]
-		}
-	}
-
-	page, lastKey, count := m.paginateResults(td.Table, results, exclusiveStartKey, limit, scannedCount)
-
-	return page, lastKey, count, nil
+	return items, lastKey, scannedCount, nil
 }
 
 // keyAttrName returns the attribute name of the key schema element with the
@@ -757,17 +748,15 @@ func (m *MemoryStorage) matchesPartitionKey(item Item, partitionKeyName string, 
 	return m.attributeValuesEqual(itemVal, *partitionKeyValue)
 }
 
-// queryCollectMatches walks the table's items, applies the partition-key match,
-// the full key condition, and the filter expression, returning the matched
-// items and the scanned count.
-func (m *MemoryStorage) queryCollectMatches(items map[string]Item, partitionKeyName string, partitionKeyValue *AttributeValue, resolvedKeyCondExpr, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue) ([]Item, int, error) {
-	var results []Item
-
-	scannedCount := 0
+// queryMatchingItems walks the table's items and returns those that match the
+// partition key and the full key condition, in table order. Filtering and
+// Limit are applied afterward, once the candidates are sorted by sort key and
+// positioned past ExclusiveStartKey, so that Limit bounds evaluated items
+// rather than post-filter matches (see evaluatePage).
+func (m *MemoryStorage) queryMatchingItems(items map[string]Item, partitionKeyName string, partitionKeyValue *AttributeValue, resolvedKeyCondExpr string, exprValues map[string]AttributeValue) ([]Item, error) {
+	var candidates []Item
 
 	for _, item := range items {
-		scannedCount++
-
 		if !m.matchesPartitionKey(item, partitionKeyName, partitionKeyValue) {
 			continue
 		}
@@ -776,7 +765,7 @@ func (m *MemoryStorage) queryCollectMatches(items map[string]Item, partitionKeyN
 		if resolvedKeyCondExpr != "" {
 			ok, err := evaluateCondition(item, ConditionInput{Expression: resolvedKeyCondExpr, ExprValues: exprValues})
 			if err != nil {
-				return nil, 0, invalidKeyConditionExpression(err)
+				return nil, invalidKeyConditionExpression(err)
 			}
 
 			if !ok {
@@ -784,52 +773,87 @@ func (m *MemoryStorage) queryCollectMatches(items map[string]Item, partitionKeyN
 			}
 		}
 
-		match, err := m.filterItem(item, filterExpr, exprNames, exprValues)
-		if err != nil {
-			return nil, 0, err
-		}
-
-		if !match {
-			continue
-		}
-
-		results = append(results, m.copyItem(item))
+		candidates = append(candidates, item)
 	}
 
-	return results, scannedCount, nil
+	return candidates, nil
 }
 
-// paginateResults applies ExclusiveStartKey and Limit to an ordered result set,
-// returning the page and the LastEvaluatedKey (nil when the page is the tail).
-func (m *MemoryStorage) paginateResults(table *Table, results []Item, exclusiveStartKey Item, limit, scannedCount int) ([]Item, Item, int) {
-	startIdx := 0
+// orderQueryCandidates sorts query candidates by sort key (DynamoDB Query
+// always returns items in sort-key order) and reverses them in place when
+// scanForward is false. A table/index without a sort key is left in its
+// original (arbitrary map iteration) order.
+func (m *MemoryStorage) orderQueryCandidates(candidates []Item, sortKeyName string, scanForward bool) {
+	if sortKeyName != "" {
+		sort.Slice(candidates, func(i, j int) bool {
+			vi := candidates[i][sortKeyName]
+			vj := candidates[j][sortKeyName]
 
-	if exclusiveStartKey != nil {
-		startKeyStr := m.serializeKey(table, exclusiveStartKey)
+			return m.compareForSort(&vi, &vj)
+		})
+	}
 
-		for i, item := range results {
-			if m.serializeKey(table, item) == startKeyStr {
-				startIdx = i + 1
+	if !scanForward {
+		for i, j := 0, len(candidates)-1; i < j; i, j = i+1, j-1 {
+			candidates[i], candidates[j] = candidates[j], candidates[i]
+		}
+	}
+}
 
-				break
-			}
+// startIndexAfterKey returns the index in ordered immediately following the
+// item whose primary key matches exclusiveStartKey, or 0 when
+// exclusiveStartKey is nil or not found among ordered.
+func (m *MemoryStorage) startIndexAfterKey(table *Table, ordered []Item, exclusiveStartKey Item) int {
+	if exclusiveStartKey == nil {
+		return 0
+	}
+
+	startKeyStr := m.serializeKey(table, exclusiveStartKey)
+
+	for i, item := range ordered {
+		if m.serializeKey(table, item) == startKeyStr {
+			return i + 1
 		}
 	}
 
-	if startIdx >= len(results) {
-		return []Item{}, nil, scannedCount
+	return 0
+}
+
+// evaluatePage evaluates candidates in order, up to Limit items when limit is
+// positive (all of them otherwise), applying FilterExpression only to the
+// evaluated page. Per AWS semantics, Limit bounds the number of EVALUATED
+// items rather than the number of post-filter matches: the returned
+// scannedCount counts every evaluated item, while items only contains the
+// ones that also pass the filter. lastEvaluatedKey is set to the last
+// evaluated item's key when evaluation stopped early because Limit was
+// reached while candidates remained, and is nil once candidates are
+// exhausted (even if that happens to coincide with Limit).
+func (m *MemoryStorage) evaluatePage(table *Table, candidates []Item, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int) ([]Item, Item, int, error) {
+	items := []Item{}
+
+	for i, item := range candidates {
+		match, err := m.filterItem(item, filterExpr, exprNames, exprValues)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+
+		if match {
+			items = append(items, m.copyItem(item))
+		}
+
+		scannedCount := i + 1
+		if limit > 0 && scannedCount >= limit {
+			var lastEvaluatedKey Item
+
+			if i+1 < len(candidates) {
+				lastEvaluatedKey = m.extractKey(table, item)
+			}
+
+			return items, lastEvaluatedKey, scannedCount, nil
+		}
 	}
 
-	results = results[startIdx:]
-
-	var lastEvaluatedKey Item
-
-	if limit > 0 && len(results) > limit {
-		results = results[:limit]
-		lastEvaluatedKey = m.extractKey(table, results[len(results)-1])
-	}
-
-	return results, lastEvaluatedKey, scannedCount
+	return items, nil, len(candidates), nil
 }
 
 // Scan scans items from a table.
@@ -855,28 +879,31 @@ func (m *MemoryStorage) Scan(_ context.Context, tableName, filterExpr string, ex
 		return nil, nil, 0, err
 	}
 
-	// Collect all items matching the segment and filter.
-	results, scannedCount, err := m.scanCollectMatches(td, filterExpr, exprNames, exprValues, segment, totalSegments)
+	// Collect the segment's candidate items; filtering and Limit are applied
+	// once the candidates are ordered by primary key and positioned past
+	// ExclusiveStartKey (see evaluatePage).
+	candidates := m.scanCandidateItems(td, segment, totalSegments)
+
+	items, lastKey, scannedCount, err := m.sortByKeyAndEvaluate(td.Table, candidates, exclusiveStartKey, filterExpr, exprNames, exprValues, limit)
 	if err != nil {
 		return nil, nil, 0, err
 	}
 
-	page, lastKey, count := m.sortByKeyAndPaginate(td.Table, results, exclusiveStartKey, limit, scannedCount)
-
-	return page, lastKey, count, nil
+	return items, lastKey, scannedCount, nil
 }
 
-// sortByKeyAndPaginate orders scan results by serialized primary key (Scan has
-// no sort-key ordering) and applies ExclusiveStartKey/Limit pagination. Keys are
+// sortByKeyAndEvaluate orders scan candidates by serialized primary key (Scan
+// has no sort-key ordering), positions past ExclusiveStartKey, and then
+// evaluates up to Limit items against the filter via evaluatePage. Keys are
 // pre-computed once so neither the sort nor the start-key lookup re-serializes.
-func (m *MemoryStorage) sortByKeyAndPaginate(table *Table, results []Item, exclusiveStartKey Item, limit, scannedCount int) ([]Item, Item, int) {
+func (m *MemoryStorage) sortByKeyAndEvaluate(table *Table, candidates []Item, exclusiveStartKey Item, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, limit int) ([]Item, Item, int, error) {
 	type keyedItem struct {
 		key  string
 		item Item
 	}
 
-	pairs := make([]keyedItem, len(results))
-	for i, it := range results {
+	pairs := make([]keyedItem, len(candidates))
+	for i, it := range candidates {
 		pairs[i] = keyedItem{key: m.serializeKey(table, it), item: it}
 	}
 
@@ -901,28 +928,17 @@ func (m *MemoryStorage) sortByKeyAndPaginate(table *Table, results []Item, exclu
 	}
 
 	if startIdx >= len(ordered) {
-		return []Item{}, nil, scannedCount
+		return []Item{}, nil, 0, nil
 	}
 
-	ordered = ordered[startIdx:]
-
-	var lastEvaluatedKey Item
-
-	if limit > 0 && len(ordered) > limit {
-		ordered = ordered[:limit]
-		lastEvaluatedKey = m.extractKey(table, ordered[len(ordered)-1])
-	}
-
-	return ordered, lastEvaluatedKey, scannedCount
+	return m.evaluatePage(table, ordered[startIdx:], filterExpr, exprNames, exprValues, limit)
 }
 
-// scanCollectMatches walks every item, applies parallel-scan segment filtering
-// and the filter expression, and returns the matched items plus the scanned
-// count. A filter parse error is returned as a ValidationException.
-func (m *MemoryStorage) scanCollectMatches(td *tableData, filterExpr string, exprNames map[string]string, exprValues map[string]AttributeValue, segment, totalSegments *int) ([]Item, int, error) {
-	var results []Item
-
-	scannedCount := 0
+// scanCandidateItems walks every item and applies parallel-scan segment
+// filtering, returning the segment's candidate items in table order.
+// FilterExpression and Limit are applied afterward by the caller.
+func (m *MemoryStorage) scanCandidateItems(td *tableData, segment, totalSegments *int) []Item {
+	var candidates []Item
 
 	for _, item := range td.Items {
 		key := m.serializeKey(td.Table, item)
@@ -930,21 +946,10 @@ func (m *MemoryStorage) scanCollectMatches(td *tableData, filterExpr string, exp
 			continue
 		}
 
-		scannedCount++
-
-		match, err := m.filterItem(item, filterExpr, exprNames, exprValues)
-		if err != nil {
-			return nil, 0, err
-		}
-
-		if !match {
-			continue
-		}
-
-		results = append(results, m.copyItem(item))
+		candidates = append(candidates, item)
 	}
 
-	return results, scannedCount, nil
+	return candidates
 }
 
 func validateScanSegment(segment, totalSegments *int) error {

--- a/internal/service/dynamodb/storage_pagination_test.go
+++ b/internal/service/dynamodb/storage_pagination_test.go
@@ -1,0 +1,165 @@
+package dynamodb
+
+import (
+	"context"
+	"testing"
+)
+
+// assertPageCounts checks a Scan/Query page's ScannedCount and Count
+// (len(items)) against the expected values. A Count mismatch is fatal since
+// callers commonly index into items right after.
+func assertPageCounts(t *testing.T, label string, items []Item, scanned, wantScanned, wantCount int) {
+	t.Helper()
+
+	if scanned != wantScanned {
+		t.Errorf("%s ScannedCount = %d, want %d", label, scanned, wantScanned)
+	}
+
+	if len(items) != wantCount {
+		t.Fatalf("%s Count = %d, want %d", label, len(items), wantCount)
+	}
+}
+
+// assertLastEvaluatedKey checks whether LastEvaluatedKey is present or absent
+// as expected.
+func assertLastEvaluatedKey(t *testing.T, label string, lastKey Item, wantPresent bool) {
+	t.Helper()
+
+	if wantPresent && lastKey == nil {
+		t.Fatalf("%s LastEvaluatedKey is nil, want present", label)
+	}
+
+	if !wantPresent && lastKey != nil {
+		t.Errorf("%s LastEvaluatedKey = %v, want nil", label, lastKey)
+	}
+}
+
+// assertItemSortKey checks an item's "SK" attribute against the expected value.
+func assertItemSortKey(t *testing.T, label string, item Item, want string) {
+	t.Helper()
+
+	if got := item["SK"].S; got == nil || *got != want {
+		t.Errorf("%s SK = %v, want %q", label, item["SK"], want)
+	}
+}
+
+// TestScanLimitAppliedBeforeFilter is the exact repro from GitHub issue #860:
+// a table with 2 items, neither matching the FilterExpression, and Limit: 1.
+// AWS applies Limit to the number of items EVALUATED before the filter runs,
+// so the first Scan must evaluate exactly 1 item, return zero matches, and
+// return a LastEvaluatedKey so the caller can continue. Continuing with that
+// key must evaluate the second (and last) item and return no LastEvaluatedKey,
+// since the item space is now exhausted.
+func TestScanLimitAppliedBeforeFilter(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := s.CreateTable(ctx, &CreateTableRequest{
+		TableName:            "scan-limit-before-filter",
+		KeySchema:            []KeySchemaElement{{AttributeName: "pk", KeyType: "HASH"}},
+		AttributeDefinitions: []AttributeDefinition{{AttributeName: "pk", AttributeType: "S"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, pk := range []string{"a", "b"} {
+		if _, err := s.PutItem(ctx, "scan-limit-before-filter", Item{
+			"pk":       {S: ptr(pk)},
+			"category": {S: ptr("other")},
+		}, false, ConditionInput{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	filterExpr := "category = :want"
+	filterValues := map[string]AttributeValue{":want": {S: ptr("target")}}
+
+	items, lastKey, scanned, err := s.Scan(ctx, "scan-limit-before-filter", filterExpr, nil, filterValues, 1, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("first Scan: %v", err)
+	}
+
+	assertPageCounts(t, "first Scan", items, scanned, 1, 0)
+	assertLastEvaluatedKey(t, "first Scan", lastKey, true)
+
+	if firstPK := lastKey["pk"].S; firstPK == nil || *firstPK != "a" {
+		t.Errorf("first Scan LastEvaluatedKey[pk] = %v, want \"a\" (scan order is by serialized key)", lastKey)
+	}
+
+	items, lastKey, scanned, err = s.Scan(ctx, "scan-limit-before-filter", filterExpr, nil, filterValues, 1, lastKey, nil, nil)
+	if err != nil {
+		t.Fatalf("second Scan: %v", err)
+	}
+
+	assertPageCounts(t, "second Scan", items, scanned, 1, 0)
+	assertLastEvaluatedKey(t, "second Scan", lastKey, false)
+}
+
+// TestQueryLimitAppliedBeforeFilter verifies that, like Scan, Query applies
+// Limit to the number of items evaluated within the key-condition-matching
+// set BEFORE the FilterExpression is applied. A filter that excludes the
+// first two of four sort-key-ordered items must still count them toward
+// Limit, so Limit=3 evaluates items sk=1..3, matches only sk=3, and leaves
+// sk=4 for a continuation page.
+func TestQueryLimitAppliedBeforeFilter(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := context.Background()
+
+	_, err := s.CreateTable(ctx, &CreateTableRequest{
+		TableName: "query-limit-before-filter",
+		KeySchema: []KeySchemaElement{
+			{AttributeName: "PK", KeyType: "HASH"},
+			{AttributeName: "SK", KeyType: "RANGE"},
+		},
+		AttributeDefinitions: []AttributeDefinition{
+			{AttributeName: "PK", AttributeType: "S"},
+			{AttributeName: "SK", AttributeType: "S"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	categories := map[string]string{"1": "other", "2": "other", "3": "target", "4": "target"}
+	for _, sk := range []string{"1", "2", "3", "4"} {
+		if _, err := s.PutItem(ctx, "query-limit-before-filter", Item{
+			"PK":       {S: ptr("tenant1")},
+			"SK":       {S: ptr(sk)},
+			"category": {S: ptr(categories[sk])},
+		}, false, ConditionInput{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	keyCondExpr := "PK = :pk"
+	filterExpr := "category = :want"
+	exprValues := map[string]AttributeValue{
+		":pk":   {S: ptr("tenant1")},
+		":want": {S: ptr("target")},
+	}
+
+	items, lastKey, scanned, err := s.Query(ctx, "query-limit-before-filter", "", keyCondExpr, filterExpr,
+		nil, exprValues, 3, nil, true)
+	if err != nil {
+		t.Fatalf("first Query: %v", err)
+	}
+
+	assertPageCounts(t, "first Query", items, scanned, 3, 1)
+	assertLastEvaluatedKey(t, "first Query", lastKey, true)
+	assertItemSortKey(t, "first Query matched item", items[0], "3")
+	assertItemSortKey(t, "first Query LastEvaluatedKey", lastKey, "3")
+
+	items, lastKey, scanned, err = s.Query(ctx, "query-limit-before-filter", "", keyCondExpr, filterExpr,
+		nil, exprValues, 3, lastKey, true)
+	if err != nil {
+		t.Fatalf("second Query: %v", err)
+	}
+
+	assertPageCounts(t, "second Query", items, scanned, 1, 1)
+	assertLastEvaluatedKey(t, "second Query", lastKey, false)
+}

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_create.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_create.golden.go
@@ -19,7 +19,7 @@
       "BillingMode": "PAY_PER_REQUEST",
       "LastUpdateToPayPerRequestDateTime": null
     },
-    "CreationDateTime": "2026-04-22T01:08:47Z",
+    "CreationDateTime": "2026-07-27T02:29:09Z",
     "DeletionProtectionEnabled": false,
     "GlobalSecondaryIndexes": [
       {
@@ -70,7 +70,7 @@
     "StreamSpecification": null,
     "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-table-gsi",
     "TableClassSummary": null,
-    "TableId": "ad896e2b-c27f-45be-a28a-8f444a5560d9",
+    "TableId": "d7d5a4a8-aae4-4faf-a4bd-b740bfbce644",
     "TableName": "test-table-gsi",
     "TableSizeBytes": 0,
     "TableStatus": "ACTIVE",

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_query_gsi.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_query_gsi.golden.go
@@ -4,20 +4,6 @@
   "Items": [
     {
       "data": {
-        "Value": "data3"
-      },
-      "gsi_pk": {
-        "Value": "region-east"
-      },
-      "pk": {
-        "Value": "user-2"
-      },
-      "sk": {
-        "Value": "order-3"
-      }
-    },
-    {
-      "data": {
         "Value": "data1"
       },
       "gsi_pk": {
@@ -29,9 +15,23 @@
       "sk": {
         "Value": "order-1"
       }
+    },
+    {
+      "data": {
+        "Value": "data3"
+      },
+      "gsi_pk": {
+        "Value": "region-east"
+      },
+      "pk": {
+        "Value": "user-2"
+      },
+      "sk": {
+        "Value": "order-3"
+      }
     }
   ],
   "LastEvaluatedKey": null,
-  "ScannedCount": 3,
+  "ScannedCount": 2,
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_query_table.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_query_table.golden.go
@@ -32,6 +32,6 @@
     }
   ],
   "LastEvaluatedKey": null,
-  "ScannedCount": 3,
+  "ScannedCount": 2,
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_Query_TestDynamoDB_Query.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_Query_TestDynamoDB_Query.golden.go
@@ -4,6 +4,17 @@
   "Items": [
     {
       "data": {
+        "Value": "data1"
+      },
+      "pk": {
+        "Value": "user-1"
+      },
+      "sk": {
+        "Value": "item-1"
+      }
+    },
+    {
+      "data": {
         "Value": "data2"
       },
       "pk": {
@@ -23,20 +34,9 @@
       "sk": {
         "Value": "item-3"
       }
-    },
-    {
-      "data": {
-        "Value": "data1"
-      },
-      "pk": {
-        "Value": "user-1"
-      },
-      "sk": {
-        "Value": "item-1"
-      }
     }
   ],
   "LastEvaluatedKey": null,
-  "ScannedCount": 4,
+  "ScannedCount": 3,
   "ResultMetadata": {}
 }

--- a/test/integration/testdata/dynamodb_test_func2_TestDynamoDB_QueryKeyConditions/non_existent_pk.golden.go
+++ b/test/integration/testdata/dynamodb_test_func2_TestDynamoDB_QueryKeyConditions/non_existent_pk.golden.go
@@ -3,5 +3,5 @@
   "Count": 0,
   "Items": [],
   "LastEvaluatedKey": null,
-  "ScannedCount": 1
+  "ScannedCount": 0
 }

--- a/test/integration/testdata/dynamodb_test_func2_TestDynamoDB_QueryKeyConditionsWithSortKey/pk_eq_sk_begins_with.golden.go
+++ b/test/integration/testdata/dynamodb_test_func2_TestDynamoDB_QueryKeyConditionsWithSortKey/pk_eq_sk_begins_with.golden.go
@@ -118,5 +118,5 @@
     }
   ],
   "LastEvaluatedKey": null,
-  "ScannedCount": 4
+  "ScannedCount": 3
 }

--- a/test/integration/testdata/dynamodb_test_func3_TestDynamoDB_QueryKeyConditionsWithSortKey/pk_eq_sk_between.golden.go
+++ b/test/integration/testdata/dynamodb_test_func3_TestDynamoDB_QueryKeyConditionsWithSortKey/pk_eq_sk_between.golden.go
@@ -80,5 +80,5 @@
     }
   ],
   "LastEvaluatedKey": null,
-  "ScannedCount": 4
+  "ScannedCount": 2
 }


### PR DESCRIPTION
## Summary
Scan/Query now count evaluated items toward Limit before applying FilterExpression, matching AWS pagination semantics (#860).

- ScannedCount = evaluated items on the page, Count = post-filter matches
- LastEvaluatedKey comes from the last evaluated item and is present whenever evaluation stopped at Limit with items remaining, absent when the item space is exhausted
- Parallel-scan segment logic is unchanged; unit tests cover the issue's repro for both Scan and Query including continuation via ExclusiveStartKey

Fixes #860

## Test plan
- [ ] New pagination unit tests pass with race detector
- [ ] Existing dynamodb tests show no regression