### PR TITLE
feat(apigatewayv2): emulate JWT authorizers for HTTP APIs

### DIFF
--- a/internal/service/apigatewayv2/authorizer.go
+++ b/internal/service/apigatewayv2/authorizer.go
@@ -1,0 +1,258 @@
+package apigatewayv2
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sivchari/kumo/internal/service/execapi"
+)
+
+// authorizerTypeJWT is the only authorizer type kumo evaluates at execute
+// time. Other types (e.g. REQUEST) are stored but never enforced.
+const authorizerTypeJWT = "JWT"
+
+// Registered JWT claim names used for authorizer validation, per "Control
+// access to HTTP APIs with JWT authorizers in API Gateway":
+// https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-jwt-authorizer.html
+const (
+	claimExp      = "exp"
+	claimIss      = "iss"
+	claimAud      = "aud"
+	claimClientID = "client_id"
+	claimScope    = "scope"
+)
+
+// authorizeJWT validates the token presented by the request against the
+// route's JWT authorizer and, on success, returns the authorizer context to
+// attach to the payload-2.0 event's requestContext. ok is false when the
+// request must be rejected with 401 Unauthorized.
+func authorizeJWT(r *http.Request, authorizer *Authorizer) (*execapi.AuthorizerContext, bool) {
+	token, ok := bearerToken(r, authorizer.IdentitySource)
+	if !ok {
+		return nil, false
+	}
+
+	claims, err := decodeJWTPayload(token)
+	if err != nil {
+		return nil, false
+	}
+
+	if !validateJWTClaims(claims, authorizer.JWTConfiguration) {
+		return nil, false
+	}
+
+	// Signature verification is intentionally skipped: kumo has no access to
+	// the identity provider's JWKS. A real check would slot in here, after
+	// claim validation and before the context is built, so a malformed or
+	// unsigned token still fails fast regardless of its claims.
+
+	return &execapi.AuthorizerContext{
+		JWT: &execapi.JWTAuthorizerClaims{
+			Claims: stringifyClaims(claims),
+			Scopes: scopesFromClaims(claims),
+		},
+	}, true
+}
+
+// bearerToken extracts the bearer token from the request header named by
+// identitySource, defaulting to Authorization. Only header-based identity
+// sources (the common case) are recognized; anything else falls back to the
+// Authorization header.
+func bearerToken(r *http.Request, identitySource []string) (string, bool) {
+	header := "Authorization"
+
+	for _, src := range identitySource {
+		if name, ok := strings.CutPrefix(src, "$request.header."); ok {
+			header = name
+
+			break
+		}
+	}
+
+	const bearerPrefix = "Bearer "
+
+	raw := r.Header.Get(header)
+	if !strings.HasPrefix(raw, bearerPrefix) {
+		return "", false
+	}
+
+	token := strings.TrimPrefix(raw, bearerPrefix)
+	if token == "" {
+		return "", false
+	}
+
+	return token, true
+}
+
+// decodeJWTPayload base64url-decodes and JSON-parses a JWT's payload (the
+// second dot-separated segment) into its claim set. It does not verify the
+// signature.
+func decodeJWTPayload(token string) (map[string]any, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("malformed JWT: expected 3 segments, got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode JWT payload: %w", err)
+	}
+
+	claims := map[string]any{}
+
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.UseNumber()
+
+	if err := dec.Decode(&claims); err != nil {
+		return nil, fmt.Errorf("unmarshal JWT payload: %w", err)
+	}
+
+	return claims, nil
+}
+
+// validateJWTClaims checks exp, iss, and aud/client_id against the
+// authorizer configuration.
+func validateJWTClaims(claims map[string]any, cfg *JWTConfiguration) bool {
+	if !expirationValid(claims) {
+		return false
+	}
+
+	if cfg == nil {
+		return true
+	}
+
+	if cfg.Issuer != "" && claimString(claims, claimIss) != cfg.Issuer {
+		return false
+	}
+
+	if len(cfg.Audience) > 0 && !audienceMatches(claims, cfg.Audience) {
+		return false
+	}
+
+	return true
+}
+
+// expirationValid rejects tokens whose exp claim is missing, unparsable, or
+// in the past.
+func expirationValid(claims map[string]any) bool {
+	num, ok := claims[claimExp].(json.Number)
+	if !ok {
+		return false
+	}
+
+	exp, err := num.Int64()
+	if err != nil {
+		return false
+	}
+
+	return time.Now().Before(time.Unix(exp, 0))
+}
+
+// audienceMatches implements API Gateway's aud/client_id precedence: aud is
+// checked when present (a string or an array of strings per RFC 7519);
+// client_id is checked only when aud is absent.
+func audienceMatches(claims map[string]any, audience []string) bool {
+	if aud, ok := claims[claimAud]; ok {
+		return containsAny(audienceValues(aud), audience)
+	}
+
+	if clientID := claimString(claims, claimClientID); clientID != "" {
+		return containsAny([]string{clientID}, audience)
+	}
+
+	return false
+}
+
+// audienceValues normalizes the aud claim into a slice of strings.
+func audienceValues(aud any) []string {
+	switch v := aud.(type) {
+	case string:
+		return []string{v}
+	case []any:
+		values := make([]string, 0, len(v))
+
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				values = append(values, s)
+			}
+		}
+
+		return values
+	default:
+		return nil
+	}
+}
+
+// containsAny reports whether any of values is present in allowed.
+func containsAny(values, allowed []string) bool {
+	for _, v := range values {
+		for _, a := range allowed {
+			if v == a {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// claimString returns a claim's value as a string, or "" if it is absent or
+// not a string.
+func claimString(claims map[string]any, key string) string {
+	s, _ := claims[key].(string)
+
+	return s
+}
+
+// stringifyClaims renders every claim value the way API Gateway does in
+// requestContext.authorizer.jwt.claims: every value, including numbers and
+// booleans, becomes a string.
+func stringifyClaims(claims map[string]any) map[string]string {
+	out := make(map[string]string, len(claims))
+
+	for k, v := range claims {
+		out[k] = stringifyClaimValue(v)
+	}
+
+	return out
+}
+
+// stringifyClaimValue converts a decoded JSON claim value to its string
+// form. json.Number preserves the token's original numeric text instead of
+// round-tripping through float64.
+func stringifyClaimValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case json.Number:
+		return val.String()
+	case bool:
+		return strconv.FormatBool(val)
+	case nil:
+		return ""
+	default:
+		data, err := json.Marshal(val)
+		if err != nil {
+			return ""
+		}
+
+		return string(data)
+	}
+}
+
+// scopesFromClaims splits the space-delimited scope claim into individual
+// scopes. Returns nil when the claim is absent.
+func scopesFromClaims(claims map[string]any) []string {
+	scope := claimString(claims, claimScope)
+	if scope == "" {
+		return nil
+	}
+
+	return strings.Fields(scope)
+}

--- a/internal/service/apigatewayv2/authorizer_test.go
+++ b/internal/service/apigatewayv2/authorizer_test.go
@@ -1,0 +1,417 @@
+package apigatewayv2
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// ---- storage CRUD ----
+
+func TestMemoryStorage_AuthorizerCRUD(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+
+	api, err := storage.CreateAPI(t.Context(), &CreateAPIRequest{Name: "auth-api", ProtocolType: "HTTP"})
+	if err != nil {
+		t.Fatalf("CreateAPI() error = %v", err)
+	}
+
+	created := checkCreateAndGetAuthorizer(t, storage, api.APIID)
+	checkUpdateAndDeleteAuthorizer(t, storage, api.APIID, created)
+}
+
+func checkCreateAndGetAuthorizer(t *testing.T, storage *MemoryStorage, apiID string) *Authorizer {
+	t.Helper()
+
+	created, err := storage.CreateAuthorizer(t.Context(), apiID, &CreateAuthorizerRequest{
+		Name:           "jwt-auth",
+		AuthorizerType: authorizerTypeJWT,
+		JWTConfiguration: &JWTConfiguration{
+			Issuer:   "https://issuer.example.com",
+			Audience: []string{"aud1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateAuthorizer() error = %v", err)
+	}
+
+	if created.AuthorizerID == "" {
+		t.Error("CreateAuthorizer() AuthorizerID is empty")
+	}
+
+	if want := []string{defaultIdentitySource}; !slices.Equal(created.IdentitySource, want) {
+		t.Errorf("CreateAuthorizer() IdentitySource = %v, want %v (default)", created.IdentitySource, want)
+	}
+
+	got, err := storage.GetAuthorizer(t.Context(), apiID, created.AuthorizerID)
+	if err != nil {
+		t.Fatalf("GetAuthorizer() error = %v", err)
+	}
+
+	if got.Name != "jwt-auth" {
+		t.Errorf("GetAuthorizer() Name = %q, want %q", got.Name, "jwt-auth")
+	}
+
+	list, err := storage.GetAuthorizers(t.Context(), apiID)
+	if err != nil {
+		t.Fatalf("GetAuthorizers() error = %v", err)
+	}
+
+	if len(list) != 1 {
+		t.Fatalf("GetAuthorizers() len = %d, want 1", len(list))
+	}
+
+	return created
+}
+
+func checkUpdateAndDeleteAuthorizer(t *testing.T, storage *MemoryStorage, apiID string, created *Authorizer) {
+	t.Helper()
+
+	updated, err := storage.UpdateAuthorizer(t.Context(), apiID, created.AuthorizerID, &CreateAuthorizerRequest{
+		Name: "jwt-auth-renamed",
+	})
+	if err != nil {
+		t.Fatalf("UpdateAuthorizer() error = %v", err)
+	}
+
+	if updated.Name != "jwt-auth-renamed" {
+		t.Errorf("UpdateAuthorizer() Name = %q, want %q", updated.Name, "jwt-auth-renamed")
+	}
+
+	if updated.JWTConfiguration == nil || updated.JWTConfiguration.Issuer != "https://issuer.example.com" {
+		t.Errorf("UpdateAuthorizer() unexpectedly cleared JWTConfiguration: %+v", updated.JWTConfiguration)
+	}
+
+	if err := storage.DeleteAuthorizer(t.Context(), apiID, created.AuthorizerID); err != nil {
+		t.Fatalf("DeleteAuthorizer() error = %v", err)
+	}
+
+	if _, err := storage.GetAuthorizer(t.Context(), apiID, created.AuthorizerID); err == nil {
+		t.Error("GetAuthorizer() after delete: expected error, got nil")
+	}
+}
+
+func TestMemoryStorage_CreateAuthorizer_APINotFound(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMemoryStorage()
+
+	_, err := storage.CreateAuthorizer(t.Context(), "missing-api", &CreateAuthorizerRequest{
+		Name:           "jwt-auth",
+		AuthorizerType: authorizerTypeJWT,
+	})
+	if err == nil {
+		t.Fatal("CreateAuthorizer() with unknown apiId: expected error, got nil")
+	}
+}
+
+// ---- JWT decode/validate ----
+
+func buildTestJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	header := map[string]string{"alg": "none", "typ": "JWT"}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+
+	enc := base64.RawURLEncoding
+
+	return enc.EncodeToString(headerJSON) + "." + enc.EncodeToString(claimsJSON) + ".signature"
+}
+
+func TestDecodeJWTPayload(t *testing.T) {
+	t.Parallel()
+
+	token := buildTestJWT(t, map[string]any{"sub": "user1", "exp": 1234567890})
+
+	claims, err := decodeJWTPayload(token)
+	if err != nil {
+		t.Fatalf("decodeJWTPayload() error = %v", err)
+	}
+
+	if claims["sub"] != "user1" {
+		t.Errorf("claims[sub] = %v, want %q", claims["sub"], "user1")
+	}
+}
+
+func TestDecodeJWTPayload_Malformed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{name: "too few segments", token: "onlyonepart"},
+		{name: "invalid base64", token: "a.!!!not-base64!!!.c"},
+		{name: "invalid json", token: "a." + base64.RawURLEncoding.EncodeToString([]byte("not json")) + ".c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := decodeJWTPayload(tt.token); err == nil {
+				t.Error("decodeJWTPayload() expected error, got nil")
+			}
+		})
+	}
+}
+
+// validateJWTClaimsTestCase is a table entry shared by the
+// TestValidateJWTClaims_* tests below, split by concern (expiration, issuer,
+// audience/client_id) to stay within funlen.
+type validateJWTClaimsTestCase struct {
+	name   string
+	claims map[string]any
+	cfg    *JWTConfiguration
+	want   bool
+}
+
+func runValidateJWTClaimsCases(t *testing.T, tests []validateJWTClaimsTestCase) {
+	t.Helper()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := validateJWTClaims(tt.claims, tt.cfg); got != tt.want {
+				t.Errorf("validateJWTClaims() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateJWTClaims_Expiration(t *testing.T) {
+	t.Parallel()
+
+	future := time.Now().Add(time.Hour).Unix()
+	past := time.Now().Add(-time.Hour).Unix()
+
+	runValidateJWTClaimsCases(t, []validateJWTClaimsTestCase{
+		{
+			name:   "valid: no config beyond exp",
+			claims: map[string]any{"exp": json.Number(intToStr(future))},
+			want:   true,
+		},
+		{
+			name:   "expired token rejected",
+			claims: map[string]any{"exp": json.Number(intToStr(past))},
+			want:   false,
+		},
+		{
+			name:   "missing exp rejected",
+			claims: map[string]any{},
+			want:   false,
+		},
+	})
+}
+
+func TestValidateJWTClaims_Issuer(t *testing.T) {
+	t.Parallel()
+
+	future := time.Now().Add(time.Hour).Unix()
+
+	runValidateJWTClaimsCases(t, []validateJWTClaimsTestCase{
+		{
+			name: "issuer mismatch rejected",
+			claims: map[string]any{
+				"exp": json.Number(intToStr(future)),
+				"iss": "https://wrong.example.com",
+			},
+			cfg:  &JWTConfiguration{Issuer: "https://issuer.example.com"},
+			want: false,
+		},
+		{
+			name: "issuer match accepted",
+			claims: map[string]any{
+				"exp": json.Number(intToStr(future)),
+				"iss": "https://issuer.example.com",
+			},
+			cfg:  &JWTConfiguration{Issuer: "https://issuer.example.com"},
+			want: true,
+		},
+	})
+}
+
+func TestValidateJWTClaims_Audience(t *testing.T) {
+	t.Parallel()
+
+	future := time.Now().Add(time.Hour).Unix()
+
+	runValidateJWTClaimsCases(t, []validateJWTClaimsTestCase{
+		{
+			name: "audience string match accepted",
+			claims: map[string]any{
+				"exp": json.Number(intToStr(future)),
+				"aud": "aud1",
+			},
+			cfg:  &JWTConfiguration{Audience: []string{"aud1", "aud2"}},
+			want: true,
+		},
+		{
+			name: "audience array match accepted",
+			claims: map[string]any{
+				"exp": json.Number(intToStr(future)),
+				"aud": []any{"other", "aud2"},
+			},
+			cfg:  &JWTConfiguration{Audience: []string{"aud1", "aud2"}},
+			want: true,
+		},
+		{
+			name: "audience mismatch rejected",
+			claims: map[string]any{
+				"exp": json.Number(intToStr(future)),
+				"aud": "unknown",
+			},
+			cfg:  &JWTConfiguration{Audience: []string{"aud1"}},
+			want: false,
+		},
+		{
+			name: "client_id used when aud absent (Cognito access tokens)",
+			claims: map[string]any{
+				"exp":       json.Number(intToStr(future)),
+				"client_id": "aud1",
+			},
+			cfg:  &JWTConfiguration{Audience: []string{"aud1"}},
+			want: true,
+		},
+		{
+			name: "aud takes precedence over client_id when both present",
+			claims: map[string]any{
+				"exp":       json.Number(intToStr(future)),
+				"aud":       "unknown",
+				"client_id": "aud1",
+			},
+			cfg:  &JWTConfiguration{Audience: []string{"aud1"}},
+			want: false,
+		},
+	})
+}
+
+func TestStringifyClaimValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{name: "string", in: "hello", want: "hello"},
+		{name: "number", in: json.Number("1700000000"), want: "1700000000"},
+		{name: "bool true", in: true, want: "true"},
+		{name: "bool false", in: false, want: "false"},
+		{name: "nil", in: nil, want: ""},
+		{name: "array", in: []any{"a", "b"}, want: `["a","b"]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := stringifyClaimValue(tt.in); got != tt.want {
+				t.Errorf("stringifyClaimValue(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopesFromClaims(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		claims map[string]any
+		want   []string
+	}{
+		{name: "absent scope", claims: map[string]any{}, want: nil},
+		{name: "single scope", claims: map[string]any{"scope": "read"}, want: []string{"read"}},
+		{
+			name:   "space-delimited scopes",
+			claims: map[string]any{"scope": "read write admin"},
+			want:   []string{"read", "write", "admin"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := scopesFromClaims(tt.claims); !slices.Equal(got, tt.want) {
+				t.Errorf("scopesFromClaims() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBearerToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		header         string
+		identitySource []string
+		wantToken      string
+		wantOK         bool
+	}{
+		{
+			name:      "missing header",
+			header:    "",
+			wantToken: "",
+			wantOK:    false,
+		},
+		{
+			name:      "malformed (no Bearer prefix)",
+			header:    "sometoken",
+			wantToken: "",
+			wantOK:    false,
+		},
+		{
+			name:      "well-formed default header",
+			header:    "Bearer abc.def.ghi",
+			wantToken: "abc.def.ghi",
+			wantOK:    true,
+		},
+		{
+			name:           "explicit default identity source",
+			header:         "Bearer abc.def.ghi",
+			identitySource: []string{"$request.header.Authorization"},
+			wantToken:      "abc.def.ghi",
+			wantOK:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/items", nil)
+			if tt.header != "" {
+				r.Header.Set("Authorization", tt.header)
+			}
+
+			token, ok := bearerToken(r, tt.identitySource)
+			if ok != tt.wantOK || token != tt.wantToken {
+				t.Errorf("bearerToken() = (%q, %v), want (%q, %v)", token, ok, tt.wantToken, tt.wantOK)
+			}
+		})
+	}
+}
+
+func intToStr(v int64) string {
+	return strconv.FormatInt(v, 10)
+}

--- a/internal/service/apigatewayv2/executeapi.go
+++ b/internal/service/apigatewayv2/executeapi.go
@@ -31,16 +31,16 @@ func (s *Service) HandleExecuteAPI(w http.ResponseWriter, r *http.Request, apiID
 		return true
 	}
 
-	routes, err := s.storage.GetRoutes(r.Context(), apiID)
-	if err != nil {
+	route, pathParams, ok := s.matchRequestRoute(r, apiID, routePath)
+	if !ok {
 		writeExecuteErrorV2(w, http.StatusNotFound, "Not Found")
 
 		return true
 	}
 
-	route, pathParams, ok := matchRoute(routes, r.Method, routePath)
+	authContext, ok := s.authorizeRoute(r, apiID, route)
 	if !ok {
-		writeExecuteErrorV2(w, http.StatusNotFound, "Not Found")
+		writeExecuteErrorV2(w, http.StatusUnauthorized, "Unauthorized")
 
 		return true
 	}
@@ -52,17 +52,7 @@ func (s *Service) HandleExecuteAPI(w http.ResponseWriter, r *http.Request, apiID
 		return true
 	}
 
-	payloadFormat := integration.PayloadFormatVersion
-	if payloadFormat == "" {
-		payloadFormat = defaultPayloadFormatVersion
-	}
-
-	execapi.Dispatch(w, r,
-		execapi.Target{
-			Type:                 integration.IntegrationType,
-			URI:                  integration.IntegrationURI,
-			PayloadFormatVersion: payloadFormat,
-		},
+	execapi.Dispatch(w, r, targetFor(integration),
 		&execapi.Request{
 			BaseURL:        s.baseURLOrDefault(),
 			APIID:          apiID,
@@ -71,10 +61,54 @@ func (s *Service) HandleExecuteAPI(w http.ResponseWriter, r *http.Request, apiID
 			RouteKey:       route.RouteKey,
 			PathParameters: pathParams,
 			StageVariables: stageObj.StageVariables,
+			Authorizer:     authContext,
 		},
 	)
 
 	return true
+}
+
+// matchRequestRoute loads the API's routes and matches the request against
+// them.
+func (s *Service) matchRequestRoute(r *http.Request, apiID, routePath string) (*Route, map[string]string, bool) {
+	routes, err := s.storage.GetRoutes(r.Context(), apiID)
+	if err != nil {
+		return nil, nil, false
+	}
+
+	return matchRoute(routes, r.Method, routePath)
+}
+
+// authorizeRoute enforces the route's JWT authorizer, if any. ok is false
+// when the request must be rejected with 401 Unauthorized. Routes without a
+// JWT authorizer (AuthorizationType != "JWT" or no AuthorizerID) are always
+// authorized, with a nil authorizer context.
+func (s *Service) authorizeRoute(r *http.Request, apiID string, route *Route) (*execapi.AuthorizerContext, bool) {
+	if route.AuthorizationType != authorizerTypeJWT || route.AuthorizerID == "" {
+		return nil, true
+	}
+
+	authorizer, err := s.storage.GetAuthorizer(r.Context(), apiID, route.AuthorizerID)
+	if err != nil {
+		return nil, false
+	}
+
+	return authorizeJWT(r, authorizer)
+}
+
+// targetFor builds the execapi.Target for an integration, defaulting the
+// payload format version when the integration does not specify one.
+func targetFor(integration *Integration) execapi.Target {
+	payloadFormat := integration.PayloadFormatVersion
+	if payloadFormat == "" {
+		payloadFormat = defaultPayloadFormatVersion
+	}
+
+	return execapi.Target{
+		Type:                 integration.IntegrationType,
+		URI:                  integration.IntegrationURI,
+		PayloadFormatVersion: payloadFormat,
+	}
 }
 
 // resolveStage determines the stage, the resolved stage object, and the

--- a/internal/service/apigatewayv2/executeapi_jwt_test.go
+++ b/internal/service/apigatewayv2/executeapi_jwt_test.go
@@ -1,0 +1,320 @@
+package apigatewayv2
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+)
+
+const (
+	testJWTIssuer   = "https://issuer.example.com"
+	testJWTAudience = "test-audience"
+)
+
+// newJWTTestAPI wires up an API with a $default stage, an AWS_PROXY
+// integration pointing at lambdaURL, and a GET /items route protected by a
+// JWT authorizer configured with testJWTIssuer/testJWTAudience. It returns
+// the service and the API's id.
+func newJWTTestAPI(t *testing.T, lambdaURL string) (*Service, string) {
+	t.Helper()
+
+	storage := NewMemoryStorage()
+	svc := New(storage)
+	svc.baseURL = lambdaURL
+
+	api, err := storage.CreateAPI(t.Context(), &CreateAPIRequest{Name: "jwt-api", ProtocolType: "HTTP"})
+	if err != nil {
+		t.Fatalf("CreateAPI() error = %v", err)
+	}
+
+	authorizer, err := storage.CreateAuthorizer(t.Context(), api.APIID, &CreateAuthorizerRequest{
+		Name:           "jwt-authorizer",
+		AuthorizerType: authorizerTypeJWT,
+		JWTConfiguration: &JWTConfiguration{
+			Issuer:   testJWTIssuer,
+			Audience: []string{testJWTAudience},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateAuthorizer() error = %v", err)
+	}
+
+	integration, err := storage.CreateIntegration(t.Context(), api.APIID, &CreateIntegrationRequest{
+		IntegrationType:      "AWS_PROXY",
+		IntegrationURI:       "arn:aws:lambda:us-east-1:000000000000:function:jwt-test-fn",
+		PayloadFormatVersion: "2.0",
+	})
+	if err != nil {
+		t.Fatalf("CreateIntegration() error = %v", err)
+	}
+
+	_, err = storage.CreateRoute(t.Context(), api.APIID, &CreateRouteRequest{
+		RouteKey:          "GET /items",
+		Target:            "integrations/" + integration.IntegrationID,
+		AuthorizationType: authorizerTypeJWT,
+		AuthorizerID:      authorizer.AuthorizerID,
+	})
+	if err != nil {
+		t.Fatalf("CreateRoute() error = %v", err)
+	}
+
+	if _, err := storage.CreateStage(t.Context(), api.APIID, &CreateStageRequest{
+		StageName:  defaultStageName,
+		AutoDeploy: true,
+	}); err != nil {
+		t.Fatalf("CreateStage() error = %v", err)
+	}
+
+	return svc, api.APIID
+}
+
+// TestHandleExecuteAPI_JWTAuthorizer_Unauthorized covers the 401 cases: a
+// missing header, a malformed token, an expired token, a wrong issuer, and a
+// wrong audience must all be rejected before the integration is invoked.
+func TestHandleExecuteAPI_JWTAuthorizer_Unauthorized(t *testing.T) {
+	future := time.Now().Add(time.Hour).Unix()
+	past := time.Now().Add(-time.Hour).Unix()
+
+	tests := []struct {
+		name   string
+		header string
+	}{
+		{
+			name:   "missing Authorization header",
+			header: "",
+		},
+		{
+			name:   "malformed token (no Bearer prefix)",
+			header: "sometoken",
+		},
+		{
+			name: "expired token",
+			header: "Bearer " + buildTestJWT(t, map[string]any{
+				"iss": testJWTIssuer,
+				"aud": testJWTAudience,
+				"exp": past,
+			}),
+		},
+		{
+			name: "wrong issuer",
+			header: "Bearer " + buildTestJWT(t, map[string]any{
+				"iss": "https://wrong-issuer.example.com",
+				"aud": testJWTAudience,
+				"exp": future,
+			}),
+		},
+		{
+			name: "wrong audience",
+			header: "Bearer " + buildTestJWT(t, map[string]any{
+				"iss": testJWTIssuer,
+				"aud": "wrong-audience",
+				"exp": future,
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkJWTUnauthorized(t, tt.header)
+		})
+	}
+}
+
+func checkJWTUnauthorized(t *testing.T, header string) {
+	t.Helper()
+
+	lambdaInvoked := false
+
+	lambda := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		lambdaInvoked = true
+	}))
+	t.Cleanup(lambda.Close)
+
+	svc, apiID := newJWTTestAPI(t, lambda.URL)
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/items", nil)
+	if header != "" {
+		r.Header.Set("Authorization", header)
+	}
+
+	w := httptest.NewRecorder()
+
+	if !svc.HandleExecuteAPI(w, r, apiID, "/items") {
+		t.Fatal("HandleExecuteAPI() returned false, want true")
+	}
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d; body=%q", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal error body: %v", err)
+	}
+
+	if body["message"] != "Unauthorized" {
+		t.Errorf("error body message = %q, want %q", body["message"], "Unauthorized")
+	}
+
+	if lambdaInvoked {
+		t.Error("lambda integration was invoked despite failed authorization")
+	}
+}
+
+// jwtEventCapture decodes the requestContext.authorizer.jwt block of a
+// payload-2.0 Lambda event.
+type jwtEventCapture struct {
+	RequestContext struct {
+		Authorizer struct {
+			JWT struct {
+				Claims map[string]string `json:"claims"`
+				Scopes []string          `json:"scopes"`
+			} `json:"jwt"`
+		} `json:"authorizer"`
+	} `json:"requestContext"`
+}
+
+// newCapturingLambda starts a mock Lambda invoke endpoint that decodes each
+// request body into captured and always responds with a 200.
+func newCapturingLambda(t *testing.T, captured *jwtEventCapture) *httptest.Server {
+	t.Helper()
+
+	lambda := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(captured); err != nil {
+			t.Fatalf("decode lambda event: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"statusCode": 200, "body": "ok"})
+	}))
+	t.Cleanup(lambda.Close)
+
+	return lambda
+}
+
+// TestHandleExecuteAPI_JWTAuthorizer_Valid proves a valid token's claims and
+// scopes are propagated to the Lambda event's
+// requestContext.authorizer.jwt block.
+func TestHandleExecuteAPI_JWTAuthorizer_Valid(t *testing.T) {
+	future := time.Now().Add(time.Hour).Unix()
+
+	var captured jwtEventCapture
+
+	lambda := newCapturingLambda(t, &captured)
+	svc, apiID := newJWTTestAPI(t, lambda.URL)
+
+	token := buildTestJWT(t, map[string]any{
+		"sub":   "user-1",
+		"iss":   testJWTIssuer,
+		"aud":   testJWTAudience,
+		"exp":   future,
+		"scope": "read write",
+	})
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/items", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+
+	if !svc.HandleExecuteAPI(w, r, apiID, "/items") {
+		t.Fatal("HandleExecuteAPI() returned false, want true")
+	}
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+
+	checkCapturedJWTClaims(t, captured, future)
+}
+
+func checkCapturedJWTClaims(t *testing.T, captured jwtEventCapture, wantExpUnix int64) {
+	t.Helper()
+
+	claims := captured.RequestContext.Authorizer.JWT.Claims
+	if claims["sub"] != "user-1" {
+		t.Errorf("claims[sub] = %q, want %q", claims["sub"], "user-1")
+	}
+
+	if claims["iss"] != testJWTIssuer {
+		t.Errorf("claims[iss] = %q, want %q", claims["iss"], testJWTIssuer)
+	}
+
+	wantExp := strconv.FormatInt(wantExpUnix, 10)
+	if claims["exp"] != wantExp {
+		t.Errorf("claims[exp] = %q, want %q (stringified number)", claims["exp"], wantExp)
+	}
+
+	wantScopes := []string{"read", "write"}
+	if gotScopes := captured.RequestContext.Authorizer.JWT.Scopes; !slices.Equal(gotScopes, wantScopes) {
+		t.Errorf("scopes = %v, want %v", gotScopes, wantScopes)
+	}
+}
+
+// TestHandleExecuteAPI_NoAuthorizer proves routes without a JWT authorizer
+// are unaffected by this feature: no Authorization header is required and no
+// authorizer block appears in the Lambda event.
+func TestHandleExecuteAPI_NoAuthorizer(t *testing.T) {
+	var capturedEvent map[string]any
+
+	lambda := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedEvent); err != nil {
+			t.Fatalf("decode lambda event: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"statusCode": 200, "body": "ok"})
+	}))
+	t.Cleanup(lambda.Close)
+
+	storage := NewMemoryStorage()
+	svc := New(storage)
+	svc.baseURL = lambda.URL
+
+	api, err := storage.CreateAPI(t.Context(), &CreateAPIRequest{Name: "no-auth-api", ProtocolType: "HTTP"})
+	if err != nil {
+		t.Fatalf("CreateAPI() error = %v", err)
+	}
+
+	integration, err := storage.CreateIntegration(t.Context(), api.APIID, &CreateIntegrationRequest{
+		IntegrationType:      "AWS_PROXY",
+		IntegrationURI:       "arn:aws:lambda:us-east-1:000000000000:function:no-auth-fn",
+		PayloadFormatVersion: "2.0",
+	})
+	if err != nil {
+		t.Fatalf("CreateIntegration() error = %v", err)
+	}
+
+	if _, err := storage.CreateRoute(t.Context(), api.APIID, &CreateRouteRequest{
+		RouteKey: "GET /items",
+		Target:   "integrations/" + integration.IntegrationID,
+	}); err != nil {
+		t.Fatalf("CreateRoute() error = %v", err)
+	}
+
+	if _, err := storage.CreateStage(t.Context(), api.APIID, &CreateStageRequest{
+		StageName:  defaultStageName,
+		AutoDeploy: true,
+	}); err != nil {
+		t.Fatalf("CreateStage() error = %v", err)
+	}
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/items", nil)
+	w := httptest.NewRecorder()
+
+	if !svc.HandleExecuteAPI(w, r, api.APIID, "/items") {
+		t.Fatal("HandleExecuteAPI() returned false, want true")
+	}
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+
+	requestContext, _ := capturedEvent["requestContext"].(map[string]any)
+	if _, present := requestContext["authorizer"]; present {
+		t.Error("requestContext.authorizer is present for a route without an authorizer")
+	}
+}

--- a/internal/service/apigatewayv2/handlers.go
+++ b/internal/service/apigatewayv2/handlers.go
@@ -204,6 +204,108 @@ func (s *Service) DeleteRoute(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// ---- Authorizer handlers ----
+
+// CreateAuthorizer handles the CreateAuthorizer API.
+func (s *Service) CreateAuthorizer(w http.ResponseWriter, r *http.Request) {
+	apiID := segmentAt(r.URL.Path, 0)
+
+	var req CreateAuthorizerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errBadRequest, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.Name == "" {
+		writeError(w, errBadRequest, "Name is required", http.StatusBadRequest)
+
+		return
+	}
+
+	if req.AuthorizerType == "" {
+		writeError(w, errBadRequest, "AuthorizerType is required", http.StatusBadRequest)
+
+		return
+	}
+
+	authorizer, err := s.storage.CreateAuthorizer(r.Context(), apiID, &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, authorizer, http.StatusCreated)
+}
+
+// GetAuthorizer handles the GetAuthorizer API.
+func (s *Service) GetAuthorizer(w http.ResponseWriter, r *http.Request) {
+	apiID, authorizerID := segmentAt(r.URL.Path, 0), segmentAt(r.URL.Path, 2)
+
+	authorizer, err := s.storage.GetAuthorizer(r.Context(), apiID, authorizerID)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, authorizer, http.StatusOK)
+}
+
+// GetAuthorizers handles the GetAuthorizers API.
+func (s *Service) GetAuthorizers(w http.ResponseWriter, r *http.Request) {
+	apiID := segmentAt(r.URL.Path, 0)
+
+	authorizers, err := s.storage.GetAuthorizers(r.Context(), apiID)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	items := make([]Authorizer, 0, len(authorizers))
+	for _, authorizer := range authorizers {
+		items = append(items, *authorizer)
+	}
+
+	writeResponse(w, &AuthorizersResponse{Items: items}, http.StatusOK)
+}
+
+// UpdateAuthorizer handles the UpdateAuthorizer API.
+func (s *Service) UpdateAuthorizer(w http.ResponseWriter, r *http.Request) {
+	apiID, authorizerID := segmentAt(r.URL.Path, 0), segmentAt(r.URL.Path, 2)
+
+	var req CreateAuthorizerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, errBadRequest, "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	authorizer, err := s.storage.UpdateAuthorizer(r.Context(), apiID, authorizerID, &req)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, authorizer, http.StatusOK)
+}
+
+// DeleteAuthorizer handles the DeleteAuthorizer API.
+func (s *Service) DeleteAuthorizer(w http.ResponseWriter, r *http.Request) {
+	apiID, authorizerID := segmentAt(r.URL.Path, 0), segmentAt(r.URL.Path, 2)
+
+	if err := s.storage.DeleteAuthorizer(r.Context(), apiID, authorizerID); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // ---- Integration handlers ----
 
 // CreateIntegration handles the CreateIntegration API.

--- a/internal/service/apigatewayv2/service.go
+++ b/internal/service/apigatewayv2/service.go
@@ -73,6 +73,13 @@ func (s *Service) RegisterRoutes(r service.Router) {
 		r.HandleFunc("PATCH", prefix+"/v2/apis/{apiId}/routes/{routeId}", s.UpdateRoute)
 		r.HandleFunc("DELETE", prefix+"/v2/apis/{apiId}/routes/{routeId}", s.DeleteRoute)
 
+		// Authorizer routes.
+		r.HandleFunc("POST", prefix+"/v2/apis/{apiId}/authorizers", s.CreateAuthorizer)
+		r.HandleFunc("GET", prefix+"/v2/apis/{apiId}/authorizers", s.GetAuthorizers)
+		r.HandleFunc("GET", prefix+"/v2/apis/{apiId}/authorizers/{authorizerId}", s.GetAuthorizer)
+		r.HandleFunc("PATCH", prefix+"/v2/apis/{apiId}/authorizers/{authorizerId}", s.UpdateAuthorizer)
+		r.HandleFunc("DELETE", prefix+"/v2/apis/{apiId}/authorizers/{authorizerId}", s.DeleteAuthorizer)
+
 		// Integration routes.
 		r.HandleFunc("POST", prefix+"/v2/apis/{apiId}/integrations", s.CreateIntegration)
 		r.HandleFunc("GET", prefix+"/v2/apis/{apiId}/integrations", s.GetIntegrations)

--- a/internal/service/apigatewayv2/storage.go
+++ b/internal/service/apigatewayv2/storage.go
@@ -23,6 +23,10 @@ const (
 // is not set.
 const defaultRegion = "us-east-1"
 
+// defaultIdentitySource is the identity source API Gateway uses for an
+// authorizer when the caller does not specify one.
+const defaultIdentitySource = "$request.header.Authorization"
+
 // Storage defines the API Gateway v2 storage interface.
 type Storage interface {
 	CreateAPI(ctx context.Context, req *CreateAPIRequest) (*API, error)
@@ -36,6 +40,12 @@ type Storage interface {
 	GetRoutes(ctx context.Context, apiID string) ([]*Route, error)
 	UpdateRoute(ctx context.Context, apiID, routeID string, req *CreateRouteRequest) (*Route, error)
 	DeleteRoute(ctx context.Context, apiID, routeID string) error
+
+	CreateAuthorizer(ctx context.Context, apiID string, req *CreateAuthorizerRequest) (*Authorizer, error)
+	GetAuthorizer(ctx context.Context, apiID, authorizerID string) (*Authorizer, error)
+	GetAuthorizers(ctx context.Context, apiID string) ([]*Authorizer, error)
+	UpdateAuthorizer(ctx context.Context, apiID, authorizerID string, req *CreateAuthorizerRequest) (*Authorizer, error)
+	DeleteAuthorizer(ctx context.Context, apiID, authorizerID string) error
 
 	CreateIntegration(ctx context.Context, apiID string, req *CreateIntegrationRequest) (*Integration, error)
 	GetIntegration(ctx context.Context, apiID, integrationID string) (*Integration, error)
@@ -87,6 +97,7 @@ type MemoryStorage struct {
 type APIData struct {
 	API          *API                    `json:"api"`
 	Routes       map[string]*Route       `json:"routes"`
+	Authorizers  map[string]*Authorizer  `json:"authorizers"`
 	Integrations map[string]*Integration `json:"integrations"`
 	Stages       map[string]*Stage       `json:"stages"`
 	Deployments  map[string]*Deployment  `json:"deployments"`
@@ -146,6 +157,17 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 		s.APIs = make(map[string]*APIData)
 	}
 
+	// Authorizers was added after the initial persistence format, so a
+	// snapshot written before this feature existed restores APIData with a
+	// nil Authorizers map; re-initialize it here the same way CreateAPI
+	// does, otherwise the first CreateAuthorizer against a restored API
+	// panics with "assignment to entry in nil map".
+	for _, data := range s.APIs {
+		if data.Authorizers == nil {
+			data.Authorizers = make(map[string]*Authorizer)
+		}
+	}
+
 	return nil
 }
 
@@ -203,6 +225,7 @@ func (s *MemoryStorage) CreateAPI(_ context.Context, req *CreateAPIRequest) (*AP
 	s.APIs[id] = &APIData{
 		API:          api,
 		Routes:       make(map[string]*Route),
+		Authorizers:  make(map[string]*Authorizer),
 		Integrations: make(map[string]*Integration),
 		Stages:       make(map[string]*Stage),
 		Deployments:  make(map[string]*Deployment),
@@ -447,6 +470,142 @@ func (s *MemoryStorage) DeleteRoute(_ context.Context, apiID, routeID string) er
 	}
 
 	delete(data.Routes, routeID)
+
+	s.saveLocked()
+
+	return nil
+}
+
+// CreateAuthorizer creates a new authorizer.
+func (s *MemoryStorage) CreateAuthorizer(_ context.Context, apiID string, req *CreateAuthorizerRequest) (*Authorizer, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, exists := s.APIs[apiID]
+	if !exists {
+		return nil, &ServiceError{Code: errNotFound, Message: "Invalid API identifier specified"}
+	}
+
+	id := generateID()
+
+	identitySource := req.IdentitySource
+	if len(identitySource) == 0 {
+		identitySource = []string{defaultIdentitySource}
+	}
+
+	authorizer := &Authorizer{
+		AuthorizerID:                   id,
+		Name:                           req.Name,
+		AuthorizerType:                 req.AuthorizerType,
+		IdentitySource:                 identitySource,
+		JWTConfiguration:               req.JWTConfiguration,
+		AuthorizerCredentialsArn:       req.AuthorizerCredentialsArn,
+		AuthorizerResultTTLInSeconds:   req.AuthorizerResultTTLInSeconds,
+		AuthorizerPayloadFormatVersion: req.AuthorizerPayloadFormatVersion,
+		AuthorizerURI:                  req.AuthorizerURI,
+		EnableSimpleResponses:          req.EnableSimpleResponses,
+		IdentityValidationExpression:   req.IdentityValidationExpression,
+	}
+
+	data.Authorizers[id] = authorizer
+
+	s.saveLocked()
+
+	return authorizer, nil
+}
+
+// GetAuthorizer returns an authorizer by ID.
+func (s *MemoryStorage) GetAuthorizer(_ context.Context, apiID, authorizerID string) (*Authorizer, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, exists := s.APIs[apiID]
+	if !exists {
+		return nil, &ServiceError{Code: errNotFound, Message: "Invalid API identifier specified"}
+	}
+
+	authorizer, exists := data.Authorizers[authorizerID]
+	if !exists {
+		return nil, &ServiceError{Code: errNotFound, Message: "Invalid authorizer identifier specified"}
+	}
+
+	return authorizer, nil
+}
+
+// GetAuthorizers returns all authorizers for an API.
+func (s *MemoryStorage) GetAuthorizers(_ context.Context, apiID string) ([]*Authorizer, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, exists := s.APIs[apiID]
+	if !exists {
+		return nil, &ServiceError{Code: errNotFound, Message: "Invalid API identifier specified"}
+	}
+
+	authorizers := make([]*Authorizer, 0, len(data.Authorizers))
+	for _, a := range data.Authorizers {
+		authorizers = append(authorizers, a)
+	}
+
+	return authorizers, nil
+}
+
+// UpdateAuthorizer updates an existing authorizer.
+func (s *MemoryStorage) UpdateAuthorizer(_ context.Context, apiID, authorizerID string, req *CreateAuthorizerRequest) (*Authorizer, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, exists := s.APIs[apiID]
+	if !exists {
+		return nil, &ServiceError{Code: errNotFound, Message: "Invalid API identifier specified"}
+	}
+
+	authorizer, exists := data.Authorizers[authorizerID]
+	if !exists {
+		return nil, &ServiceError{Code: errNotFound, Message: "Invalid authorizer identifier specified"}
+	}
+
+	mergeStr(&authorizer.Name, req.Name)
+	mergeStr(&authorizer.AuthorizerType, req.AuthorizerType)
+	mergeStr(&authorizer.AuthorizerCredentialsArn, req.AuthorizerCredentialsArn)
+	mergeStr(&authorizer.AuthorizerPayloadFormatVersion, req.AuthorizerPayloadFormatVersion)
+	mergeStr(&authorizer.AuthorizerURI, req.AuthorizerURI)
+	mergeStr(&authorizer.IdentityValidationExpression, req.IdentityValidationExpression)
+
+	if req.IdentitySource != nil {
+		authorizer.IdentitySource = req.IdentitySource
+	}
+
+	if req.JWTConfiguration != nil {
+		authorizer.JWTConfiguration = req.JWTConfiguration
+	}
+
+	if req.AuthorizerResultTTLInSeconds != 0 {
+		authorizer.AuthorizerResultTTLInSeconds = req.AuthorizerResultTTLInSeconds
+	}
+
+	authorizer.EnableSimpleResponses = req.EnableSimpleResponses
+
+	s.saveLocked()
+
+	return authorizer, nil
+}
+
+// DeleteAuthorizer deletes an authorizer.
+func (s *MemoryStorage) DeleteAuthorizer(_ context.Context, apiID, authorizerID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, exists := s.APIs[apiID]
+	if !exists {
+		return &ServiceError{Code: errNotFound, Message: "Invalid API identifier specified"}
+	}
+
+	if _, exists := data.Authorizers[authorizerID]; !exists {
+		return &ServiceError{Code: errNotFound, Message: "Invalid authorizer identifier specified"}
+	}
+
+	delete(data.Authorizers, authorizerID)
 
 	s.saveLocked()
 

--- a/internal/service/apigatewayv2/types.go
+++ b/internal/service/apigatewayv2/types.go
@@ -119,6 +119,28 @@ type AccessLogSettings struct {
 	Format         string `json:"format,omitempty"`
 }
 
+// Authorizer represents an authorizer for an API. kumo only enforces the JWT
+// authorizer type at execute time; other types are stored but not evaluated.
+type Authorizer struct {
+	AuthorizerID                   string            `json:"authorizerId"`
+	Name                           string            `json:"name"`
+	AuthorizerType                 string            `json:"authorizerType"`
+	IdentitySource                 []string          `json:"identitySource,omitempty"`
+	JWTConfiguration               *JWTConfiguration `json:"jwtConfiguration,omitempty"`
+	AuthorizerCredentialsArn       string            `json:"authorizerCredentialsArn,omitempty"`
+	AuthorizerResultTTLInSeconds   int32             `json:"authorizerResultTtlInSeconds,omitempty"`
+	AuthorizerPayloadFormatVersion string            `json:"authorizerPayloadFormatVersion,omitempty"`
+	AuthorizerURI                  string            `json:"authorizerUri,omitempty"`
+	EnableSimpleResponses          bool              `json:"enableSimpleResponses,omitempty"`
+	IdentityValidationExpression   string            `json:"identityValidationExpression,omitempty"`
+}
+
+// JWTConfiguration represents the configuration of a JWT authorizer.
+type JWTConfiguration struct {
+	Audience []string `json:"audience,omitempty"`
+	Issuer   string   `json:"issuer,omitempty"`
+}
+
 // Deployment represents a deployment for an API.
 type Deployment struct {
 	DeploymentID     string    `json:"deploymentId"`
@@ -175,6 +197,20 @@ type CreateRouteRequest struct {
 	RequestParameters                map[string]ParameterConstraints `json:"requestParameters,omitempty"`
 	ModelSelectionExpression         string                          `json:"modelSelectionExpression,omitempty"`
 	RouteResponseSelectionExpression string                          `json:"routeResponseSelectionExpression,omitempty"`
+}
+
+// CreateAuthorizerRequest represents a CreateAuthorizer request.
+type CreateAuthorizerRequest struct {
+	Name                           string            `json:"name"`
+	AuthorizerType                 string            `json:"authorizerType"`
+	IdentitySource                 []string          `json:"identitySource,omitempty"`
+	JWTConfiguration               *JWTConfiguration `json:"jwtConfiguration,omitempty"`
+	AuthorizerCredentialsArn       string            `json:"authorizerCredentialsArn,omitempty"`
+	AuthorizerResultTTLInSeconds   int32             `json:"authorizerResultTtlInSeconds,omitempty"`
+	AuthorizerPayloadFormatVersion string            `json:"authorizerPayloadFormatVersion,omitempty"`
+	AuthorizerURI                  string            `json:"authorizerUri,omitempty"`
+	EnableSimpleResponses          bool              `json:"enableSimpleResponses,omitempty"`
+	IdentityValidationExpression   string            `json:"identityValidationExpression,omitempty"`
 }
 
 // CreateIntegrationRequest represents a CreateIntegration request.
@@ -248,6 +284,12 @@ type APIResponse struct {
 type APIsResponse struct {
 	Items     []APIResponse `json:"items"`
 	NextToken string        `json:"nextToken,omitempty"`
+}
+
+// AuthorizersResponse represents a GetAuthorizers response.
+type AuthorizersResponse struct {
+	Items     []Authorizer `json:"items"`
+	NextToken string       `json:"nextToken,omitempty"`
 }
 
 // RoutesResponse represents a GetRoutes response.

--- a/internal/service/execapi/event.go
+++ b/internal/service/execapi/event.go
@@ -84,11 +84,12 @@ type proxyEventV2 struct {
 }
 
 type requestContextV2 struct {
-	APIID     string `json:"apiId"`
-	Stage     string `json:"stage"`
-	RouteKey  string `json:"routeKey"`
-	RequestID string `json:"requestId"`
-	HTTP      httpV2 `json:"http"`
+	APIID      string             `json:"apiId"`
+	Stage      string             `json:"stage"`
+	RouteKey   string             `json:"routeKey"`
+	RequestID  string             `json:"requestId"`
+	HTTP       httpV2             `json:"http"`
+	Authorizer *AuthorizerContext `json:"authorizer,omitempty"`
 }
 
 type httpV2 struct {
@@ -96,6 +97,19 @@ type httpV2 struct {
 	Path     string `json:"path"`
 	Protocol string `json:"protocol"`
 	SourceIP string `json:"sourceIp"`
+}
+
+// AuthorizerContext is the requestContext.authorizer block for a route
+// protected by an authorizer. Only the JWT authorizer shape is emulated.
+type AuthorizerContext struct {
+	JWT *JWTAuthorizerClaims `json:"jwt,omitempty"`
+}
+
+// JWTAuthorizerClaims is requestContext.authorizer.jwt: the validated
+// token's claims (stringified the way API Gateway renders them) and scopes.
+type JWTAuthorizerClaims struct {
+	Claims map[string]string `json:"claims"`
+	Scopes []string          `json:"scopes,omitempty"`
 }
 
 // buildEventV2 builds the payload-2.0 proxy event from the HTTP request.
@@ -126,6 +140,7 @@ func buildEventV2(r *http.Request, req *Request, body []byte) ([]byte, error) {
 				Protocol: r.Proto,
 				SourceIP: r.RemoteAddr,
 			},
+			Authorizer: req.Authorizer,
 		},
 	}
 

--- a/internal/service/execapi/execapi.go
+++ b/internal/service/execapi/execapi.go
@@ -47,6 +47,9 @@ type Request struct {
 	RouteKey       string // v2 route key, e.g. "GET /items" or "$default"
 	PathParameters map[string]string
 	StageVariables map[string]string
+	// Authorizer carries the result of a JWT authorizer evaluation for the
+	// route (v2 payload format only). Nil for routes without an authorizer.
+	Authorizer *AuthorizerContext
 }
 
 // Dispatch resolves the integration target and writes the HTTP response. It is

--- a/test/integration/apigatewayv2_test.go
+++ b/test/integration/apigatewayv2_test.go
@@ -144,6 +144,83 @@ func TestAPIGatewayV2_CreateRoute(t *testing.T) {
 	golden.New(t, golden.WithIgnoreFields("RouteId", "ResultMetadata")).Assert(t.Name()+"_get", getOutput)
 }
 
+func TestAPIGatewayV2_CreateAuthorizer(t *testing.T) {
+	client := newAPIGatewayV2Client(t)
+	ctx := t.Context()
+
+	apiOutput, err := client.CreateApi(ctx, &apigatewayv2.CreateApiInput{
+		Name:         aws.String("test-authorizer-api"),
+		ProtocolType: types.ProtocolTypeHttp,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createOutput, err := client.CreateAuthorizer(ctx, &apigatewayv2.CreateAuthorizerInput{
+		ApiId:          apiOutput.ApiId,
+		Name:           aws.String("test-jwt-authorizer"),
+		AuthorizerType: types.AuthorizerTypeJwt,
+		IdentitySource: []string{"$request.header.Authorization"},
+		JwtConfiguration: &types.JWTConfiguration{
+			Audience: []string{"test-audience"},
+			Issuer:   aws.String("https://issuer.example.com"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("AuthorizerId", "ResultMetadata")).Assert(t.Name()+"_create", createOutput)
+
+	getOutput, err := client.GetAuthorizer(ctx, &apigatewayv2.GetAuthorizerInput{
+		ApiId:        apiOutput.ApiId,
+		AuthorizerId: createOutput.AuthorizerId,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("AuthorizerId", "ResultMetadata")).Assert(t.Name()+"_get", getOutput)
+
+	updateOutput, err := client.UpdateAuthorizer(ctx, &apigatewayv2.UpdateAuthorizerInput{
+		ApiId:        apiOutput.ApiId,
+		AuthorizerId: createOutput.AuthorizerId,
+		Name:         aws.String("test-jwt-authorizer-renamed"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields("AuthorizerId", "ResultMetadata")).Assert(t.Name()+"_update", updateOutput)
+
+	listOutput, err := client.GetAuthorizers(ctx, &apigatewayv2.GetAuthorizersInput{
+		ApiId: apiOutput.ApiId,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(listOutput.Items) != 1 {
+		t.Fatalf("GetAuthorizers() len = %d, want 1", len(listOutput.Items))
+	}
+
+	_, err = client.DeleteAuthorizer(ctx, &apigatewayv2.DeleteAuthorizerInput{
+		ApiId:        apiOutput.ApiId,
+		AuthorizerId: createOutput.AuthorizerId,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.GetAuthorizer(ctx, &apigatewayv2.GetAuthorizerInput{
+		ApiId:        apiOutput.ApiId,
+		AuthorizerId: createOutput.AuthorizerId,
+	})
+	if err == nil {
+		t.Error("expected error for deleted authorizer")
+	}
+}
+
 func TestAPIGatewayV2_CreateIntegration(t *testing.T) {
 	client := newAPIGatewayV2Client(t)
 	ctx := t.Context()

--- a/test/integration/testdata/apigatewayv2_test_TestAPIGatewayV2_CreateAuthorizer_TestAPIGatewayV2_CreateAuthorizer_create.golden.go
+++ b/test/integration/testdata/apigatewayv2_test_TestAPIGatewayV2_CreateAuthorizer_TestAPIGatewayV2_CreateAuthorizer_create.golden.go
@@ -1,0 +1,21 @@
+{
+  "AuthorizerCredentialsArn": null,
+  "AuthorizerId": "1ab2bde1-f",
+  "AuthorizerPayloadFormatVersion": null,
+  "AuthorizerResultTtlInSeconds": null,
+  "AuthorizerType": "JWT",
+  "AuthorizerUri": null,
+  "EnableSimpleResponses": null,
+  "IdentitySource": [
+    "$request.header.Authorization"
+  ],
+  "IdentityValidationExpression": null,
+  "JwtConfiguration": {
+    "Audience": [
+      "test-audience"
+    ],
+    "Issuer": "https://issuer.example.com"
+  },
+  "Name": "test-jwt-authorizer",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/apigatewayv2_test_TestAPIGatewayV2_CreateAuthorizer_TestAPIGatewayV2_CreateAuthorizer_get.golden.go
+++ b/test/integration/testdata/apigatewayv2_test_TestAPIGatewayV2_CreateAuthorizer_TestAPIGatewayV2_CreateAuthorizer_get.golden.go
@@ -1,0 +1,21 @@
+{
+  "AuthorizerCredentialsArn": null,
+  "AuthorizerId": "1ab2bde1-f",
+  "AuthorizerPayloadFormatVersion": null,
+  "AuthorizerResultTtlInSeconds": null,
+  "AuthorizerType": "JWT",
+  "AuthorizerUri": null,
+  "EnableSimpleResponses": null,
+  "IdentitySource": [
+    "$request.header.Authorization"
+  ],
+  "IdentityValidationExpression": null,
+  "JwtConfiguration": {
+    "Audience": [
+      "test-audience"
+    ],
+    "Issuer": "https://issuer.example.com"
+  },
+  "Name": "test-jwt-authorizer",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/apigatewayv2_test_TestAPIGatewayV2_CreateAuthorizer_TestAPIGatewayV2_CreateAuthorizer_update.golden.go
+++ b/test/integration/testdata/apigatewayv2_test_TestAPIGatewayV2_CreateAuthorizer_TestAPIGatewayV2_CreateAuthorizer_update.golden.go
@@ -1,0 +1,21 @@
+{
+  "AuthorizerCredentialsArn": null,
+  "AuthorizerId": "1ab2bde1-f",
+  "AuthorizerPayloadFormatVersion": null,
+  "AuthorizerResultTtlInSeconds": null,
+  "AuthorizerType": "JWT",
+  "AuthorizerUri": null,
+  "EnableSimpleResponses": null,
+  "IdentitySource": [
+    "$request.header.Authorization"
+  ],
+  "IdentityValidationExpression": null,
+  "JwtConfiguration": {
+    "Audience": [
+      "test-audience"
+    ],
+    "Issuer": "https://issuer.example.com"
+  },
+  "Name": "test-jwt-authorizer-renamed",
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
API Gateway v2 (HTTP API) routes can already be configured with `AuthorizationType: JWT`, but execute-api never enforced it and the payload-2.0 event had no place to carry claims. This adds:

- Authorizer CRUD (JWT type, with JwtConfiguration Issuer/Audience)
- Execute-time enforcement: bearer token decode + exp/iss/aud (or client_id, per API Gateway's precedence for Cognito-style tokens) validation, 401 on failure
- `requestContext.authorizer.jwt.claims`/`scopes` injected into the event a Lambda proxy integration receives

Signature verification is intentionally out of scope for the emulator (no JWKS access); the check is structured so it can slot in later, e.g. reusing #816's Cognito JWKS infrastructure if it lands.

Fixes #858

## Test plan
- [ ] Authorizer CRUD golden tests
- [ ] Execute path: valid token yields claims/scopes on the Lambda event
- [ ] 401 on missing/expired/wrong-issuer/wrong-audience tokens