### PR TITLE
feat(sfn): distributed Map with ItemReader, ItemSelector, ItemBatcher, ResultWriter, and tolerated failures

### DIFF
--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -21,6 +21,13 @@ type stateMachineDefinition struct {
 	StartAt string                     `json:"StartAt"`
 	States  map[string]stateDefinition `json:"States"`
 
+	// ProcessorConfig selects a Map state's ItemProcessor processing mode
+	// (see mapstate.go). It is decoded on every stateMachineDefinition,
+	// since Parallel Branches reuse this same struct, but it is only
+	// meaningful when this stateMachineDefinition is itself a Map state's
+	// ItemProcessor.
+	ProcessorConfig *processorConfig `json:"ProcessorConfig"`
+
 	// TimeoutSeconds bounds the whole execution's wall-clock time. It is only
 	// meaningful on the top-level definition; MemoryStorage.runExecution is
 	// the sole reader of this field, since sub-state-machines (Parallel
@@ -67,18 +74,31 @@ type stateDefinition struct {
 
 	// Map state fields. ItemProcessor is the current field name; Iterator is
 	// the legacy alias for the same sub-state-machine. If both are present,
-	// ItemProcessor takes precedence. ItemSelector, ItemBatcher,
-	// ResultWriter, and distributed-mode Map are out of scope; the engine
-	// never reads these four fields, but validateStateMachineDefinition
-	// decodes them to flag definitions that rely on them (see validate.go).
-	ItemsPath      string                  `json:"ItemsPath"`
-	ItemProcessor  *stateMachineDefinition `json:"ItemProcessor"`
-	Iterator       *stateMachineDefinition `json:"Iterator"`
-	MaxConcurrency int                     `json:"MaxConcurrency"`
-	ItemReader     json.RawMessage         `json:"ItemReader"`
-	ItemSelector   json.RawMessage         `json:"ItemSelector"`
-	ItemBatcher    json.RawMessage         `json:"ItemBatcher"`
-	ResultWriter   json.RawMessage         `json:"ResultWriter"`
+	// ItemProcessor takes precedence. See mapstate.go, itemselector.go,
+	// itemreader.go, itembatcher.go, and resultwriter.go for how
+	// ItemSelector/ItemReader/ItemBatcher/ResultWriter are implemented, and
+	// requireDistributedModeForFields in mapstate.go for which of these
+	// fields require ItemProcessor.ProcessorConfig.Mode "DISTRIBUTED".
+	// MaxItemsPerBatchPath/MaxInputBytesPerBatchPath/MaxConcurrencyPath/
+	// ToleratedFailurePercentagePath/ToleratedFailureCountPath (the dynamic,
+	// reference-path forms of these fields) are not implemented.
+	ItemsPath                  string                  `json:"ItemsPath"`
+	ItemProcessor              *stateMachineDefinition `json:"ItemProcessor"`
+	Iterator                   *stateMachineDefinition `json:"Iterator"`
+	MaxConcurrency             int                     `json:"MaxConcurrency"`
+	ItemReader                 json.RawMessage         `json:"ItemReader"`
+	ItemSelector               json.RawMessage         `json:"ItemSelector"`
+	ItemBatcher                json.RawMessage         `json:"ItemBatcher"`
+	ResultWriter               json.RawMessage         `json:"ResultWriter"`
+	ToleratedFailurePercentage *float64                `json:"ToleratedFailurePercentage"`
+	ToleratedFailureCount      *int                    `json:"ToleratedFailureCount"`
+
+	// ToleratedFailurePercentagePath/ToleratedFailureCountPath are decoded
+	// only so validate.go can flag them as unimplemented; the engine never
+	// reads them (see resolveMapTolerance in maptolerance.go, which only
+	// reads the static ToleratedFailurePercentage/ToleratedFailureCount).
+	ToleratedFailurePercentagePath string `json:"ToleratedFailurePercentagePath"`
+	ToleratedFailureCountPath      string `json:"ToleratedFailureCountPath"`
 
 	// Task state timeout fields. TimeoutSeconds/TimeoutSecondsPath bound a
 	// single execution attempt of the task (see timeout.go); per the ASL
@@ -111,6 +131,11 @@ const (
 	errorStatesTimeout         = "States.Timeout"
 	errorStatesAll             = "States.ALL"
 	errorStatesBranchFailed    = "States.BranchFailed"
+
+	// errorStatesExceedToleratedFailureThreshold is reported when a
+	// distributed-mode Map state's ToleratedFailurePercentage/
+	// ToleratedFailureCount is exceeded (see mapstate.go).
+	errorStatesExceedToleratedFailureThreshold = "States.ExceedToleratedFailureThreshold"
 )
 
 // taskFailedError marks a failure of the task invocation itself so the
@@ -439,6 +464,14 @@ func wrapTaskResult(output string, err error) (string, error) {
 // resolveParameters resolves parameter values, handling JSONPath references
 // (keys ending with ".$" whose values are JSONPath expressions like "$.field").
 func resolveParameters(params map[string]any, input string) (map[string]any, error) {
+	return resolveParametersWithContext(params, input, nil)
+}
+
+// resolveParametersWithContext extends resolveParameters with an optional
+// Context object ($$.) lookup: contextData is nil everywhere except
+// ItemSelector (see itemselector.go), which is the only place the Amazon
+// States Language allows "$$." references.
+func resolveParametersWithContext(params map[string]any, input string, contextData map[string]any) (map[string]any, error) {
 	if params == nil {
 		return map[string]any{}, nil
 	}
@@ -451,7 +484,7 @@ func resolveParameters(params map[string]any, input string) (map[string]any, err
 	for key, value := range params {
 		// A ".$" suffix marks a JSONPath reference; otherwise it is a static value.
 		if strings.HasSuffix(key, ".$") {
-			resolvedValue, parsed, err := resolveJSONPathRef(key, value, input, inputData)
+			resolvedValue, parsed, err := resolveJSONPathRef(key, value, input, inputData, contextData)
 			if err != nil {
 				return nil, err
 			}
@@ -462,7 +495,7 @@ func resolveParameters(params map[string]any, input string) (map[string]any, err
 			continue
 		}
 
-		resolvedValue, err := resolveStaticValue(value, input)
+		resolvedValue, err := resolveStaticValue(value, input, contextData)
 		if err != nil {
 			return nil, err
 		}
@@ -473,14 +506,28 @@ func resolveParameters(params map[string]any, input string) (map[string]any, err
 	return resolved, nil
 }
 
-// resolveJSONPathRef resolves a "key.$" JSONPath reference against the input.
-// inputData is the lazily-parsed input (nil until first use); the possibly newly
-// parsed map is returned so the caller can reuse it for later references,
-// keeping the input JSON unmarshaled at most once per resolveParameters call.
-func resolveJSONPathRef(key string, value any, input string, inputData map[string]any) (any, map[string]any, error) {
+// resolveJSONPathRef resolves a "key.$" JSONPath reference against the
+// input, or, for a "$$."-prefixed path, against contextData. inputData is
+// the lazily-parsed input (nil until first use); the possibly newly parsed
+// map is returned so the caller can reuse it for later references, keeping
+// the input JSON unmarshaled at most once per resolveParameters call.
+func resolveJSONPathRef(key string, value any, input string, inputData, contextData map[string]any) (any, map[string]any, error) {
 	pathStr, ok := value.(string)
 	if !ok {
 		return nil, inputData, fmt.Errorf("jsonPath reference for key %q must be a string", key)
+	}
+
+	if strings.HasPrefix(pathStr, "$$.") {
+		if contextData == nil {
+			return nil, inputData, fmt.Errorf("jsonPath reference for key %q uses the Context object (%q), which is only available in ItemSelector", key, pathStr)
+		}
+
+		resolvedValue, err := resolveJSONPath(contextData, "$"+strings.TrimPrefix(pathStr, "$$"))
+		if err != nil {
+			return nil, inputData, fmt.Errorf("resolve Context object path %q for key %q: %w", pathStr, key, err)
+		}
+
+		return resolvedValue, inputData, nil
 	}
 
 	if inputData == nil {
@@ -499,13 +546,13 @@ func resolveJSONPathRef(key string, value any, input string, inputData map[strin
 
 // resolveStaticValue returns a non-reference parameter value, recursing into
 // nested maps and leaving scalars unchanged.
-func resolveStaticValue(value any, input string) (any, error) {
+func resolveStaticValue(value any, input string, contextData map[string]any) (any, error) {
 	subMap, ok := value.(map[string]any)
 	if !ok {
 		return value, nil
 	}
 
-	return resolveParameters(subMap, input)
+	return resolveParametersWithContext(subMap, input, contextData)
 }
 
 // resolveJSONPath resolves a simple JSONPath expression ("$" or "$.field") against the input data.

--- a/internal/service/sfn/itembatcher.go
+++ b/internal/service/sfn/itembatcher.go
@@ -1,0 +1,163 @@
+package sfn
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// itemBatcherDef is the decoded ItemBatcher field. JSON tags are
+// lowerCamelCase rather than the Amazon States Language's own PascalCase;
+// see retrier in retry.go for why this still decodes AWS's PascalCase field
+// names correctly.
+//
+// MaxItemsPerBatchPath and MaxInputBytesPerBatchPath (the dynamic,
+// reference-path forms of MaxItemsPerBatch/MaxInputBytesPerBatch) are
+// decoded only so validate.go can flag them as unimplemented; the engine
+// never reads them.
+type itemBatcherDef struct {
+	MaxItemsPerBatch          *int           `json:"maxItemsPerBatch"`
+	MaxInputBytesPerBatch     *int           `json:"maxInputBytesPerBatch"`
+	MaxItemsPerBatchPath      string         `json:"maxItemsPerBatchPath"`
+	MaxInputBytesPerBatchPath string         `json:"maxInputBytesPerBatchPath"`
+	BatchInput                map[string]any `json:"batchInput"`
+}
+
+// mapUnit is a single processor invocation: either one dataset item (no
+// ItemBatcher) or a batch envelope (with ItemBatcher). itemCount is how
+// many original dataset items this unit represents, which is what
+// ToleratedFailurePercentage/ToleratedFailureCount count against (see
+// mapTolerance in mapstate.go).
+type mapUnit struct {
+	input     string
+	itemCount int
+}
+
+// buildProcessorUnits groups items into one mapUnit per item, or, when
+// ItemBatcher is set, into batch envelopes shaped exactly as AWS documents
+// for the processor's input: {"BatchInput": {...}, "Items": [...]} (see
+// https://docs.aws.amazon.com/step-functions/latest/dg/input-output-itembatcher.html).
+func buildProcessorUnits(raw json.RawMessage, items []json.RawMessage, mapInput string) ([]mapUnit, error) {
+	if len(raw) == 0 {
+		return itemUnits(items), nil
+	}
+
+	var def itemBatcherDef
+	if err := json.Unmarshal(raw, &def); err != nil {
+		return nil, fmt.Errorf("parse ItemBatcher: %w", err)
+	}
+
+	if def.MaxItemsPerBatch == nil && def.MaxInputBytesPerBatch == nil {
+		return nil, fmt.Errorf("itemBatcher requires MaxItemsPerBatch or MaxInputBytesPerBatch")
+	}
+
+	batchInput, err := resolveBatchInput(def.BatchInput, mapInput)
+	if err != nil {
+		return nil, err
+	}
+
+	batches := groupIntoBatches(items, def.MaxItemsPerBatch, def.MaxInputBytesPerBatch)
+
+	units := make([]mapUnit, len(batches))
+
+	for i, batch := range batches {
+		envelope, err := marshalBatchEnvelope(batchInput, batch)
+		if err != nil {
+			return nil, err
+		}
+
+		units[i] = mapUnit{input: envelope, itemCount: len(batch)}
+	}
+
+	return units, nil
+}
+
+// itemUnits wraps each item as its own one-item mapUnit, the default when
+// ItemBatcher is not set.
+func itemUnits(items []json.RawMessage) []mapUnit {
+	units := make([]mapUnit, len(items))
+
+	for i, item := range items {
+		units[i] = mapUnit{input: string(item), itemCount: 1}
+	}
+
+	return units
+}
+
+// resolveBatchInput resolves ItemBatcher.BatchInput's static/".$" values
+// against the Map state's own input, mirroring how ItemSelector resolves
+// "$." paths (see itemselector.go).
+func resolveBatchInput(batchInput map[string]any, mapInput string) (map[string]any, error) {
+	if batchInput == nil {
+		return map[string]any{}, nil
+	}
+
+	resolved, err := resolveParameters(batchInput, mapInput)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ItemBatcher BatchInput: %w", err)
+	}
+
+	return resolved, nil
+}
+
+// groupIntoBatches splits items into batches bounded by maxItems and/or
+// maxBytes (either may be nil, but buildProcessorUnits requires at least
+// one to be set). A batch always contains at least one item, even if that
+// item alone exceeds maxBytes, so a single oversized item cannot stall
+// batching entirely.
+func groupIntoBatches(items []json.RawMessage, maxItems, maxBytes *int) [][]json.RawMessage {
+	var (
+		batches      [][]json.RawMessage
+		current      = newBatch(maxItems, len(items))
+		currentBytes int
+	)
+
+	for _, item := range items {
+		itemBytes := len(item)
+		exceedsItems := maxItems != nil && len(current) >= *maxItems
+		exceedsBytes := maxBytes != nil && len(current) > 0 && currentBytes+itemBytes > *maxBytes
+
+		if exceedsItems || exceedsBytes {
+			batches = append(batches, current)
+			current = newBatch(maxItems, len(items))
+			currentBytes = 0
+		}
+
+		current = append(current, item)
+		currentBytes += itemBytes
+	}
+
+	if len(current) > 0 {
+		batches = append(batches, current)
+	}
+
+	return batches
+}
+
+// newBatch allocates a batch slice, sized to maxItems when set so
+// groupIntoBatches does not repeatedly grow it via append.
+func newBatch(maxItems *int, totalItems int) []json.RawMessage {
+	capacity := totalItems
+	if maxItems != nil && *maxItems < capacity {
+		capacity = *maxItems
+	}
+
+	return make([]json.RawMessage, 0, capacity)
+}
+
+// marshalBatchEnvelope builds one child processor invocation's input JSON.
+// A plain map (rather than a struct) is used so the wire keys "BatchInput"
+// and "Items" -- which must match AWS's documented envelope exactly -- do
+// not require a struct-tag casing exception.
+func marshalBatchEnvelope(batchInput map[string]any, items []json.RawMessage) (string, error) {
+	envelope := map[string]any{
+		"BatchInput": batchInput,
+		"Items":      items,
+	}
+
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		return "", fmt.Errorf("marshal batch envelope: %w", err)
+	}
+
+	return string(encoded), nil
+}

--- a/internal/service/sfn/itembatcher_test.go
+++ b/internal/service/sfn/itembatcher_test.go
@@ -1,0 +1,123 @@
+package sfn
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// itemBatcherMapDefinition builds a single-state Map state machine
+// definition batching its items via ItemBatcher, with an echo
+// ItemProcessor so the Map's output reflects exactly what envelope each
+// batch invocation received.
+func itemBatcherMapDefinition(itemBatcherJSON string) string {
+	return fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemBatcher": %s,
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, itemBatcherJSON, distributedItemProcessorJSON)
+}
+
+// batchEnvelope decodes the AWS-documented ItemBatcher processor input
+// shape: {"BatchInput": {...}, "Items": [...]}. JSON tags are lowerCamelCase
+// (encoding/json matches the wire's PascalCase case-insensitively; see
+// itemBatcherDef in itembatcher.go for why).
+type batchEnvelope struct {
+	BatchInput map[string]any `json:"batchInput"`
+	Items      []any          `json:"items"`
+}
+
+func TestMapStateItemBatcherGroupsItemsAndBuildsEnvelope(t *testing.T) {
+	t.Parallel()
+
+	itemBatcher := `{"MaxItemsPerBatch": 2, "BatchInput": {"tag": "batch"}}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-itembatcher-group", itemBatcherMapDefinition(itemBatcher))
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `[1,2,3,4,5]`)
+
+	var envelopes []batchEnvelope
+	if err := json.Unmarshal([]byte(exec.Output), &envelopes); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(envelopes) != 3 {
+		t.Fatalf("batches: got %d, want 3", len(envelopes))
+	}
+
+	wantItems := [][]any{
+		{float64(1), float64(2)},
+		{float64(3), float64(4)},
+		{float64(5)},
+	}
+
+	for i, want := range wantItems {
+		if !jsonDeepEqual(envelopes[i].Items, want) {
+			t.Fatalf("batch %d items: got %+v, want %+v", i, envelopes[i].Items, want)
+		}
+
+		if envelopes[i].BatchInput["tag"] != "batch" {
+			t.Fatalf("batch %d BatchInput: got %+v, want tag=batch", i, envelopes[i].BatchInput)
+		}
+	}
+}
+
+func TestMapStateItemBatcherResolvesBatchInputFromMapInput(t *testing.T) {
+	t.Parallel()
+
+	itemBatcher := `{"MaxItemsPerBatch": 10, "BatchInput": {"label.$": "$.tag"}}`
+	definition := fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemsPath": "$.items",
+				"ItemBatcher": %s,
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, itemBatcher, distributedItemProcessorJSON)
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-itembatcher-input-path", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"items":[1,2,3],"tag":"hello"}`)
+
+	var envelopes []batchEnvelope
+	if err := json.Unmarshal([]byte(exec.Output), &envelopes); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(envelopes) != 1 {
+		t.Fatalf("batches: got %d, want 1", len(envelopes))
+	}
+
+	if got := envelopes[0].BatchInput["label"]; got != "hello" {
+		t.Fatalf("BatchInput.label: got %v, want %q", got, "hello")
+	}
+}
+
+// jsonDeepEqual compares two already-decoded JSON values by re-encoding
+// them, avoiding a reflect.DeepEqual dependency on map/slice identity.
+func jsonDeepEqual(a, b any) bool {
+	aJSON, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+
+	bJSON, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+
+	return bytes.Equal(aJSON, bJSON)
+}

--- a/internal/service/sfn/itemreader.go
+++ b/internal/service/sfn/itemreader.go
@@ -1,0 +1,250 @@
+package sfn
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ItemReader.ReaderConfig.InputType values kumo implements.
+const (
+	itemReaderInputTypeJSON  = "JSON"
+	itemReaderInputTypeJSONL = "JSONL"
+	itemReaderInputTypeCSV   = "CSV"
+)
+
+// ItemReader.ReaderConfig.CSVHeaderLocation values.
+const (
+	csvHeaderLocationFirstRow = "FIRST_ROW"
+	csvHeaderLocationGiven    = "GIVEN"
+)
+
+// ItemReader.Resource values. Only s3:getObject is implemented;
+// s3:listObjectsV2 is documented but out of scope (see readItemsFromS3).
+const (
+	itemReaderResourceS3GetObject     = "arn:aws:states:::s3:getObject"
+	itemReaderResourceS3ListObjectsV2 = "arn:aws:states:::s3:listObjectsV2"
+)
+
+// itemReaderDef is the decoded ItemReader field. JSON tags are
+// lowerCamelCase; see itemBatcherDef in itembatcher.go for why.
+type itemReaderDef struct {
+	Resource     string           `json:"resource"`
+	Parameters   map[string]any   `json:"parameters"`
+	ReaderConfig itemReaderConfig `json:"readerConfig"`
+}
+
+// itemReaderConfig is ItemReader.ReaderConfig. ItemsPointer and
+// CSVDelimiter are not implemented. MaxItemsPath is decoded only so
+// validate.go can flag it as unimplemented; the engine never reads it (see
+// applyMaxItems, which only reads the static MaxItems).
+type itemReaderConfig struct {
+	InputType         string   `json:"inputType"`
+	CSVHeaderLocation string   `json:"csvHeaderLocation"`
+	CSVHeaders        []string `json:"csvHeaders"`
+	MaxItems          *int     `json:"maxItems"`
+	MaxItemsPath      string   `json:"maxItemsPath"`
+}
+
+// readItemsFromS3 resolves a Map state's ItemReader field into the item
+// list it selects, fetching the underlying object from kumo's own S3 over
+// plain HTTP (see (*executionEngine).getS3Object).
+func readItemsFromS3(ctx context.Context, e *executionEngine, raw json.RawMessage, mapInput string) ([]json.RawMessage, error) {
+	var def itemReaderDef
+	if err := json.Unmarshal(raw, &def); err != nil {
+		return nil, fmt.Errorf("parse ItemReader: %w", err)
+	}
+
+	if def.Resource != itemReaderResourceS3GetObject {
+		if def.Resource == itemReaderResourceS3ListObjectsV2 {
+			return nil, fmt.Errorf("itemReader resource %q is not implemented; only %q is supported", def.Resource, itemReaderResourceS3GetObject)
+		}
+
+		return nil, fmt.Errorf("unsupported ItemReader resource %q", def.Resource)
+	}
+
+	params, err := resolveParameters(def.Parameters, mapInput)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ItemReader Parameters: %w", err)
+	}
+
+	bucket, _ := params["Bucket"].(string)
+	key, _ := params["Key"].(string)
+
+	if bucket == "" || key == "" {
+		return nil, fmt.Errorf("itemReader s3:getObject requires Parameters.Bucket and Parameters.Key")
+	}
+
+	body, err := e.getS3Object(ctx, bucket, key)
+	if err != nil {
+		return nil, fmt.Errorf("itemReader: %w", err)
+	}
+
+	items, err := parseItemReaderBody(body, &def.ReaderConfig)
+	if err != nil {
+		return nil, fmt.Errorf("itemReader: %w", err)
+	}
+
+	return applyMaxItems(items, def.ReaderConfig.MaxItems), nil
+}
+
+// getS3Object fetches an object from kumo's own S3 service using the same
+// path-style addressing S3 itself registers its routes under
+// (GET /{bucket}/{key}).
+func (e *executionEngine) getS3Object(ctx context.Context, bucket, key string) ([]byte, error) {
+	url := fmt.Sprintf("%s/%s/%s", e.baseURL, bucket, key)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create request for s3://%s/%s: %w", bucket, key, err)
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get s3://%s/%s: %w", bucket, key, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read s3://%s/%s: %w", bucket, key, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get s3://%s/%s: unexpected status %d: %s", bucket, key, resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+// parseItemReaderBody parses an S3 object's body per ReaderConfig.InputType.
+// An empty InputType defaults to JSON, matching the plain-JSON-array
+// dataset AWS documents as the simplest ItemReader case.
+func parseItemReaderBody(body []byte, cfg *itemReaderConfig) ([]json.RawMessage, error) {
+	switch strings.ToUpper(cfg.InputType) {
+	case itemReaderInputTypeJSON, "":
+		return parseJSONArrayBody(body)
+	case itemReaderInputTypeJSONL:
+		return parseJSONLBody(body)
+	case itemReaderInputTypeCSV:
+		return parseCSVBody(body, cfg)
+	default:
+		return nil, fmt.Errorf("unsupported ReaderConfig.InputType %q", cfg.InputType)
+	}
+}
+
+// parseJSONArrayBody parses ReaderConfig.InputType "JSON": a single JSON
+// document containing an array.
+func parseJSONArrayBody(body []byte) ([]json.RawMessage, error) {
+	var items []json.RawMessage
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, fmt.Errorf("parse JSON array: %w", err)
+	}
+
+	return items, nil
+}
+
+// parseJSONLBody parses ReaderConfig.InputType "JSONL": one JSON document
+// per line, blank lines skipped.
+func parseJSONLBody(body []byte) ([]json.RawMessage, error) {
+	var items []json.RawMessage
+
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		var v json.RawMessage
+		if err := json.Unmarshal([]byte(line), &v); err != nil {
+			return nil, fmt.Errorf("parse JSONL line: %w", err)
+		}
+
+		items = append(items, v)
+	}
+
+	return items, nil
+}
+
+// parseCSVBody parses ReaderConfig.InputType "CSV", turning each data row
+// into a JSON object keyed by the resolved header (see csvHeaders).
+func parseCSVBody(body []byte, cfg *itemReaderConfig) ([]json.RawMessage, error) {
+	reader := csv.NewReader(bytes.NewReader(body))
+	reader.FieldsPerRecord = -1
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("parse CSV: %w", err)
+	}
+
+	headers, rows, err := csvHeaders(records, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]json.RawMessage, len(rows))
+
+	for i, row := range rows {
+		encoded, err := json.Marshal(csvRowToObject(headers, row))
+		if err != nil {
+			return nil, fmt.Errorf("marshal CSV row %d: %w", i, err)
+		}
+
+		items[i] = encoded
+	}
+
+	return items, nil
+}
+
+// csvHeaders resolves a CSV dataset's column headers and the remaining data
+// rows, per ReaderConfig.CSVHeaderLocation. An empty CSVHeaderLocation
+// defaults to FIRST_ROW, matching the ItemReader (Map) dev guide example.
+func csvHeaders(records [][]string, cfg *itemReaderConfig) (headers []string, rows [][]string, err error) {
+	switch cfg.CSVHeaderLocation {
+	case csvHeaderLocationGiven:
+		if len(cfg.CSVHeaders) == 0 {
+			return nil, nil, fmt.Errorf("readerConfig.CSVHeaderLocation %q requires CSVHeaders", csvHeaderLocationGiven)
+		}
+
+		return cfg.CSVHeaders, records, nil
+	case csvHeaderLocationFirstRow, "":
+		if len(records) == 0 {
+			return nil, nil, nil
+		}
+
+		return records[0], records[1:], nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported ReaderConfig.CSVHeaderLocation %q", cfg.CSVHeaderLocation)
+	}
+}
+
+// csvRowToObject zips a CSV data row with its headers into a JSON object,
+// dropping any header without a corresponding column in a short row.
+func csvRowToObject(headers, row []string) map[string]string {
+	obj := make(map[string]string, len(headers))
+
+	for i, header := range headers {
+		if i < len(row) {
+			obj[header] = row[i]
+		}
+	}
+
+	return obj
+}
+
+// applyMaxItems trims items to ReaderConfig.MaxItems, per item order,
+// leaving items unchanged when maxItems is unset or not smaller than
+// len(items).
+func applyMaxItems(items []json.RawMessage, maxItems *int) []json.RawMessage {
+	if maxItems == nil || *maxItems < 0 || *maxItems >= len(items) {
+		return items
+	}
+
+	return items[:*maxItems]
+}

--- a/internal/service/sfn/itemreader_test.go
+++ b/internal/service/sfn/itemreader_test.go
@@ -1,0 +1,134 @@
+package sfn
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// distributedItemProcessorJSON is a minimal echo ItemProcessor running in
+// Distributed mode, required for every ItemReader/ItemBatcher/ResultWriter/
+// ToleratedFailure* test (see requireDistributedModeForFields).
+const distributedItemProcessorJSON = `{
+	"ProcessorConfig": {"Mode": "DISTRIBUTED", "ExecutionType": "STANDARD"},
+	"StartAt": "Echo",
+	"States": {"Echo": {"Type": "Pass", "End": true}}
+}`
+
+// itemReaderMapDefinition builds a single-state Map state machine definition
+// reading its items via ItemReader, with an echo ItemProcessor.
+func itemReaderMapDefinition(readerConfigJSON string) string {
+	return fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemReader": {
+					"Resource": "arn:aws:states:::s3:getObject",
+					"Parameters": {"Bucket": "src-bucket", "Key": "items.dat"},
+					"ReaderConfig": %s
+				},
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, readerConfigJSON, distributedItemProcessorJSON)
+}
+
+func TestMapStateItemReaderJSONArray(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+	server.putObject("src-bucket", "items.dat", `[{"n":1},{"n":2},{"n":3}]`)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-itemreader-json", itemReaderMapDefinition(`{"InputType": "JSON"}`))
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	if want := `[{"n":1},{"n":2},{"n":3}]`; exec.Output != want {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, want)
+	}
+}
+
+func TestMapStateItemReaderJSONL(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+	server.putObject("src-bucket", "items.dat", "{\"n\":1}\n{\"n\":2}\n")
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-itemreader-jsonl", itemReaderMapDefinition(`{"InputType": "JSONL"}`))
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	if want := `[{"n":1},{"n":2}]`; exec.Output != want {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, want)
+	}
+}
+
+func TestMapStateItemReaderCSVFirstRowHeader(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+	server.putObject("src-bucket", "items.dat", "id,name\n1,alice\n2,bob\n")
+
+	readerConfig := `{"InputType": "CSV", "CSVHeaderLocation": "FIRST_ROW"}`
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-itemreader-csv", itemReaderMapDefinition(readerConfig))
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	var outputs []map[string]string
+	if err := json.Unmarshal([]byte(exec.Output), &outputs); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	want := []map[string]string{
+		{"id": "1", "name": "alice"},
+		{"id": "2", "name": "bob"},
+	}
+
+	if len(outputs) != len(want) || outputs[0]["id"] != want[0]["id"] || outputs[0]["name"] != want[0]["name"] ||
+		outputs[1]["id"] != want[1]["id"] || outputs[1]["name"] != want[1]["name"] {
+		t.Fatalf("csv rows: got %+v, want %+v", outputs, want)
+	}
+}
+
+func TestMapStateItemReaderMaxItems(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+	server.putObject("src-bucket", "items.dat", `[1,2,3,4,5]`)
+
+	readerConfig := `{"InputType": "JSON", "MaxItems": 2}`
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-itemreader-maxitems", itemReaderMapDefinition(readerConfig))
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	if want := `[1,2]`; exec.Output != want {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, want)
+	}
+}
+
+func TestMapStateItemReaderMissingObjectFails(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+	// No object seeded at src-bucket/items.dat.
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-itemreader-missing", itemReaderMapDefinition(`{"InputType": "JSON"}`))
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesRuntime {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesRuntime)
+	}
+
+	if !strings.Contains(exec.Cause, "404") {
+		t.Fatalf("execution cause: got %q, want it to mention the 404 status", exec.Cause)
+	}
+}

