### PR TITLE
feat(sfn): task and execution timeouts plus structural definition validation

### DIFF
--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -20,6 +20,13 @@ type stateMachineDefinition struct {
 	Comment string                     `json:"Comment"`
 	StartAt string                     `json:"StartAt"`
 	States  map[string]stateDefinition `json:"States"`
+
+	// TimeoutSeconds bounds the whole execution's wall-clock time. It is only
+	// meaningful on the top-level definition; MemoryStorage.runExecution is
+	// the sole reader of this field, since sub-state-machines (Parallel
+	// Branches / Map ItemProcessor) reuse this same struct but must not
+	// inherit an outer execution's timeout as their own.
+	TimeoutSeconds *int `json:"TimeoutSeconds"`
 }
 
 // stateDefinition represents a single state in a state machine definition.
@@ -61,23 +68,47 @@ type stateDefinition struct {
 	// Map state fields. ItemProcessor is the current field name; Iterator is
 	// the legacy alias for the same sub-state-machine. If both are present,
 	// ItemProcessor takes precedence. ItemSelector, ItemBatcher,
-	// ResultWriter, and distributed-mode Map are out of scope.
+	// ResultWriter, and distributed-mode Map are out of scope; the engine
+	// never reads these four fields, but validateStateMachineDefinition
+	// decodes them to flag definitions that rely on them (see validate.go).
 	ItemsPath      string                  `json:"ItemsPath"`
 	ItemProcessor  *stateMachineDefinition `json:"ItemProcessor"`
 	Iterator       *stateMachineDefinition `json:"Iterator"`
 	MaxConcurrency int                     `json:"MaxConcurrency"`
+	ItemReader     json.RawMessage         `json:"ItemReader"`
+	ItemSelector   json.RawMessage         `json:"ItemSelector"`
+	ItemBatcher    json.RawMessage         `json:"ItemBatcher"`
+	ResultWriter   json.RawMessage         `json:"ResultWriter"`
+
+	// Task state timeout fields. TimeoutSeconds/TimeoutSecondsPath bound a
+	// single execution attempt of the task (see timeout.go); per the ASL
+	// spec's default of 99999999 seconds (~3.17 years) when absent, kumo
+	// treats "unset" as no timeout at all rather than wrapping every task in
+	// a multi-year context.
+	TimeoutSeconds     *int   `json:"TimeoutSeconds"`
+	TimeoutSecondsPath string `json:"TimeoutSecondsPath"`
+
+	// HeartbeatSeconds/HeartbeatSecondsPath are decoded but intentionally
+	// never enforced: kumo has no activity/callback (.waitForTaskToken) task
+	// token support, so a task can never send a heartbeat. Enforcing this
+	// field would fail every task that sets it, for a reason kumo can never
+	// satisfy.
+	HeartbeatSeconds     *int   `json:"HeartbeatSeconds"`
+	HeartbeatSecondsPath string `json:"HeartbeatSecondsPath"`
 }
 
 // Execution error codes surfaced via DescribeExecution. States.TaskFailed is
 // reserved for failures of a Task state's work itself; States.NoChoiceMatched
 // is reserved for a Choice state with no matching rule and no Default;
-// States.ALL is the Retry/Catch wildcard that matches any other Error Name;
-// every other engine-level failure (unsupported state, bad definition
-// wiring) is States.Runtime.
+// States.Timeout is reported when a Task or the whole execution exceeds its
+// TimeoutSeconds; States.ALL is the Retry/Catch wildcard that matches any
+// other Error Name; every other engine-level failure (unsupported state, bad
+// definition wiring) is States.Runtime.
 const (
 	errorStatesRuntime         = "States.Runtime"
 	errorStatesTaskFailed      = "States.TaskFailed"
 	errorStatesNoChoiceMatched = "States.NoChoiceMatched"
+	errorStatesTimeout         = "States.Timeout"
 	errorStatesAll             = "States.ALL"
 	errorStatesBranchFailed    = "States.BranchFailed"
 )
