### PR TITLE
feat(sfn): execute Choice, Wait, Succeed, and Fail states and plain Lambda ARN tasks

### DIFF
--- a/internal/service/sfn/choice.go
+++ b/internal/service/sfn/choice.go
@@ -1,0 +1,281 @@
+package sfn
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// choiceRule is a single rule within a Choice state's Choices array. Per the
+// Amazon States Language spec it is either a Data-test Expression (a
+// "Variable" JSONPath plus exactly one comparison operator) or a Boolean
+// Expression (And/Or/Not combining nested rules).
+//
+// JSON tags are lowerCamelCase rather than the Amazon States Language's own
+// PascalCase (e.g. "Variable", "StringEquals"); encoding/json matches object
+// keys to struct fields case-insensitively when there is no exact match, so
+// definitions using the spec's PascalCase field names still decode correctly.
+type choiceRule struct {
+	Variable string `json:"variable"`
+	Next     string `json:"next"`
+
+	StringEquals            *string `json:"stringEquals"`
+	StringLessThan          *string `json:"stringLessThan"`
+	StringGreaterThan       *string `json:"stringGreaterThan"`
+	StringLessThanEquals    *string `json:"stringLessThanEquals"`
+	StringGreaterThanEquals *string `json:"stringGreaterThanEquals"`
+
+	NumericEquals            *float64 `json:"numericEquals"`
+	NumericLessThan          *float64 `json:"numericLessThan"`
+	NumericGreaterThan       *float64 `json:"numericGreaterThan"`
+	NumericLessThanEquals    *float64 `json:"numericLessThanEquals"`
+	NumericGreaterThanEquals *float64 `json:"numericGreaterThanEquals"`
+
+	BooleanEquals *bool `json:"booleanEquals"`
+
+	TimestampEquals      *string `json:"timestampEquals"`
+	TimestampLessThan    *string `json:"timestampLessThan"`
+	TimestampGreaterThan *string `json:"timestampGreaterThan"`
+
+	IsPresent *bool `json:"isPresent"`
+	IsNull    *bool `json:"isNull"`
+
+	And []choiceRule `json:"and"`
+	Or  []choiceRule `json:"or"`
+	Not *choiceRule  `json:"not"`
+}
+
+// evaluateChoiceRule evaluates a single Choice Rule (Data-test Expression or
+// Boolean Expression) against the parsed state input.
+func evaluateChoiceRule(rule *choiceRule, input map[string]any) (bool, error) {
+	switch {
+	case len(rule.And) > 0:
+		return evaluateAnd(rule.And, input)
+	case len(rule.Or) > 0:
+		return evaluateOr(rule.Or, input)
+	case rule.Not != nil:
+		matched, err := evaluateChoiceRule(rule.Not, input)
+		if err != nil {
+			return false, err
+		}
+
+		return !matched, nil
+	default:
+		return evaluateDataTest(rule, input)
+	}
+}
+
+// evaluateAnd evaluates an "And" Boolean Expression, short-circuiting on the
+// first rule that does not match.
+func evaluateAnd(rules []choiceRule, input map[string]any) (bool, error) {
+	for i := range rules {
+		matched, err := evaluateChoiceRule(&rules[i], input)
+		if err != nil {
+			return false, err
+		}
+
+		if !matched {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// evaluateOr evaluates an "Or" Boolean Expression, short-circuiting on the
+// first rule that matches.
+func evaluateOr(rules []choiceRule, input map[string]any) (bool, error) {
+	for i := range rules {
+		matched, err := evaluateChoiceRule(&rules[i], input)
+		if err != nil {
+			return false, err
+		}
+
+		if matched {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// evaluateDataTest evaluates a Data-test Expression: a Variable path plus
+// exactly one comparison operator.
+func evaluateDataTest(rule *choiceRule, input map[string]any) (bool, error) {
+	if rule.Variable == "" {
+		return false, fmt.Errorf("choice rule: Variable is required")
+	}
+
+	if rule.IsPresent != nil {
+		_, err := resolveJSONPath(input, rule.Variable)
+
+		return (err == nil) == *rule.IsPresent, nil
+	}
+
+	value, err := resolveJSONPath(input, rule.Variable)
+	if err != nil {
+		return false, fmt.Errorf("choice rule: resolve Variable %q: %w", rule.Variable, err)
+	}
+
+	if rule.IsNull != nil {
+		return (value == nil) == *rule.IsNull, nil
+	}
+
+	if matched, handled := evaluateStringComparison(rule, value); handled {
+		return matched, nil
+	}
+
+	if matched, handled := evaluateNumericComparison(rule, value); handled {
+		return matched, nil
+	}
+
+	if rule.BooleanEquals != nil {
+		b, ok := value.(bool)
+
+		return ok && b == *rule.BooleanEquals, nil
+	}
+
+	if matched, handled := evaluateTimestampComparison(rule, value); handled {
+		return matched, nil
+	}
+
+	return false, fmt.Errorf("choice rule: no comparison operator set for Variable %q", rule.Variable)
+}
+
+// evaluateStringComparison evaluates the String* comparators. handled is
+// false if rule does not set any of them.
+func evaluateStringComparison(rule *choiceRule, value any) (matched, handled bool) {
+	switch {
+	case rule.StringEquals != nil:
+		cmp, ok := stringCompare(value, *rule.StringEquals)
+
+		return ok && cmp == 0, true
+	case rule.StringLessThan != nil:
+		cmp, ok := stringCompare(value, *rule.StringLessThan)
+
+		return ok && cmp < 0, true
+	case rule.StringGreaterThan != nil:
+		cmp, ok := stringCompare(value, *rule.StringGreaterThan)
+
+		return ok && cmp > 0, true
+	case rule.StringLessThanEquals != nil:
+		cmp, ok := stringCompare(value, *rule.StringLessThanEquals)
+
+		return ok && cmp <= 0, true
+	case rule.StringGreaterThanEquals != nil:
+		cmp, ok := stringCompare(value, *rule.StringGreaterThanEquals)
+
+		return ok && cmp >= 0, true
+	default:
+		return false, false
+	}
+}
+
+// evaluateNumericComparison evaluates the Numeric* comparators. handled is
+// false if rule does not set any of them.
+func evaluateNumericComparison(rule *choiceRule, value any) (matched, handled bool) {
+	switch {
+	case rule.NumericEquals != nil:
+		cmp, ok := numericCompare(value, *rule.NumericEquals)
+
+		return ok && cmp == 0, true
+	case rule.NumericLessThan != nil:
+		cmp, ok := numericCompare(value, *rule.NumericLessThan)
+
+		return ok && cmp < 0, true
+	case rule.NumericGreaterThan != nil:
+		cmp, ok := numericCompare(value, *rule.NumericGreaterThan)
+
+		return ok && cmp > 0, true
+	case rule.NumericLessThanEquals != nil:
+		cmp, ok := numericCompare(value, *rule.NumericLessThanEquals)
+
+		return ok && cmp <= 0, true
+	case rule.NumericGreaterThanEquals != nil:
+		cmp, ok := numericCompare(value, *rule.NumericGreaterThanEquals)
+
+		return ok && cmp >= 0, true
+	default:
+		return false, false
+	}
+}
+
+// evaluateTimestampComparison evaluates the Timestamp* comparators. handled
+// is false if rule does not set any of them.
+func evaluateTimestampComparison(rule *choiceRule, value any) (matched, handled bool) {
+	switch {
+	case rule.TimestampEquals != nil:
+		cmp, ok := timestampCompare(value, *rule.TimestampEquals)
+
+		return ok && cmp == 0, true
+	case rule.TimestampLessThan != nil:
+		cmp, ok := timestampCompare(value, *rule.TimestampLessThan)
+
+		return ok && cmp < 0, true
+	case rule.TimestampGreaterThan != nil:
+		cmp, ok := timestampCompare(value, *rule.TimestampGreaterThan)
+
+		return ok && cmp > 0, true
+	default:
+		return false, false
+	}
+}
+
+// stringCompare compares value (expected to be a string) against want,
+// returning ok=false if value is not a string.
+func stringCompare(value any, want string) (cmp int, ok bool) {
+	s, ok := value.(string)
+	if !ok {
+		return 0, false
+	}
+
+	return strings.Compare(s, want), true
+}
+
+// numericCompare compares value (expected to be a float64, as produced by
+// encoding/json for JSON numbers) against want, returning ok=false if value
+// is not a number.
+func numericCompare(value any, want float64) (cmp int, ok bool) {
+	n, ok := value.(float64)
+	if !ok {
+		return 0, false
+	}
+
+	switch {
+	case n < want:
+		return -1, true
+	case n > want:
+		return 1, true
+	default:
+		return 0, true
+	}
+}
+
+// timestampCompare compares value (expected to be an RFC3339 string) against
+// want, returning ok=false if either side is not a parseable RFC3339
+// timestamp.
+func timestampCompare(value any, want string) (cmp int, ok bool) {
+	s, ok := value.(string)
+	if !ok {
+		return 0, false
+	}
+
+	valueTime, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return 0, false
+	}
+
+	wantTime, err := time.Parse(time.RFC3339, want)
+	if err != nil {
+		return 0, false
+	}
+
+	switch {
+	case valueTime.Before(wantTime):
+		return -1, true
+	case valueTime.After(wantTime):
+		return 1, true
+	default:
+		return 0, true
+	}
+}

--- a/internal/service/sfn/choice_test.go
+++ b/internal/service/sfn/choice_test.go
@@ -1,0 +1,371 @@
+package sfn
+
+import (
+	"testing"
+)
+
+// JSONPath and value literals shared across the choiceRuleTests table,
+// factored into consts to stay under goconst's repeated-literal threshold.
+const (
+	pathMode    = "$.mode"
+	pathName    = "$.name"
+	pathValue   = "$.value"
+	pathTS      = "$.ts"
+	pathMissing = "$.missing"
+
+	valueFast = "fast"
+	valueSlow = "slow"
+
+	fieldName  = "name"
+	fieldValue = "value"
+	fieldMode  = "mode"
+)
+
+func float64Ptr(v float64) *float64 { return &v }
+
+func strPtr(v string) *string { return &v }
+
+func boolPtr(v bool) *bool { return &v }
+
+// choiceRuleTests exercises the individual comparison operators via
+// evaluateChoiceRule. Kept as a package-level var so the driving test
+// function itself stays short.
+var choiceRuleTests = []struct {
+	name  string
+	rule  choiceRule
+	input map[string]any
+	want  bool
+}{
+	{
+		name:  "StringEquals match",
+		rule:  choiceRule{Variable: pathMode, StringEquals: strPtr(valueFast)},
+		input: map[string]any{fieldMode: valueFast},
+		want:  true,
+	},
+	{
+		name:  "StringEquals no match",
+		rule:  choiceRule{Variable: pathMode, StringEquals: strPtr(valueFast)},
+		input: map[string]any{fieldMode: valueSlow},
+		want:  false,
+	},
+	{
+		name:  "StringLessThan",
+		rule:  choiceRule{Variable: pathName, StringLessThan: strPtr("m")},
+		input: map[string]any{fieldName: "alice"},
+		want:  true,
+	},
+	{
+		name:  "StringGreaterThan",
+		rule:  choiceRule{Variable: pathName, StringGreaterThan: strPtr("m")},
+		input: map[string]any{fieldName: "zeke"},
+		want:  true,
+	},
+	{
+		name:  "StringLessThanEquals equal",
+		rule:  choiceRule{Variable: pathName, StringLessThanEquals: strPtr("mode")},
+		input: map[string]any{fieldName: "mode"},
+		want:  true,
+	},
+	{
+		name:  "StringGreaterThanEquals equal",
+		rule:  choiceRule{Variable: pathName, StringGreaterThanEquals: strPtr("mode")},
+		input: map[string]any{fieldName: "mode"},
+		want:  true,
+	},
+	{
+		name:  "NumericEquals match",
+		rule:  choiceRule{Variable: pathValue, NumericEquals: float64Ptr(20)},
+		input: map[string]any{fieldValue: float64(20)},
+		want:  true,
+	},
+	{
+		name:  "NumericLessThan match",
+		rule:  choiceRule{Variable: pathValue, NumericLessThan: float64Ptr(30)},
+		input: map[string]any{fieldValue: float64(20)},
+		want:  true,
+	},
+	{
+		name:  "NumericGreaterThan match",
+		rule:  choiceRule{Variable: pathValue, NumericGreaterThan: float64Ptr(10)},
+		input: map[string]any{fieldValue: float64(20)},
+		want:  true,
+	},
+	{
+		name:  "NumericLessThanEquals equal",
+		rule:  choiceRule{Variable: pathValue, NumericLessThanEquals: float64Ptr(20)},
+		input: map[string]any{fieldValue: float64(20)},
+		want:  true,
+	},
+	{
+		name:  "NumericGreaterThanEquals equal",
+		rule:  choiceRule{Variable: pathValue, NumericGreaterThanEquals: float64Ptr(20)},
+		input: map[string]any{fieldValue: float64(20)},
+		want:  true,
+	},
+	{
+		name:  "NumericGreaterThanEquals no match",
+		rule:  choiceRule{Variable: pathValue, NumericGreaterThanEquals: float64Ptr(21)},
+		input: map[string]any{fieldValue: float64(20)},
+		want:  false,
+	},
+	{
+		name:  "BooleanEquals match",
+		rule:  choiceRule{Variable: "$.enabled", BooleanEquals: boolPtr(true)},
+		input: map[string]any{"enabled": true},
+		want:  true,
+	},
+	{
+		name:  "BooleanEquals no match",
+		rule:  choiceRule{Variable: "$.enabled", BooleanEquals: boolPtr(true)},
+		input: map[string]any{"enabled": false},
+		want:  false,
+	},
+	{
+		name:  "TimestampEquals match",
+		rule:  choiceRule{Variable: pathTS, TimestampEquals: strPtr("2020-01-01T00:00:00Z")},
+		input: map[string]any{"ts": "2020-01-01T00:00:00Z"},
+		want:  true,
+	},
+	{
+		name:  "TimestampLessThan match",
+		rule:  choiceRule{Variable: pathTS, TimestampLessThan: strPtr("2020-06-01T00:00:00Z")},
+		input: map[string]any{"ts": "2020-01-01T00:00:00Z"},
+		want:  true,
+	},
+	{
+		name:  "TimestampGreaterThan match",
+		rule:  choiceRule{Variable: pathTS, TimestampGreaterThan: strPtr("2020-01-01T00:00:00Z")},
+		input: map[string]any{"ts": "2020-06-01T00:00:00Z"},
+		want:  true,
+	},
+	{
+		name:  "TimestampGreaterThan malformed value does not match",
+		rule:  choiceRule{Variable: pathTS, TimestampGreaterThan: strPtr("2020-01-01T00:00:00Z")},
+		input: map[string]any{"ts": "not-a-timestamp"},
+		want:  false,
+	},
+	{
+		name:  "IsPresent true for present field",
+		rule:  choiceRule{Variable: pathMode, IsPresent: boolPtr(true)},
+		input: map[string]any{fieldMode: valueFast},
+		want:  true,
+	},
+	{
+		name:  "IsPresent false for missing field",
+		rule:  choiceRule{Variable: pathMissing, IsPresent: boolPtr(false)},
+		input: map[string]any{fieldMode: valueFast},
+		want:  true,
+	},
+	{
+		name:  "IsPresent true expectation fails for missing field",
+		rule:  choiceRule{Variable: pathMissing, IsPresent: boolPtr(true)},
+		input: map[string]any{fieldMode: valueFast},
+		want:  false,
+	},
+	{
+		name:  "IsNull true for null field",
+		rule:  choiceRule{Variable: pathValue, IsNull: boolPtr(true)},
+		input: map[string]any{fieldValue: nil},
+		want:  true,
+	},
+	{
+		name:  "IsNull false for non-null field",
+		rule:  choiceRule{Variable: pathValue, IsNull: boolPtr(false)},
+		input: map[string]any{fieldValue: "x"},
+		want:  true,
+	},
+	{
+		name: "And all match",
+		rule: choiceRule{And: []choiceRule{
+			{Variable: pathValue, IsPresent: boolPtr(true)},
+			{Variable: pathValue, NumericGreaterThanEquals: float64Ptr(20)},
+			{Variable: pathValue, NumericLessThan: float64Ptr(30)},
+		}},
+		input: map[string]any{fieldValue: float64(22)},
+		want:  true,
+	},
+	{
+		name: "And one mismatch",
+		rule: choiceRule{And: []choiceRule{
+			{Variable: pathValue, NumericGreaterThanEquals: float64Ptr(20)},
+			{Variable: pathValue, NumericLessThan: float64Ptr(21)},
+		}},
+		input: map[string]any{fieldValue: float64(22)},
+		want:  false,
+	},
+	{
+		name: "Or one match",
+		rule: choiceRule{Or: []choiceRule{
+			{Variable: pathMode, StringEquals: strPtr(valueFast)},
+			{Variable: pathMode, StringEquals: strPtr(valueSlow)},
+		}},
+		input: map[string]any{fieldMode: valueSlow},
+		want:  true,
+	},
+	{
+		name:  "Not negates match",
+		rule:  choiceRule{Not: &choiceRule{Variable: pathMode, StringEquals: strPtr(valueFast)}},
+		input: map[string]any{fieldMode: valueSlow},
+		want:  true,
+	},
+	{
+		name:  "Not negates non-match",
+		rule:  choiceRule{Not: &choiceRule{Variable: pathMode, StringEquals: strPtr(valueFast)}},
+		input: map[string]any{fieldMode: valueFast},
+		want:  false,
+	},
+}
+
+func TestEvaluateChoiceRule(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range choiceRuleTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := evaluateChoiceRule(&tt.rule, tt.input)
+			if err != nil {
+				t.Fatalf("evaluateChoiceRule: %v", err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("evaluateChoiceRule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateChoiceRuleMissingVariableErrors(t *testing.T) {
+	t.Parallel()
+
+	rule := choiceRule{Variable: pathMissing, StringEquals: strPtr(valueFast)}
+
+	_, err := evaluateChoiceRule(&rule, map[string]any{fieldMode: valueFast})
+	if err == nil {
+		t.Fatal("evaluateChoiceRule: want error for unresolvable Variable, got nil")
+	}
+}
+
+const choiceReproDefinition = `{
+	"StartAt": "Decide",
+	"States": {
+		"Decide": {
+			"Type": "Choice",
+			"Choices": [{"Variable": "$.mode", "StringEquals": "fast", "Next": "Fast"}],
+			"Default": "Slow"
+		},
+		"Fast": {"Type": "Pass", "Result": {"picked": "fast"}, "End": true},
+		"Slow": {"Type": "Pass", "Result": {"picked": "slow"}, "End": true}
+	}
+}`
+
+func TestChoiceStateRoutesToMatchedNext(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "choice-fast", choiceReproDefinition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"mode":"fast"}`)
+
+	if exec.Output != `{"picked":"fast"}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"picked":"fast"}`)
+	}
+}
+
+func TestChoiceStateFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "choice-slow", choiceReproDefinition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"mode":"slow"}`)
+
+	if exec.Output != `{"picked":"slow"}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"picked":"slow"}`)
+	}
+}
+
+func TestChoiceStateNoMatchNoDefaultReportsNoChoiceMatched(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Decide",
+		"States": {
+			"Decide": {
+				"Type": "Choice",
+				"Choices": [{"Variable": "$.mode", "StringEquals": "fast", "Next": "Fast"}]
+			},
+			"Fast": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "choice-no-match", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{"mode":"slow"}`)
+
+	if exec.Error != errorStatesNoChoiceMatched {
+		t.Fatalf("execution error: got %q, want %q (cause: %s)", exec.Error, errorStatesNoChoiceMatched, exec.Cause)
+	}
+}
+
+func TestChoiceStateNumericAndCombinator(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Decide",
+		"States": {
+			"Decide": {
+				"Type": "Choice",
+				"Choices": [{
+					"And": [
+						{"Variable": "$.value", "NumericGreaterThanEquals": 20},
+						{"Variable": "$.value", "NumericLessThan": 30}
+					],
+					"Next": "Twenties"
+				}],
+				"Default": "Other"
+			},
+			"Twenties": {"Type": "Pass", "Result": {"range": "twenties"}, "End": true},
+			"Other": {"Type": "Pass", "Result": {"range": "other"}, "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "choice-and", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"value":22}`)
+
+	if exec.Output != `{"range":"twenties"}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"range":"twenties"}`)
+	}
+}
+
+func TestChoiceStateIsPresentGuardsMissingField(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Decide",
+		"States": {
+			"Decide": {
+				"Type": "Choice",
+				"Choices": [{
+					"Not": {"Variable": "$.mode", "IsPresent": true},
+					"Next": "NoMode"
+				}],
+				"Default": "HasMode"
+			},
+			"NoMode": {"Type": "Pass", "Result": {"picked": "no-mode"}, "End": true},
+			"HasMode": {"Type": "Pass", "Result": {"picked": "has-mode"}, "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "choice-ispresent", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Output != `{"picked":"no-mode"}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"picked":"no-mode"}`)
+	}
+}

--- a/internal/service/sfn/execution_error_test.go
+++ b/internal/service/sfn/execution_error_test.go
@@ -48,7 +48,7 @@ func TestFailedExecutionReportsRuntimeErrorForUnsupportedState(t *testing.T) {
 	store := NewMemoryStorage()
 	sm := createExecutionTestStateMachine(t, store, "runtime-error", definition)
 
-	exec := startAndAwaitFailure(t, store, sm.StateMachineArn)
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, "{}")
 
 	if exec.Error != errorStatesRuntime {
 		t.Fatalf("engine failure error code: got %q, want %q (cause: %s)", exec.Error, errorStatesRuntime, exec.Cause)
@@ -75,7 +75,7 @@ func TestFailedExecutionReportsTaskFailedForTaskInvocationError(t *testing.T) {
 	store := NewMemoryStorage(WithBaseURL("http://127.0.0.1:1"))
 	sm := createExecutionTestStateMachine(t, store, "task-error", definition)
 
-	exec := startAndAwaitFailure(t, store, sm.StateMachineArn)
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, "{}")
 
 	if exec.Error != errorStatesTaskFailed {
 		t.Fatalf("task failure error code: got %q, want %q (cause: %s)", exec.Error, errorStatesTaskFailed, exec.Cause)
@@ -97,12 +97,40 @@ func createExecutionTestStateMachine(t *testing.T, store *MemoryStorage, name, d
 	return sm
 }
 
-func startAndAwaitFailure(t *testing.T, store *MemoryStorage, stateMachineArn string) *Execution {
+func startAndAwaitFailure(t *testing.T, store *MemoryStorage, stateMachineArn, input string) *Execution {
+	t.Helper()
+
+	exec := startAndAwaitTerminal(t, store, stateMachineArn, input)
+
+	if exec.Status != ExecutionStatusFailed {
+		t.Fatalf("execution ended with status %q, want FAILED", exec.Status)
+	}
+
+	return exec
+}
+
+// startAndAwaitSuccess starts an execution and polls DescribeExecution until
+// it reaches SUCCEEDED, failing the test if it instead fails or times out.
+func startAndAwaitSuccess(t *testing.T, store *MemoryStorage, stateMachineArn, input string) *Execution {
+	t.Helper()
+
+	exec := startAndAwaitTerminal(t, store, stateMachineArn, input)
+
+	if exec.Status != ExecutionStatusSucceeded {
+		t.Fatalf("execution ended with status %q, want SUCCEEDED (error: %s, cause: %s)", exec.Status, exec.Error, exec.Cause)
+	}
+
+	return exec
+}
+
+// startAndAwaitTerminal starts an execution and polls DescribeExecution until
+// it leaves RUNNING, failing the test if it does not terminate in time.
+func startAndAwaitTerminal(t *testing.T, store *MemoryStorage, stateMachineArn, input string) *Execution {
 	t.Helper()
 
 	ctx := context.Background()
 
-	started, err := store.StartExecution(ctx, stateMachineArn, "", "{}", "")
+	started, err := store.StartExecution(ctx, stateMachineArn, "", input, "")
 	if err != nil {
 		t.Fatalf("StartExecution: %v", err)
 	}
@@ -114,18 +142,14 @@ func startAndAwaitFailure(t *testing.T, store *MemoryStorage, stateMachineArn st
 			t.Fatalf("DescribeExecution: %v", err)
 		}
 
-		if exec.Status == ExecutionStatusFailed {
-			return exec
-		}
-
 		if exec.Status != ExecutionStatusRunning {
-			t.Fatalf("execution ended with status %q, want FAILED", exec.Status)
+			return exec
 		}
 
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	t.Fatal("execution did not fail within the deadline")
+	t.Fatal("execution did not terminate within the deadline")
 
 	return nil
 }

--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -36,14 +36,31 @@ type stateDefinition struct {
 	InputPath  *string        `json:"InputPath"`
 	OutputPath *string        `json:"OutputPath"`
 	Comment    string         `json:"Comment"`
+
+	// Choice state fields.
+	Choices []choiceRule `json:"Choices"`
+	Default string       `json:"Default"`
+
+	// Wait state fields. Exactly one of these is expected to be set.
+	Seconds       *int   `json:"Seconds"`
+	SecondsPath   string `json:"SecondsPath"`
+	Timestamp     string `json:"Timestamp"`
+	TimestampPath string `json:"TimestampPath"`
+
+	// Fail state fields.
+	Error string `json:"Error"`
+	Cause string `json:"Cause"`
 }
 
 // Execution error codes surfaced via DescribeExecution. States.TaskFailed is
-// reserved for failures of a Task state's work itself; every engine-level
-// failure (unsupported state, bad definition wiring) is States.Runtime.
+// reserved for failures of a Task state's work itself; States.NoChoiceMatched
+// is reserved for a Choice state with no matching rule and no Default; every
+// other engine-level failure (unsupported state, bad definition wiring) is
+// States.Runtime.
 const (
-	errorStatesRuntime    = "States.Runtime"
-	errorStatesTaskFailed = "States.TaskFailed"
+	errorStatesRuntime         = "States.Runtime"
+	errorStatesTaskFailed      = "States.TaskFailed"
+	errorStatesNoChoiceMatched = "States.NoChoiceMatched"
 )
 
 // taskFailedError marks a failure of the task invocation itself so the
@@ -56,6 +73,32 @@ func (e *taskFailedError) Error() string { return e.err.Error() }
 
 func (e *taskFailedError) Unwrap() error { return e.err }
 
+// noChoiceMatchedError marks a Choice state that failed to match any Choice
+// Rule and had no Default. Per the Amazon States Language spec, the
+// interpreter throws a runtime States.NoChoiceMatched error in this case.
+type noChoiceMatchedError struct {
+	state string
+}
+
+func (e *noChoiceMatchedError) Error() string {
+	return fmt.Sprintf("state %q: no Choice Rule matched and no Default was specified", e.state)
+}
+
+// failStateError carries the Error and Cause declared on a Fail state so the
+// execution reports those exact values instead of a generic engine failure.
+type failStateError struct {
+	errorName string
+	cause     string
+}
+
+func (e *failStateError) Error() string {
+	if e.cause != "" {
+		return fmt.Sprintf("%s: %s", e.errorName, e.cause)
+	}
+
+	return e.errorName
+}
+
 // executionErrorCode maps an engine error to the Step Functions error code
 // reported on the failed execution.
 func executionErrorCode(err error) string {
@@ -64,7 +107,29 @@ func executionErrorCode(err error) string {
 		return errorStatesTaskFailed
 	}
 
+	var choiceErr *noChoiceMatchedError
+	if errors.As(err, &choiceErr) {
+		return errorStatesNoChoiceMatched
+	}
+
+	var failErr *failStateError
+	if errors.As(err, &failErr) {
+		return failErr.errorName
+	}
+
 	return errorStatesRuntime
+}
+
+// executionErrorCause returns the cause message reported on the failed
+// execution. A Fail state reports its own declared Cause verbatim instead of
+// the wrapped "execute state ...: ..." error chain every other failure uses.
+func executionErrorCause(err error) string {
+	var failErr *failStateError
+	if errors.As(err, &failErr) {
+		return failErr.cause
+	}
+
+	return err.Error()
 }
 
 // executionEngine executes a state machine definition.
@@ -112,33 +177,62 @@ func (e *executionEngine) execute(ctx context.Context, def *stateMachineDefiniti
 			return "", fmt.Errorf("state %q not found in definition", currentState)
 		}
 
-		output, err := e.executeState(ctx, currentState, &state, currentInput)
+		output, nextOverride, err := e.executeState(ctx, currentState, &state, currentInput)
 		if err != nil {
 			return "", fmt.Errorf("execute state %q: %w", currentState, err)
+		}
+
+		// Succeed states are always terminal, regardless of End/Next.
+		if state.Type == "Succeed" {
+			return output, nil
+		}
+
+		next := state.Next
+		if nextOverride != "" {
+			next = nextOverride
 		}
 
 		if state.End {
 			return output, nil
 		}
 
-		if state.Next == "" {
+		if next == "" {
 			return "", fmt.Errorf("state %q has no End or Next", currentState)
 		}
 
 		currentInput = output
-		currentState = state.Next
+		currentState = next
 	}
 }
 
-// executeState executes a single state and returns the output.
-func (e *executionEngine) executeState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
+// executeState executes a single state and returns its output and, for
+// states that determine the next state dynamically (Choice), the name of
+// that next state. nextOverride is empty for states that use the state's own
+// Next/End fields.
+func (e *executionEngine) executeState(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
 	switch state.Type {
 	case "Pass":
-		return e.executePassState(state, input)
+		output, err := e.executePassState(state, input)
+
+		return output, "", err
 	case "Task":
-		return e.executeTaskState(ctx, name, state, input)
+		output, err := e.executeTaskState(ctx, name, state, input)
+
+		return output, "", err
+	case "Choice":
+		return e.executeChoiceState(name, state, input)
+	case "Wait":
+		output, err := e.executeWaitState(ctx, state, input)
+
+		return output, "", err
+	case "Succeed":
+		output, err := e.executeSucceedState(state, input)
+
+		return output, "", err
+	case "Fail":
+		return "", "", e.executeFailState(state)
 	default:
-		return "", fmt.Errorf("unsupported state type %q", state.Type)
+		return "", "", fmt.Errorf("unsupported state type %q", state.Type)
 	}
 }
 
@@ -156,6 +250,84 @@ func (e *executionEngine) executePassState(state *stateDefinition, input string)
 	return input, nil
 }
 
+// executeChoiceState executes a Choice state. It evaluates each Choice Rule
+// in order and transitions to the first match's Next state, falling back to
+// Default. The output is always the unmodified input.
+func (e *executionEngine) executeChoiceState(name string, state *stateDefinition, input string) (string, string, error) {
+	var inputData map[string]any
+	if err := json.Unmarshal([]byte(input), &inputData); err != nil {
+		return "", "", fmt.Errorf("choice state %q: parse input: %w", name, err)
+	}
+
+	for i := range state.Choices {
+		matched, err := evaluateChoiceRule(&state.Choices[i], inputData)
+		if err != nil {
+			return "", "", fmt.Errorf("choice state %q: %w", name, err)
+		}
+
+		if matched {
+			if state.Choices[i].Next == "" {
+				return "", "", fmt.Errorf("choice state %q: matched rule has no Next", name)
+			}
+
+			return input, state.Choices[i].Next, nil
+		}
+	}
+
+	if state.Default == "" {
+		return "", "", &noChoiceMatchedError{state: name}
+	}
+
+	return input, state.Default, nil
+}
+
+// executeSucceedState executes a Succeed state, narrowing the output through
+// InputPath/OutputPath if present.
+func (e *executionEngine) executeSucceedState(state *stateDefinition, input string) (string, error) {
+	narrowed, err := applyPath(state.InputPath, input)
+	if err != nil {
+		return "", fmt.Errorf("succeed state: %w", err)
+	}
+
+	output, err := applyPath(state.OutputPath, narrowed)
+	if err != nil {
+		return "", fmt.Errorf("succeed state: %w", err)
+	}
+
+	return output, nil
+}
+
+// executeFailState executes a Fail state, always returning a failStateError
+// carrying the state's declared Error and Cause.
+func (e *executionEngine) executeFailState(state *stateDefinition) error {
+	return &failStateError{errorName: state.Error, cause: state.Cause}
+}
+
+// applyPath narrows a JSON value using a JSONPath (InputPath/OutputPath). A
+// nil path returns data unchanged.
+func applyPath(path *string, data string) (string, error) {
+	if path == nil {
+		return data, nil
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(data), &parsed); err != nil {
+		return "", fmt.Errorf("parse data for path %q: %w", *path, err)
+	}
+
+	resolved, err := resolveJSONPath(parsed, *path)
+	if err != nil {
+		return "", fmt.Errorf("resolve path %q: %w", *path, err)
+	}
+
+	out, err := json.Marshal(resolved)
+	if err != nil {
+		return "", fmt.Errorf("marshal path %q result: %w", *path, err)
+	}
+
+	return string(out), nil
+}
+
 // executeTaskState executes a Task state by calling the appropriate service.
 func (e *executionEngine) executeTaskState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
 	resource := state.Resource
@@ -169,11 +341,13 @@ func (e *executionEngine) executeTaskState(ctx context.Context, name string, sta
 		return "", fmt.Errorf("resolve parameters for state %q: %w", name, err)
 	}
 
-	switch resource {
-	case "arn:aws:states:::sqs:sendMessage":
+	switch {
+	case resource == "arn:aws:states:::sqs:sendMessage":
 		return wrapTaskResult(e.executeSQSSendMessage(ctx, params))
-	case "arn:aws:states:::lambda:invoke":
+	case resource == "arn:aws:states:::lambda:invoke":
 		return wrapTaskResult(e.executeLambdaInvoke(ctx, params))
+	case strings.HasPrefix(resource, "arn:aws:lambda:"):
+		return wrapTaskResult(e.executeLambdaFunctionTask(ctx, name, resource, params, input))
 	default:
 		return "", fmt.Errorf("unsupported task resource %q", resource)
 	}
@@ -368,8 +542,6 @@ func formatMessageBody(v any) (string, error) {
 }
 
 // executeLambdaInvoke invokes a Lambda function via HTTP.
-//
-//nolint:funlen // Straightforward HTTP call with error handling.
 func (e *executionEngine) executeLambdaInvoke(ctx context.Context, params map[string]any) (string, error) {
 	functionName, _ := params["FunctionName"].(string)
 	if functionName == "" {
@@ -392,36 +564,16 @@ func (e *executionEngine) executeLambdaInvoke(ctx context.Context, params map[st
 		payload = []byte("{}")
 	}
 
-	invokeURL := fmt.Sprintf("%s/lambda/2015-03-31/functions/%s/invocations", e.baseURL, functionName)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, invokeURL, bytes.NewReader(payload))
+	respBody, err := e.callLambda(ctx, functionName, payload)
 	if err != nil {
-		return "", fmt.Errorf("lambda invoke: create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := e.client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("lambda invoke: send request: %w", err)
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("lambda invoke: read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("lambda invoke: unexpected status %d: %s", resp.StatusCode, string(respBody))
+		return "", err
 	}
 
 	slog.Debug("SFN executor: Lambda invoke succeeded", "function", functionName)
 
 	// Wrap Lambda response in the Step Functions format.
 	lambdaResult := map[string]any{
-		"StatusCode": resp.StatusCode,
+		"StatusCode": http.StatusOK,
 	}
 
 	// Try to parse the response body as JSON for the Payload field.
@@ -438,6 +590,68 @@ func (e *executionEngine) executeLambdaInvoke(ctx context.Context, params map[st
 	}
 
 	return string(result), nil
+}
+
+// executeLambdaFunctionTask invokes a Lambda function specified directly by
+// ARN in a Task state's Resource field (the "directly specified function
+// resource" integration, as opposed to the optimized
+// arn:aws:states:::lambda:invoke integration). With this integration the
+// state input becomes the invocation payload verbatim, or resolved
+// Parameters if given, and the task output is the function's response
+// payload directly with no ExecutedVersion/Payload/StatusCode wrapping.
+func (e *executionEngine) executeLambdaFunctionTask(ctx context.Context, name, resourceARN string, params map[string]any, input string) (string, error) {
+	functionName := extractLambdaFunctionName(resourceARN)
+
+	payload := []byte(input)
+
+	if len(params) > 0 {
+		var err error
+
+		payload, err = json.Marshal(params)
+		if err != nil {
+			return "", fmt.Errorf("marshal parameters for state %q: %w", name, err)
+		}
+	}
+
+	respBody, err := e.callLambda(ctx, functionName, payload)
+	if err != nil {
+		return "", err
+	}
+
+	slog.Debug("SFN executor: Lambda function invoke succeeded", "function", functionName)
+
+	return string(respBody), nil
+}
+
+// callLambda performs the HTTP call to invoke a Lambda function and returns
+// the raw response body.
+func (e *executionEngine) callLambda(ctx context.Context, functionName string, payload []byte) ([]byte, error) {
+	invokeURL := fmt.Sprintf("%s/lambda/2015-03-31/functions/%s/invocations", e.baseURL, functionName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, invokeURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("lambda invoke: create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("lambda invoke: send request: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("lambda invoke: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("lambda invoke: unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
 }
 
 // extractLambdaFunctionName extracts the function name from an ARN or returns the input as-is.

--- a/internal/service/sfn/lambda_task_test.go
+++ b/internal/service/sfn/lambda_task_test.go
@@ -1,0 +1,127 @@
+package sfn
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newEchoLambdaServer returns an httptest server that stands in for kumo's
+// Lambda invoke endpoint: it echoes the request body back as the response,
+// mirroring what a real Lambda function that returns its own event would do.
+func newEchoLambdaServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func TestTaskStatePlainLambdaARNSendsStateInputAsPayload(t *testing.T) {
+	t.Parallel()
+
+	server := newEchoLambdaServer(t)
+
+	definition := fmt.Sprintf(`{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:%s",
+				"End": true
+			}
+		}
+	}`, "echo-fn")
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "lambda-arn-task", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"greeting":"hello"}`)
+
+	if exec.Output != `{"greeting":"hello"}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"greeting":"hello"}`)
+	}
+}
+
+func TestTaskStatePlainLambdaARNResolvesParametersAsPayload(t *testing.T) {
+	t.Parallel()
+
+	server := newEchoLambdaServer(t)
+
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:echo-fn",
+				"Parameters": {"name.$": "$.who", "greeting": "hi"},
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "lambda-arn-task-params", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"who":"world"}`)
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(exec.Output), &output); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if output["name"] != "world" || output["greeting"] != "hi" {
+		t.Fatalf("execution output: got %v, want name=world greeting=hi", output)
+	}
+}
+
+func TestExecuteLambdaFunctionTaskCallsExtractedFunctionName(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	engine := newExecutionEngine(server.URL)
+
+	output, err := engine.executeLambdaFunctionTask(
+		t.Context(),
+		"Invoke",
+		"arn:aws:lambda:us-east-1:000000000000:function:my-function",
+		nil,
+		`{"x":1}`,
+	)
+	if err != nil {
+		t.Fatalf("executeLambdaFunctionTask: %v", err)
+	}
+
+	if output != `{"ok":true}` {
+		t.Fatalf("output: got %q, want %q", output, `{"ok":true}`)
+	}
+
+	if !strings.HasSuffix(gotPath, "/functions/my-function/invocations") {
+		t.Fatalf("invocation path: got %q, want suffix %q", gotPath, "/functions/my-function/invocations")
+	}
+}

--- a/internal/service/sfn/storage.go
+++ b/internal/service/sfn/storage.go
@@ -347,7 +347,7 @@ func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string
 
 	output, err := s.engine.execute(ctx, def, input)
 	if err != nil {
-		s.failExecution(ed, lastEventID, executionErrorCode(err), err.Error())
+		s.failExecution(ed, lastEventID, executionErrorCode(err), executionErrorCause(err))
 
 		return
 	}

--- a/internal/service/sfn/succeed_fail_test.go
+++ b/internal/service/sfn/succeed_fail_test.go
@@ -1,0 +1,47 @@
+package sfn
+
+import "testing"
+
+func TestSucceedStateTerminatesWithInputAsOutput(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Done",
+		"States": {
+			"Done": {"Type": "Succeed"}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "succeed-passthrough", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"result":"ok"}`)
+
+	if exec.Output != `{"result":"ok"}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"result":"ok"}`)
+	}
+}
+
+func TestFailStateReportsCustomErrorAndCause(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Boom",
+		"States": {
+			"Boom": {"Type": "Fail", "Error": "CustomError", "Cause": "something went wrong"}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "fail-custom", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != "CustomError" {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, "CustomError")
+	}
+
+	if exec.Cause != "something went wrong" {
+		t.Fatalf("execution cause: got %q, want %q", exec.Cause, "something went wrong")
+	}
+}

--- a/internal/service/sfn/wait.go
+++ b/internal/service/sfn/wait.go
@@ -1,0 +1,132 @@
+package sfn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// executeWaitState executes a Wait state by sleeping for the duration
+// determined by Seconds, SecondsPath, Timestamp, or TimestampPath.
+//
+// The wait is not artificially capped: kumo sleeps for the full requested
+// duration but honors ctx cancellation, and every execution already runs
+// under the 5-minute timeout applied in MemoryStorage.runExecution, which
+// bounds how long any single Wait can actually block.
+func (e *executionEngine) executeWaitState(ctx context.Context, state *stateDefinition, input string) (string, error) {
+	d, err := waitDuration(state, input)
+	if err != nil {
+		return "", fmt.Errorf("wait state: %w", err)
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return "", fmt.Errorf("wait state: %w", ctx.Err())
+	case <-timer.C:
+	}
+
+	return input, nil
+}
+
+// waitDuration determines how long a Wait state should sleep from whichever
+// of Seconds, SecondsPath, Timestamp, or TimestampPath is set.
+func waitDuration(state *stateDefinition, input string) (time.Duration, error) {
+	switch {
+	case state.Seconds != nil:
+		if *state.Seconds < 0 {
+			return 0, fmt.Errorf("seconds must be non-negative")
+		}
+
+		return time.Duration(*state.Seconds) * time.Second, nil
+
+	case state.SecondsPath != "":
+		seconds, err := resolveNumberPath(state.SecondsPath, input)
+		if err != nil {
+			return 0, fmt.Errorf("resolve SecondsPath: %w", err)
+		}
+
+		return time.Duration(seconds * float64(time.Second)), nil
+
+	case state.Timestamp != "":
+		return durationUntilTimestamp(state.Timestamp)
+
+	case state.TimestampPath != "":
+		ts, err := resolveStringPath(state.TimestampPath, input)
+		if err != nil {
+			return 0, fmt.Errorf("resolve TimestampPath: %w", err)
+		}
+
+		return durationUntilTimestamp(ts)
+
+	default:
+		return 0, fmt.Errorf("wait state requires one of Seconds, SecondsPath, Timestamp, TimestampPath")
+	}
+}
+
+// durationUntilTimestamp parses an RFC3339 timestamp and returns the
+// duration from now until that time, floored at zero for timestamps already
+// in the past.
+func durationUntilTimestamp(ts string) (time.Duration, error) {
+	target, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return 0, fmt.Errorf("parse timestamp %q: %w", ts, err)
+	}
+
+	d := time.Until(target)
+	if d < 0 {
+		d = 0
+	}
+
+	return d, nil
+}
+
+// resolveNumberPath resolves a JSONPath against input and requires the
+// result to be a JSON number.
+func resolveNumberPath(path, input string) (float64, error) {
+	value, err := resolvePath(path, input)
+	if err != nil {
+		return 0, err
+	}
+
+	n, ok := value.(float64)
+	if !ok {
+		return 0, fmt.Errorf("jsonPath %q did not resolve to a number", path)
+	}
+
+	return n, nil
+}
+
+// resolveStringPath resolves a JSONPath against input and requires the
+// result to be a JSON string.
+func resolveStringPath(path, input string) (string, error) {
+	value, err := resolvePath(path, input)
+	if err != nil {
+		return "", err
+	}
+
+	s, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("jsonPath %q did not resolve to a string", path)
+	}
+
+	return s, nil
+}
+
+// resolvePath parses input as JSON and resolves a JSONPath against it.
+func resolvePath(path, input string) (any, error) {
+	var data map[string]any
+	if err := json.Unmarshal([]byte(input), &data); err != nil {
+		return nil, fmt.Errorf("parse input: %w", err)
+	}
+
+	value, err := resolveJSONPath(data, path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve JSONPath %q: %w", path, err)
+	}
+
+	return value, nil
+}

--- a/internal/service/sfn/wait_test.go
+++ b/internal/service/sfn/wait_test.go
@@ -1,0 +1,73 @@
+package sfn
+
+import "testing"
+
+// waitStateType is the state machine definition's Type value for a Wait
+// state, factored out to keep the "Wait" literal below goconst's threshold.
+const waitStateType = "Wait"
+
+func TestWaitStateSecondsZeroCompletesAndPassesInputThrough(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Wait",
+		"States": {
+			"Wait": {"Type": "Wait", "Seconds": 0, "Next": "Done"},
+			"Done": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "wait-zero", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"value":1}`)
+
+	if exec.Output != `{"value":1}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"value":1}`)
+	}
+}
+
+func TestWaitStateSecondsOneCompletesAndPassesInputThrough(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Wait",
+		"States": {
+			"Wait": {"Type": "Wait", "Seconds": 1, "Next": "Done"},
+			"Done": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "wait-one", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"value":1}`)
+
+	if exec.Output != `{"value":1}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"value":1}`)
+	}
+}
+
+func TestWaitDurationRequiresOneField(t *testing.T) {
+	t.Parallel()
+
+	_, err := waitDuration(&stateDefinition{Type: waitStateType}, "{}")
+	if err == nil {
+		t.Fatal("waitDuration: want error when no wait field is set, got nil")
+	}
+}
+
+func TestWaitDurationSecondsPath(t *testing.T) {
+	t.Parallel()
+
+	state := &stateDefinition{Type: waitStateType, SecondsPath: "$.waitSeconds"}
+
+	d, err := waitDuration(state, `{"waitSeconds": 0}`)
+	if err != nil {
+		t.Fatalf("waitDuration: %v", err)
+	}
+
+	if d != 0 {
+		t.Fatalf("waitDuration() = %v, want 0", d)
+	}
+}


### PR DESCRIPTION
## Summary
Implements the priority tier of #861: the execution engine previously ran only Pass and Task (with two optimized integrations), so most real state machines failed at runtime despite validating OK.

- Choice: String/Numeric/Boolean/Timestamp comparators, IsPresent/IsNull, And/Or/Not, Default; no match without Default fails with States.NoChoiceMatched (verbatim ASL spec name)
- Wait: Seconds/SecondsPath/Timestamp/TimestampPath, honoring context cancellation (bounded by the existing 5-minute execution timeout)
- Succeed / Fail: proper terminal states; Fail surfaces its declared Error and Cause verbatim instead of a wrapped runtime error
- Task with a plain arn:aws:lambda:...:function:name resource invokes the function with the raw state input and returns the function output unwrapped, matching AWS's directly-specified-resource semantics

Parallel, Map, Retry, and Catch are follow-ups, so this refs #861 rather than closing it.

## Test plan
- [ ] Table-driven comparator tests plus execution-level tests for each new state type (race detector clean)
- [ ] Plain-ARN task payload in/out shape verified against an echo endpoint