--- a/internal/service/sfn/itemselector.go
+++ b/internal/service/sfn/itemselector.go
@@ -1,0 +1,68 @@
+package sfn
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// applyItemSelector transforms every item per the Map state's ItemSelector
+// field, which works identically in Inline and Distributed mode (see
+// https://docs.aws.amazon.com/step-functions/latest/dg/input-output-itemselector.html).
+// ItemSelector's key-value pairs may be static values, "$."-prefixed
+// JSONPath references against the Map state's own input (mapInput), or
+// "$$."-prefixed Context object references: $$.Map.Item.Value (the
+// current item) and $$.Map.Item.Index (its 0-based index). An unset
+// ItemSelector leaves items unchanged.
+func applyItemSelector(raw json.RawMessage, items []json.RawMessage, mapInput string) ([]json.RawMessage, error) {
+	if len(raw) == 0 {
+		return items, nil
+	}
+
+	var selector map[string]any
+	if err := json.Unmarshal(raw, &selector); err != nil {
+		return nil, fmt.Errorf("parse ItemSelector: %w", err)
+	}
+
+	selected := make([]json.RawMessage, len(items))
+
+	for i, item := range items {
+		itemContext, err := mapItemContext(i, item)
+		if err != nil {
+			return nil, fmt.Errorf("itemSelector: build Context object for item %d: %w", i, err)
+		}
+
+		resolved, err := resolveParametersWithContext(selector, mapInput, itemContext)
+		if err != nil {
+			return nil, fmt.Errorf("itemSelector: item %d: %w", i, err)
+		}
+
+		encoded, err := json.Marshal(resolved)
+		if err != nil {
+			return nil, fmt.Errorf("itemSelector: marshal item %d: %w", i, err)
+		}
+
+		selected[i] = encoded
+	}
+
+	return selected, nil
+}
+
+// mapItemContext builds the "$$." Context object exposed to ItemSelector
+// for one item: {"Map": {"Item": {"Index": index, "Value": <item>}}}.
+// Map.Item.Source (which real AWS sets for S3 ListObjectsV2 datasets) is
+// not modeled; kumo's ItemReader always yields STATE_DATA-equivalent items.
+func mapItemContext(index int, item json.RawMessage) (map[string]any, error) {
+	var value any
+	if err := json.Unmarshal(item, &value); err != nil {
+		return nil, fmt.Errorf("parse item: %w", err)
+	}
+
+	return map[string]any{
+		"Map": map[string]any{
+			"Item": map[string]any{
+				"Index": index,
+				"Value": value,
+			},
+		},
+	}, nil
+}