@@ -129,6 +160,11 @@ func executionErrorCode(err error) string {
 	var choiceErr *noChoiceMatchedError
 	if errors.As(err, &choiceErr) {
 		return errorStatesNoChoiceMatched
+	}
+
+	var timeoutErr *taskTimeoutError
+	if errors.As(err, &timeoutErr) {
+		return errorStatesTimeout
 	}
 
 	var failErr *failStateError
@@ -264,10 +300,12 @@ func (e *executionEngine) executeState(ctx context.Context, name string, state *
 }
 
 // executeTaskStateWithPolicy executes a Task state's underlying work,
-// applying its Retry and Catch policy.
+// applying its Retry and Catch policy. Each attempt (initial or retried) is
+// individually bounded by the state's TimeoutSeconds/TimeoutSecondsPath; see
+// executeTaskStateWithTimeout in timeout.go.
 func (e *executionEngine) executeTaskStateWithPolicy(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
 	return e.runWithRetryCatch(ctx, name, state, input, func(ctx context.Context) (string, error) {
-		return e.executeTaskState(ctx, name, state, input)
+		return e.executeTaskStateWithTimeout(ctx, name, state, input)
 	})
 }
 

--- a/internal/service/sfn/handlers.go
+++ b/internal/service/sfn/handlers.go
@@ -11,9 +11,6 @@ import (
 	"github.com/sivchari/kumo/internal/service"
 )
 
-// Validation result values.
-const validationResultOK = "OK"
-
 // handlerFunc is a type alias for handler functions.
 type handlerFunc func(http.ResponseWriter, *http.Request)
 
@@ -407,20 +404,30 @@ func (s *Service) SendTaskHeartbeat(w http.ResponseWriter, _ *http.Request) {
 	writeError(w, "InvalidToken", "Invalid token", http.StatusBadRequest)
 }
 
-// ValidateStateMachineDefinition reports the supplied definition as valid.
+// ValidateStateMachineDefinition runs kumo's structural checks against the
+// supplied definition and reports diagnostics in AWS's documented shape.
 //
 // terraform-provider-aws calls ValidateStateMachineDefinition during the
 // plan phase of every aws_sfn_state_machine, before issuing CreateStateMachine.
 // Without it, `tofu plan` fails with InvalidAction and the resource never
 // reaches the create path.
-//
-// Definitions are not statically validated in kumo; this returns OK
-// so the apply pipeline proceeds and CreateStateMachine does the real
-// shape check.
-func (s *Service) ValidateStateMachineDefinition(w http.ResponseWriter, _ *http.Request) {
+func (s *Service) ValidateStateMachineDefinition(w http.ResponseWriter, r *http.Request) {
+	var req ValidateStateMachineDefinitionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	diagnostics := validateStateMachineDefinition(req.Definition)
+	result := diagnosticsResult(diagnostics)
+
+	filtered, truncated := filterAndCapDiagnostics(diagnostics, req.Severity, req.MaxResults)
+
 	writeResponse(w, ValidateStateMachineDefinitionResponse{
-		Result:      validationResultOK,
-		Diagnostics: []validateDiagnostic{},
+		Result:      result,
+		Diagnostics: filtered,
+		Truncated:   truncated,
 	})
 }
 

--- a/internal/service/sfn/storage.go
+++ b/internal/service/sfn/storage.go
@@ -3,6 +3,7 @@ package sfn
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -333,11 +334,17 @@ func (s *MemoryStorage) StartExecution(_ context.Context, stateMachineArn, name,
 	return copyExecution(exec), nil
 }
 
-// runExecution executes the state machine in a background goroutine.
-func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string, lastEventID int64) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+// executionTimeoutCap is kumo's own safety valve on how long a background
+// execution goroutine may run, independent of whether the definition sets
+// its own TimeoutSeconds. Standard state machine executions have no default
+// timeout in real AWS; this cap exists purely to bound the emulator's own
+// resource usage, so it must never be reported as a real States.Timeout --
+// see executionTimeoutDiagnosis.
+const executionTimeoutCap = 5 * time.Minute
 
+// runExecution executes the state machine in a background goroutine, bounded
+// by min(definition TimeoutSeconds, executionTimeoutCap).
+func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string, lastEventID int64) {
 	def, err := parseDefinition(definition)
 	if err != nil {
 		s.failExecution(ed, lastEventID, errorStatesRuntime, fmt.Sprintf("Failed to parse definition: %v", err))
@@ -345,14 +352,63 @@ func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string
 		return
 	}
 
+	ctx, cancel, definitionTimeoutApplies := executionContext(def)
+	defer cancel()
+
 	output, err := s.engine.execute(ctx, def, input)
 	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			code, cause := executionTimeoutDiagnosis(def, definitionTimeoutApplies)
+			s.failExecution(ed, lastEventID, code, cause)
+
+			return
+		}
+
 		s.failExecution(ed, lastEventID, executionErrorCode(err), executionErrorCause(err))
 
 		return
 	}
 
 	s.succeedExecution(ed, lastEventID, output)
+}
+
+// executionContext builds the context a top-level execution runs under. The
+// deadline is min(definition TimeoutSeconds, executionTimeoutCap): kumo
+// always enforces its own cap so a runaway execution cannot leak a goroutine
+// forever, even when the definition sets no timeout or one longer than the
+// cap. definitionTimeoutApplies reports whether the definition's own
+// TimeoutSeconds is the tighter (and therefore effective) bound.
+func executionContext(def *stateMachineDefinition) (ctx context.Context, cancel context.CancelFunc, definitionTimeoutApplies bool) {
+	effective := executionTimeoutCap
+
+	if def.TimeoutSeconds != nil && *def.TimeoutSeconds > 0 {
+		defTimeout := time.Duration(*def.TimeoutSeconds) * time.Second
+		if defTimeout <= effective {
+			effective = defTimeout
+			definitionTimeoutApplies = true
+		}
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), effective)
+
+	return ctx, cancel, definitionTimeoutApplies
+}
+
+// executionTimeoutDiagnosis reports the error code and cause for an
+// execution that hit its context deadline. A definition-set TimeoutSeconds
+// that was reached is a real States.Timeout; kumo's own executionTimeoutCap
+// firing on its own is an emulator implementation detail with no AWS
+// equivalent, so it is reported as States.Runtime with a cause that says so,
+// keeping the two causes distinguishable.
+func executionTimeoutDiagnosis(def *stateMachineDefinition, definitionTimeoutApplies bool) (code, cause string) {
+	if definitionTimeoutApplies {
+		return errorStatesTimeout, fmt.Sprintf("State machine execution exceeded its TimeoutSeconds (%d)", *def.TimeoutSeconds)
+	}
+
+	return errorStatesRuntime, fmt.Sprintf(
+		"kumo enforced its internal %s execution cap; the state machine did not set a TimeoutSeconds within that bound",
+		executionTimeoutCap,
+	)
 }
 
 // succeedExecution marks an execution as SUCCEEDED.

