### PR TITLE
fix(lambda): serialize sync and async invocations per function

### DIFF
--- a/internal/service/lambda/async.go
+++ b/internal/service/lambda/async.go
@@ -62,6 +62,7 @@ type asyncDispatcher struct {
 
 	mu     sync.Mutex
 	queues map[string]chan *asyncEvent
+	gates  map[string]invokeGate
 }
 
 func newAsyncDispatcher() *asyncDispatcher {
@@ -72,7 +73,56 @@ func newAsyncDispatcher() *asyncDispatcher {
 		maxBackoff:     asyncMaxBackoff,
 		maxEventAge:    asyncMaxEventAge,
 		queues:         make(map[string]chan *asyncEvent),
+		gates:          make(map[string]invokeGate),
 	}
+}
+
+// gate returns (creating if needed) the semaphore that serializes every
+// InvokeEndpoint HTTP call for functionName, synchronous and asynchronous
+// alike, so a single-concurrency endpoint (e.g. the Lambda RIE) never
+// receives two overlapping requests (issue #859). The dispatcher's own mu
+// only guards the lookup/creation below; it is never held while a caller
+// blocks on the returned gate.
+func (d *asyncDispatcher) gate(functionName string) invokeGate {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	g, ok := d.gates[functionName]
+	if !ok {
+		g = newInvokeGate()
+		d.gates[functionName] = g
+	}
+
+	return g
+}
+
+// invokeGate is a binary semaphore (a capacity-1 channel) that serializes
+// InvokeEndpoint HTTP calls for one function across the synchronous and
+// asynchronous invoke paths. Acquisition is context-aware: a caller gives up
+// waiting when its context is done instead of blocking forever on a peer
+// that never releases the gate. This matters most for the async drain
+// goroutine, whose delivery context is canceled when the dispatcher closes —
+// without that, a stuck synchronous invoke holding the gate would prevent
+// asyncDispatcher.close from ever returning.
+type invokeGate chan struct{}
+
+func newInvokeGate() invokeGate {
+	return make(invokeGate, 1)
+}
+
+// acquire blocks until the gate is free or ctx is done, reporting which.
+func (g invokeGate) acquire(ctx context.Context) bool {
+	select {
+	case g <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// release frees the gate for the next acquirer.
+func (g invokeGate) release() {
+	<-g
 }
 
 // enqueue places an event on the function's FIFO queue without blocking the
@@ -200,6 +250,11 @@ func (d *asyncDispatcher) deliver(ctx context.Context, functionName string, ev *
 type endpointDeliverer struct {
 	client   *http.Client
 	endpoint string
+
+	// gate serializes this attempt's HTTP call against every other
+	// InvokeEndpoint call (sync or async) for the same function; see
+	// asyncDispatcher.gate.
+	gate invokeGate
 }
 
 // deliver performs a single delivery attempt.
@@ -213,7 +268,16 @@ func (e *endpointDeliverer) deliver(ctx context.Context, functionName string, pa
 
 	req.Header.Set("Content-Type", "application/json")
 
+	if !e.gate.acquire(ctx) {
+		// The dispatcher is shutting down (or the event's own context was
+		// canceled): give up waiting on a peer holding the gate rather than
+		// blocking asyncDispatcher.close forever.
+		return asyncSystemError
+	}
+
 	resp, err := e.client.Do(req)
+	e.gate.release()
+
 	if err != nil {
 		slog.Warn("async invoke attempt failed, will retry", "function", functionName, "error", err)
 

--- a/internal/service/lambda/async_test.go
+++ b/internal/service/lambda/async_test.go
@@ -1,12 +1,14 @@
 package lambda
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -109,7 +111,7 @@ func TestAsyncDispatcher_DeliversAfterEndpointRecovers(t *testing.T) {
 	addr := reserveAddr(t)
 
 	endpoint := "http://" + addr + "/invoke"
-	deliverer := &endpointDeliverer{client: d.client, endpoint: endpoint}
+	deliverer := &endpointDeliverer{client: d.client, endpoint: endpoint, gate: d.gate("fn")}
 
 	for i := 1; i <= 3; i++ {
 		d.enqueue("fn", deliverer, fmt.Appendf(nil, `{"seq":%d}`, i))
@@ -169,7 +171,7 @@ func TestAsyncDispatcher_FunctionErrorRetries(t *testing.T) {
 		return attempts
 	}
 
-	d.enqueue("fn", &endpointDeliverer{client: d.client, endpoint: srv.URL}, []byte(`{}`))
+	d.enqueue("fn", &endpointDeliverer{client: d.client, endpoint: srv.URL, gate: d.gate("fn")}, []byte(`{}`))
 
 	wantAttempts := 1 + asyncMaxFunctionErrorRetries
 	if !waitFor(t, 5*time.Second, func() bool { return count() == wantAttempts }) {
@@ -192,7 +194,7 @@ func TestAsyncDispatcher_ExpiredEventDropped(t *testing.T) {
 
 	addr := reserveAddr(t)
 
-	d.enqueue("fn", &endpointDeliverer{client: d.client, endpoint: "http://" + addr + "/invoke"}, []byte(`{}`))
+	d.enqueue("fn", &endpointDeliverer{client: d.client, endpoint: "http://" + addr + "/invoke", gate: d.gate("fn")}, []byte(`{}`))
 
 	// Wait until the event is past its deadline and has been dropped.
 	time.Sleep(200 * time.Millisecond)
@@ -202,6 +204,45 @@ func TestAsyncDispatcher_ExpiredEventDropped(t *testing.T) {
 
 	if waitFor(t, 300*time.Millisecond, func() bool { return len(rec.snapshot()) > 0 }) {
 		t.Fatalf("expected expired event to be dropped, got deliveries %v", rec.snapshot())
+	}
+}
+
+// TestAsyncDispatcher_CloseDoesNotHangOnStuckGate guards the per-function
+// gate's context-cancelable acquire (issue #859): if a synchronous invoke
+// acquires a function's gate and never releases it -- e.g. it is blocked
+// forever inside its own HTTP call against a wedged InvokeEndpoint -- the
+// async drain goroutine waiting on that same gate must still give up when
+// the dispatcher closes, instead of blocking asyncDispatcher.close forever.
+func TestAsyncDispatcher_CloseDoesNotHangOnStuckGate(t *testing.T) {
+	t.Parallel()
+
+	d := newAsyncDispatcher()
+	d.initialBackoff = 5 * time.Millisecond
+	d.maxBackoff = 20 * time.Millisecond
+
+	gate := d.gate("fn")
+	if !gate.acquire(t.Context()) {
+		t.Fatal("failed to acquire gate")
+	}
+	// Deliberately never released: simulates a sync invoke stuck forever.
+
+	d.enqueue("fn", &endpointDeliverer{client: d.client, endpoint: "http://127.0.0.1:0/invoke", gate: gate}, []byte(`{}`))
+
+	// Give the drain goroutine time to start waiting on the (permanently
+	// held) gate before closing.
+	time.Sleep(20 * time.Millisecond)
+
+	closed := make(chan struct{})
+
+	go func() {
+		d.close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("asyncDispatcher.close hung waiting on a gate held by a stuck peer")
 	}
 }
 
@@ -424,4 +465,223 @@ func TestAsyncDispatcher_RuntimeFunctionErrorOnResponseTimeout(t *testing.T) {
 	if got := count(); got != wantAttempts {
 		t.Fatalf("expected exactly %d attempts, got %d", wantAttempts, got)
 	}
+}
+
+// singleFlightServer is an InvokeEndpoint stand-in that fails the test the
+// moment it observes two overlapping requests, mimicking a single-concurrency
+// runtime such as the Lambda RIE.
+type singleFlightServer struct {
+	t        *testing.T
+	inFlight atomic.Int32
+	maxSeen  atomic.Int32
+	handled  atomic.Int32
+	sleep    time.Duration
+}
+
+func newSingleFlightServer(t *testing.T, sleep time.Duration) (*httptest.Server, *singleFlightServer) {
+	t.Helper()
+
+	sfs := &singleFlightServer{t: t, sleep: sleep}
+
+	return httptest.NewServer(http.HandlerFunc(sfs.serve)), sfs
+}
+
+func (sfs *singleFlightServer) serve(w http.ResponseWriter, _ *http.Request) {
+	n := sfs.inFlight.Add(1)
+	defer sfs.inFlight.Add(-1)
+
+	for {
+		seen := sfs.maxSeen.Load()
+		if n <= seen || sfs.maxSeen.CompareAndSwap(seen, n) {
+			break
+		}
+	}
+
+	if n > 1 {
+		sfs.t.Errorf("endpoint saw %d overlapping requests, want at most 1", n)
+	}
+
+	time.Sleep(sfs.sleep)
+	sfs.handled.Add(1)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{}`))
+}
+
+// newInvokeTestService returns a Service backed by an in-memory storage with
+// fn already registered against endpoint as its InvokeEndpoint.
+func newInvokeTestService(t *testing.T, fn, endpoint string) *Service {
+	t.Helper()
+
+	return newInvokeTestServiceMulti(t, map[string]string{fn: endpoint})
+}
+
+// newInvokeTestServiceMulti returns a Service backed by an in-memory storage
+// with each function in endpoints already registered against its
+// InvokeEndpoint.
+func newInvokeTestServiceMulti(t *testing.T, endpoints map[string]string) *Service {
+	t.Helper()
+
+	storage := NewMemoryStorage(defaultBaseURL)
+	svc := New(storage, defaultBaseURL)
+
+	t.Cleanup(func() {
+		if err := svc.Close(); err != nil {
+			t.Fatalf("close service: %v", err)
+		}
+	})
+
+	for fn, endpoint := range endpoints {
+		if _, err := storage.CreateFunction(t.Context(), &CreateFunctionRequest{
+			FunctionName:   fn,
+			Role:           "arn:aws:iam::000000000000:role/test",
+			InvokeEndpoint: endpoint,
+		}); err != nil {
+			t.Fatalf("create function %s: %v", fn, err)
+		}
+	}
+
+	return svc
+}
+
+// invokeRequest builds an Invoke request for fn with the given invocation
+// type ("" for RequestResponse).
+func invokeRequest(t *testing.T, fn, invocationType string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/2015-03-31/functions/"+fn+"/invocations", bytes.NewReader([]byte(`{}`)))
+	if invocationType != "" {
+		req.Header.Set("X-Amz-Invocation-Type", invocationType)
+	}
+
+	return req.WithContext(t.Context())
+}
+
+// TestInvoke_SyncAndAsyncSerializedPerFunction reproduces issue #859: a
+// synchronous (RequestResponse) invoke and an asynchronous (Event) invoke
+// against the same function's InvokeEndpoint must never be in flight at the
+// same time, so a single-concurrency runtime (e.g. the Lambda RIE) never
+// sees overlapping requests.
+func TestInvoke_SyncAndAsyncSerializedPerFunction(t *testing.T) {
+	t.Parallel()
+
+	srv, sfs := newSingleFlightServer(t, 100*time.Millisecond)
+	t.Cleanup(srv.Close)
+
+	svc := newInvokeTestService(t, "fn", srv.URL)
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	syncRec := httptest.NewRecorder()
+
+	go func() {
+		defer wg.Done()
+
+		svc.Invoke(syncRec, invokeRequest(t, "fn", "RequestResponse"))
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		asyncRec := httptest.NewRecorder()
+		svc.Invoke(asyncRec, invokeRequest(t, "fn", "Event"))
+
+		if asyncRec.Code != http.StatusAccepted {
+			t.Errorf("async invoke status = %d, want %d", asyncRec.Code, http.StatusAccepted)
+		}
+	}()
+
+	wg.Wait()
+
+	if syncRec.Code != http.StatusOK {
+		t.Errorf("sync invoke status = %d, want %d, body %s", syncRec.Code, http.StatusOK, syncRec.Body.String())
+	}
+
+	// The sync invoke has already completed above; the async delivery may
+	// still be draining, so wait for it to land too before asserting the
+	// endpoint's final view of concurrency.
+	if !waitFor(t, 5*time.Second, func() bool { return sfs.handled.Load() == 2 }) {
+		t.Fatalf("expected 2 deliveries to the endpoint, got %d", sfs.handled.Load())
+	}
+
+	if got := sfs.maxSeen.Load(); got > 1 {
+		t.Errorf("endpoint saw up to %d overlapping requests, want at most 1", got)
+	}
+}
+
+// newTrackedServer returns an httptest server whose handler closes started
+// on receiving a request, then blocks until release is closed.
+func newTrackedServer(t *testing.T, started chan struct{}, release <-chan struct{}) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// invokeSyncAndAssertOK fires a RequestResponse invoke for fn and records a
+// t.Errorf if it doesn't come back 200 OK. Intended to run as `go
+// invokeSyncAndAssertOK(...)`; it calls wg.Done itself.
+func invokeSyncAndAssertOK(t *testing.T, wg *sync.WaitGroup, svc *Service, fn string) {
+	t.Helper()
+
+	defer wg.Done()
+
+	rec := httptest.NewRecorder()
+	svc.Invoke(rec, invokeRequest(t, fn, "RequestResponse"))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("%s invoke status = %d, want %d", fn, rec.Code, http.StatusOK)
+	}
+}
+
+// TestInvoke_DifferentFunctionsNotSerialized verifies that invocations
+// targeting different functions are not gated against each other: two
+// concurrent requests to two different functions' endpoints must be allowed
+// to overlap.
+func TestInvoke_DifferentFunctionsNotSerialized(t *testing.T) {
+	t.Parallel()
+
+	var (
+		aStarted = make(chan struct{})
+		bStarted = make(chan struct{})
+		release  = make(chan struct{})
+	)
+
+	srvA := newTrackedServer(t, aStarted, release)
+	srvB := newTrackedServer(t, bStarted, release)
+
+	svc := newInvokeTestServiceMulti(t, map[string]string{"fn-a": srvA.URL, "fn-b": srvB.URL})
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go invokeSyncAndAssertOK(t, &wg, svc, "fn-a")
+	go invokeSyncAndAssertOK(t, &wg, svc, "fn-b")
+
+	// Both handlers must be able to start concurrently: neither is gated
+	// against the other, so both reach their <-release wait without one
+	// blocking on the other's in-flight request.
+	select {
+	case <-aStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fn-a endpoint never started, functions may be wrongly serialized")
+	}
+
+	select {
+	case <-bStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fn-b endpoint never started while fn-a was in flight, functions are wrongly serialized")
+	}
+
+	close(release)
+	wg.Wait()
 }

--- a/internal/service/lambda/handlers.go
+++ b/internal/service/lambda/handlers.go
@@ -340,16 +340,21 @@ func (s *Service) invokeViaRuntime(w http.ResponseWriter, r *http.Request, fn st
 
 // invokeViaEndpoint forwards to a function's configured InvokeEndpoint.
 // Async invocations are queued on the dispatcher so the 202 means "accepted
-// for delivery": failed deliveries are retried instead of dropped.
+// for delivery": failed deliveries are retried instead of dropped. Both the
+// async delivery attempt and the synchronous call below share the same
+// per-function gate (asyncDispatcher.gate) so a single-concurrency endpoint,
+// such as the Lambda RIE, never sees two overlapping requests (issue #859).
 func (s *Service) invokeViaEndpoint(w http.ResponseWriter, r *http.Request, fn, endpoint string, payload []byte, async bool) {
+	gate := s.async.gate(fn)
+
 	if async {
-		s.async.enqueue(fn, &endpointDeliverer{client: s.async.client, endpoint: endpoint}, payload)
+		s.async.enqueue(fn, &endpointDeliverer{client: s.async.client, endpoint: endpoint, gate: gate}, payload)
 		writeInvokeAccepted(w)
 
 		return
 	}
 
-	s.invokeSync(r.Context(), w, endpoint, payload)
+	s.invokeSync(r.Context(), w, endpoint, payload, gate)
 }
 
 // invokeNoBackend handles a function with neither a Runtime API handler nor an
@@ -411,7 +416,11 @@ func writeInvokeHeaders(w http.ResponseWriter) {
 }
 
 // invokeSync invokes the function synchronously and writes the response.
-func (s *Service) invokeSync(ctx context.Context, w http.ResponseWriter, endpoint string, payload []byte) {
+// gate is held only around the HTTP call so it never overlaps with an async
+// delivery attempt for the same function (issue #859). Acquiring is bounded
+// by ctx, so a client that disconnects while waiting for a peer to finish
+// gives up instead of leaking this goroutine.
+func (s *Service) invokeSync(ctx context.Context, w http.ResponseWriter, endpoint string, payload []byte, gate invokeGate) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
 		writeFunctionError(w, ErrServiceException,
@@ -422,7 +431,17 @@ func (s *Service) invokeSync(ctx context.Context, w http.ResponseWriter, endpoin
 
 	req.Header.Set("Content-Type", "application/json")
 
+	if !gate.acquire(ctx) {
+		writeFunctionError(w, ErrServiceException,
+			fmt.Sprintf("Failed to invoke endpoint: %v", ctx.Err()), http.StatusInternalServerError)
+
+		return
+	}
+
 	resp, err := http.DefaultClient.Do(req)
+
+	gate.release()
+
 	if err != nil {
 		writeFunctionError(w, ErrServiceException,
 			fmt.Sprintf("Failed to invoke endpoint: %v", err), http.StatusInternalServerError)


### PR DESCRIPTION
## Summary
Synchronous (RequestResponse) invokes bypassed the per-function async delivery gate entirely, so a sync invoke and an async delivery to the same InvokeEndpoint could run concurrently. Single-concurrency runtimes (the RIE behind PackageType Image is the common case) crash on the second overlapping request.

Both paths now acquire a per-function gate before calling the endpoint. The gate is a context-aware channel semaphore rather than a plain mutex, so a caller whose context is canceled gives up instead of blocking async delivery — or graceful shutdown — indefinitely.

Fixes #859

## Test plan
- [ ] Regression test proves a single-flight endpoint never sees concurrent sync+async requests to the same function
- [ ] Two different functions are NOT serialized against each other
- [ ] Close() does not hang when a gate is stuck (shutdown regression guard)