--- a/internal/service/sfn/itemselector_test.go
+++ b/internal/service/sfn/itemselector_test.go
@@ -1,0 +1,77 @@
+package sfn
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestMapStateItemSelectorStaticAndContextAndInputPaths exercises
+// ItemSelector's three reference forms in Inline mode: a static value, a
+// "$$.Map.Item.Value"/"$$.Map.Item.Index" Context object reference, and a
+// "$." reference against the Map state's own input.
+func TestMapStateItemSelectorStaticAndContextAndInputPaths(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemsPath": "$.items",
+				"ItemSelector": {
+					"static": "fixed",
+					"value.$": "$$.Map.Item.Value",
+					"index.$": "$$.Map.Item.Index",
+					"courier.$": "$.courier"
+				},
+				"ItemProcessor": ` + echoItemProcessorJSON + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-item-selector", definition)
+
+	input := `{"items":[{"a":1},{"a":2}],"courier":"UQS"}`
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, input)
+
+	var outputs []map[string]any
+	if err := json.Unmarshal([]byte(exec.Output), &outputs); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(outputs) != 2 {
+		t.Fatalf("outputs: got %d entries, want 2", len(outputs))
+	}
+
+	want := []map[string]any{
+		{"static": "fixed", "value": map[string]any{"a": float64(1)}, "index": float64(0), "courier": "UQS"},
+		{"static": "fixed", "value": map[string]any{"a": float64(2)}, "index": float64(1), "courier": "UQS"},
+	}
+
+	for i, w := range want {
+		assertMapEqual(t, i, w, outputs[i])
+	}
+}
+
+// assertMapEqual fails the test unless got deep-equals want, field by
+// field, reporting the specific mismatched key when it doesn't.
+func assertMapEqual(t *testing.T, index int, want, got map[string]any) {
+	t.Helper()
+
+	for k, wv := range want {
+		gv, ok := got[k]
+		if !ok {
+			t.Fatalf("item %d: missing key %q in %+v", index, k, got)
+		}
+
+		wantJSON, _ := json.Marshal(wv)
+		gotJSON, _ := json.Marshal(gv)
+
+		if !bytes.Equal(wantJSON, gotJSON) {
+			t.Fatalf("item %d: key %q: got %s, want %s", index, k, gotJSON, wantJSON)
+		}
+	}
+}

--- a/internal/service/sfn/map_distributed_test.go
+++ b/internal/service/sfn/map_distributed_test.go
@@ -1,0 +1,199 @@
+package sfn
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestMapStateItemReaderWithoutDistributedModeFailsAtRuntime verifies
+// requireDistributedModeForFields: ItemReader is a Distributed-mode-only
+// field (see mapstate.go), so setting it on an Inline-mode ItemProcessor
+// (the default when ProcessorConfig is absent) must fail the execution
+// rather than silently ignore ItemReader.
+func TestMapStateItemReaderWithoutDistributedModeFailsAtRuntime(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemReader": {
+					"Resource": "arn:aws:states:::s3:getObject",
+					"Parameters": {"Bucket": "b", "Key": "k"},
+					"ReaderConfig": {"InputType": "JSON"}
+				},
+				"ItemProcessor": ` + echoItemProcessorJSON + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-itemreader-inline-mode", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesRuntime {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesRuntime)
+	}
+
+	if !strings.Contains(exec.Cause, "ItemReader") || !strings.Contains(exec.Cause, "DISTRIBUTED") {
+		t.Fatalf("execution cause: got %q, want it to mention ItemReader and DISTRIBUTED", exec.Cause)
+	}
+}
+
+// TestValidateMapDistributedOnlyFieldWarnsWithoutDistributedMode covers the
+// validate.go half of the same rule: a definition using ItemReader without
+// Distributed mode still validates OK (kumo never rejects a definition the
+// engine can parse), but with a WARNING diagnostic.
+func TestValidateMapDistributedOnlyFieldWarnsWithoutDistributedMode(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemReader": {"Resource": "arn:aws:states:::s3:getObject", "Parameters": {"Bucket": "b", "Key": "k"}},
+				"ItemProcessor": ` + echoItemProcessorJSON + `,
+				"End": true
+			}
+		}
+	}`
+
+	diagnostics := validateStateMachineDefinition(definition)
+
+	tt := &diagnosticTest{
+		wantSeverity: diagnosticSeverityWarning,
+		wantCode:     codeUnsupportedRuntimeConstruct,
+		wantLocation: "/States/Each/ItemReader",
+	}
+	assertHasDiagnostic(t, diagnostics, tt)
+}
+
+// TestValidateMapDistributedModeRequiresExecutionType covers AWS's
+// documented requirement that ProcessorConfig.Mode "DISTRIBUTED" must also
+// set ExecutionType.
+func TestValidateMapDistributedModeRequiresExecutionType(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemProcessor": {
+					"ProcessorConfig": {"Mode": "DISTRIBUTED"},
+					"StartAt": "Echo",
+					"States": {"Echo": {"Type": "Pass", "End": true}}
+				},
+				"End": true
+			}
+		}
+	}`
+
+	diagnostics := validateStateMachineDefinition(definition)
+
+	tt := &diagnosticTest{
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeSchemaValidationFailed,
+		wantLocation: "/States/Each/ItemProcessor/ProcessorConfig/ExecutionType",
+	}
+	assertHasDiagnostic(t, diagnostics, tt)
+
+	if got := diagnosticsResult(diagnostics); got != validationResultFail {
+		t.Fatalf("result: got %q, want %q", got, validationResultFail)
+	}
+}
+
+// TestMapStateDistributedEndToEnd combines ItemReader (S3 JSON array),
+// ItemSelector (Context object), ItemBatcher, and a Task processor calling
+// Lambda, exercising the full distributed-Map pipeline together.
+func TestMapStateDistributedEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t).withEchoLambda()
+	server.putObject("nums-bucket", "nums.json", `[1,2,3,4]`)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-distributed-end-to-end", endToEndDefinition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	var results []endToEndBatchResult
+	if err := json.Unmarshal([]byte(exec.Output), &results); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	assertEndToEndBatches(t, results)
+}
+
+// endToEndDefinition combines ItemReader (S3 JSON array), ItemSelector
+// (Context object), ItemBatcher, and a Task processor calling Lambda.
+const endToEndDefinition = `{
+	"StartAt": "Each",
+	"States": {
+		"Each": {
+			"Type": "Map",
+			"ItemReader": {
+				"Resource": "arn:aws:states:::s3:getObject",
+				"Parameters": {"Bucket": "nums-bucket", "Key": "nums.json"},
+				"ReaderConfig": {"InputType": "JSON"}
+			},
+			"ItemSelector": {"value.$": "$$.Map.Item.Value"},
+			"ItemBatcher": {"MaxItemsPerBatch": 2},
+			"ItemProcessor": {
+				"ProcessorConfig": {"Mode": "DISTRIBUTED", "ExecutionType": "STANDARD"},
+				"StartAt": "Invoke",
+				"States": {
+					"Invoke": {
+						"Type": "Task",
+						"Resource": "arn:aws:states:::lambda:invoke",
+						"Parameters": {"FunctionName": "echo-fn", "Payload.$": "$"},
+						"End": true
+					}
+				}
+			},
+			"End": true
+		}
+	}
+}`
+
+// endToEndBatchResult decodes one batch's Lambda-invoke Task output. JSON
+// tags are lowerCamelCase (encoding/json matches the wire's PascalCase
+// case-insensitively; see itemBatcherDef in itembatcher.go for why).
+type endToEndBatchResult struct {
+	StatusCode int `json:"statusCode"`
+	Payload    struct {
+		BatchInput map[string]any `json:"batchInput"`
+		Items      []any          `json:"items"`
+	} `json:"payload"`
+}
+
+// assertEndToEndBatches checks that ItemReader's four items, after
+// ItemSelector and ItemBatcher(MaxItemsPerBatch: 2), reached the Lambda
+// processor as two batches of the expected transformed items.
+func assertEndToEndBatches(t *testing.T, results []endToEndBatchResult) {
+	t.Helper()
+
+	if len(results) != 2 {
+		t.Fatalf("batches: got %d, want 2", len(results))
+	}
+
+	wantBatches := [][]any{
+		{map[string]any{"value": float64(1)}, map[string]any{"value": float64(2)}},
+		{map[string]any{"value": float64(3)}, map[string]any{"value": float64(4)}},
+	}
+
+	for i, want := range wantBatches {
+		if results[i].StatusCode != 200 {
+			t.Fatalf("batch %d StatusCode: got %d, want 200", i, results[i].StatusCode)
+		}
+
+		if !jsonDeepEqual(results[i].Payload.Items, want) {
+			t.Fatalf("batch %d items: got %+v, want %+v", i, results[i].Payload.Items, want)
+		}
+	}
+}