--- a/internal/service/sfn/timeout.go
+++ b/internal/service/sfn/timeout.go
@@ -1,0 +1,69 @@
+package sfn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// taskTimeoutError marks a Task state whose invocation attempt exceeded its
+// TimeoutSeconds/TimeoutSecondsPath. Per the Amazon States Language spec
+// this reports as States.Timeout which, unlike States.Runtime, is an
+// ordinary named error: Retry/Catch can match it like any other Error Name.
+type taskTimeoutError struct {
+	state string
+}
+
+func (e *taskTimeoutError) Error() string {
+	return fmt.Sprintf("state %q: task execution exceeded TimeoutSeconds", e.state)
+}
+
+// executeTaskStateWithTimeout wraps a single Task state invocation attempt
+// in a context bounded by TimeoutSeconds/TimeoutSecondsPath. It is called
+// once per Retry attempt (see executeTaskStateWithPolicy), so each attempt
+// gets its own fresh timeout window: TimeoutSeconds bounds one execution
+// attempt of the task, not the state's total retry budget.
+func (e *executionEngine) executeTaskStateWithTimeout(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
+	timeout, err := taskTimeout(state, input)
+	if err != nil {
+		return "", fmt.Errorf("task state %q: %w", name, err)
+	}
+
+	if timeout <= 0 {
+		return e.executeTaskState(ctx, name, state, input)
+	}
+
+	taskCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	output, err := e.executeTaskState(taskCtx, name, state, input)
+	if err != nil && errors.Is(taskCtx.Err(), context.DeadlineExceeded) {
+		return "", &taskTimeoutError{state: name}
+	}
+
+	return output, err
+}
+
+// taskTimeout resolves a Task state's timeout duration from TimeoutSeconds
+// or TimeoutSecondsPath, preferring the path form when both are set. It
+// returns zero -- meaning "do not wrap the call in a timeout context at all"
+// -- when neither field is set, since the spec's default of 99999999
+// seconds (~3.17 years) is effectively unbounded.
+func taskTimeout(state *stateDefinition, input string) (time.Duration, error) {
+	switch {
+	case state.TimeoutSecondsPath != "":
+		seconds, err := resolveNumberPath(state.TimeoutSecondsPath, input)
+		if err != nil {
+			return 0, fmt.Errorf("resolve TimeoutSecondsPath: %w", err)
+		}
+
+		return time.Duration(seconds * float64(time.Second)), nil
+
+	case state.TimeoutSeconds != nil:
+		return time.Duration(*state.TimeoutSeconds) * time.Second, nil
+
+	default:
+		return 0, nil
+	}
+}

--- a/internal/service/sfn/timeout_test.go
+++ b/internal/service/sfn/timeout_test.go
@@ -1,0 +1,172 @@
+package sfn
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// slowLambdaSleep only needs to clear the 1-second TimeoutSeconds used by
+// every test in this file by a small margin: net/http servers do not
+// reliably observe a POST request's r.Context() cancellation once the
+// client gives up (the connection isn't torn down until the handler itself
+// returns), so httptest.Server.Close ends up waiting out this full duration
+// regardless of how early the client-side call returns.
+const slowLambdaSleep = 1200 * time.Millisecond
+
+// newSlowLambdaServer returns an httptest server standing in for kumo's
+// Lambda invoke endpoint that never responds in time for a Task state's
+// TimeoutSeconds to matter.
+func newSlowLambdaServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(slowLambdaSleep)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func TestTaskTimeoutSecondsFailsExecutionWithStatesTimeout(t *testing.T) {
+	t.Parallel()
+
+	server := newSlowLambdaServer(t)
+
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:slow-fn",
+				"TimeoutSeconds": 1,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "task-timeout", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesTimeout {
+		t.Fatalf("execution error: got %q, want %q (cause: %s)", exec.Error, errorStatesTimeout, exec.Cause)
+	}
+}
+
+func TestTaskTimeoutSecondsPathFailsExecutionWithStatesTimeout(t *testing.T) {
+	t.Parallel()
+
+	server := newSlowLambdaServer(t)
+
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:slow-fn",
+				"TimeoutSecondsPath": "$.timeout",
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "task-timeout-path", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{"timeout":1}`)
+
+	if exec.Error != errorStatesTimeout {
+		t.Fatalf("execution error: got %q, want %q (cause: %s)", exec.Error, errorStatesTimeout, exec.Cause)
+	}
+}
+
+func TestTaskTimeoutCaughtByCatchRecoversExecution(t *testing.T) {
+	t.Parallel()
+
+	server := newSlowLambdaServer(t)
+
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:slow-fn",
+				"TimeoutSeconds": 1,
+				"Catch": [{"ErrorEquals": ["States.Timeout"], "Next": "Fallback"}],
+				"End": true
+			},
+			"Fallback": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "task-timeout-catch", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	var errorOutput map[string]string
+	if err := json.Unmarshal([]byte(exec.Output), &errorOutput); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if errorOutput["Error"] != errorStatesTimeout {
+		t.Fatalf("caught error output Error: got %q, want %q", errorOutput["Error"], errorStatesTimeout)
+	}
+}
+
+func TestDefinitionTimeoutSecondsFailsExecutionWithStatesTimeout(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "LongWait",
+		"TimeoutSeconds": 1,
+		"States": {
+			"LongWait": {"Type": "Wait", "Seconds": 5, "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "definition-timeout", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesTimeout {
+		t.Fatalf("execution error: got %q, want %q (cause: %s)", exec.Error, errorStatesTimeout, exec.Cause)
+	}
+}
+
+func TestHeartbeatFieldsAreAcceptedWithoutError(t *testing.T) {
+	t.Parallel()
+
+	server := newEchoLambdaServer(t)
+
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:echo-fn",
+				"HeartbeatSeconds": 5,
+				"HeartbeatSecondsPath": "$.heartbeat",
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "heartbeat-ignored", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"heartbeat":5}`)
+
+	if exec.Output != `{"heartbeat":5}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"heartbeat":5}`)
+	}
+}

