### PR TITLE
feat(sfn): support Parallel and Map states with Retry and Catch

### DIFF
--- a/internal/service/sfn/catch_test.go
+++ b/internal/service/sfn/catch_test.go
@@ -1,0 +1,111 @@
+package sfn
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTaskCatchRoutesToFallbackWithDefaultResultPath(t *testing.T) {
+	t.Parallel()
+
+	// No listener on this port, so the task invocation itself fails and
+	// reports States.TaskFailed, which the Catch below matches.
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:missing-fn",
+				"Catch": [{"ErrorEquals": ["States.TaskFailed"], "Next": "Fallback"}],
+				"End": true
+			},
+			"Fallback": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL("http://127.0.0.1:1"))
+	sm := createExecutionTestStateMachine(t, store, "catch-default", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"orig":"data"}`)
+
+	var errorOutput map[string]string
+	if err := json.Unmarshal([]byte(exec.Output), &errorOutput); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if errorOutput["Error"] != errorStatesTaskFailed {
+		t.Fatalf("caught error output Error: got %q, want %q", errorOutput["Error"], errorStatesTaskFailed)
+	}
+
+	if errorOutput["Cause"] == "" {
+		t.Fatal("caught error output Cause: got empty string, want a non-empty cause")
+	}
+}
+
+func TestTaskCatchInjectsErrorViaResultPath(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:missing-fn",
+				"Catch": [{"ErrorEquals": ["States.ALL"], "ResultPath": "$.err", "Next": "Fallback"}],
+				"End": true
+			},
+			"Fallback": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL("http://127.0.0.1:1"))
+	sm := createExecutionTestStateMachine(t, store, "catch-resultpath", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"orig":"data"}`)
+
+	var output struct {
+		Orig string            `json:"orig"`
+		Err  map[string]string `json:"err"`
+	}
+
+	if err := json.Unmarshal([]byte(exec.Output), &output); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if output.Orig != "data" {
+		t.Fatalf("original input field: got %q, want %q", output.Orig, "data")
+	}
+
+	if output.Err["Error"] != errorStatesTaskFailed {
+		t.Fatalf("injected error output Error: got %q, want %q", output.Err["Error"], errorStatesTaskFailed)
+	}
+}
+
+func TestTaskCatchDoesNotMatchStatesRuntimeEvenWithStatesAll(t *testing.T) {
+	t.Parallel()
+
+	// An unsupported Resource format fails with a plain engine error, which
+	// executionErrorCode reports as States.Runtime -- never caught, even by
+	// the States.ALL wildcard.
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "not-a-supported-resource",
+				"Catch": [{"ErrorEquals": ["States.ALL"], "Next": "Fallback"}],
+				"End": true
+			},
+			"Fallback": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "catch-runtime-uncaught", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesRuntime {
+		t.Fatalf("execution error: got %q, want %q (States.ALL must not catch States.Runtime)", exec.Error, errorStatesRuntime)
+	}
+}

--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -50,17 +50,36 @@ type stateDefinition struct {
 	// Fail state fields.
 	Error string `json:"Error"`
 	Cause string `json:"Cause"`
+
+	// Retry/Catch fields, valid on Task, Parallel, and Map states.
+	Retry []retrier `json:"Retry"`
+	Catch []catcher `json:"Catch"`
+
+	// Parallel state fields.
+	Branches []stateMachineDefinition `json:"Branches"`
+
+	// Map state fields. ItemProcessor is the current field name; Iterator is
+	// the legacy alias for the same sub-state-machine. If both are present,
+	// ItemProcessor takes precedence. ItemSelector, ItemBatcher,
+	// ResultWriter, and distributed-mode Map are out of scope.
+	ItemsPath      string                  `json:"ItemsPath"`
+	ItemProcessor  *stateMachineDefinition `json:"ItemProcessor"`
+	Iterator       *stateMachineDefinition `json:"Iterator"`
+	MaxConcurrency int                     `json:"MaxConcurrency"`
 }
 
 // Execution error codes surfaced via DescribeExecution. States.TaskFailed is
 // reserved for failures of a Task state's work itself; States.NoChoiceMatched
-// is reserved for a Choice state with no matching rule and no Default; every
-// other engine-level failure (unsupported state, bad definition wiring) is
-// States.Runtime.
+// is reserved for a Choice state with no matching rule and no Default;
+// States.ALL is the Retry/Catch wildcard that matches any other Error Name;
+// every other engine-level failure (unsupported state, bad definition
+// wiring) is States.Runtime.
 const (
 	errorStatesRuntime         = "States.Runtime"
 	errorStatesTaskFailed      = "States.TaskFailed"
 	errorStatesNoChoiceMatched = "States.NoChoiceMatched"
+	errorStatesAll             = "States.ALL"
+	errorStatesBranchFailed    = "States.BranchFailed"
 )
 
 // taskFailedError marks a failure of the task invocation itself so the