--- a/internal/service/sfn/mapconcurrency.go
+++ b/internal/service/sfn/mapconcurrency.go
@@ -1,0 +1,111 @@
+package sfn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// mapUnitResult is one mapUnit's outcome: output is nil when err is set.
+type mapUnitResult struct {
+	output json.RawMessage
+	err    error
+}
+
+// mapUnitRunner holds the state shared by every goroutine started for one
+// Map state's units, so runMapUnit does not need a long parameter list.
+type mapUnitRunner struct {
+	e         *executionEngine
+	processor *stateMachineDefinition
+	units     []mapUnit
+	results   []mapUnitResult
+	tolerant  bool
+	cancel    context.CancelFunc
+	sem       chan struct{}
+
+	once     sync.Once
+	firstErr error
+}
+
+// runMapUnits executes the processor once per unit, honoring MaxConcurrency
+// (0 or negative means unlimited).
+//
+// When tolerant is false (the default: no ToleratedFailurePercentage/
+// ToleratedFailureCount configured), the first unit to fail cancels the
+// remaining units via cancel and its error is returned immediately --
+// matching real AWS Inline-mode Map, where any iteration failure fails the
+// whole state.
+//
+// When tolerant is true, every unit runs to completion regardless of
+// individual failures, cancel is never called, and runMapUnits always
+// returns a nil error; the caller (executeMapState) decides whether the
+// aggregate failure count exceeds the configured threshold.
+func runMapUnits(ctx context.Context, e *executionEngine, processor *stateMachineDefinition, units []mapUnit, maxConcurrency int, tolerant bool, cancel context.CancelFunc) ([]mapUnitResult, error) {
+	r := &mapUnitRunner{
+		e:         e,
+		processor: processor,
+		units:     units,
+		results:   make([]mapUnitResult, len(units)),
+		tolerant:  tolerant,
+		cancel:    cancel,
+	}
+
+	if maxConcurrency > 0 {
+		r.sem = make(chan struct{}, maxConcurrency)
+	}
+
+	var wg sync.WaitGroup
+
+	for i := range units {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			r.runOne(ctx, i)
+		}(i)
+	}
+
+	wg.Wait()
+
+	if !r.tolerant && r.firstErr != nil {
+		return nil, r.firstErr
+	}
+
+	return r.results, nil
+}
+
+// runOne runs a single unit, recording its result and, for the
+// non-tolerant fast-fail path, canceling the remaining units on the first
+// failure.
+func (r *mapUnitRunner) runOne(ctx context.Context, i int) {
+	if r.sem != nil {
+		select {
+		case r.sem <- struct{}{}:
+			defer func() { <-r.sem }()
+		case <-ctx.Done():
+			// Another unit already failed and canceled ctx before this
+			// queued unit got a slot; skip it rather than starting work
+			// whose result will be discarded.
+			return
+		}
+	}
+
+	out, err := r.e.execute(ctx, r.processor, r.units[i].input)
+	if err != nil {
+		r.results[i].err = fmt.Errorf("item %d: %w", i, err)
+
+		if !r.tolerant {
+			r.once.Do(func() {
+				r.firstErr = r.results[i].err
+
+				r.cancel()
+			})
+		}
+
+		return
+	}
+
+	r.results[i].output = json.RawMessage(out)
+}