--- a/internal/service/sfn/types.go
+++ b/internal/service/sfn/types.go
@@ -410,12 +410,19 @@ type ListStateMachineAliasesResponse struct {
 type ValidateStateMachineDefinitionRequest struct {
 	Definition string `json:"definition"`
 	Type       string `json:"type,omitempty"`
+	// Severity filters the returned diagnostics: "ERROR" (the default)
+	// returns only ERROR-severity diagnostics, "WARNING" returns both.
+	Severity string `json:"severity,omitempty"`
+	// MaxResults caps the number of diagnostics returned; kumo defaults and
+	// caps this at defaultValidateMaxResults, same as AWS.
+	MaxResults int32 `json:"maxResults,omitempty"`
 }
 
 // ValidateStateMachineDefinitionResponse is the response for ValidateStateMachineDefinition.
 type ValidateStateMachineDefinitionResponse struct {
 	Result      string               `json:"result"`
 	Diagnostics []validateDiagnostic `json:"diagnostics"`
+	Truncated   bool                 `json:"truncated"`
 }
 
 // validateDiagnostic is a single ValidateStateMachineDefinition diagnostic.

--- a/internal/service/sfn/validate.go
+++ b/internal/service/sfn/validate.go
@@ -1,0 +1,440 @@
+package sfn
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Diagnostic severities and validation results, matching the exact wire
+// values AWS documents for ValidateStateMachineDefinition.
+const (
+	diagnosticSeverityError   = "ERROR"
+	diagnosticSeverityWarning = "WARNING"
+
+	validationResultOK   = "OK"
+	validationResultFail = "FAIL"
+
+	// defaultValidateMaxResults matches AWS's own documented default and cap
+	// on the number of diagnostics returned per call.
+	defaultValidateMaxResults = 100
+)
+
+// Diagnostic codes. The first block reuses AWS's own documented codes where
+// kumo's check matches their meaning exactly. The second block is best
+// effort: AWS does not document a code for these two checks, so kumo names
+// them descriptively rather than guessing at an undocumented AWS string.
+const (
+	codeInvalidJSONDescription  = "INVALID_JSON_DESCRIPTION"
+	codeSchemaValidationFailed  = "SCHEMA_VALIDATION_FAILED"
+	codeInvalidResource         = "INVALID_RESOURCE"
+	codeMissingEndState         = "MISSING_END_STATE"
+	codeMissingTransitionTarget = "MISSING_TRANSITION_TARGET"
+
+	codeUnreachableState            = "UNREACHABLE_STATE"
+	codeUnsupportedRuntimeConstruct = "UNSUPPORTED_RUNTIME_CONSTRUCT"
+)
+
+// terminalStateTypes lists ASL state Types that need neither "Next" nor
+// "End": true, per their own spec rules: Choice always branches via
+// Choices/Default, and Succeed/Fail are always terminal.
+var terminalStateTypes = map[string]bool{
+	"Choice":  true,
+	"Succeed": true,
+	"Fail":    true,
+}
+
+// mapEmulationGapFields are Map state fields the ASL spec defines but
+// kumo's executor does not implement (see mapstate.go): ItemSelector,
+// ItemBatcher and ResultWriter are unimplemented in every mode, and
+// ItemReader is the marker for distributed-mode Map, which kumo only ever
+// runs in inline (ItemProcessor/Iterator) mode.
+var mapEmulationGapFields = []struct {
+	name string
+	get  func(*stateDefinition) json.RawMessage
+}{
+	{"ItemReader", func(s *stateDefinition) json.RawMessage { return s.ItemReader }},
+	{"ItemSelector", func(s *stateDefinition) json.RawMessage { return s.ItemSelector }},
+	{"ItemBatcher", func(s *stateDefinition) json.RawMessage { return s.ItemBatcher }},
+	{"ResultWriter", func(s *stateDefinition) json.RawMessage { return s.ResultWriter }},
+}
+
+// validateStateMachineDefinition runs kumo's best-effort structural checks
+// against a Step Functions definition and returns diagnostics in AWS's
+// documented ValidateStateMachineDefinition shape. Definitions that
+// CreateStateMachine already accepts must keep validating with no ERROR
+// diagnostics; only genuinely broken or kumo-unsupported constructs are
+// flagged, so this never rejects anything the engine can actually run.
+func validateStateMachineDefinition(definition string) []validateDiagnostic {
+	var def stateMachineDefinition
+	if err := json.Unmarshal([]byte(definition), &def); err != nil {
+		return []validateDiagnostic{{
+			Severity: diagnosticSeverityError,
+			Code:     codeInvalidJSONDescription,
+			Message:  fmt.Sprintf("Failed to parse the state machine definition: %v", err),
+		}}
+	}
+
+	v := &definitionValidator{diagnostics: []validateDiagnostic{}}
+	v.validateStateMachine(&def, "")
+
+	return v.diagnostics
+}
+
+// definitionValidator accumulates diagnostics while walking a state machine
+// definition and its nested Parallel Branches / Map ItemProcessor
+// sub-definitions.
+type definitionValidator struct {
+	diagnostics []validateDiagnostic
+}
+
+func (v *definitionValidator) addError(code, location, message string) {
+	v.diagnostics = append(v.diagnostics, validateDiagnostic{
+		Severity: diagnosticSeverityError,
+		Code:     code,
+		Message:  message,
+		Location: location,
+	})
+}
+
+func (v *definitionValidator) addWarning(code, location, message string) {
+	v.diagnostics = append(v.diagnostics, validateDiagnostic{
+		Severity: diagnosticSeverityWarning,
+		Code:     code,
+		Message:  message,
+		Location: location,
+	})
+}
+
+// validateStateMachine validates one state machine's worth of States --
+// the top-level definition, or a Parallel Branch / Map ItemProcessor
+// sub-definition -- prefixing every diagnostic's location with
+// locationPrefix so nested diagnostics point at the right JSON path.
+func (v *definitionValidator) validateStateMachine(def *stateMachineDefinition, locationPrefix string) {
+	if def.StartAt == "" {
+		v.addError(codeSchemaValidationFailed, locationPrefix+"/StartAt", "state machine is missing required field \"StartAt\"")
+	}
+
+	if len(def.States) == 0 {
+		v.addError(codeSchemaValidationFailed, locationPrefix+"/States", "state machine is missing required field \"States\"")
+
+		return
+	}
+
+	if def.StartAt != "" {
+		if _, ok := def.States[def.StartAt]; !ok {
+			v.addError(codeMissingTransitionTarget, locationPrefix+"/StartAt",
+				fmt.Sprintf("StartAt %q does not refer to a state in \"States\"", def.StartAt))
+		}
+	}
+
+	names := sortedStateNames(def.States)
+
+	for _, name := range names {
+		state := def.States[name]
+		v.validateState(name, &state, def.States, locationPrefix)
+	}
+
+	v.warnUnreachableStates(def, locationPrefix, names)
+}
+
+// sortedStateNames returns a state machine's state names in a deterministic
+// order, so diagnostics are reported in a stable order across calls despite
+// Go's randomized map iteration.
+func sortedStateNames(states map[string]stateDefinition) []string {
+	names := make([]string, 0, len(states))
+	for name := range states {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+// validateState runs every check that applies to a single state: transition
+// targets, the Next-or-End requirement, Catch entries, and any type-specific
+// required fields.
+func (v *definitionValidator) validateState(name string, state *stateDefinition, states map[string]stateDefinition, locationPrefix string) {
+	location := locationPrefix + "/States/" + name
+
+	if state.Next != "" {
+		if _, ok := states[state.Next]; !ok {
+			v.addError(codeMissingTransitionTarget, location+"/Next",
+				fmt.Sprintf("state %q: Next %q does not refer to a state in \"States\"", name, state.Next))
+		}
+	}
+
+	if !state.End && state.Next == "" && !terminalStateTypes[state.Type] {
+		v.addError(codeMissingEndState, location, fmt.Sprintf("state %q must have either \"Next\" or \"End\": true", name))
+	}
+
+	v.validateCatchers(name, state, states, location)
+
+	switch state.Type {
+	case "Task":
+		v.validateTaskState(name, state, location)
+	case "Choice":
+		v.validateChoiceState(name, state, states, location)
+	case "Parallel":
+		v.validateParallelState(name, state, location)
+	case "Map":
+		v.validateMapState(name, state, location)
+	case "Wait":
+		v.validateWaitState(name, state, location)
+	}
+}
+
+// validateCatchers checks every Catch entry's Next reference. ASL restricts
+// Catch to Task, Parallel and Map states, but the check itself is generic:
+// it simply validates whatever Catch entries are present.
+func (v *definitionValidator) validateCatchers(name string, state *stateDefinition, states map[string]stateDefinition, location string) {
+	for i, c := range state.Catch {
+		catchLocation := fmt.Sprintf("%s/Catch/%d/Next", location, i)
+
+		if c.Next == "" {
+			v.addError(codeMissingTransitionTarget, catchLocation,
+				fmt.Sprintf("state %q: Catch entry %d is missing required field \"Next\"", name, i))
+
+			continue
+		}
+
+		if _, ok := states[c.Next]; !ok {
+			v.addError(codeMissingTransitionTarget, catchLocation,
+				fmt.Sprintf("state %q: Catch entry %d's Next %q does not refer to a state in \"States\"", name, i, c.Next))
+		}
+	}
+}
+
+// validateTaskState checks a Task state's required Resource field.
+func (v *definitionValidator) validateTaskState(name string, state *stateDefinition, location string) {
+	if state.Resource == "" {
+		v.addError(codeInvalidResource, location+"/Resource", fmt.Sprintf("Task state %q is missing required field \"Resource\"", name))
+	}
+}
+
+// validateChoiceState checks a Choice state's Choices (non-empty, each with
+// a valid Next) and Default (if set, a valid transition target).
+func (v *definitionValidator) validateChoiceState(name string, state *stateDefinition, states map[string]stateDefinition, location string) {
+	if len(state.Choices) == 0 {
+		v.addError(codeSchemaValidationFailed, location+"/Choices", fmt.Sprintf("Choice state %q requires at least one entry in \"Choices\"", name))
+	}
+
+	for i := range state.Choices {
+		choice := &state.Choices[i]
+		choiceLocation := fmt.Sprintf("%s/Choices/%d/Next", location, i)
+
+		if choice.Next == "" {
+			v.addError(codeMissingTransitionTarget, choiceLocation,
+				fmt.Sprintf("state %q: Choices entry %d is missing required field \"Next\"", name, i))
+
+			continue
+		}
+
+		if _, ok := states[choice.Next]; !ok {
+			v.addError(codeMissingTransitionTarget, choiceLocation,
+				fmt.Sprintf("state %q: Choices entry %d's Next %q does not refer to a state in \"States\"", name, i, choice.Next))
+		}
+	}
+
+	if state.Default != "" {
+		if _, ok := states[state.Default]; !ok {
+			v.addError(codeMissingTransitionTarget, location+"/Default",
+				fmt.Sprintf("state %q: Default %q does not refer to a state in \"States\"", name, state.Default))
+		}
+	}
+}
+
+// validateParallelState checks a Parallel state's Branches (non-empty) and
+// recursively validates each branch as its own state machine.
+func (v *definitionValidator) validateParallelState(name string, state *stateDefinition, location string) {
+	if len(state.Branches) == 0 {
+		v.addError(codeSchemaValidationFailed, location+"/Branches", fmt.Sprintf("Parallel state %q requires at least one entry in \"Branches\"", name))
+
+		return
+	}
+
+	for i := range state.Branches {
+		v.validateStateMachine(&state.Branches[i], fmt.Sprintf("%s/Branches/%d", location, i))
+	}
+}
+
+// validateMapState checks a Map state's ItemProcessor/Iterator (required,
+// recursively validated) and warns about ASL fields kumo's engine does not
+// implement.
+func (v *definitionValidator) validateMapState(name string, state *stateDefinition, location string) {
+	switch {
+	case state.ItemProcessor != nil:
+		v.validateStateMachine(state.ItemProcessor, location+"/ItemProcessor")
+	case state.Iterator != nil:
+		v.validateStateMachine(state.Iterator, location+"/Iterator")
+	default:
+		v.addError(codeSchemaValidationFailed, location, fmt.Sprintf("Map state %q requires \"ItemProcessor\" (or the legacy \"Iterator\")", name))
+	}
+
+	v.warnUnsupportedMapFields(name, state, location)
+}
+
+// warnUnsupportedMapFields flags Map fields the engine silently ignores at
+// runtime (see mapstate.go), so a definition that structurally validates
+// does not still surprise the caller when it runs -- the class of gap
+// reported in issue #861.
+func (v *definitionValidator) warnUnsupportedMapFields(name string, state *stateDefinition, location string) {
+	for _, field := range mapEmulationGapFields {
+		if len(field.get(state)) == 0 {
+			continue
+		}
+
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/"+field.name, fmt.Sprintf(
+			"Map state %q sets %q, which kumo's engine does not implement (only the inline ItemProcessor/Iterator mode is supported); this definition will pass validation but will not run as expected",
+			name, field.name,
+		))
+	}
+}
+
+// validateWaitState checks that exactly one of Seconds, SecondsPath,
+// Timestamp, TimestampPath is set, per the Amazon States Language spec.
+func (v *definitionValidator) validateWaitState(name string, state *stateDefinition, location string) {
+	set := 0
+
+	for _, isSet := range []bool{
+		state.Seconds != nil,
+		state.SecondsPath != "",
+		state.Timestamp != "",
+		state.TimestampPath != "",
+	} {
+		if isSet {
+			set++
+		}
+	}
+
+	if set != 1 {
+		v.addError(codeSchemaValidationFailed, location, fmt.Sprintf(
+			"Wait state %q must set exactly one of \"Seconds\", \"SecondsPath\", \"Timestamp\", \"TimestampPath\" (found %d)",
+			name, set,
+		))
+	}
+}
+
+// warnUnreachableStates flags every state that cannot be reached from
+// StartAt by following Next, Default, Choices[].Next, or Catch[].Next
+// edges.
+func (v *definitionValidator) warnUnreachableStates(def *stateMachineDefinition, locationPrefix string, names []string) {
+	if def.StartAt == "" {
+		return
+	}
+
+	if _, ok := def.States[def.StartAt]; !ok {
+		return
+	}
+
+	reachable := reachableStates(def)
+
+	for _, name := range names {
+		if !reachable[name] {
+			v.addWarning(codeUnreachableState, locationPrefix+"/States/"+name, fmt.Sprintf("state %q is not reachable from \"StartAt\"", name))
+		}
+	}
+}
+
+// reachableStates returns the set of state names reachable from StartAt via
+// breadth-first traversal of every transition edge.
+func reachableStates(def *stateMachineDefinition) map[string]bool {
+	reachable := map[string]bool{def.StartAt: true}
+	queue := []string{def.StartAt}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		state, ok := def.States[current]
+		if !ok {
+			continue
+		}
+
+		for _, next := range stateTransitionTargets(&state) {
+			if reachable[next] {
+				continue
+			}
+
+			if _, exists := def.States[next]; !exists {
+				continue
+			}
+
+			reachable[next] = true
+
+			queue = append(queue, next)
+		}
+	}
+
+	return reachable
+}
+
+// stateTransitionTargets lists every state name a state can transition to:
+// Next, Default, each Choices[].Next, and each Catch[].Next.
+func stateTransitionTargets(state *stateDefinition) []string {
+	var targets []string
+
+	if state.Next != "" {
+		targets = append(targets, state.Next)
+	}
+
+	if state.Default != "" {
+		targets = append(targets, state.Default)
+	}
+
+	for i := range state.Choices {
+		if state.Choices[i].Next != "" {
+			targets = append(targets, state.Choices[i].Next)
+		}
+	}
+
+	for _, c := range state.Catch {
+		if c.Next != "" {
+			targets = append(targets, c.Next)
+		}
+	}
+
+	return targets
+}
+
+// diagnosticsResult reports the ValidateStateMachineDefinition "result"
+// value: FAIL if any ERROR-severity diagnostic is present, regardless of
+// what the severity filter below ends up returning to the caller.
+func diagnosticsResult(diagnostics []validateDiagnostic) string {
+	for _, d := range diagnostics {
+		if d.Severity == diagnosticSeverityError {
+			return validationResultFail
+		}
+	}
+
+	return validationResultOK
+}
+
+// filterAndCapDiagnostics applies the request's Severity filter (ERROR
+// only, unless the caller asked for WARNING too) and MaxResults cap,
+// reporting whether the result was truncated.
+func filterAndCapDiagnostics(diagnostics []validateDiagnostic, severity string, maxResults int32) ([]validateDiagnostic, bool) {
+	if severity != diagnosticSeverityWarning {
+		filtered := make([]validateDiagnostic, 0, len(diagnostics))
+
+		for _, d := range diagnostics {
+			if d.Severity == diagnosticSeverityError {
+				filtered = append(filtered, d)
+			}
+		}
+
+		diagnostics = filtered
+	}
+
+	limit := int(maxResults)
+	if limit <= 0 || limit > defaultValidateMaxResults {
+		limit = defaultValidateMaxResults
+	}
+
+	if len(diagnostics) > limit {
+		return diagnostics[:limit], true
+	}
+
+	return diagnostics, false
+}