@@ -187,21 +206,27 @@ func (e *executionEngine) execute(ctx context.Context, def *stateMachineDefiniti
 			return output, nil
 		}
 
-		next := state.Next
+		// nextOverride is set by states that pick their own successor
+		// dynamically: Choice, and any Task/Parallel/Map whose Catch routed
+		// to a fallback state. It always takes priority over End/Next, since
+		// a Catch must be able to redirect even a state marked End: true.
 		if nextOverride != "" {
-			next = nextOverride
+			currentInput = output
+			currentState = nextOverride
+
+			continue
 		}
 
 		if state.End {
 			return output, nil
 		}
 
-		if next == "" {
+		if state.Next == "" {
 			return "", fmt.Errorf("state %q has no End or Next", currentState)
 		}
 
 		currentInput = output
-		currentState = next
+		currentState = state.Next
 	}
 }
 
@@ -216,9 +241,7 @@ func (e *executionEngine) executeState(ctx context.Context, name string, state *
 
 		return output, "", err
 	case "Task":
-		output, err := e.executeTaskState(ctx, name, state, input)
-
-		return output, "", err
+		return e.executeTaskStateWithPolicy(ctx, name, state, input)
 	case "Choice":
 		return e.executeChoiceState(name, state, input)
 	case "Wait":
@@ -231,9 +254,21 @@ func (e *executionEngine) executeState(ctx context.Context, name string, state *
 		return output, "", err
 	case "Fail":
 		return "", "", e.executeFailState(state)
+	case "Parallel":
+		return e.executeParallelStateWithPolicy(ctx, name, state, input)
+	case "Map":
+		return e.executeMapStateWithPolicy(ctx, name, state, input)
 	default:
 		return "", "", fmt.Errorf("unsupported state type %q", state.Type)
 	}
+}
+
+// executeTaskStateWithPolicy executes a Task state's underlying work,
+// applying its Retry and Catch policy.
+func (e *executionEngine) executeTaskStateWithPolicy(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
+	return e.runWithRetryCatch(ctx, name, state, input, func(ctx context.Context) (string, error) {
+		return e.executeTaskState(ctx, name, state, input)
+	})
 }
 
 // executePassState executes a Pass state.

--- a/internal/service/sfn/map_test.go
+++ b/internal/service/sfn/map_test.go
@@ -1,0 +1,238 @@
+package sfn
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const echoItemProcessorJSON = `{"StartAt": "Echo", "States": {"Echo": {"Type": "Pass", "End": true}}}`
+
+func TestMapStateProcessesItemsInOrder(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemProcessor": ` + echoItemProcessorJSON + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-order", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `[1,2,3]`)
+
+	if exec.Output != `[1,2,3]` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `[1,2,3]`)
+	}
+}
+
+func TestMapStateResolvesItemsPath(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemsPath": "$.items",
+				"ItemProcessor": ` + echoItemProcessorJSON + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-itemspath", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"items":[10,20,30]}`)
+
+	if exec.Output != `[10,20,30]` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `[10,20,30]`)
+	}
+}
+
+func TestMapStateIteratorAliasWorks(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"Iterator": ` + echoItemProcessorJSON + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-iterator-alias", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `["x","y"]`)
+
+	if exec.Output != `["x","y"]` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `["x","y"]`)
+	}
+}
+
+func TestMapStateItemFailureFailsTheMap(t *testing.T) {
+	t.Parallel()
+
+	// The item's processor has no listener at this port, so every item
+	// invocation fails and reports States.TaskFailed.
+	processor := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:missing-fn",
+				"End": true
+			}
+		}
+	}`
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemProcessor": ` + processor + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL("http://127.0.0.1:1"))
+	sm := createExecutionTestStateMachine(t, store, "map-item-fails", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `[1,2,3]`)
+
+	if exec.Error != errorStatesTaskFailed {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesTaskFailed)
+	}
+}
+
+// newConcurrencyTrackingServer returns an httptest server that briefly
+// sleeps on every request and records the maximum number of requests it
+// ever saw in flight at once, so a test can assert MaxConcurrency was
+// honored.
+func newConcurrencyTrackingServer(t *testing.T) (*httptest.Server, *int32) {
+	t.Helper()
+
+	var current, maxSeen int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&current, 1)
+
+		for {
+			m := atomic.LoadInt32(&maxSeen)
+			if n <= m || atomic.CompareAndSwapInt32(&maxSeen, m, n) {
+				break
+			}
+		}
+
+		time.Sleep(50 * time.Millisecond)
+		atomic.AddInt32(&current, -1)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server, &maxSeen
+}
+
+func TestMapStateMaxConcurrencyOneSerializesItems(t *testing.T) {
+	t.Parallel()
+
+	server, maxSeen := newConcurrencyTrackingServer(t)
+
+	processor := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:slow-fn",
+				"End": true
+			}
+		}
+	}`
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"MaxConcurrency": 1,
+				"ItemProcessor": ` + processor + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-max-concurrency", definition)
+
+	startAndAwaitSuccess(t, store, sm.StateMachineArn, `[1,2,3]`)
+
+	if got := atomic.LoadInt32(maxSeen); got != 1 {
+		t.Fatalf("max observed concurrent item invocations: got %d, want 1", got)
+	}
+}
+
+func TestMapStateItemProcessorTaskRetryRecovers(t *testing.T) {
+	t.Parallel()
+
+	server, attempts := newFlakyLambdaServer(t, 1)
+
+	processor := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:flaky-fn",
+				"Retry": [{"ErrorEquals": ["States.TaskFailed"], "IntervalSeconds": 1, "MaxAttempts": 1}],
+				"End": true
+			}
+		}
+	}`
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemProcessor": ` + processor + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-item-retry-recovers", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `[1]`)
+
+	var outputs []map[string]bool
+	if err := json.Unmarshal([]byte(exec.Output), &outputs); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(outputs) != 1 || !outputs[0]["ok"] {
+		t.Fatalf("execution output: got %q, want a single-item array with ok:true", exec.Output)
+	}
+
+	if got := atomic.LoadInt32(attempts); got != 2 {
+		t.Fatalf("lambda invocation count: got %d, want 2 (1 failure + 1 successful retry)", got)
+	}
+}