--- a/internal/service/sfn/mapfakeaws_test.go
+++ b/internal/service/sfn/mapfakeaws_test.go
@@ -1,0 +1,122 @@
+package sfn
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// fakeS3Put records one PUT request the fake S3 server received.
+type fakeS3Put struct {
+	bucket string
+	key    string
+	body   []byte
+}
+
+// fakeAWSServer is an httptest server standing in for kumo's own S3 (and,
+// optionally, Lambda) endpoints, addressed the same way the real engine
+// addresses them: path-style S3 (GET/PUT /{bucket}/{key}) and the Lambda
+// invoke path. Tests use it as the engine's WithBaseURL target for
+// ItemReader/ResultWriter (and, for the end-to-end test, Task processors).
+type fakeAWSServer struct {
+	*httptest.Server
+
+	mux *http.ServeMux
+
+	mu      sync.Mutex
+	objects map[string][]byte
+	puts    []fakeS3Put
+}
+
+// newFakeAWSServer starts a fake S3 server. Every GET/PUT on
+// /{bucket}/{key...} is served in-memory; a Lambda invoke handler is added
+// separately by tests that need one, via withEchoLambda.
+func newFakeAWSServer(t *testing.T) *fakeAWSServer {
+	t.Helper()
+
+	s := &fakeAWSServer{objects: map[string][]byte{}, mux: http.NewServeMux()}
+
+	s.mux.HandleFunc("GET /{bucket}/{key...}", s.handleGet)
+	s.mux.HandleFunc("PUT /{bucket}/{key...}", s.handlePut)
+
+	s.Server = httptest.NewServer(s.mux)
+	t.Cleanup(s.Close)
+
+	return s
+}
+
+// withEchoLambda adds a Lambda invoke handler that echoes the request body
+// back verbatim as its response, so a Task processor's output reflects
+// exactly what it sent.
+func (s *fakeAWSServer) withEchoLambda() *fakeAWSServer {
+	s.mux.HandleFunc("POST /lambda/2015-03-31/functions/{name}/invocations", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+
+	return s
+}
+
+func (s *fakeAWSServer) handleGet(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+	key := r.PathValue("key")
+
+	s.mu.Lock()
+	body, ok := s.objects[bucket+"/"+key]
+	s.mu.Unlock()
+
+	if !ok {
+		http.Error(w, "NoSuchKey: the specified key does not exist", http.StatusNotFound)
+
+		return
+	}
+
+	_, _ = w.Write(body)
+}
+
+func (s *fakeAWSServer) handlePut(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+	key := r.PathValue("key")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusInternalServerError)
+
+		return
+	}
+
+	s.mu.Lock()
+	s.objects[bucket+"/"+key] = body
+	s.puts = append(s.puts, fakeS3Put{bucket: bucket, key: key, body: body})
+	s.mu.Unlock()
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// putObject pre-seeds an object for a test's ItemReader to read.
+func (s *fakeAWSServer) putObject(bucket, key, body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.objects[bucket+"/"+key] = []byte(body)
+}
+
+// lastPut returns the most recent PUT request received, failing the test
+// if none were.
+func (s *fakeAWSServer) lastPut(t *testing.T) fakeS3Put {
+	t.Helper()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.puts) == 0 {
+		t.Fatal("fakeAWSServer: no PUT requests recorded")
+	}
+
+	return s.puts[len(s.puts)-1]
+}

--- a/internal/service/sfn/mapstate.go
+++ b/internal/service/sfn/mapstate.go
@@ -5,7 +5,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
+)
+
+// processorConfig is a Map state's ItemProcessor.ProcessorConfig, which
+// selects Inline vs Distributed processing. JSON tags are lowerCamelCase;
+// see itemBatcherDef in itembatcher.go for why.
+type processorConfig struct {
+	Mode          string `json:"mode"`
+	ExecutionType string `json:"executionType"`
+}
+
+// ProcessorConfig.Mode values.
+const (
+	mapProcessorModeInline      = "INLINE"
+	mapProcessorModeDistributed = "DISTRIBUTED"
 )
 
 // executeMapStateWithPolicy executes a Map state's item processing,
@@ -16,32 +29,78 @@ func (e *executionEngine) executeMapStateWithPolicy(ctx context.Context, name st
 	})
 }
 
-// executeMapState resolves ItemsPath into a JSON array and runs every item
+// executeMapState resolves a Map state's item list (from ItemsPath or, in
+// Distributed mode, ItemReader), applies ItemSelector, groups items into
+// processor units (individually, or via ItemBatcher), and runs every unit
 // through the state's ItemProcessor (or its legacy alias, Iterator),
-// bounding concurrency at MaxConcurrency when it is positive. Item outputs
-// are collected, in item order, as a JSON array. The first item to fail
-// cancels the remaining items and the Map state fails with that item's
-// error.
+// bounding concurrency at MaxConcurrency when it is positive.
 //
-// ItemSelector, ItemBatcher, ResultWriter, and distributed-mode Map are out
-// of scope; only the inline processor mode is supported.
+// Both Inline and Distributed mode run in-process in kumo: kumo has no
+// child-execution or Map Run resource, so DescribeMapRun/ListMapRuns and
+// child-execution tracking are out of scope (see the ResultWriter
+// simplification documented in resultwriter.go for the same reason).
 func (e *executionEngine) executeMapState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
 	processor, err := itemProcessorDefinition(state)
 	if err != nil {
 		return "", fmt.Errorf("map state %q: %w", name, err)
 	}
 
-	items, err := resolveItemsPath(state.ItemsPath, input)
+	if err := requireDistributedModeForFields(state, processor); err != nil {
+		return "", fmt.Errorf("map state %q: %w", name, err)
+	}
+
+	items, err := resolveMapItems(ctx, e, state, input)
 	if err != nil {
 		return "", fmt.Errorf("map state %q: %w", name, err)
 	}
 