--- a/internal/service/sfn/validate_test.go
+++ b/internal/service/sfn/validate_test.go
@@ -1,0 +1,340 @@
+package sfn
+
+import "testing"
+
+// comprehensiveValidDefinition exercises every state type kumo's engine
+// supports (Task, Choice, Wait, Succeed, Fail, Parallel, Map, plus Retry and
+// Catch), standing in for every currently-passing definition used in kumo's
+// own test suite, which must keep validating OK.
+const comprehensiveValidDefinition = `{
+	"StartAt": "Decide",
+	"States": {
+		"Decide": {
+			"Type": "Choice",
+			"Choices": [{"Variable": "$.mode", "StringEquals": "fast", "Next": "Fork"}],
+			"Default": "Wait"
+		},
+		"Wait": {"Type": "Wait", "Seconds": 1, "Next": "Fork"},
+		"Fork": {
+			"Type": "Parallel",
+			"Branches": [
+				{"StartAt": "A", "States": {"A": {"Type": "Pass", "End": true}}}
+			],
+			"Retry": [{"ErrorEquals": ["States.ALL"], "MaxAttempts": 1}],
+			"Catch": [{"ErrorEquals": ["States.ALL"], "Next": "Failed"}],
+			"Next": "Items"
+		},
+		"Items": {
+			"Type": "Map",
+			"ItemProcessor": {"StartAt": "Item", "States": {"Item": {"Type": "Pass", "End": true}}},
+			"Next": "Invoke"
+		},
+		"Invoke": {
+			"Type": "Task",
+			"Resource": "arn:aws:lambda:us-east-1:000000000000:function:fn",
+			"Catch": [{"ErrorEquals": ["States.ALL"], "Next": "Failed"}],
+			"Next": "Done"
+		},
+		"Done": {"Type": "Succeed"},
+		"Failed": {"Type": "Fail", "Error": "BadThing", "Cause": "it broke"}
+	}
+}`
+
+func TestValidateStateMachineDefinitionExistingDefinitionsStillOK(t *testing.T) {
+	t.Parallel()
+
+	for name, definition := range map[string]string{
+		"comprehensive":  comprehensiveValidDefinition,
+		"execution test": executionTestDefinition,
+		"choice repro":   choiceReproDefinition,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diagnostics := validateStateMachineDefinition(definition)
+			if got := diagnosticsResult(diagnostics); got != validationResultOK {
+				t.Fatalf("result: got %q, want %q (diagnostics: %+v)", got, validationResultOK, diagnostics)
+			}
+		})
+	}
+}
+
+// diagnosticTest is one case in validateDiagnosticTests: a definition and
+// the single diagnostic it must produce, identified by code and location.
+type diagnosticTest struct {
+	name         string
+	definition   string
+	wantSeverity string
+	wantCode     string
+	wantLocation string
+}
+
+var validateDiagnosticTests = []diagnosticTest{
+	{
+		name: "missing StartAt target",
+		definition: `{
+			"StartAt": "Nope",
+			"States": {"Done": {"Type": "Pass", "End": true}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeMissingTransitionTarget,
+		wantLocation: "/StartAt",
+	},
+	{
+		name: "dangling Next",
+		definition: `{
+			"StartAt": "Start",
+			"States": {"Start": {"Type": "Pass", "Next": "Nope"}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeMissingTransitionTarget,
+		wantLocation: "/States/Start/Next",
+	},
+	{
+		name: "missing Task Resource",
+		definition: `{
+			"StartAt": "Invoke",
+			"States": {"Invoke": {"Type": "Task", "End": true}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeInvalidResource,
+		wantLocation: "/States/Invoke/Resource",
+	},
+	{
+		name: "dead-end state missing Next or End",
+		definition: `{
+			"StartAt": "Start",
+			"States": {"Start": {"Type": "Pass"}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeMissingEndState,
+		wantLocation: "/States/Start",
+	},
+	{
+		name: "empty Choices",
+		definition: `{
+			"StartAt": "Decide",
+			"States": {"Decide": {"Type": "Choice", "Choices": []}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeSchemaValidationFailed,
+		wantLocation: "/States/Decide/Choices",
+	},
+	{
+		name: "empty Branches",
+		definition: `{
+			"StartAt": "Fork",
+			"States": {"Fork": {"Type": "Parallel", "Branches": [], "End": true}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeSchemaValidationFailed,
+		wantLocation: "/States/Fork/Branches",
+	},
+	{
+		name: "Map missing ItemProcessor and Iterator",
+		definition: `{
+			"StartAt": "Items",
+			"States": {"Items": {"Type": "Map", "End": true}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeSchemaValidationFailed,
+		wantLocation: "/States/Items",
+	},
+	{
+		name: "Wait with no duration field",
+		definition: `{
+			"StartAt": "W",
+			"States": {"W": {"Type": "Wait", "End": true}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeSchemaValidationFailed,
+		wantLocation: "/States/W",
+	},
+	{
+		name: "Wait with more than one duration field",
+		definition: `{
+			"StartAt": "W",
+			"States": {"W": {"Type": "Wait", "Seconds": 1, "SecondsPath": "$.s", "End": true}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeSchemaValidationFailed,
+		wantLocation: "/States/W",
+	},
+	{
+		name: "dangling Catch Next",
+		definition: `{
+			"StartAt": "Invoke",
+			"States": {
+				"Invoke": {
+					"Type": "Task",
+					"Resource": "arn:aws:lambda:us-east-1:000000000000:function:fn",
+					"Catch": [{"ErrorEquals": ["States.ALL"], "Next": "Nope"}],
+					"End": true
+				}
+			}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeMissingTransitionTarget,
+		wantLocation: "/States/Invoke/Catch/0/Next",
+	},
+	{
+		name: "unreachable state",
+		definition: `{
+			"StartAt": "Start",
+			"States": {
+				"Start": {"Type": "Pass", "End": true},
+				"Orphan": {"Type": "Pass", "End": true}
+			}
+		}`,
+		wantSeverity: diagnosticSeverityWarning,
+		wantCode:     codeUnreachableState,
+		wantLocation: "/States/Orphan",
+	},
+	{
+		name: "Map field kumo does not implement",
+		definition: `{
+			"StartAt": "Items",
+			"States": {
+				"Items": {
+					"Type": "Map",
+					"ItemProcessor": {"StartAt": "Item", "States": {"Item": {"Type": "Pass", "End": true}}},
+					"ResultWriter": {"Resource": "arn:aws:states:::s3:putObject"},
+					"End": true
+				}
+			}
+		}`,
+		wantSeverity: diagnosticSeverityWarning,
+		wantCode:     codeUnsupportedRuntimeConstruct,
+		wantLocation: "/States/Items/ResultWriter",
+	},
+	{
+		name: "nested branch dangling Next",
+		definition: `{
+			"StartAt": "Fork",
+			"States": {
+				"Fork": {
+					"Type": "Parallel",
+					"Branches": [
+						{"StartAt": "A", "States": {"A": {"Type": "Pass", "Next": "Nope"}}}
+					],
+					"End": true
+				}
+			}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeMissingTransitionTarget,
+		wantLocation: "/States/Fork/Branches/0/States/A/Next",
+	},
+	{
+		name:         "invalid JSON",
+		definition:   `{not json`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeInvalidJSONDescription,
+		wantLocation: "",
+	},
+}
+
+func TestValidateStateMachineDefinitionDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range validateDiagnosticTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertHasDiagnostic(t, validateStateMachineDefinition(tt.definition), &tt)
+		})
+	}
+}
+
+// assertHasDiagnostic fails the test unless diagnostics contains an entry
+// matching tt's expected code, location, and severity, with a non-empty
+// message.
+func assertHasDiagnostic(t *testing.T, diagnostics []validateDiagnostic, tt *diagnosticTest) {
+	t.Helper()
+
+	for _, d := range diagnostics {
+		if d.Code != tt.wantCode || d.Location != tt.wantLocation {
+			continue
+		}
+
+		if d.Severity != tt.wantSeverity {
+			t.Fatalf("diagnostic %q at %q: severity got %q, want %q", d.Code, d.Location, d.Severity, tt.wantSeverity)
+		}
+
+		if d.Message == "" {
+			t.Fatalf("diagnostic %q at %q: want non-empty message", d.Code, d.Location)
+		}
+
+		return
+	}
+
+	t.Fatalf("diagnostics %+v: want one with code %q at location %q", diagnostics, tt.wantCode, tt.wantLocation)
+}
+
+func TestValidateStateMachineDefinitionValidDefinitionHasNoDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := validateStateMachineDefinition(comprehensiveValidDefinition)
+	if len(diagnostics) != 0 {
+		t.Fatalf("diagnostics: got %+v, want none", diagnostics)
+	}
+}
+
+func TestDiagnosticsResultFailsOnlyForErrorSeverity(t *testing.T) {
+	t.Parallel()
+
+	warningOnly := []validateDiagnostic{{Severity: diagnosticSeverityWarning}}
+	if got := diagnosticsResult(warningOnly); got != validationResultOK {
+		t.Fatalf("result for warning-only diagnostics: got %q, want %q", got, validationResultOK)
+	}
+
+	withError := []validateDiagnostic{{Severity: diagnosticSeverityWarning}, {Severity: diagnosticSeverityError}}
+	if got := diagnosticsResult(withError); got != validationResultFail {
+		t.Fatalf("result with an ERROR diagnostic present: got %q, want %q", got, validationResultFail)
+	}
+}
+
+func TestFilterAndCapDiagnosticsDefaultsToErrorOnly(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := []validateDiagnostic{
+		{Severity: diagnosticSeverityError, Code: "E"},
+		{Severity: diagnosticSeverityWarning, Code: "W"},
+	}
+
+	filtered, truncated := filterAndCapDiagnostics(diagnostics, "", 0)
+	if truncated {
+		t.Fatal("truncated: got true, want false")
+	}
+
+	if len(filtered) != 1 || filtered[0].Code != "E" {
+		t.Fatalf("filtered diagnostics: got %+v, want only the ERROR entry", filtered)
+	}
+
+	filtered, truncated = filterAndCapDiagnostics(diagnostics, diagnosticSeverityWarning, 0)
+	if truncated {
+		t.Fatal("truncated: got true, want false")
+	}
+
+	if len(filtered) != 2 {
+		t.Fatalf("filtered diagnostics with severity=WARNING: got %+v, want both entries", filtered)
+	}
+}
+
+func TestFilterAndCapDiagnosticsCapsAtMaxResults(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := make([]validateDiagnostic, 0, 3)
+	for i := 0; i < 3; i++ {
+		diagnostics = append(diagnostics, validateDiagnostic{Severity: diagnosticSeverityError})
+	}
+
+	filtered, truncated := filterAndCapDiagnostics(diagnostics, "", 2)
+	if !truncated {
+		t.Fatal("truncated: got false, want true")
+	}
+
+	if len(filtered) != 2 {
+		t.Fatalf("filtered diagnostics: got %d entries, want 2", len(filtered))
+	}
+}

--- a/internal/service/sfn/wait.go
+++ b/internal/service/sfn/wait.go
@@ -12,8 +12,9 @@ import (
 //
 // The wait is not artificially capped: kumo sleeps for the full requested
 // duration but honors ctx cancellation, and every execution already runs
-// under the 5-minute timeout applied in MemoryStorage.runExecution, which
-// bounds how long any single Wait can actually block.
+// under the timeout context applied in MemoryStorage.runExecution
+// (min(definition TimeoutSeconds, executionTimeoutCap)), which bounds how
+// long any single Wait can actually block.
 func (e *executionEngine) executeWaitState(ctx context.Context, state *stateDefinition, input string) (string, error) {
 	d, err := waitDuration(state, input)
 	if err != nil {


### PR DESCRIPTION
## Summary
Two of the three remaining Step Functions follow-ups from #861/#867/#869.

- Task TimeoutSeconds/TimeoutSecondsPath fail with States.Timeout, which flows through Retry/Catch like any ordinary error (each retry attempt gets a fresh timeout window); HeartbeatSeconds is accepted but ignored since kumo has no activity/callback channel to receive heartbeats
- Definition-level TimeoutSeconds bounds the execution with States.Timeout, reported distinctly from kumo's internal 5-minute safety cap
- ValidateStateMachineDefinition performs structural validation (StartAt/Next/Default/Catch target existence, per-type required fields, Wait's exactly-one-of rule, dead-end states, unreachable-state warnings, recursive Branches/ItemProcessor validation) in the AWS response shape, and emits warnings for distributed-Map fields the engine does not execute yet — so 'validates OK but fails at runtime' cannot recur silently

Distributed Map execution itself lands separately.

## Test plan
- [ ] Timeout tests: exceeded/caught/TimeoutSecondsPath, definition-level timeout
- [ ] Table-driven validation diagnostics incl. nested branch checks
- [ ] Existing SFN integration goldens unchanged (verified against a live server)