--- a/internal/service/sfn/mapstate.go
+++ b/internal/service/sfn/mapstate.go
@@ -1,0 +1,200 @@
+package sfn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// executeMapStateWithPolicy executes a Map state's item processing,
+// applying its Retry and Catch policy.
+func (e *executionEngine) executeMapStateWithPolicy(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
+	return e.runWithRetryCatch(ctx, name, state, input, func(ctx context.Context) (string, error) {
+		return e.executeMapState(ctx, name, state, input)
+	})
+}
+
+// executeMapState resolves ItemsPath into a JSON array and runs every item
+// through the state's ItemProcessor (or its legacy alias, Iterator),
+// bounding concurrency at MaxConcurrency when it is positive. Item outputs
+// are collected, in item order, as a JSON array. The first item to fail
+// cancels the remaining items and the Map state fails with that item's
+// error.
+//
+// ItemSelector, ItemBatcher, ResultWriter, and distributed-mode Map are out
+// of scope; only the inline processor mode is supported.
+func (e *executionEngine) executeMapState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
+	processor, err := itemProcessorDefinition(state)
+	if err != nil {
+		return "", fmt.Errorf("map state %q: %w", name, err)
+	}
+
+	items, err := resolveItemsPath(state.ItemsPath, input)
+	if err != nil {
+		return "", fmt.Errorf("map state %q: %w", name, err)
+	}
+
+	itemCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	outputs, err := runMapItems(itemCtx, e, processor, items, state.MaxConcurrency, cancel)
+	if err != nil {
+		return "", fmt.Errorf("map state %q: %w", name, err)
+	}
+
+	result, err := json.Marshal(outputs)
+	if err != nil {
+		return "", fmt.Errorf("map state %q: marshal item outputs: %w", name, err)
+	}
+
+	return string(result), nil
+}
+
+// itemProcessorDefinition returns the Map state's sub-state-machine.
+// ItemProcessor is the current field name; Iterator is the legacy alias. If
+// both are present, ItemProcessor takes precedence.
+func itemProcessorDefinition(state *stateDefinition) (*stateMachineDefinition, error) {
+	switch {
+	case state.ItemProcessor != nil:
+		return state.ItemProcessor, nil
+	case state.Iterator != nil:
+		return state.Iterator, nil
+	default:
+		return nil, fmt.Errorf("map state requires ItemProcessor or Iterator")
+	}
+}
+
+// runMapItems executes the processor once per item, honoring MaxConcurrency
+// (0 or negative means unlimited), and returns the item outputs in item
+// order, or the error of the first item to fail.
+func runMapItems(ctx context.Context, e *executionEngine, processor *stateMachineDefinition, items []json.RawMessage, maxConcurrency int, cancel context.CancelFunc) ([]json.RawMessage, error) {
+	outputs := make([]json.RawMessage, len(items))
+
+	var sem chan struct{}
+	if maxConcurrency > 0 {
+		sem = make(chan struct{}, maxConcurrency)
+	}
+
+	var (
+		wg       sync.WaitGroup
+		once     sync.Once
+		firstErr error
+	)
+
+	for i := range items {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			if sem != nil {
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-ctx.Done():
+					// Another item already failed and canceled ctx before
+					// this queued item got a slot; skip it rather than
+					// starting work whose result will be discarded.
+					return
+				}
+			}
+
+			out, err := e.execute(ctx, processor, string(items[i]))
+			if err != nil {
+				once.Do(func() {
+					firstErr = fmt.Errorf("item %d: %w", i, err)
+
+					cancel()
+				})
+
+				return
+			}
+
+			outputs[i] = json.RawMessage(out)
+		}(i)
+	}
+
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	return outputs, nil
+}
+
+// resolveItemsPath resolves a Map state's ItemsPath (default "$") against
+// its raw JSON input and requires the result to be a JSON array.
+func resolveItemsPath(path, input string) ([]json.RawMessage, error) {
+	if path == "" {
+		path = "$"
+	}
+
+	var data any
+	if err := json.Unmarshal([]byte(input), &data); err != nil {
+		return nil, fmt.Errorf("parse input: %w", err)
+	}
+
+	value, err := resolveAnyJSONPath(path, data)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ItemsPath %q: %w", path, err)
+	}
+
+	items, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("itemsPath %q did not resolve to an array", path)
+	}
+
+	return marshalItems(items)
+}
+
+// marshalItems re-encodes each already-decoded item as its own JSON text.
+func marshalItems(items []any) ([]json.RawMessage, error) {
+	raw := make([]json.RawMessage, len(items))
+
+	for i, item := range items {
+		encoded, err := json.Marshal(item)
+		if err != nil {
+			return nil, fmt.Errorf("marshal item %d: %w", i, err)
+		}
+
+		raw[i] = encoded
+	}
+
+	return raw, nil
+}
+
+// resolveAnyJSONPath resolves "$" or "$.field[.field...]" against an
+// already-decoded JSON value of any shape. It mirrors resolveJSONPath's
+// supported subset but, unlike resolveJSONPath, does not require the root
+// value to be a JSON object, so ItemsPath can select the entire input when
+// the input itself is a JSON array.
+func resolveAnyJSONPath(path string, data any) (any, error) {
+	if path == "$" {
+		return data, nil
+	}
+
+	if !strings.HasPrefix(path, "$.") {
+		return nil, fmt.Errorf("unsupported JSONPath %q: must start with $", path)
+	}
+
+	current := data
+
+	for _, part := range strings.Split(strings.TrimPrefix(path, "$."), ".") {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("jsonPath %q: cannot access field %q on non-object", path, part)
+		}
+
+		val, exists := m[part]
+		if !exists {
+			return nil, fmt.Errorf("jsonPath %q: field %q not found", path, part)
+		}
+
+		current = val
+	}
+
+	return current, nil
+}