+	items, err = applyItemSelector(state.ItemSelector, items, input)
+	if err != nil {
+		return "", fmt.Errorf("map state %q: %w", name, err)
+	}
+
+	units, err := buildProcessorUnits(state.ItemBatcher, items, input)
+	if err != nil {
+		return "", fmt.Errorf("map state %q: %w", name, err)
+	}
+
+	return e.runMapProcessorUnits(ctx, name, state, processor, units, len(items), input)
+}
+
+// runMapProcessorUnits runs every processor unit and shapes the Map
+// state's output: the ExceedToleratedFailureThreshold check, the plain
+// item-output array, or -- when ResultWriter is set -- the
+// ResultWriterDetails{Bucket, Key} shape (see resultwriter.go).
+func (e *executionEngine) runMapProcessorUnits(ctx context.Context, name string, state *stateDefinition, processor *stateMachineDefinition, units []mapUnit, totalItems int, input string) (string, error) {
+	tolerance := resolveMapTolerance(state)
+
 	itemCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	outputs, err := runMapItems(itemCtx, e, processor, items, state.MaxConcurrency, cancel)
+	results, err := runMapUnits(itemCtx, e, processor, units, state.MaxConcurrency, tolerance.enabled(), cancel)
 	if err != nil {
 		return "", fmt.Errorf("map state %q: %w", name, err)
+	}
+
+	outputs, failedItems := collectMapResults(units, results)
+
+	if tolerance.enabled() && tolerance.exceeds(failedItems, totalItems) {
+		return "", &failStateError{
+			errorName: errorStatesExceedToleratedFailureThreshold,
+			cause: fmt.Sprintf(
+				"map state %q: %d of %d items failed, exceeding the configured tolerated failure threshold",
+				name, failedItems, totalItems,
+			),
+		}
+	}
+
+	if len(state.ResultWriter) > 0 {
+		written, err := writeMapResultToS3(ctx, e, state.ResultWriter, outputs, input)
+		if err != nil {
+			return "", fmt.Errorf("map state %q: %w", name, err)
+		}
+
+		return written, nil
 	}
 
 	result, err := json.Marshal(outputs)
@@ -52,9 +111,34 @@ func (e *executionEngine) executeMapState(ctx context.Context, name string, stat
 	return string(result), nil
 }
 
+// collectMapResults turns per-unit results into the Map state's output
+// array and the total count of dataset items that failed. A failed unit
+// contributes a JSON null for every item it represented, rather than being
+// omitted, so the output array's length always matches the unit count --
+// an emulator simplification, since AWS does not document the exact
+// per-item output shape for a partially-failed Map Run that isn't exported
+// via ResultWriter.
+func collectMapResults(units []mapUnit, results []mapUnitResult) (outputs []json.RawMessage, failedItems int) {
+	outputs = make([]json.RawMessage, len(results))
+
+	for i, r := range results {
+		if r.err != nil {
+			failedItems += units[i].itemCount
+			outputs[i] = json.RawMessage("null")
+
+			continue
+		}
+
+		outputs[i] = r.output
+	}
+
+	return outputs, failedItems
+}
+
 // itemProcessorDefinition returns the Map state's sub-state-machine.
-// ItemProcessor is the current field name; Iterator is the legacy alias. If
-// both are present, ItemProcessor takes precedence.
+// ItemProcessor is the current field name; Iterator is the legacy alias for
+// the same sub-state-machine. If both are present, ItemProcessor takes
+// precedence.
 func itemProcessorDefinition(state *stateDefinition) (*stateMachineDefinition, error) {
 	switch {
 	case state.ItemProcessor != nil:
@@ -66,63 +150,74 @@ func itemProcessorDefinition(state *stateDefinition) (*stateMachineDefinition, e
 	}
 }
 
-// runMapItems executes the processor once per item, honoring MaxConcurrency
-// (0 or negative means unlimited), and returns the item outputs in item
-// order, or the error of the first item to fail.
-func runMapItems(ctx context.Context, e *executionEngine, processor *stateMachineDefinition, items []json.RawMessage, maxConcurrency int, cancel context.CancelFunc) ([]json.RawMessage, error) {
-	outputs := make([]json.RawMessage, len(items))
+// isDistributedMode reports whether a Map state's ItemProcessor runs in
+// Distributed mode. An absent ProcessorConfig, or a Mode other than
+// "DISTRIBUTED", is Inline mode -- ASL's own documented default.
+func isDistributedMode(processor *stateMachineDefinition) bool {
+	return processor.ProcessorConfig != nil && strings.EqualFold(processor.ProcessorConfig.Mode, mapProcessorModeDistributed)
+}
 
-	var sem chan struct{}
-	if maxConcurrency > 0 {
-		sem = make(chan struct{}, maxConcurrency)
+// requireDistributedModeForFields enforces AWS's rule that ItemReader,
+// ItemBatcher, ResultWriter, ToleratedFailurePercentage, and
+// ToleratedFailureCount are Distributed-mode-only Map state fields (see
+// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-inline.html,
+// whose field list omits all five, versus
+// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-distributed.html,
+// which documents them). validateMapDistributedFields in validate.go
+// reports the same rule as a definition-time diagnostic.
+func requireDistributedModeForFields(state *stateDefinition, processor *stateMachineDefinition) error {
+	if isDistributedMode(processor) {
+		return nil
 	}
 
-	var (
-		wg       sync.WaitGroup
-		once     sync.Once
-		firstErr error
+	fields := distributedOnlyFieldsSet(state)
+	if len(fields) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%s require ItemProcessor.ProcessorConfig.Mode %q",
+		strings.Join(fields, ", "), mapProcessorModeDistributed,
 	)
+}
 
-	for i := range items {
-		wg.Add(1)
+// distributedOnlyFieldsSet lists which of the Distributed-mode-only Map
+// fields are present on state.
+func distributedOnlyFieldsSet(state *stateDefinition) []string {
+	var fields []string
 
-		go func(i int) {
-			defer wg.Done()
-
-			if sem != nil {
-				select {
-				case sem <- struct{}{}:
-					defer func() { <-sem }()
-				case <-ctx.Done():
-					// Another item already failed and canceled ctx before
-					// this queued item got a slot; skip it rather than
-					// starting work whose result will be discarded.
-					return
-				}
-			}
-
-			out, err := e.execute(ctx, processor, string(items[i]))
-			if err != nil {
-				once.Do(func() {
-					firstErr = fmt.Errorf("item %d: %w", i, err)
-
-					cancel()
-				})
-
-				return
-			}
-
-			outputs[i] = json.RawMessage(out)
-		}(i)
+	if len(state.ItemReader) > 0 {
+		fields = append(fields, "ItemReader")
 	}
 
-	wg.Wait()
-
-	if firstErr != nil {
-		return nil, firstErr
+	if len(state.ItemBatcher) > 0 {
+		fields = append(fields, "ItemBatcher")
 	}
 
-	return outputs, nil
+	if len(state.ResultWriter) > 0 {
+		fields = append(fields, "ResultWriter")
+	}
+
+	if state.ToleratedFailurePercentage != nil {
+		fields = append(fields, "ToleratedFailurePercentage")
+	}
+
+	if state.ToleratedFailureCount != nil {
+		fields = append(fields, "ToleratedFailureCount")
+	}
+
+	return fields
+}
+
+// resolveMapItems resolves a Map state's item list: from ItemReader (an S3
+// dataset, Distributed mode only) if set, otherwise from ItemsPath against
+// the state's own input.
+func resolveMapItems(ctx context.Context, e *executionEngine, state *stateDefinition, input string) ([]json.RawMessage, error) {
+	if len(state.ItemReader) > 0 {
+		return readItemsFromS3(ctx, e, state.ItemReader, input)
+	}
+
+	return resolveItemsPath(state.ItemsPath, input)
 }
 
 // resolveItemsPath resolves a Map state's ItemsPath (default "$") against

--- a/internal/service/sfn/maptolerance.go
+++ b/internal/service/sfn/maptolerance.go
@@ -1,0 +1,49 @@
+package sfn
+
+// mapTolerance is a Map state's resolved ToleratedFailurePercentage/
+// ToleratedFailureCount (see
+// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-distributed.html#state-map-fields-failure-tolerance).
+// ToleratedFailurePercentagePath/ToleratedFailureCountPath (the dynamic,
+// reference-path forms of these fields) are not implemented.
+type mapTolerance struct {
+	percentage *float64
+	count      *int
+}
+
+// resolveMapTolerance reads a Map state's tolerance fields. Only
+// requireDistributedModeForFields lets these fields take effect at all
+// (they are Distributed-mode-only), so resolveMapTolerance itself does not
+// need to check mode.
+func resolveMapTolerance(state *stateDefinition) mapTolerance {
+	return mapTolerance{
+		percentage: state.ToleratedFailurePercentage,
+		count:      state.ToleratedFailureCount,
+	}
+}
+
+// enabled reports whether either threshold was configured. When neither is
+// set, AWS's documented default (a 0% tolerated failure percentage) means
+// any single item failure fails the Map Run; runMapProcessorUnits achieves
+// that identical result more cheaply via the non-tolerant fast-fail path in
+// runMapUnits, without needing every unit to run to completion first.
+func (t mapTolerance) enabled() bool {
+	return t.percentage != nil || t.count != nil
+}
+
+// exceeds reports whether failedItems out of totalItems exceeds the
+// configured threshold. Per AWS docs, a Map Run fails if it exceeds either
+// configured threshold when both are set.
+func (t mapTolerance) exceeds(failedItems, totalItems int) bool {
+	if t.count != nil && failedItems > *t.count {
+		return true
+	}
+
+	if t.percentage != nil && totalItems > 0 {
+		failedPercentage := float64(failedItems) / float64(totalItems) * 100
+		if failedPercentage > *t.percentage {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/service/sfn/resultwriter.go
+++ b/internal/service/sfn/resultwriter.go
@@ -1,0 +1,140 @@
+package sfn
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ResultWriter.Resource. Only s3:putObject is implemented.
+const resultWriterResourceS3PutObject = "arn:aws:states:::s3:putObject"
+
+// resultWriterFileName is the single combined result file kumo writes for
+// every Map Run (see writeMapResultToS3 for why this deviates from AWS's
+// real multi-file layout).
+const resultWriterFileName = "result.json"
+
+// resultWriterDef is the decoded ResultWriter field. JSON tags are
+// lowerCamelCase; see itemBatcherDef in itembatcher.go for why.
+//
+// WriterConfig (Transformation/OutputType) is not implemented: kumo always
+// writes the plain JSON array of item outputs, equivalent to AWS's
+// Transformation "COMPACT" with OutputType "JSON". It is decoded only so
+// validate.go can flag it as unimplemented.
+type resultWriterDef struct {
+	Resource     string          `json:"resource"`
+	Parameters   map[string]any  `json:"parameters"`
+	WriterConfig json.RawMessage `json:"writerConfig"`
+}
+
+// writeMapResultToS3 uploads outputs -- the Map state's would-be plain-array
+// result -- as a single JSON file to kumo's S3 under Parameters.Prefix, and
+// returns the Map state's output in AWS's documented
+// ResultWriterDetails{Bucket, Key} shape (see
+// https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultwriter.html#export-s3).
+//
+// This is a deliberate emulator simplification of AWS's real behavior: AWS
+// partitions results into a manifest.json plus per-status
+// SUCCEEDED_n.json/FAILED_n.json files, and the top-level result also
+// carries a MapRunArn. kumo has no Map Run resource (DescribeMapRun/
+// ListMapRuns and child-execution tracking are out of scope, see
+// mapstate.go), so it writes one combined result file and omits MapRunArn.
+func writeMapResultToS3(ctx context.Context, e *executionEngine, raw json.RawMessage, outputs []json.RawMessage, mapInput string) (string, error) {
+	var def resultWriterDef
+	if err := json.Unmarshal(raw, &def); err != nil {
+		return "", fmt.Errorf("parse ResultWriter: %w", err)
+	}
+
+	if def.Resource != resultWriterResourceS3PutObject {
+		return "", fmt.Errorf("unsupported ResultWriter resource %q", def.Resource)
+	}
+
+	params, err := resolveParameters(def.Parameters, mapInput)
+	if err != nil {
+		return "", fmt.Errorf("resolve ResultWriter Parameters: %w", err)
+	}
+
+	bucket, _ := params["Bucket"].(string)
+	prefix, _ := params["Prefix"].(string)
+
+	if bucket == "" {
+		return "", fmt.Errorf("resultWriter s3:putObject requires Parameters.Bucket")
+	}
+
+	key := resultWriterKey(prefix)
+
+	body, err := json.Marshal(outputs)
+	if err != nil {
+		return "", fmt.Errorf("marshal ResultWriter output: %w", err)
+	}
+
+	if err := e.putS3Object(ctx, bucket, key, body); err != nil {
+		return "", fmt.Errorf("resultWriter: %w", err)
+	}
+
+	return marshalResultWriterOutput(bucket, key)
+}
+
+// resultWriterKey builds the combined result file's object key under Prefix.
+func resultWriterKey(prefix string) string {
+	if prefix == "" {
+		return resultWriterFileName
+	}
+
+	return strings.TrimSuffix(prefix, "/") + "/" + resultWriterFileName
+}
+
+// marshalResultWriterOutput builds the Map state's output when ResultWriter
+// exported to S3: {"ResultWriterDetails": {"Bucket": ..., "Key": ...}}. A
+// plain map is used so the wire keys need not be exempted from tagliatelle.
+func marshalResultWriterOutput(bucket, key string) (string, error) {
+	result := map[string]any{
+		"ResultWriterDetails": map[string]any{
+			"Bucket": bucket,
+			"Key":    key,
+		},
+	}
+
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("marshal ResultWriter result: %w", err)
+	}
+
+	return string(encoded), nil
+}
+
+// putS3Object writes an object to kumo's own S3 service using the same
+// path-style addressing S3 itself registers its routes under
+// (PUT /{bucket}/{key}).
+func (e *executionEngine) putS3Object(ctx context.Context, bucket, key string, body []byte) error {
+	url := fmt.Sprintf("%s/%s/%s", e.baseURL, bucket, key)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request for s3://%s/%s: %w", bucket, key, err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("put s3://%s/%s: %w", bucket, key, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response for put s3://%s/%s: %w", bucket, key, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("put s3://%s/%s: unexpected status %d: %s", bucket, key, resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}

--- a/internal/service/sfn/resultwriter_test.go
+++ b/internal/service/sfn/resultwriter_test.go
@@ -1,0 +1,66 @@
+package sfn
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestMapStateResultWriterExportsToS3(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+
+	resultWriter := `{
+		"Resource": "arn:aws:states:::s3:putObject",
+		"Parameters": {"Bucket": "dst-bucket", "Prefix": "out"}
+	}`
+
+	definition := fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ResultWriter": %s,
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, resultWriter, distributedItemProcessorJSON)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-resultwriter", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `[1,2,3]`)
+
+	// JSON tags are lowerCamelCase (encoding/json matches the wire's
+	// PascalCase case-insensitively; see itemBatcherDef in itembatcher.go
+	// for why).
+	var output struct {
+		ResultWriterDetails struct {
+			Bucket string `json:"bucket"`
+			Key    string `json:"key"`
+		} `json:"resultWriterDetails"`
+	}
+
+	if err := json.Unmarshal([]byte(exec.Output), &output); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if output.ResultWriterDetails.Bucket != "dst-bucket" {
+		t.Fatalf("ResultWriterDetails.Bucket: got %q, want %q", output.ResultWriterDetails.Bucket, "dst-bucket")
+	}
+
+	if want := "out/result.json"; output.ResultWriterDetails.Key != want {
+		t.Fatalf("ResultWriterDetails.Key: got %q, want %q", output.ResultWriterDetails.Key, want)
+	}
+
+	put := server.lastPut(t)
+	if put.bucket != "dst-bucket" || put.key != "out/result.json" {
+		t.Fatalf("PUT target: got bucket=%q key=%q, want bucket=%q key=%q", put.bucket, put.key, "dst-bucket", "out/result.json")
+	}
+
+	if want := `[1,2,3]`; string(put.body) != want {
+		t.Fatalf("PUT body: got %q, want %q", string(put.body), want)
+	}
+}

--- a/internal/service/sfn/toleratedfailure_test.go
+++ b/internal/service/sfn/toleratedfailure_test.go
@@ -1,0 +1,105 @@
+package sfn
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// conditionalFailProcessorJSON is a Distributed-mode ItemProcessor that
+// fails an item whose "ok" field is not true, so tolerance tests can
+// control exactly which items fail without any external HTTP dependency.
+const conditionalFailProcessorJSON = `{
+	"ProcessorConfig": {"Mode": "DISTRIBUTED", "ExecutionType": "STANDARD"},
+	"StartAt": "Check",
+	"States": {
+		"Check": {
+			"Type": "Choice",
+			"Choices": [{"Variable": "$.ok", "BooleanEquals": true, "Next": "Ok"}],
+			"Default": "Bad"
+		},
+		"Ok": {"Type": "Pass", "End": true},
+		"Bad": {"Type": "Fail", "Error": "ItemFailed", "Cause": "item was not ok"}
+	}
+}`
+
+// toleratedFailureMapDefinition builds a Map state using
+// conditionalFailProcessorJSON with the given ToleratedFailure* field set
+// verbatim in the state body (e.g. `"ToleratedFailurePercentage": 50`).
+func toleratedFailureMapDefinition(toleranceField string) string {
+	return fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				%s,
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, toleranceField, conditionalFailProcessorJSON)
+}
+
+// oneOfFourFailsInput is one failing item ("ok": false) out of four (25%).
+const oneOfFourFailsInput = `[{"ok":true},{"ok":true},{"ok":false},{"ok":true}]`
+
+func TestMapStateToleratedFailurePercentageWithinToleranceSucceeds(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-tolerated-pct-ok", toleratedFailureMapDefinition(`"ToleratedFailurePercentage": 50`))
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, oneOfFourFailsInput)
+
+	var outputs []json.RawMessage
+	if err := json.Unmarshal([]byte(exec.Output), &outputs); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(outputs) != 4 {
+		t.Fatalf("outputs: got %d entries, want 4", len(outputs))
+	}
+
+	if string(outputs[2]) != "null" {
+		t.Fatalf("failed item output: got %s, want null", outputs[2])
+	}
+
+	if string(outputs[0]) == "null" {
+		t.Fatalf("succeeded item output: got null, want the item's own output")
+	}
+}
+
+func TestMapStateToleratedFailurePercentageExceedingToleranceFails(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-tolerated-pct-fail", toleratedFailureMapDefinition(`"ToleratedFailurePercentage": 10`))
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, oneOfFourFailsInput)
+
+	if exec.Error != errorStatesExceedToleratedFailureThreshold {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesExceedToleratedFailureThreshold)
+	}
+}
+
+func TestMapStateToleratedFailureCountWithinToleranceSucceeds(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-tolerated-count-ok", toleratedFailureMapDefinition(`"ToleratedFailureCount": 1`))
+
+	startAndAwaitSuccess(t, store, sm.StateMachineArn, oneOfFourFailsInput)
+}
+
+func TestMapStateToleratedFailureCountExceedingToleranceFails(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-tolerated-count-fail", toleratedFailureMapDefinition(`"ToleratedFailureCount": 0`))
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, oneOfFourFailsInput)
+
+	if exec.Error != errorStatesExceedToleratedFailureThreshold {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesExceedToleratedFailureThreshold)
+	}
+}

--- a/internal/service/sfn/validate.go
+++ b/internal/service/sfn/validate.go
@@ -44,19 +44,21 @@ var terminalStateTypes = map[string]bool{
 	"Fail":    true,
 }
 
-// mapEmulationGapFields are Map state fields the ASL spec defines but
-// kumo's executor does not implement (see mapstate.go): ItemSelector,
-// ItemBatcher and ResultWriter are unimplemented in every mode, and
-// ItemReader is the marker for distributed-mode Map, which kumo only ever
-// runs in inline (ItemProcessor/Iterator) mode.
-var mapEmulationGapFields = []struct {
-	name string
-	get  func(*stateDefinition) json.RawMessage
+// mapDistributedOnlyFields are Map state fields AWS documents only under
+// Distributed mode (see requireDistributedModeForFields in mapstate.go):
+// they are absent from the Inline Map state field list at
+// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-inline.html
+// but present at
+// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-distributed.html.
+var mapDistributedOnlyFields = []struct {
+	name  string
+	isSet func(*stateDefinition) bool
 }{
-	{"ItemReader", func(s *stateDefinition) json.RawMessage { return s.ItemReader }},
-	{"ItemSelector", func(s *stateDefinition) json.RawMessage { return s.ItemSelector }},
-	{"ItemBatcher", func(s *stateDefinition) json.RawMessage { return s.ItemBatcher }},
-	{"ResultWriter", func(s *stateDefinition) json.RawMessage { return s.ResultWriter }},
+	{"ItemReader", func(s *stateDefinition) bool { return len(s.ItemReader) > 0 }},
+	{"ItemBatcher", func(s *stateDefinition) bool { return len(s.ItemBatcher) > 0 }},
+	{"ResultWriter", func(s *stateDefinition) bool { return len(s.ResultWriter) > 0 }},
+	{"ToleratedFailurePercentage", func(s *stateDefinition) bool { return s.ToleratedFailurePercentage != nil }},
+	{"ToleratedFailureCount", func(s *stateDefinition) bool { return s.ToleratedFailureCount != nil }},
 }
 
 // validateStateMachineDefinition runs kumo's best-effort structural checks
@@ -260,35 +262,143 @@ func (v *definitionValidator) validateParallelState(name string, state *stateDef
 }
 
 // validateMapState checks a Map state's ItemProcessor/Iterator (required,
-// recursively validated) and warns about ASL fields kumo's engine does not
-// implement.
+// recursively validated), the Distributed-mode-only field rules, and
+// ASL/kumo constructs still not implemented.
 func (v *definitionValidator) validateMapState(name string, state *stateDefinition, location string) {
+	var processor *stateMachineDefinition
+
 	switch {
 	case state.ItemProcessor != nil:
-		v.validateStateMachine(state.ItemProcessor, location+"/ItemProcessor")
+		processor = state.ItemProcessor
+		v.validateStateMachine(processor, location+"/ItemProcessor")
 	case state.Iterator != nil:
-		v.validateStateMachine(state.Iterator, location+"/Iterator")
+		processor = state.Iterator
+		v.validateStateMachine(processor, location+"/Iterator")
 	default:
 		v.addError(codeSchemaValidationFailed, location, fmt.Sprintf("Map state %q requires \"ItemProcessor\" (or the legacy \"Iterator\")", name))
 	}
 
-	v.warnUnsupportedMapFields(name, state, location)
+	v.validateMapDistributedFields(name, state, processor, location)
 }
 
-// warnUnsupportedMapFields flags Map fields the engine silently ignores at
-// runtime (see mapstate.go), so a definition that structurally validates
-// does not still surprise the caller when it runs -- the class of gap
-// reported in issue #861.
-func (v *definitionValidator) warnUnsupportedMapFields(name string, state *stateDefinition, location string) {
-	for _, field := range mapEmulationGapFields {
-		if len(field.get(state)) == 0 {
+// validateMapDistributedFields checks the Distributed-mode rules
+// requireDistributedModeForFields enforces at runtime (see mapstate.go),
+// and flags constructs kumo does not implement at all. processor is nil
+// when neither ItemProcessor nor Iterator was set (already reported by
+// validateMapState).
+func (v *definitionValidator) validateMapDistributedFields(name string, state *stateDefinition, processor *stateMachineDefinition, location string) {
+	if processor != nil && isDistributedMode(processor) {
+		v.validateDistributedExecutionType(name, processor, location)
+	} else {
+		v.warnDistributedOnlyFields(name, state, location)
+	}
+
+	v.warnUnimplementedMapConstructs(name, state, location)
+}
+
+// validateDistributedExecutionType checks AWS's documented requirement
+// that ProcessorConfig.Mode "DISTRIBUTED" must also set ExecutionType.
+func (v *definitionValidator) validateDistributedExecutionType(name string, processor *stateMachineDefinition, location string) {
+	if processor.ProcessorConfig.ExecutionType != "" {
+		return
+	}
+
+	v.addError(codeSchemaValidationFailed, location+"/ItemProcessor/ProcessorConfig/ExecutionType", fmt.Sprintf(
+		"Map state %q: ProcessorConfig.Mode %q requires ProcessorConfig.ExecutionType", name, mapProcessorModeDistributed,
+	))
+}
+
+// warnDistributedOnlyFields flags Map fields AWS documents as
+// Distributed-mode-only (see mapDistributedOnlyFields) that are set
+// without ProcessorConfig.Mode "DISTRIBUTED": requireDistributedModeForFields
+// fails these at runtime, so a definition that structurally validates does
+// not still surprise the caller when it runs -- the class of gap reported
+// in issue #861.
+func (v *definitionValidator) warnDistributedOnlyFields(name string, state *stateDefinition, location string) {
+	for _, field := range mapDistributedOnlyFields {
+		if !field.isSet(state) {
 			continue
 		}
 
 		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/"+field.name, fmt.Sprintf(
-			"Map state %q sets %q, which kumo's engine does not implement (only the inline ItemProcessor/Iterator mode is supported); this definition will pass validation but will not run as expected",
-			name, field.name,
+			"Map state %q sets %q, which requires ItemProcessor.ProcessorConfig.Mode %q; without it, this field fails at runtime",
+			name, field.name, mapProcessorModeDistributed,
 		))
+	}
+}
+
+// warnUnimplementedMapConstructs flags Map/ItemReader/ItemBatcher/
+// ResultWriter constructs kumo's engine does not implement at all (see
+// itemreader.go, itembatcher.go, resultwriter.go), so a definition that
+// structurally validates does not still surprise the caller when it runs.
+func (v *definitionValidator) warnUnimplementedMapConstructs(name string, state *stateDefinition, location string) {
+	v.warnUnimplementedItemReaderConstructs(name, state.ItemReader, location)
+	v.warnUnimplementedItemBatcherConstructs(name, state.ItemBatcher, location)
+	v.warnUnimplementedResultWriterConstructs(name, state.ResultWriter, location)
+
+	if state.ToleratedFailurePercentagePath != "" {
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ToleratedFailurePercentagePath",
+			fmt.Sprintf("Map state %q: ToleratedFailurePercentagePath is not implemented; use the static ToleratedFailurePercentage instead", name))
+	}
+
+	if state.ToleratedFailureCountPath != "" {
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ToleratedFailureCountPath",
+			fmt.Sprintf("Map state %q: ToleratedFailureCountPath is not implemented; use the static ToleratedFailureCount instead", name))
+	}
+}
+
+// warnUnimplementedItemReaderConstructs flags an ItemReader Resource kumo
+// does not implement (only s3:getObject is supported) and the unimplemented
+// ReaderConfig.MaxItemsPath field.
+func (v *definitionValidator) warnUnimplementedItemReaderConstructs(name string, raw json.RawMessage, location string) {
+	var def itemReaderDef
+	if len(raw) == 0 || json.Unmarshal(raw, &def) != nil {
+		return
+	}
+
+	if def.Resource != "" && def.Resource != itemReaderResourceS3GetObject {
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ItemReader/Resource", fmt.Sprintf(
+			"Map state %q: ItemReader Resource %q is not implemented; only %q is supported", name, def.Resource, itemReaderResourceS3GetObject,
+		))
+	}
+
+	if def.ReaderConfig.MaxItemsPath != "" {
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ItemReader/ReaderConfig/MaxItemsPath",
+			fmt.Sprintf("Map state %q: ItemReader ReaderConfig.MaxItemsPath is not implemented; use the static MaxItems instead", name))
+	}
+}
+
+// warnUnimplementedItemBatcherConstructs flags ItemBatcher's unimplemented
+// reference-path sub-fields.
+func (v *definitionValidator) warnUnimplementedItemBatcherConstructs(name string, raw json.RawMessage, location string) {
+	var def itemBatcherDef
+	if len(raw) == 0 || json.Unmarshal(raw, &def) != nil {
+		return
+	}
+
+	if def.MaxItemsPerBatchPath != "" {
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ItemBatcher/MaxItemsPerBatchPath",
+			fmt.Sprintf("Map state %q: ItemBatcher MaxItemsPerBatchPath is not implemented; use the static MaxItemsPerBatch instead", name))
+	}
+
+	if def.MaxInputBytesPerBatchPath != "" {
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ItemBatcher/MaxInputBytesPerBatchPath",
+			fmt.Sprintf("Map state %q: ItemBatcher MaxInputBytesPerBatchPath is not implemented; use the static MaxInputBytesPerBatch instead", name))
+	}
+}
+
+// warnUnimplementedResultWriterConstructs flags ResultWriter.WriterConfig,
+// which kumo does not implement (kumo always writes the plain item-output
+// array; see resultwriter.go).
+func (v *definitionValidator) warnUnimplementedResultWriterConstructs(name string, raw json.RawMessage, location string) {
+	var def resultWriterDef
+	if len(raw) == 0 || json.Unmarshal(raw, &def) != nil {
+		return
+	}
+
+	if len(def.WriterConfig) > 0 {
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ResultWriter/WriterConfig",
+			fmt.Sprintf("Map state %q: ResultWriter WriterConfig is not implemented; kumo always writes the plain item-output array", name))
 	}
 }
 


### PR DESCRIPTION
## Summary
Completes the last Step Functions follow-up: the distributed-Map feature set, executed in-process like the rest of the emulator.

- ItemSelector (inline + distributed) with $$.Map.Item.Value / $$.Map.Item.Index context refs
- ItemReader from kumo's S3 (s3:getObject; JSON / JSONL / CSV with header, MaxItems)
- ItemBatcher with the documented {BatchInput, Items} envelope
- ResultWriter to S3 with ResultWriterDetails output (single result file as a documented emulator simplification of AWS's manifest layout)
- ToleratedFailurePercentage/Count; exceeding tolerance fails with States.ExceedToleratedFailureThreshold
- Distributed-only fields are enforced against ProcessorConfig.Mode per AWS rules at both validation and runtime

Out of scope (documented in code): s3:listObjectsV2 reader, *Path reference forms, WriterConfig, and the MapRun APIs (DescribeMapRun/ListMapRuns).

## Test plan
- [ ] Unit tests per component (reader formats, batching envelope, selector context refs, writer output, tolerance both directions) plus an ItemReader+ItemSelector+ItemBatcher+Task end-to-end run against a fake S3/Lambda
- [ ] Full sfn suite race-clean; existing tests unmodified