--- a/internal/service/sfn/parallel.go
+++ b/internal/service/sfn/parallel.go
@@ -1,0 +1,86 @@
+package sfn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// executeParallelStateWithPolicy executes a Parallel state's Branches,
+// applying its Retry and Catch policy.
+func (e *executionEngine) executeParallelStateWithPolicy(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
+	return e.runWithRetryCatch(ctx, name, state, input, func(ctx context.Context) (string, error) {
+		return e.executeParallelState(ctx, name, state, input)
+	})
+}
+
+// executeParallelState runs every Branch concurrently against the same
+// state input and collects their outputs, in branch order, as a JSON array.
+// The first branch to fail cancels the remaining branches and the Parallel
+// state fails with States.BranchFailed, carrying the branch's own failure
+// as the cause, matching real Step Functions.
+func (e *executionEngine) executeParallelState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
+	if len(state.Branches) == 0 {
+		return "", fmt.Errorf("parallel state %q: Branches is required", name)
+	}
+
+	branchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	outputs, err := runBranches(branchCtx, e, state.Branches, input, cancel)
+	if err != nil {
+		return "", &failStateError{
+			errorName: errorStatesBranchFailed,
+			cause:     fmt.Sprintf("parallel state %q: %s", name, err),
+		}
+	}
+
+	result, err := json.Marshal(outputs)
+	if err != nil {
+		return "", fmt.Errorf("parallel state %q: marshal branch outputs: %w", name, err)
+	}
+
+	return string(result), nil
+}
+
+// runBranches executes each branch concurrently, returning the branch
+// outputs in branch order, or the error of the first branch to fail.
+func runBranches(ctx context.Context, e *executionEngine, branches []stateMachineDefinition, input string, cancel context.CancelFunc) ([]json.RawMessage, error) {
+	outputs := make([]json.RawMessage, len(branches))
+
+	var (
+		wg       sync.WaitGroup
+		once     sync.Once
+		firstErr error
+	)
+
+	for i := range branches {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			out, err := e.execute(ctx, &branches[i], input)
+			if err != nil {
+				once.Do(func() {
+					firstErr = fmt.Errorf("branch %d: %w", i, err)
+
+					cancel()
+				})
+
+				return
+			}
+
+			outputs[i] = json.RawMessage(out)
+		}(i)
+	}
+
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	return outputs, nil
+}

--- a/internal/service/sfn/parallel_test.go
+++ b/internal/service/sfn/parallel_test.go
@@ -1,0 +1,107 @@
+package sfn
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParallelStateCollectsBranchOutputsInOrder(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Fork",
+		"States": {
+			"Fork": {
+				"Type": "Parallel",
+				"Branches": [
+					{"StartAt": "A", "States": {"A": {"Type": "Pass", "Result": {"branch": "a"}, "End": true}}},
+					{"StartAt": "B", "States": {"B": {"Type": "Pass", "Result": {"branch": "b"}, "End": true}}}
+				],
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "parallel-ordered", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	var outputs []map[string]string
+	if err := json.Unmarshal([]byte(exec.Output), &outputs); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(outputs) != 2 || outputs[0]["branch"] != "a" || outputs[1]["branch"] != "b" {
+		t.Fatalf("branch outputs: got %v, want [{branch:a} {branch:b}] in that order", outputs)
+	}
+}
+
+func TestParallelStateFailsWhenABranchFails(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Fork",
+		"States": {
+			"Fork": {
+				"Type": "Parallel",
+				"Branches": [
+					{"StartAt": "A", "States": {"A": {"Type": "Pass", "Result": {"branch": "a"}, "End": true}}},
+					{"StartAt": "B", "States": {"B": {"Type": "Fail", "Error": "BranchBoom", "Cause": "branch b failed"}}}
+				],
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "parallel-branch-fails", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesBranchFailed {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesBranchFailed)
+	}
+
+	if !strings.Contains(exec.Cause, "BranchBoom") {
+		t.Fatalf("execution cause %q must carry the branch failure", exec.Cause)
+	}
+}
+
+func TestParallelStateCatchRecoversFromBranchFailure(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Fork",
+		"States": {
+			"Fork": {
+				"Type": "Parallel",
+				"Branches": [
+					{"StartAt": "B", "States": {"B": {"Type": "Fail", "Error": "BranchBoom", "Cause": "branch b failed"}}}
+				],
+				"Catch": [{"ErrorEquals": ["States.BranchFailed"], "Next": "Fallback"}],
+				"End": true
+			},
+			"Fallback": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "parallel-catch-recovers", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	var errorOutput map[string]string
+	if err := json.Unmarshal([]byte(exec.Output), &errorOutput); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if errorOutput["Error"] != errorStatesBranchFailed {
+		t.Fatalf("caught error output Error: got %q, want %q", errorOutput["Error"], errorStatesBranchFailed)
+	}
+
+	if !strings.Contains(errorOutput["Cause"], "BranchBoom") {
+		t.Fatalf("caught error output Cause %q must carry the branch failure", errorOutput["Cause"])
+	}
+}

--- a/internal/service/sfn/retry.go
+++ b/internal/service/sfn/retry.go
@@ -1,0 +1,299 @@
+package sfn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+// retrier is a single entry in a Task/Parallel/Map state's Retry field.
+//
+// JSON tags are lowerCamelCase rather than the Amazon States Language's own
+// PascalCase (e.g. "ErrorEquals", "IntervalSeconds"); encoding/json matches
+// object keys to struct fields case-insensitively when there is no exact
+// match, so definitions using the spec's PascalCase field names still decode
+// correctly.
+type retrier struct {
+	ErrorEquals     []string `json:"errorEquals"`
+	IntervalSeconds *int     `json:"intervalSeconds"`
+	MaxAttempts     *int     `json:"maxAttempts"`
+	BackoffRate     *float64 `json:"backoffRate"`
+	MaxDelaySeconds *int     `json:"maxDelaySeconds"`
+
+	// JitterStrategy is accepted but not implemented: kumo is a
+	// deterministic emulator, and randomizing retry delays would make retry
+	// timing (and therefore test timing) non-reproducible.
+	JitterStrategy string `json:"jitterStrategy"`
+}
+
+// catcher is a single entry in a Task/Parallel/Map state's Catch field. See
+// retrier for why its JSON tags are lowerCamelCase.
+type catcher struct {
+	ErrorEquals []string `json:"errorEquals"`
+	Next        string   `json:"next"`
+
+	// ResultPath is left as raw JSON so an explicit "null" (discard the
+	// Error Output, keep the original input) can be told apart from the
+	// field being absent (default "$", full replacement by the Error
+	// Output); both unmarshal to the same value through a plain *string.
+	ResultPath json.RawMessage `json:"resultPath"`
+}
+
+// Retry defaults per the Amazon States Language spec.
+const (
+	defaultRetryIntervalSeconds = 1
+	defaultRetryMaxAttempts     = 3
+	defaultRetryBackoffRate     = 2.0
+)
+
+// runWithRetryCatch executes fn (a state's own work for one execution),
+// applying that state's Retry and Catch policy: retries are attempted
+// first, using the matching Retrier's backoff schedule; if retries do not
+// resolve the error, or no Retrier matches, the first matching Catcher
+// routes to its Next state with the Catcher's Error Output as input. The
+// return shape mirrors executeState: nextOverride is non-empty only when a
+// Catcher matched.
+func (e *executionEngine) runWithRetryCatch(ctx context.Context, name string, state *stateDefinition, input string, fn func(context.Context) (string, error)) (string, string, error) {
+	output, err := e.runWithRetry(ctx, state, fn)
+	if err == nil {
+		return output, "", nil
+	}
+
+	catchOutput, catchNext, matched, buildErr := applyCatch(state, input, err)
+	if buildErr != nil {
+		return "", "", fmt.Errorf("state %q: %w", name, buildErr)
+	}
+
+	if !matched {
+		return "", "", err
+	}
+
+	return catchOutput, catchNext, nil
+}
+
+// runWithRetry executes fn, applying the state's Retry policy. Per the
+// spec, the interpreter scans the Retriers in order and uses the first one
+// whose ErrorEquals matches the reported error; each Retrier's attempt
+// budget (MaxAttempts) is independent of the others, and the budgets reset
+// whenever the state is entered anew, which holds naturally here since
+// runWithRetry is scoped to a single state execution.
+func (e *executionEngine) runWithRetry(ctx context.Context, state *stateDefinition, fn func(context.Context) (string, error)) (string, error) {
+	attemptsUsed := make([]int, len(state.Retry))
+
+	for {
+		output, err := fn(ctx)
+		if err == nil {
+			return output, nil
+		}
+
+		idx := matchingRetrierIndex(state.Retry, executionErrorCode(err))
+		if idx == -1 {
+			return "", err
+		}
+
+		attemptsUsed[idx]++
+
+		r := &state.Retry[idx]
+		if attemptsUsed[idx] > retryMaxAttempts(r) {
+			return "", err
+		}
+
+		if sleepErr := sleepForRetry(ctx, retryDelay(r, attemptsUsed[idx])); sleepErr != nil {
+			return "", sleepErr
+		}
+	}
+}
+
+// matchingRetrierIndex returns the index of the first Retrier whose
+// ErrorEquals matches errName, or -1 if none match.
+func matchingRetrierIndex(retriers []retrier, errName string) int {
+	for i := range retriers {
+		if errorNameMatches(retriers[i].ErrorEquals, errName) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// errorNameMatches reports whether errName is matched by an ErrorEquals
+// list from a Retrier or Catcher. States.Runtime is a special case: per AWS
+// documentation it "isn't retriable, and will always cause the execution to
+// fail" -- it is never matched, even by an explicit "States.Runtime" entry
+// or by the States.ALL wildcard.
+func errorNameMatches(errorEquals []string, errName string) bool {
+	if errName == errorStatesRuntime {
+		return false
+	}
+
+	for _, want := range errorEquals {
+		if want == errorStatesAll || want == errName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// retryMaxAttempts and retryBackoffRate apply the Retrier's spec defaults.
+func retryMaxAttempts(r *retrier) int {
+	if r.MaxAttempts != nil {
+		return *r.MaxAttempts
+	}
+
+	return defaultRetryMaxAttempts
+}
+
+func retryBackoffRate(r *retrier) float64 {
+	if r.BackoffRate != nil {
+		return *r.BackoffRate
+	}
+
+	return defaultRetryBackoffRate
+}
+
+// retryIntervalSeconds applies the Retrier's spec default.
+func retryIntervalSeconds(r *retrier) int {
+	if r.IntervalSeconds != nil {
+		return *r.IntervalSeconds
+	}
+
+	return defaultRetryIntervalSeconds
+}
+
+// retryDelay computes the sleep duration before retry attempt number
+// attempt (1-based: the first retry is attempt 1), applying BackoffRate and,
+// if set, capping at MaxDelaySeconds.
+func retryDelay(r *retrier, attempt int) time.Duration {
+	delay := float64(retryIntervalSeconds(r)) * math.Pow(retryBackoffRate(r), float64(attempt-1))
+
+	if r.MaxDelaySeconds != nil && delay > float64(*r.MaxDelaySeconds) {
+		delay = float64(*r.MaxDelaySeconds)
+	}
+
+	return time.Duration(delay * float64(time.Second))
+}
+
+// sleepForRetry sleeps for d, honoring ctx cancellation.
+func sleepForRetry(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("retry wait: %w", ctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}
+
+// applyCatch scans the state's Catchers, in array order, for the first one
+// whose ErrorEquals matches err's Error Name. matched is false if none did,
+// in which case the caller must propagate err unchanged.
+func applyCatch(state *stateDefinition, input string, err error) (output, next string, matched bool, buildErr error) {
+	errName := executionErrorCode(err)
+	cause := executionErrorCause(err)
+
+	for i := range state.Catch {
+		c := &state.Catch[i]
+		if !errorNameMatches(c.ErrorEquals, errName) {
+			continue
+		}
+
+		output, buildErr = buildCatchOutput(c.ResultPath, input, errName, cause)
+
+		return output, c.Next, true, buildErr
+	}
+
+	return "", "", false, nil
+}
+
+// buildCatchOutput builds a Catcher's output: the Error Output object
+// {"Error": errName, "Cause": cause}, optionally injected into the state's
+// original input per ResultPath. The default (ResultPath absent) is "$",
+// meaning the output is the Error Output alone; an explicit null ResultPath
+// discards the Error Output and passes the original input through
+// unchanged. Only "$" and single-level "$.field" paths are supported;
+// anything deeper is reported as a plain error, which executionErrorCode
+// surfaces as States.Runtime like any other unsupported definition
+// construct.
+func buildCatchOutput(rawResultPath json.RawMessage, input, errName, cause string) (string, error) {
+	path, isNull, err := parseCatcherResultPath(rawResultPath)
+	if err != nil {
+		return "", err
+	}
+
+	if isNull {
+		return input, nil
+	}
+
+	errorOutput := map[string]string{"Error": errName, "Cause": cause}
+
+	if path == "$" {
+		out, err := json.Marshal(errorOutput)
+		if err != nil {
+			return "", fmt.Errorf("marshal error output: %w", err)
+		}
+
+		return string(out), nil
+	}
+
+	return injectCatchResultPath(path, input, errorOutput)
+}
+
+// parseCatcherResultPath interprets a Catcher's raw ResultPath JSON.
+func parseCatcherResultPath(raw json.RawMessage) (path string, isNull bool, err error) {
+	if len(raw) == 0 {
+		return "$", false, nil
+	}
+
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false, fmt.Errorf("parse ResultPath: %w", err)
+	}
+
+	if value == nil {
+		return "", true, nil
+	}
+
+	path, ok := value.(string)
+	if !ok {
+		return "", false, fmt.Errorf("resultPath must be a string or null")
+	}
+
+	return path, false, nil
+}
+
+// injectCatchResultPath injects errorOutput into input at a single-level
+// "$.field" path, replacing or creating that top-level field.
+func injectCatchResultPath(path, input string, errorOutput map[string]string) (string, error) {
+	field, ok := strings.CutPrefix(path, "$.")
+	if !ok || field == "" || strings.Contains(field, ".") {
+		return "", fmt.Errorf("unsupported ResultPath %q: only \"$\" and single-level \"$.field\" are supported", path)
+	}
+
+	var inputData map[string]any
+	if err := json.Unmarshal([]byte(input), &inputData); err != nil {
+		return "", fmt.Errorf("resultPath %q requires an object input: %w", path, err)
+	}
+
+	if inputData == nil {
+		inputData = map[string]any{}
+	}
+
+	inputData[field] = errorOutput
+
+	out, err := json.Marshal(inputData)
+	if err != nil {
+		return "", fmt.Errorf("marshal ResultPath result: %w", err)
+	}
+
+	return string(out), nil
+}

--- a/internal/service/sfn/retry_test.go
+++ b/internal/service/sfn/retry_test.go
@@ -1,0 +1,120 @@
+package sfn
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// newFlakyLambdaServer returns an httptest server standing in for kumo's
+// Lambda invoke endpoint: it fails the first failCount calls with a 500
+// status (so the Task state's callLambda reports an error) and succeeds on
+// every call after that. The returned counter tracks the number of calls
+// received.
+func newFlakyLambdaServer(t *testing.T, failCount int) (*httptest.Server, *int32) {
+	t.Helper()
+
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if int(n) <= failCount {
+			http.Error(w, "boom", http.StatusInternalServerError)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server, &attempts
+}
+
+func retryTaskDefinition(retryJSON string) string {
+	return fmt.Sprintf(`{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:flaky-fn",
+				"Retry": [%s],
+				"End": true
+			}
+		}
+	}`, retryJSON)
+}
+
+func TestTaskRetrySucceedsOnAttemptAfterMatchingFailures(t *testing.T) {
+	t.Parallel()
+
+	// The endpoint fails once, so a single retry (IntervalSeconds: 1)
+	// resolves it on the second attempt.
+	server, attempts := newFlakyLambdaServer(t, 1)
+
+	definition := retryTaskDefinition(`{"ErrorEquals": ["States.TaskFailed"], "IntervalSeconds": 1, "MaxAttempts": 1}`)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "retry-succeeds", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Output != `{"ok":true}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"ok":true}`)
+	}
+
+	if got := atomic.LoadInt32(attempts); got != 2 {
+		t.Fatalf("lambda invocation count: got %d, want 2 (1 failure + 1 successful retry)", got)
+	}
+}
+
+func TestTaskRetryExhaustionFailsWithOriginalError(t *testing.T) {
+	t.Parallel()
+
+	// The endpoint always fails; MaxAttempts: 1 allows exactly one retry
+	// before the interpreter gives up and fails the state.
+	server, attempts := newFlakyLambdaServer(t, 1<<30)
+
+	definition := retryTaskDefinition(`{"ErrorEquals": ["States.TaskFailed"], "IntervalSeconds": 1, "MaxAttempts": 1}`)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "retry-exhausted", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesTaskFailed {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesTaskFailed)
+	}
+
+	if got := atomic.LoadInt32(attempts); got != 2 {
+		t.Fatalf("lambda invocation count: got %d, want 2 (1 initial + 1 retry)", got)
+	}
+}
+
+func TestTaskRetryErrorEqualsMismatchDoesNotRetry(t *testing.T) {
+	t.Parallel()
+
+	// The Retrier only matches "SomeOtherError", never the States.TaskFailed
+	// the endpoint actually produces, so the state must fail immediately
+	// without consuming any retry attempts.
+	server, attempts := newFlakyLambdaServer(t, 1<<30)
+
+	definition := retryTaskDefinition(`{"ErrorEquals": ["SomeOtherError"], "IntervalSeconds": 1, "MaxAttempts": 3}`)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "retry-mismatch", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesTaskFailed {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesTaskFailed)
+	}
+
+	if got := atomic.LoadInt32(attempts); got != 1 {
+		t.Fatalf("lambda invocation count: got %d, want 1 (no retry attempted)", got)
+	}
+}


### PR DESCRIPTION
## Summary
Completes the Step Functions execution-engine work started in #867 (the follow-ups noted when closing #861): Parallel, Map, Retry, and Catch.

- Retry with spec defaults (IntervalSeconds 1, MaxAttempts 3, BackoffRate 2.0), MaxDelaySeconds cap, per-retrier attempt budgets, context-aware backoff
- Catch routes to Next with the {Error, Cause} error output, honoring ResultPath (default replace, $.field injection, explicit null passthrough)
- States.Runtime is never retried or caught, even by States.ALL, per documented Step Functions behavior
- Parallel runs branches concurrently, collects outputs in branch order, and surfaces a branch failure as States.BranchFailed with the branch's failure as the cause
- Map supports ItemsPath, inline ItemProcessor (Iterator alias), MaxConcurrency, item-ordered output

Out of scope (documented in code): distributed Map (ItemSelector/ItemBatcher/ResultWriter), JitterStrategy (deterministic emulator), TimeoutSeconds/HeartbeatSeconds.

## Test plan
- [ ] Retry recovery/exhaustion/mismatch, Catch default and ResultPath variants, States.Runtime uncatchable
- [ ] Parallel ordered output, cancellation on branch failure, Catch on States.BranchFailed
- [ ] Map ordering, MaxConcurrency=1 serialization, Iterator alias, item failure, nested Retry inside a Map processor