### PR TITLE
feat(sfn): complete the ASL input/output processing pipeline

### DIFF
--- a/internal/service/sfn/catch_test.go
+++ b/internal/service/sfn/catch_test.go
@@ -81,6 +81,52 @@ func TestTaskCatchInjectsErrorViaResultPath(t *testing.T) {
 	}
 }
 
+func TestTaskCatchInjectsErrorViaDeepResultPath(t *testing.T) {
+	t.Parallel()
+
+	// The Catcher's ResultPath is now backed by the same arbitrary-depth
+	// applyResultPath used elsewhere, so a multi-level path must create
+	// intermediate objects exactly like a state's top-level ResultPath does.
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:missing-fn",
+				"Catch": [{"ErrorEquals": ["States.ALL"], "ResultPath": "$.a.b.c", "Next": "Fallback"}],
+				"End": true
+			},
+			"Fallback": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL("http://127.0.0.1:1"))
+	sm := createExecutionTestStateMachine(t, store, "catch-deep-resultpath", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"orig":"data"}`)
+
+	var output struct {
+		Orig string `json:"orig"`
+		A    struct {
+			B struct {
+				C map[string]string `json:"c"`
+			} `json:"b"`
+		} `json:"a"`
+	}
+
+	if err := json.Unmarshal([]byte(exec.Output), &output); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if output.Orig != "data" {
+		t.Fatalf("original input field: got %q, want %q", output.Orig, "data")
+	}
+
+	if output.A.B.C["Error"] != errorStatesTaskFailed {
+		t.Fatalf("injected error output at $.a.b.c: got %q, want %q", output.A.B.C["Error"], errorStatesTaskFailed)
+	}
+}
+
 func TestTaskCatchDoesNotMatchStatesRuntimeEvenWithStatesAll(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/sfn/choice.go
+++ b/internal/service/sfn/choice.go
@@ -11,6 +11,12 @@ import (
 // "Variable" JSONPath plus exactly one comparison operator) or a Boolean
 // Expression (And/Or/Not combining nested rules).
 //
+// Every comparison operator also has a "*Path" variant (e.g.
+// "StringEqualsPath"), whose value is a Path resolved against the state's
+// effective input to yield the comparison operand, instead of a static
+// literal -- see resolveStringOperand/resolveNumericOperand/
+// resolveBooleanOperand.
+//
 // JSON tags are lowerCamelCase rather than the Amazon States Language's own
 // PascalCase (e.g. "Variable", "StringEquals"); encoding/json matches object
 // keys to struct fields case-insensitively when there is no exact match, so
@@ -25,17 +31,38 @@ type choiceRule struct {
 	StringLessThanEquals    *string `json:"stringLessThanEquals"`
 	StringGreaterThanEquals *string `json:"stringGreaterThanEquals"`
 
+	StringEqualsPath            *string `json:"stringEqualsPath"`
+	StringLessThanPath          *string `json:"stringLessThanPath"`
+	StringGreaterThanPath       *string `json:"stringGreaterThanPath"`
+	StringLessThanEqualsPath    *string `json:"stringLessThanEqualsPath"`
+	StringGreaterThanEqualsPath *string `json:"stringGreaterThanEqualsPath"`
+
 	NumericEquals            *float64 `json:"numericEquals"`
 	NumericLessThan          *float64 `json:"numericLessThan"`
 	NumericGreaterThan       *float64 `json:"numericGreaterThan"`
 	NumericLessThanEquals    *float64 `json:"numericLessThanEquals"`
 	NumericGreaterThanEquals *float64 `json:"numericGreaterThanEquals"`
 
-	BooleanEquals *bool `json:"booleanEquals"`
+	NumericEqualsPath            *string `json:"numericEqualsPath"`
+	NumericLessThanPath          *string `json:"numericLessThanPath"`
+	NumericGreaterThanPath       *string `json:"numericGreaterThanPath"`
+	NumericLessThanEqualsPath    *string `json:"numericLessThanEqualsPath"`
+	NumericGreaterThanEqualsPath *string `json:"numericGreaterThanEqualsPath"`
 
-	TimestampEquals      *string `json:"timestampEquals"`
-	TimestampLessThan    *string `json:"timestampLessThan"`
-	TimestampGreaterThan *string `json:"timestampGreaterThan"`
+	BooleanEquals     *bool   `json:"booleanEquals"`
+	BooleanEqualsPath *string `json:"booleanEqualsPath"`
+
+	TimestampEquals            *string `json:"timestampEquals"`
+	TimestampLessThan          *string `json:"timestampLessThan"`
+	TimestampGreaterThan       *string `json:"timestampGreaterThan"`
+	TimestampLessThanEquals    *string `json:"timestampLessThanEquals"`
+	TimestampGreaterThanEquals *string `json:"timestampGreaterThanEquals"`
+
+	TimestampEqualsPath            *string `json:"timestampEqualsPath"`
+	TimestampLessThanPath          *string `json:"timestampLessThanPath"`
+	TimestampGreaterThanPath       *string `json:"timestampGreaterThanPath"`
+	TimestampLessThanEqualsPath    *string `json:"timestampLessThanEqualsPath"`
+	TimestampGreaterThanEqualsPath *string `json:"timestampGreaterThanEqualsPath"`
 
 	IsPresent *bool `json:"isPresent"`
 	IsNull    *bool `json:"isNull"`
@@ -46,7 +73,7 @@ type choiceRule struct {
 }
 
 // evaluateChoiceRule evaluates a single Choice Rule (Data-test Expression or
-// Boolean Expression) against the parsed state input.
+// Boolean Expression) against the parsed effective input.
 func evaluateChoiceRule(rule *choiceRule, input map[string]any) (bool, error) {
 	switch {
 	case len(rule.And) > 0:
@@ -121,104 +148,213 @@ func evaluateDataTest(rule *choiceRule, input map[string]any) (bool, error) {
 		return (value == nil) == *rule.IsNull, nil
 	}
 
-	if matched, handled := evaluateStringComparison(rule, value); handled {
-		return matched, nil
+	if matched, handled, err := evaluateStringComparison(rule, value, input); handled {
+		return matched, err
 	}
 
-	if matched, handled := evaluateNumericComparison(rule, value); handled {
-		return matched, nil
+	if matched, handled, err := evaluateNumericComparison(rule, value, input); handled {
+		return matched, err
 	}
 
-	if rule.BooleanEquals != nil {
-		b, ok := value.(bool)
-
-		return ok && b == *rule.BooleanEquals, nil
+	if matched, handled, err := evaluateBooleanComparison(rule, value, input); handled {
+		return matched, err
 	}
 
-	if matched, handled := evaluateTimestampComparison(rule, value); handled {
-		return matched, nil
+	if matched, handled, err := evaluateTimestampComparison(rule, value, input); handled {
+		return matched, err
 	}
 
 	return false, fmt.Errorf("choice rule: no comparison operator set for Variable %q", rule.Variable)
 }
 
-// evaluateStringComparison evaluates the String* comparators. handled is
-// false if rule does not set any of them.
-func evaluateStringComparison(rule *choiceRule, value any) (matched, handled bool) {
+// evaluateStringComparison evaluates the String* comparators, including
+// their "*Path" variants. handled is false if rule sets none of them.
+func evaluateStringComparison(rule *choiceRule, value any, input map[string]any) (matched, handled bool, err error) {
 	switch {
-	case rule.StringEquals != nil:
-		cmp, ok := stringCompare(value, *rule.StringEquals)
-
-		return ok && cmp == 0, true
-	case rule.StringLessThan != nil:
-		cmp, ok := stringCompare(value, *rule.StringLessThan)
-
-		return ok && cmp < 0, true
-	case rule.StringGreaterThan != nil:
-		cmp, ok := stringCompare(value, *rule.StringGreaterThan)
-
-		return ok && cmp > 0, true
-	case rule.StringLessThanEquals != nil:
-		cmp, ok := stringCompare(value, *rule.StringLessThanEquals)
-
-		return ok && cmp <= 0, true
-	case rule.StringGreaterThanEquals != nil:
-		cmp, ok := stringCompare(value, *rule.StringGreaterThanEquals)
-
-		return ok && cmp >= 0, true
+	case rule.StringEquals != nil || rule.StringEqualsPath != nil:
+		return compareStringWith(value, rule.StringEquals, rule.StringEqualsPath, input, func(cmp int) bool { return cmp == 0 })
+	case rule.StringLessThan != nil || rule.StringLessThanPath != nil:
+		return compareStringWith(value, rule.StringLessThan, rule.StringLessThanPath, input, func(cmp int) bool { return cmp < 0 })
+	case rule.StringGreaterThan != nil || rule.StringGreaterThanPath != nil:
+		return compareStringWith(value, rule.StringGreaterThan, rule.StringGreaterThanPath, input, func(cmp int) bool { return cmp > 0 })
+	case rule.StringLessThanEquals != nil || rule.StringLessThanEqualsPath != nil:
+		return compareStringWith(value, rule.StringLessThanEquals, rule.StringLessThanEqualsPath, input, func(cmp int) bool { return cmp <= 0 })
+	case rule.StringGreaterThanEquals != nil || rule.StringGreaterThanEqualsPath != nil:
+		return compareStringWith(value, rule.StringGreaterThanEquals, rule.StringGreaterThanEqualsPath, input, func(cmp int) bool { return cmp >= 0 })
 	default:
-		return false, false
+		return false, false, nil
 	}
 }
 
-// evaluateNumericComparison evaluates the Numeric* comparators. handled is
-// false if rule does not set any of them.
-func evaluateNumericComparison(rule *choiceRule, value any) (matched, handled bool) {
+// compareStringWith resolves a String* comparator's operand -- from a
+// static value or, for the "*Path" variant, by resolving path against
+// input -- and reports whether value satisfies it per matches.
+func compareStringWith(value any, static, path *string, input map[string]any, matches func(cmp int) bool) (matched, handled bool, err error) {
+	want, ok, err := resolveStringOperand(static, path, input)
+	if err != nil {
+		return false, true, err
+	}
+
+	if !ok {
+		return false, true, nil
+	}
+
+	cmp, ok := stringCompare(value, want)
+
+	return ok && matches(cmp), true, nil
+}
+
+// resolveStringOperand resolves a String*/Timestamp* comparator's operand:
+// the static value if set, else the "*Path" variant's Path resolved
+// against input. ok is false if path resolves to a non-string value, per
+// the spec's "if the values are not both of the appropriate type... the
+// comparison will return false".
+func resolveStringOperand(static, path *string, input map[string]any) (want string, ok bool, err error) {
+	if static != nil {
+		return *static, true, nil
+	}
+
+	resolved, err := resolveJSONPath(input, *path)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve comparator path %q: %w", *path, err)
+	}
+
+	s, isString := resolved.(string)
+
+	return s, isString, nil
+}
+
+// evaluateNumericComparison evaluates the Numeric* comparators, including
+// their "*Path" variants. handled is false if rule sets none of them.
+func evaluateNumericComparison(rule *choiceRule, value any, input map[string]any) (matched, handled bool, err error) {
 	switch {
-	case rule.NumericEquals != nil:
-		cmp, ok := numericCompare(value, *rule.NumericEquals)
-
-		return ok && cmp == 0, true
-	case rule.NumericLessThan != nil:
-		cmp, ok := numericCompare(value, *rule.NumericLessThan)
-
-		return ok && cmp < 0, true
-	case rule.NumericGreaterThan != nil:
-		cmp, ok := numericCompare(value, *rule.NumericGreaterThan)
-
-		return ok && cmp > 0, true
-	case rule.NumericLessThanEquals != nil:
-		cmp, ok := numericCompare(value, *rule.NumericLessThanEquals)
-
-		return ok && cmp <= 0, true
-	case rule.NumericGreaterThanEquals != nil:
-		cmp, ok := numericCompare(value, *rule.NumericGreaterThanEquals)
-
-		return ok && cmp >= 0, true
+	case rule.NumericEquals != nil || rule.NumericEqualsPath != nil:
+		return compareNumericWith(value, rule.NumericEquals, rule.NumericEqualsPath, input, func(cmp int) bool { return cmp == 0 })
+	case rule.NumericLessThan != nil || rule.NumericLessThanPath != nil:
+		return compareNumericWith(value, rule.NumericLessThan, rule.NumericLessThanPath, input, func(cmp int) bool { return cmp < 0 })
+	case rule.NumericGreaterThan != nil || rule.NumericGreaterThanPath != nil:
+		return compareNumericWith(value, rule.NumericGreaterThan, rule.NumericGreaterThanPath, input, func(cmp int) bool { return cmp > 0 })
+	case rule.NumericLessThanEquals != nil || rule.NumericLessThanEqualsPath != nil:
+		return compareNumericWith(value, rule.NumericLessThanEquals, rule.NumericLessThanEqualsPath, input, func(cmp int) bool { return cmp <= 0 })
+	case rule.NumericGreaterThanEquals != nil || rule.NumericGreaterThanEqualsPath != nil:
+		return compareNumericWith(value, rule.NumericGreaterThanEquals, rule.NumericGreaterThanEqualsPath, input, func(cmp int) bool { return cmp >= 0 })
 	default:
-		return false, false
+		return false, false, nil
 	}
 }
 
-// evaluateTimestampComparison evaluates the Timestamp* comparators. handled
-// is false if rule does not set any of them.
-func evaluateTimestampComparison(rule *choiceRule, value any) (matched, handled bool) {
-	switch {
-	case rule.TimestampEquals != nil:
-		cmp, ok := timestampCompare(value, *rule.TimestampEquals)
-
-		return ok && cmp == 0, true
-	case rule.TimestampLessThan != nil:
-		cmp, ok := timestampCompare(value, *rule.TimestampLessThan)
-
-		return ok && cmp < 0, true
-	case rule.TimestampGreaterThan != nil:
-		cmp, ok := timestampCompare(value, *rule.TimestampGreaterThan)
-
-		return ok && cmp > 0, true
-	default:
-		return false, false
+// compareNumericWith resolves a Numeric* comparator's operand -- from a
+// static value or, for the "*Path" variant, by resolving path against
+// input -- and reports whether value satisfies it per matches.
+func compareNumericWith(value any, static *float64, path *string, input map[string]any, matches func(cmp int) bool) (matched, handled bool, err error) {
+	want, ok, err := resolveNumericOperand(static, path, input)
+	if err != nil {
+		return false, true, err
 	}
+
+	if !ok {
+		return false, true, nil
+	}
+
+	cmp, ok := numericCompare(value, want)
+
+	return ok && matches(cmp), true, nil
+}
+
+// resolveNumericOperand resolves a Numeric* comparator's operand: the
+// static value if set, else the "*Path" variant's Path resolved against
+// input. ok is false if path resolves to a non-number value.
+func resolveNumericOperand(static *float64, path *string, input map[string]any) (want float64, ok bool, err error) {
+	if static != nil {
+		return *static, true, nil
+	}
+
+	resolved, err := resolveJSONPath(input, *path)
+	if err != nil {
+		return 0, false, fmt.Errorf("resolve comparator path %q: %w", *path, err)
+	}
+
+	n, isNumber := resolved.(float64)
+
+	return n, isNumber, nil
+}
+
+// evaluateBooleanComparison evaluates BooleanEquals/BooleanEqualsPath.
+// handled is false if rule sets neither.
+func evaluateBooleanComparison(rule *choiceRule, value any, input map[string]any) (matched, handled bool, err error) {
+	if rule.BooleanEquals == nil && rule.BooleanEqualsPath == nil {
+		return false, false, nil
+	}
+
+	want, ok, err := resolveBooleanOperand(rule.BooleanEquals, rule.BooleanEqualsPath, input)
+	if err != nil {
+		return false, true, err
+	}
+
+	if !ok {
+		return false, true, nil
+	}
+
+	b, isBool := value.(bool)
+
+	return isBool && b == want, true, nil
+}
+
+// resolveBooleanOperand resolves BooleanEquals/BooleanEqualsPath's operand:
+// the static value if set, else BooleanEqualsPath's Path resolved against
+// input. ok is false if path resolves to a non-boolean value.
+func resolveBooleanOperand(static *bool, path *string, input map[string]any) (want, ok bool, err error) {
+	if static != nil {
+		return *static, true, nil
+	}
+
+	resolved, err := resolveJSONPath(input, *path)
+	if err != nil {
+		return false, false, fmt.Errorf("resolve comparator path %q: %w", *path, err)
+	}
+
+	b, isBool := resolved.(bool)
+
+	return b, isBool, nil
+}
+
+// evaluateTimestampComparison evaluates the Timestamp* comparators,
+// including their "*Path" variants. handled is false if rule sets none of
+// them.
+func evaluateTimestampComparison(rule *choiceRule, value any, input map[string]any) (matched, handled bool, err error) {
+	switch {
+	case rule.TimestampEquals != nil || rule.TimestampEqualsPath != nil:
+		return compareTimestampWith(value, rule.TimestampEquals, rule.TimestampEqualsPath, input, func(cmp int) bool { return cmp == 0 })
+	case rule.TimestampLessThan != nil || rule.TimestampLessThanPath != nil:
+		return compareTimestampWith(value, rule.TimestampLessThan, rule.TimestampLessThanPath, input, func(cmp int) bool { return cmp < 0 })
+	case rule.TimestampGreaterThan != nil || rule.TimestampGreaterThanPath != nil:
+		return compareTimestampWith(value, rule.TimestampGreaterThan, rule.TimestampGreaterThanPath, input, func(cmp int) bool { return cmp > 0 })
+	case rule.TimestampLessThanEquals != nil || rule.TimestampLessThanEqualsPath != nil:
+		return compareTimestampWith(value, rule.TimestampLessThanEquals, rule.TimestampLessThanEqualsPath, input, func(cmp int) bool { return cmp <= 0 })
+	case rule.TimestampGreaterThanEquals != nil || rule.TimestampGreaterThanEqualsPath != nil:
+		return compareTimestampWith(value, rule.TimestampGreaterThanEquals, rule.TimestampGreaterThanEqualsPath, input, func(cmp int) bool { return cmp >= 0 })
+	default:
+		return false, false, nil
+	}
+}
+
+// compareTimestampWith resolves a Timestamp* comparator's operand -- from a
+// static value or, for the "*Path" variant, by resolving path against
+// input -- and reports whether value satisfies it per matches. The operand
+// is a string in both cases, so this reuses resolveStringOperand.
+func compareTimestampWith(value any, static, path *string, input map[string]any, matches func(cmp int) bool) (matched, handled bool, err error) {
+	want, ok, err := resolveStringOperand(static, path, input)
+	if err != nil {
+		return false, true, err
+	}
+
+	if !ok {
+		return false, true, nil
+	}
+
+	cmp, ok := timestampCompare(value, want)
+
+	return ok && matches(cmp), true, nil
 }
 
 // stringCompare compares value (expected to be a string) against want,

--- a/internal/service/sfn/choice_test.go
+++ b/internal/service/sfn/choice_test.go
@@ -12,13 +12,17 @@ const (
 	pathValue   = "$.value"
 	pathTS      = "$.ts"
 	pathMissing = "$.missing"
+	pathOther   = "$.other"
+	pathTSOther = "$.tsOther"
 
 	valueFast = "fast"
 	valueSlow = "slow"
 
-	fieldName  = "name"
-	fieldValue = "value"
-	fieldMode  = "mode"
+	fieldName    = "name"
+	fieldValue   = "value"
+	fieldMode    = "mode"
+	fieldOther   = "other"
+	fieldTSOther = "tsOther"
 )
 
 func float64Ptr(v float64) *float64 { return &v }
@@ -145,6 +149,128 @@ var choiceRuleTests = []struct {
 		want:  false,
 	},
 	{
+		name:  "TimestampLessThanEquals equal",
+		rule:  choiceRule{Variable: pathTS, TimestampLessThanEquals: strPtr("2020-01-01T00:00:00Z")},
+		input: map[string]any{"ts": "2020-01-01T00:00:00Z"},
+		want:  true,
+	},
+	{
+		name:  "TimestampGreaterThanEquals equal",
+		rule:  choiceRule{Variable: pathTS, TimestampGreaterThanEquals: strPtr("2020-01-01T00:00:00Z")},
+		input: map[string]any{"ts": "2020-01-01T00:00:00Z"},
+		want:  true,
+	},
+	{
+		name:  "StringEqualsPath match",
+		rule:  choiceRule{Variable: pathMode, StringEqualsPath: strPtr(pathOther)},
+		input: map[string]any{fieldMode: valueFast, fieldOther: valueFast},
+		want:  true,
+	},
+	{
+		name:  "StringEqualsPath no match",
+		rule:  choiceRule{Variable: pathMode, StringEqualsPath: strPtr(pathOther)},
+		input: map[string]any{fieldMode: valueFast, fieldOther: valueSlow},
+		want:  false,
+	},
+	{
+		name:  "StringLessThanPath match",
+		rule:  choiceRule{Variable: pathName, StringLessThanPath: strPtr(pathOther)},
+		input: map[string]any{fieldName: "alice", fieldOther: "m"},
+		want:  true,
+	},
+	{
+		name:  "StringGreaterThanPath match",
+		rule:  choiceRule{Variable: pathName, StringGreaterThanPath: strPtr(pathOther)},
+		input: map[string]any{fieldName: "zeke", fieldOther: "m"},
+		want:  true,
+	},
+	{
+		name:  "StringLessThanEqualsPath equal",
+		rule:  choiceRule{Variable: pathName, StringLessThanEqualsPath: strPtr(pathOther)},
+		input: map[string]any{fieldName: "mode", fieldOther: "mode"},
+		want:  true,
+	},
+	{
+		name:  "StringGreaterThanEqualsPath equal",
+		rule:  choiceRule{Variable: pathName, StringGreaterThanEqualsPath: strPtr(pathOther)},
+		input: map[string]any{fieldName: "mode", fieldOther: "mode"},
+		want:  true,
+	},
+	{
+		// Mirrors the ASL spec's own worked example: {"Variable": "$.rating",
+		// "NumericGreaterThanPath": "$.auditThreshold"}.
+		name:  "NumericGreaterThanPath match",
+		rule:  choiceRule{Variable: "$.rating", NumericGreaterThanPath: strPtr("$.auditThreshold")},
+		input: map[string]any{"rating": float64(30), "auditThreshold": float64(20)},
+		want:  true,
+	},
+	{
+		name:  "NumericEqualsPath no match",
+		rule:  choiceRule{Variable: pathValue, NumericEqualsPath: strPtr(pathOther)},
+		input: map[string]any{fieldValue: float64(20), fieldOther: float64(21)},
+		want:  false,
+	},
+	{
+		name:  "NumericLessThanPath match",
+		rule:  choiceRule{Variable: pathValue, NumericLessThanPath: strPtr(pathOther)},
+		input: map[string]any{fieldValue: float64(20), fieldOther: float64(30)},
+		want:  true,
+	},
+	{
+		name:  "NumericGreaterThanEqualsPath equal",
+		rule:  choiceRule{Variable: pathValue, NumericGreaterThanEqualsPath: strPtr(pathOther)},
+		input: map[string]any{fieldValue: float64(20), fieldOther: float64(20)},
+		want:  true,
+	},
+	{
+		name:  "NumericLessThanEqualsPath equal",
+		rule:  choiceRule{Variable: pathValue, NumericLessThanEqualsPath: strPtr(pathOther)},
+		input: map[string]any{fieldValue: float64(20), fieldOther: float64(20)},
+		want:  true,
+	},
+	{
+		name:  "BooleanEqualsPath match",
+		rule:  choiceRule{Variable: "$.enabled", BooleanEqualsPath: strPtr(pathOther)},
+		input: map[string]any{"enabled": true, fieldOther: true},
+		want:  true,
+	},
+	{
+		name:  "BooleanEqualsPath type mismatch does not match",
+		rule:  choiceRule{Variable: "$.enabled", BooleanEqualsPath: strPtr(pathOther)},
+		input: map[string]any{"enabled": true, fieldOther: "not-a-bool"},
+		want:  false,
+	},
+	{
+		name:  "TimestampEqualsPath match",
+		rule:  choiceRule{Variable: pathTS, TimestampEqualsPath: strPtr(pathTSOther)},
+		input: map[string]any{"ts": "2020-01-01T00:00:00Z", fieldTSOther: "2020-01-01T00:00:00Z"},
+		want:  true,
+	},
+	{
+		name:  "TimestampLessThanPath match",
+		rule:  choiceRule{Variable: pathTS, TimestampLessThanPath: strPtr(pathTSOther)},
+		input: map[string]any{"ts": "2020-01-01T00:00:00Z", fieldTSOther: "2020-06-01T00:00:00Z"},
+		want:  true,
+	},
+	{
+		name:  "TimestampGreaterThanPath match",
+		rule:  choiceRule{Variable: pathTS, TimestampGreaterThanPath: strPtr(pathTSOther)},
+		input: map[string]any{"ts": "2020-06-01T00:00:00Z", fieldTSOther: "2020-01-01T00:00:00Z"},
+		want:  true,
+	},
+	{
+		name:  "TimestampLessThanEqualsPath equal",
+		rule:  choiceRule{Variable: pathTS, TimestampLessThanEqualsPath: strPtr(pathTSOther)},
+		input: map[string]any{"ts": "2020-01-01T00:00:00Z", fieldTSOther: "2020-01-01T00:00:00Z"},
+		want:  true,
+	},
+	{
+		name:  "TimestampGreaterThanEqualsPath equal",
+		rule:  choiceRule{Variable: pathTS, TimestampGreaterThanEqualsPath: strPtr(pathTSOther)},
+		input: map[string]any{"ts": "2020-01-01T00:00:00Z", fieldTSOther: "2020-01-01T00:00:00Z"},
+		want:  true,
+	},
+	{
 		name:  "IsPresent true for present field",
 		rule:  choiceRule{Variable: pathMode, IsPresent: boolPtr(true)},
 		input: map[string]any{fieldMode: valueFast},
@@ -243,6 +369,20 @@ func TestEvaluateChoiceRuleMissingVariableErrors(t *testing.T) {
 	_, err := evaluateChoiceRule(&rule, map[string]any{fieldMode: valueFast})
 	if err == nil {
 		t.Fatal("evaluateChoiceRule: want error for unresolvable Variable, got nil")
+	}
+}
+
+func TestEvaluateChoiceRulePathComparatorUnresolvableOperandErrors(t *testing.T) {
+	t.Parallel()
+
+	// The "*Path" comparator's own Path -- as opposed to Variable -- fails
+	// to resolve here, which must also surface as an error rather than a
+	// silent non-match.
+	rule := choiceRule{Variable: pathMode, StringEqualsPath: strPtr(pathMissing)}
+
+	_, err := evaluateChoiceRule(&rule, map[string]any{fieldMode: valueFast})
+	if err == nil {
+		t.Fatal("evaluateChoiceRule: want error for unresolvable *Path comparator operand, got nil")
 	}
 }
 
@@ -367,5 +507,46 @@ func TestChoiceStateIsPresentGuardsMissingField(t *testing.T) {
 
 	if exec.Output != `{"picked":"no-mode"}` {
 		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"picked":"no-mode"}`)
+	}
+}
+
+// TestChoiceStateNumericGreaterThanPathComparesTwoInputFields mirrors the
+// ASL spec's own worked example of a "*Path" comparator: {"Variable":
+// "$.rating", "NumericGreaterThanPath": "$.auditThreshold"} compares two
+// fields of the same input against each other, rather than a field against
+// a static literal.
+func TestChoiceStateNumericGreaterThanPathComparesTwoInputFields(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Decide",
+		"States": {
+			"Decide": {
+				"Type": "Choice",
+				"Choices": [{
+					"Variable": "$.rating",
+					"NumericGreaterThanPath": "$.auditThreshold",
+					"Next": "StartAudit"
+				}],
+				"Default": "NoAudit"
+			},
+			"StartAudit": {"Type": "Pass", "Result": {"decision": "audit"}, "End": true},
+			"NoAudit": {"Type": "Pass", "Result": {"decision": "none"}, "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "choice-numeric-greater-than-path", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"rating":90,"auditThreshold":80}`)
+
+	if exec.Output != `{"decision":"audit"}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"decision":"audit"}`)
+	}
+
+	exec = startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"rating":50,"auditThreshold":80}`)
+
+	if exec.Output != `{"decision":"none"}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"decision":"none"}`)
 	}
 }

--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -46,10 +46,22 @@ type stateDefinition struct {
 	Next       string         `json:"Next"`
 	End        bool           `json:"End"`
 	Result     any            `json:"Result"`
-	ResultPath *string        `json:"ResultPath"`
-	InputPath  *string        `json:"InputPath"`
-	OutputPath *string        `json:"OutputPath"`
 	Comment    string         `json:"Comment"`
+
+	// ResultSelector, ResultPath, InputPath, and OutputPath are the
+	// remaining fields of the standard data-flow pipeline (see iodata.go).
+	// ResultPath, InputPath, and OutputPath are left as raw JSON so an
+	// explicit "null" (which, per the ASL spec, discards data) can be told
+	// apart from the field being absent (which defaults to "$", no
+	// filtering/replacement); both would otherwise unmarshal to the same
+	// value through a plain *string. Per the spec's per-state field table,
+	// not every state type honors every field -- see resolveEffectiveInput,
+	// runRetryCatchResultPipeline in retry.go, and validateStateFields in
+	// validate.go for which types actually apply which fields.
+	ResultSelector map[string]any  `json:"ResultSelector"`
+	ResultPath     json.RawMessage `json:"ResultPath"`
+	InputPath      json.RawMessage `json:"InputPath"`
+	OutputPath     json.RawMessage `json:"OutputPath"`
 
 	// Choice state fields.
 	Choices []choiceRule `json:"Choices"`
@@ -298,7 +310,7 @@ func (e *executionEngine) execute(ctx context.Context, def *stateMachineDefiniti
 func (e *executionEngine) executeState(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
 	switch state.Type {
 	case "Pass":
-		output, err := e.executePassState(state, input)
+		output, err := e.executePassState(name, state, input)
 
 		return output, "", err
 	case "Task":
@@ -324,70 +336,127 @@ func (e *executionEngine) executeState(ctx context.Context, name string, state *
 	}
 }
 
-// executeTaskStateWithPolicy executes a Task state's underlying work,
-// applying its Retry and Catch policy. Each attempt (initial or retried) is
-// individually bounded by the state's TimeoutSeconds/TimeoutSecondsPath; see
-// executeTaskStateWithTimeout in timeout.go.
+// executeTaskStateWithPolicy executes a Task state's full standard field
+// pipeline: InputPath narrows the raw input to the effective input, Retry
+// and Catch govern the work itself (each attempt individually bounded by
+// TimeoutSeconds/TimeoutSecondsPath; see executeTaskStateWithTimeout in
+// timeout.go), and on success ResultSelector/ResultPath/OutputPath shape
+// the effective output. Parameters is resolved inside executeTaskState,
+// against the effective input, since its resolved value doubles as the
+// resource invocation's request payload rather than a generic JSON blob.
 func (e *executionEngine) executeTaskStateWithPolicy(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
-	return e.runWithRetryCatch(ctx, name, state, input, func(ctx context.Context) (string, error) {
-		return e.executeTaskStateWithTimeout(ctx, name, state, input)
+	effectiveInput, err := applyInputPath(state.InputPath, input)
+	if err != nil {
+		return "", "", fmt.Errorf("state %q: %w", name, err)
+	}
+
+	return e.runRetryCatchResultPipeline(ctx, name, state, input, effectiveInput, func(ctx context.Context) (string, error) {
+		return e.executeTaskStateWithTimeout(ctx, name, state, effectiveInput)
 	})
 }
 
-// executePassState executes a Pass state.
-func (e *executionEngine) executePassState(state *stateDefinition, input string) (string, error) {
-	if state.Result != nil {
-		result, err := json.Marshal(state.Result)
-		if err != nil {
-			return "", fmt.Errorf("marshal pass result: %w", err)
-		}
-
-		return string(result), nil
+// executePassState executes a Pass state's full standard field pipeline:
+// InputPath and Parameters build the effective input, Result (if present)
+// -- else the effective input itself -- is the state's result, and
+// ResultPath/OutputPath shape the effective output. Pass has no
+// ResultSelector; see the spec's per-state field table.
+func (e *executionEngine) executePassState(name string, state *stateDefinition, input string) (string, error) {
+	effectiveInput, err := resolveEffectiveInput(state.InputPath, state.Parameters, input)
+	if err != nil {
+		return "", fmt.Errorf("pass state %q: %w", name, err)
 	}
 
-	return input, nil
+	result := effectiveInput
+
+	if state.Result != nil {
+		marshaled, err := json.Marshal(state.Result)
+		if err != nil {
+			return "", fmt.Errorf("pass state %q: marshal Result: %w", name, err)
+		}
+
+		result = string(marshaled)
+	}
+
+	merged, err := applyResultPath(state.ResultPath, effectiveInput, result)
+	if err != nil {
+		return "", fmt.Errorf("pass state %q: %w", name, err)
+	}
+
+	output, err := applyOutputPath(state.OutputPath, merged)
+	if err != nil {
+		return "", fmt.Errorf("pass state %q: %w", name, err)
+	}
+
+	return output, nil
 }
 
-// executeChoiceState executes a Choice state. It evaluates each Choice Rule
-// in order and transitions to the first match's Next state, falling back to
-// Default. The output is always the unmodified input.
+// executeChoiceState executes a Choice state: InputPath narrows the raw
+// input to the effective input, which the Choice Rules -- including the
+// "*Path" comparators (see choice.go) -- are evaluated against; the first
+// matching rule's Next is chosen, falling back to Default. Choice has no
+// Parameters/ResultSelector/ResultPath (it produces no result of its own),
+// so the state output is simply the effective input, narrowed by
+// OutputPath.
 func (e *executionEngine) executeChoiceState(name string, state *stateDefinition, input string) (string, string, error) {
+	effectiveInput, err := applyInputPath(state.InputPath, input)
+	if err != nil {
+		return "", "", fmt.Errorf("choice state %q: %w", name, err)
+	}
+
 	var inputData map[string]any
-	if err := json.Unmarshal([]byte(input), &inputData); err != nil {
+	if err := json.Unmarshal([]byte(effectiveInput), &inputData); err != nil {
 		return "", "", fmt.Errorf("choice state %q: parse input: %w", name, err)
 	}
 
+	next, err := chooseNextState(name, state, inputData)
+	if err != nil {
+		return "", "", err
+	}
+
+	output, err := applyOutputPath(state.OutputPath, effectiveInput)
+	if err != nil {
+		return "", "", fmt.Errorf("choice state %q: %w", name, err)
+	}
+
+	return output, next, nil
+}
+
+// chooseNextState scans a Choice state's Choices in order for the first
+// matching rule's Next, falling back to Default, or reporting
+// noChoiceMatchedError if neither exists.
+func chooseNextState(name string, state *stateDefinition, inputData map[string]any) (string, error) {
 	for i := range state.Choices {
 		matched, err := evaluateChoiceRule(&state.Choices[i], inputData)
 		if err != nil {
-			return "", "", fmt.Errorf("choice state %q: %w", name, err)
+			return "", fmt.Errorf("choice state %q: %w", name, err)
 		}
 
 		if matched {
 			if state.Choices[i].Next == "" {
-				return "", "", fmt.Errorf("choice state %q: matched rule has no Next", name)
+				return "", fmt.Errorf("choice state %q: matched rule has no Next", name)
 			}
 
-			return input, state.Choices[i].Next, nil
+			return state.Choices[i].Next, nil
 		}
 	}
 
 	if state.Default == "" {
-		return "", "", &noChoiceMatchedError{state: name}
+		return "", &noChoiceMatchedError{state: name}
 	}
 
-	return input, state.Default, nil
+	return state.Default, nil
 }
 
 // executeSucceedState executes a Succeed state, narrowing the output through
-// InputPath/OutputPath if present.
+// InputPath/OutputPath if present. Succeed has neither Parameters, Result,
+// nor ResultPath: its output is always its (possibly filtered) input.
 func (e *executionEngine) executeSucceedState(state *stateDefinition, input string) (string, error) {
-	narrowed, err := applyPath(state.InputPath, input)
+	narrowed, err := applyInputPath(state.InputPath, input)
 	if err != nil {
 		return "", fmt.Errorf("succeed state: %w", err)
 	}
 
-	output, err := applyPath(state.OutputPath, narrowed)
+	output, err := applyOutputPath(state.OutputPath, narrowed)
 	if err != nil {
 		return "", fmt.Errorf("succeed state: %w", err)
 	}
@@ -396,34 +465,10 @@ func (e *executionEngine) executeSucceedState(state *stateDefinition, input stri
 }
 
 // executeFailState executes a Fail state, always returning a failStateError
-// carrying the state's declared Error and Cause.
+// carrying the state's declared Error and Cause. Fail has neither
+// InputPath, OutputPath, nor any other data-flow field.
 func (e *executionEngine) executeFailState(state *stateDefinition) error {
 	return &failStateError{errorName: state.Error, cause: state.Cause}
-}
-
-// applyPath narrows a JSON value using a JSONPath (InputPath/OutputPath). A
-// nil path returns data unchanged.
-func applyPath(path *string, data string) (string, error) {
-	if path == nil {
-		return data, nil
-	}
-
-	var parsed map[string]any
-	if err := json.Unmarshal([]byte(data), &parsed); err != nil {
-		return "", fmt.Errorf("parse data for path %q: %w", *path, err)
-	}
-
-	resolved, err := resolveJSONPath(parsed, *path)
-	if err != nil {
-		return "", fmt.Errorf("resolve path %q: %w", *path, err)
-	}
-
-	out, err := json.Marshal(resolved)
-	if err != nil {
-		return "", fmt.Errorf("marshal path %q result: %w", *path, err)
-	}
-
-	return string(out), nil
 }
 
 // executeTaskState executes a Task state by calling the appropriate service.
@@ -477,7 +522,10 @@ func resolveParametersWithContext(params map[string]any, input string, contextDa
 	}
 
 	// inputData is parsed lazily on the first JSONPath reference and reused.
-	var inputData map[string]any
+	// It is typed any, not map[string]any, since a Payload Template's input
+	// is not always a JSON object -- ResultSelector, in particular, resolves
+	// against a Parallel/Map state's result, which is a JSON array.
+	var inputData any
 
 	resolved := make(map[string]any, len(params))
 
@@ -509,9 +557,12 @@ func resolveParametersWithContext(params map[string]any, input string, contextDa
 // resolveJSONPathRef resolves a "key.$" JSONPath reference against the
 // input, or, for a "$$."-prefixed path, against contextData. inputData is
 // the lazily-parsed input (nil until first use); the possibly newly parsed
-// map is returned so the caller can reuse it for later references, keeping
-// the input JSON unmarshaled at most once per resolveParameters call.
-func resolveJSONPathRef(key string, value any, input string, inputData, contextData map[string]any) (any, map[string]any, error) {
+// value is returned so the caller can reuse it for later references,
+// keeping the input JSON unmarshaled at most once per resolveParameters
+// call. inputData -- and therefore the path resolution against it -- uses
+// resolveAnyJSONPath rather than resolveJSONPath, since the input is not
+// always a JSON object (see resolveParametersWithContext).
+func resolveJSONPathRef(key string, value any, input string, inputData any, contextData map[string]any) (any, any, error) {
 	pathStr, ok := value.(string)
 	if !ok {
 		return nil, inputData, fmt.Errorf("jsonPath reference for key %q must be a string", key)
@@ -536,7 +587,7 @@ func resolveJSONPathRef(key string, value any, input string, inputData, contextD
 		}
 	}
 
-	resolvedValue, err := resolveJSONPath(inputData, pathStr)
+	resolvedValue, err := resolveAnyJSONPath(pathStr, inputData)
 	if err != nil {
 		return nil, inputData, fmt.Errorf("resolve JSONPath %q for key %q: %w", pathStr, key, err)
 	}

--- a/internal/service/sfn/iodata.go
+++ b/internal/service/sfn/iodata.go
@@ -1,0 +1,245 @@
+package sfn
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// This file implements the Amazon States Language's standard data-flow
+// field pipeline (InputPath, Parameters, ResultSelector, ResultPath,
+// OutputPath), shared by every state type per
+// https://states-language.net/spec.html#filters:
+//
+//   - "raw input" is the JSON text a state receives.
+//   - "effective input" is the raw input after InputPath (and, on the state
+//     types that support it, Parameters).
+//   - "result" is whatever the state's own work produces (a Task response,
+//     a Parallel/Map branch-output array, a Pass state's Result-or-input).
+//   - "effective result" is the result after ResultSelector.
+//   - "effective output" is the effective result merged into the effective
+//     input per ResultPath, then narrowed by OutputPath.
+//
+// A state that fails to apply one of these fields (a ResultPath that
+// cannot address its base, an OutputPath that matches nothing, malformed
+// JSON) reports a plain error, which executionErrorCode surfaces as
+// States.Runtime: per AWS's own documentation, States.Runtime is "often
+// caused by errors at runtime, such as attempting to apply InputPath or
+// OutputPath on a null JSON payload," is not retriable, and is never
+// matched by Retry/Catch (including the States.ALL wildcard) -- see
+// errorNameMatches in retry.go.
+
+// parsePathField interprets a JSONPath-valued field (InputPath, OutputPath,
+// ResultPath, or a Catcher's ResultPath) decoded as raw JSON so that an
+// explicit "null" -- which per the spec discards the raw input/result --
+// can be told apart from the field being absent from the definition, which
+// defaults to "$" (no filtering or replacement); both would otherwise
+// unmarshal to the same value through a plain *string.
+func parsePathField(raw json.RawMessage) (path string, isNull bool, err error) {
+	if len(raw) == 0 {
+		return "$", false, nil
+	}
+
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false, fmt.Errorf("parse path: %w", err)
+	}
+
+	if value == nil {
+		return "", true, nil
+	}
+
+	path, ok := value.(string)
+	if !ok {
+		return "", false, fmt.Errorf("path must be a string or null")
+	}
+
+	return path, false, nil
+}
+
+// applyInputPath narrows a state's raw input per InputPath (default "$",
+// meaning unchanged). An explicit null InputPath discards the raw input
+// entirely, yielding an empty JSON object as the effective input.
+func applyInputPath(raw json.RawMessage, rawInput string) (string, error) {
+	out, err := applyPathField(raw, rawInput)
+	if err != nil {
+		return "", fmt.Errorf("inputPath: %w", err)
+	}
+
+	return out, nil
+}
+
+// applyOutputPath narrows a state's output per OutputPath (default "$",
+// meaning unchanged). An explicit null OutputPath discards both the input
+// and result that produced it, yielding an empty JSON object.
+func applyOutputPath(raw json.RawMessage, output string) (string, error) {
+	out, err := applyPathField(raw, output)
+	if err != nil {
+		return "", fmt.Errorf("outputPath: %w", err)
+	}
+
+	return out, nil
+}
+
+// applyPathField implements the InputPath/OutputPath semantics shared by
+// both fields: null discards the data (yielding "{}"), "$" (the default)
+// leaves it unchanged, and any other Path narrows it via resolveAnyJSONPath.
+func applyPathField(raw json.RawMessage, data string) (string, error) {
+	path, isNull, err := parsePathField(raw)
+	if err != nil {
+		return "", err
+	}
+
+	if isNull {
+		return "{}", nil
+	}
+
+	if path == "$" {
+		return data, nil
+	}
+
+	var parsed any
+	if err := json.Unmarshal([]byte(data), &parsed); err != nil {
+		return "", fmt.Errorf("parse data for path %q: %w", path, err)
+	}
+
+	resolved, err := resolveAnyJSONPath(path, parsed)
+	if err != nil {
+		return "", fmt.Errorf("resolve path %q: %w", path, err)
+	}
+
+	out, err := json.Marshal(resolved)
+	if err != nil {
+		return "", fmt.Errorf("marshal path %q result: %w", path, err)
+	}
+
+	return string(out), nil
+}
+
+// resolveEffectiveInput computes a state's effective input: InputPath
+// applied to the raw input, then -- on the state types where Parameters
+// means "the Payload Template that becomes the effective input" (Task,
+// Parallel, Pass; Map's "Parameters" is instead the deprecated alias for
+// ItemSelector, so callers for Map must not use this helper) -- Parameters
+// resolved against that filtered input.
+func resolveEffectiveInput(inputPath json.RawMessage, parameters map[string]any, rawInput string) (string, error) {
+	filtered, err := applyInputPath(inputPath, rawInput)
+	if err != nil {
+		return "", err
+	}
+
+	if parameters == nil {
+		return filtered, nil
+	}
+
+	resolved, err := resolveParameters(parameters, filtered)
+	if err != nil {
+		return "", fmt.Errorf("parameters: %w", err)
+	}
+
+	out, err := json.Marshal(resolved)
+	if err != nil {
+		return "", fmt.Errorf("parameters: marshal effective input: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// applyResultSelector transforms a state's result per ResultSelector, a
+// Payload Template resolved the same way as Parameters -- static values, or
+// "$."-prefixed JSONPath references, except resolved against the result
+// itself rather than the state's input. A nil ResultSelector leaves the
+// result unchanged, per its spec default of "no effect".
+func applyResultSelector(selector map[string]any, result string) (string, error) {
+	if selector == nil {
+		return result, nil
+	}
+
+	resolved, err := resolveParameters(selector, result)
+	if err != nil {
+		return "", fmt.Errorf("resultSelector: %w", err)
+	}
+
+	out, err := json.Marshal(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resultSelector: marshal result: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// applyResultPath merges a state's effective result into its effective
+// input per ResultPath (default "$", meaning the result replaces the input
+// entirely). An explicit null ResultPath discards the result, passing the
+// effective input through unchanged. Any other Reference Path injects the
+// result at that location, relative to the effective input, creating
+// intermediate objects as needed.
+func applyResultPath(raw json.RawMessage, effectiveInput, result string) (string, error) {
+	path, isNull, err := parsePathField(raw)
+	if err != nil {
+		return "", fmt.Errorf("resultPath: %w", err)
+	}
+
+	if isNull {
+		return effectiveInput, nil
+	}
+
+	if path == "$" {
+		return result, nil
+	}
+
+	out, err := injectResultPath(path, effectiveInput, result)
+	if err != nil {
+		return "", fmt.Errorf("resultPath: %w", err)
+	}
+
+	return out, nil
+}
+
+// injectResultPath injects a JSON-encoded result into base at an
+// arbitrary-depth "$.a.b.c" Reference Path, creating intermediate objects
+// as needed and overwriting whatever was already at that location -- see
+// the spec's "Input and Output Processing" section's worked example of
+// "$.master.result.sum" building a chain of new fields.
+func injectResultPath(path, base, result string) (string, error) {
+	field, ok := strings.CutPrefix(path, "$.")
+	if !ok || field == "" {
+		return "", fmt.Errorf("unsupported path %q: must be \"$\" or \"$.field[.field...]\"", path)
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal([]byte(base), &root); err != nil {
+		return "", fmt.Errorf("path %q requires an object base: %w", path, err)
+	}
+
+	if root == nil {
+		root = map[string]any{}
+	}
+
+	var resultValue any
+	if err := json.Unmarshal([]byte(result), &resultValue); err != nil {
+		return "", fmt.Errorf("path %q: parse result: %w", path, err)
+	}
+
+	parts := strings.Split(field, ".")
+
+	current := root
+	for _, part := range parts[:len(parts)-1] {
+		next, ok := current[part].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			current[part] = next
+		}
+
+		current = next
+	}
+
+	current[parts[len(parts)-1]] = resultValue
+
+	out, err := json.Marshal(root)
+	if err != nil {
+		return "", fmt.Errorf("path %q: marshal result: %w", path, err)
+	}
+
+	return string(out), nil
+}

--- a/internal/service/sfn/iodata_test.go
+++ b/internal/service/sfn/iodata_test.go
@@ -1,0 +1,319 @@
+package sfn
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestParsePathField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        json.RawMessage
+		wantPath   string
+		wantIsNull bool
+		wantErr    bool
+	}{
+		{name: "absent defaults to $", raw: nil, wantPath: "$", wantIsNull: false},
+		{name: "explicit null", raw: json.RawMessage(`null`), wantIsNull: true},
+		{name: "string path", raw: json.RawMessage(`"$.a.b"`), wantPath: "$.a.b"},
+		{name: "non-string value errors", raw: json.RawMessage(`42`), wantErr: true},
+		{name: "malformed JSON errors", raw: json.RawMessage(`{not json`), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path, isNull, err := parsePathField(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parsePathField: want error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parsePathField: %v", err)
+			}
+
+			if isNull != tt.wantIsNull {
+				t.Fatalf("isNull: got %v, want %v", isNull, tt.wantIsNull)
+			}
+
+			if !isNull && path != tt.wantPath {
+				t.Fatalf("path: got %q, want %q", path, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestApplyInputPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     json.RawMessage
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "absent leaves input unchanged", raw: nil, input: `{"a":1}`, want: `{"a":1}`},
+		{name: "explicit $ leaves input unchanged", raw: json.RawMessage(`"$"`), input: `{"a":1}`, want: `{"a":1}`},
+		{name: "explicit null discards input", raw: json.RawMessage(`null`), input: `{"a":1}`, want: `{}`},
+		{name: "single-level field", raw: json.RawMessage(`"$.a"`), input: `{"a":{"b":1}}`, want: `{"b":1}`},
+		{name: "arbitrary depth field", raw: json.RawMessage(`"$.a.b.c"`), input: `{"a":{"b":{"c":42}}}`, want: `42`},
+		{name: "missing field errors", raw: json.RawMessage(`"$.missing"`), input: `{"a":1}`, wantErr: true},
+		{name: "field access on non-object errors", raw: json.RawMessage(`"$.a.b"`), input: `{"a":"not-an-object"}`, wantErr: true},
+		{name: "malformed input passes through unchanged when path is absent", raw: nil, input: `{not json`, want: `{not json`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := applyInputPath(tt.raw, tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("applyInputPath: want error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("applyInputPath: %v", err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("applyInputPath: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyInputPathMalformedInputWithPathErrors(t *testing.T) {
+	t.Parallel()
+
+	// Unlike the "$"-default case (which returns malformed input verbatim,
+	// since nothing needs to be parsed), a non-"$" path requires parsing the
+	// input and must fail cleanly on malformed JSON.
+	_, err := applyInputPath(json.RawMessage(`"$.a"`), `{not json`)
+	if err == nil {
+		t.Fatal("applyInputPath: want error for malformed input, got nil")
+	}
+}
+
+func TestApplyOutputPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     json.RawMessage
+		output  string
+		want    string
+		wantErr bool
+	}{
+		{name: "absent leaves output unchanged", raw: nil, output: `{"a":1}`, want: `{"a":1}`},
+		{name: "explicit null discards output", raw: json.RawMessage(`null`), output: `{"a":1}`, want: `{}`},
+		{name: "narrows to a field", raw: json.RawMessage(`"$.a"`), output: `{"a":{"b":2}}`, want: `{"b":2}`},
+		{name: "path matching nothing errors", raw: json.RawMessage(`"$.missing"`), output: `{"a":1}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := applyOutputPath(tt.raw, tt.output)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("applyOutputPath: want error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("applyOutputPath: %v", err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("applyOutputPath: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyResultSelector(t *testing.T) {
+	t.Parallel()
+
+	// A nil selector has no effect: the result passes through unchanged.
+	got, err := applyResultSelector(nil, `{"status":"ok"}`)
+	if err != nil {
+		t.Fatalf("applyResultSelector: %v", err)
+	}
+
+	if got != `{"status":"ok"}` {
+		t.Fatalf("applyResultSelector with nil selector: got %q, want unchanged result", got)
+	}
+
+	// A selector resolves ".$" references against the result, not the
+	// state's input.
+	selector := map[string]any{
+		"status.$": "$.status",
+		"fixed":    "value",
+	}
+
+	got, err = applyResultSelector(selector, `{"status":"ok","ignored":true}`)
+	if err != nil {
+		t.Fatalf("applyResultSelector: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+		t.Fatalf("unmarshal applyResultSelector output %q: %v", got, err)
+	}
+
+	if decoded["status"] != "ok" || decoded["fixed"] != "value" {
+		t.Fatalf("applyResultSelector output: got %v, want status=ok fixed=value", decoded)
+	}
+
+	if _, ok := decoded["ignored"]; ok {
+		t.Fatalf("applyResultSelector output %v: must not carry fields the selector did not select", decoded)
+	}
+}
+
+// applyResultPathTests exercises applyResultPath's null/"$"/arbitrary-depth
+// semantics. Kept as a package-level var, mirroring choiceRuleTests in
+// choice_test.go, so the driving test function itself stays short.
+var applyResultPathTests = []struct {
+	name           string
+	raw            json.RawMessage
+	effectiveInput string
+	result         string
+	want           string
+	wantErr        bool
+}{
+	{
+		name: "absent defaults to $ replaces input entirely",
+		raw:  nil, effectiveInput: `{"a":1}`, result: `{"sum":7}`,
+		want: `{"sum":7}`,
+	},
+	{
+		name: "explicit null discards result, keeps effective input",
+		raw:  json.RawMessage(`null`), effectiveInput: `{"a":1}`, result: `{"sum":7}`,
+		want: `{"a":1}`,
+	},
+	{
+		name: "single-level path merges into input",
+		raw:  json.RawMessage(`"$.sum"`), effectiveInput: `{"a":1}`, result: `7`,
+		want: `{"a":1,"sum":7}`,
+	},
+	{
+		name: "arbitrary depth path creates intermediate objects",
+		raw:  json.RawMessage(`"$.master.result.sum"`), effectiveInput: `{"master":{"detail":[1,2,3]}}`, result: `6`,
+		want: `{"master":{"detail":[1,2,3],"result":{"sum":6}}}`,
+	},
+	{
+		name: "path overwrites an existing field",
+		raw:  json.RawMessage(`"$.master.detail"`), effectiveInput: `{"master":{"detail":[1,2,3]}}`, result: `6`,
+		want: `{"master":{"detail":6}}`,
+	},
+	{
+		name: "non-object base fails to apply",
+		raw:  json.RawMessage(`"$.x"`), effectiveInput: `"foo"`, result: `"bar"`,
+		wantErr: true,
+	},
+	{
+		name: "path without leading $. errors",
+		raw:  json.RawMessage(`"foo"`), effectiveInput: `{}`, result: `1`,
+		wantErr: true,
+	},
+}
+
+func TestApplyResultPath(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range applyResultPathTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := applyResultPath(tt.raw, tt.effectiveInput, tt.result)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("applyResultPath: want error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("applyResultPath: %v", err)
+			}
+
+			assertJSONEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestResolveEffectiveInput(t *testing.T) {
+	t.Parallel()
+
+	// With neither InputPath nor Parameters set, the effective input is the
+	// raw input unchanged.
+	got, err := resolveEffectiveInput(nil, nil, `{"a":1}`)
+	if err != nil {
+		t.Fatalf("resolveEffectiveInput: %v", err)
+	}
+
+	if got != `{"a":1}` {
+		t.Fatalf("resolveEffectiveInput with neither field: got %q, want unchanged input", got)
+	}
+
+	// InputPath narrows the raw input before Parameters resolves against
+	// that narrowed value.
+	got, err = resolveEffectiveInput(
+		json.RawMessage(`"$.numbers"`),
+		map[string]any{"total.$": "$.val1"},
+		`{"numbers":{"val1":3,"val2":4}}`,
+	)
+	if err != nil {
+		t.Fatalf("resolveEffectiveInput: %v", err)
+	}
+
+	assertJSONEqual(t, got, `{"total":3}`)
+}
+
+// assertJSONEqual fails the test unless got and want decode to
+// deep-equal JSON values, so tests are not sensitive to key ordering
+// (encoding/json's map marshaling order is not guaranteed to match a
+// hand-written literal).
+func assertJSONEqual(t *testing.T, got, want string) {
+	t.Helper()
+
+	var gotVal, wantVal any
+	if err := json.Unmarshal([]byte(got), &gotVal); err != nil {
+		t.Fatalf("unmarshal got %q: %v", got, err)
+	}
+
+	if err := json.Unmarshal([]byte(want), &wantVal); err != nil {
+		t.Fatalf("unmarshal want %q: %v", want, err)
+	}
+
+	gotNorm, err := json.Marshal(gotVal)
+	if err != nil {
+		t.Fatalf("marshal got: %v", err)
+	}
+
+	wantNorm, err := json.Marshal(wantVal)
+	if err != nil {
+		t.Fatalf("marshal want: %v", err)
+	}
+
+	if !bytes.Equal(gotNorm, wantNorm) {
+		t.Fatalf("JSON mismatch: got %s, want %s", got, want)
+	}
+}

--- a/internal/service/sfn/mapstate.go
+++ b/internal/service/sfn/mapstate.go
@@ -21,11 +21,22 @@ const (
 	mapProcessorModeDistributed = "DISTRIBUTED"
 )
 
-// executeMapStateWithPolicy executes a Map state's item processing,
-// applying its Retry and Catch policy.
+// executeMapStateWithPolicy executes a Map state's full standard field
+// pipeline: InputPath builds the effective input that ItemsPath resolves
+// the Items Array against (Map's own "Parameters" field, when present, is
+// the deprecated alias for ItemSelector rather than the standard
+// effective-input Payload Template, so it is deliberately not folded in
+// here -- see resolveEffectiveInput), Retry and Catch govern item
+// processing as a whole, and on success ResultSelector/ResultPath/
+// OutputPath shape the effective output.
 func (e *executionEngine) executeMapStateWithPolicy(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
-	return e.runWithRetryCatch(ctx, name, state, input, func(ctx context.Context) (string, error) {
-		return e.executeMapState(ctx, name, state, input)
+	effectiveInput, err := applyInputPath(state.InputPath, input)
+	if err != nil {
+		return "", "", fmt.Errorf("map state %q: %w", name, err)
+	}
+
+	return e.runRetryCatchResultPipeline(ctx, name, state, input, effectiveInput, func(ctx context.Context) (string, error) {
+		return e.executeMapState(ctx, name, state, effectiveInput)
 	})
 }
 

--- a/internal/service/sfn/parallel.go
+++ b/internal/service/sfn/parallel.go
@@ -7,11 +7,19 @@ import (
 	"sync"
 )
 
-// executeParallelStateWithPolicy executes a Parallel state's Branches,
-// applying its Retry and Catch policy.
+// executeParallelStateWithPolicy executes a Parallel state's full standard
+// field pipeline: InputPath and Parameters build the effective input fed to
+// every Branch's StartAt state, Retry and Catch govern the branches as a
+// whole, and on success ResultSelector/ResultPath/OutputPath shape the
+// effective output.
 func (e *executionEngine) executeParallelStateWithPolicy(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
-	return e.runWithRetryCatch(ctx, name, state, input, func(ctx context.Context) (string, error) {
-		return e.executeParallelState(ctx, name, state, input)
+	effectiveInput, err := resolveEffectiveInput(state.InputPath, state.Parameters, input)
+	if err != nil {
+		return "", "", fmt.Errorf("state %q: %w", name, err)
+	}
+
+	return e.runRetryCatchResultPipeline(ctx, name, state, input, effectiveInput, func(ctx context.Context) (string, error) {
+		return e.executeParallelState(ctx, name, state, effectiveInput)
 	})
 }
 

--- a/internal/service/sfn/pipeline_test.go
+++ b/internal/service/sfn/pipeline_test.go
@@ -1,0 +1,302 @@
+package sfn
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestTaskStatePipelineAppliesFullDataFlow exercises a Task state's full
+// standard field pipeline end to end: InputPath narrows the raw input
+// before it becomes the Lambda payload, ResultSelector reshapes the Lambda
+// response, ResultPath merges it back into the (InputPath-filtered)
+// effective input, and OutputPath narrows the merged output.
+func TestTaskStatePipelineAppliesFullDataFlow(t *testing.T) {
+	t.Parallel()
+
+	server := newEchoLambdaServer(t)
+
+	definition := fmt.Sprintf(`{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:%s",
+				"InputPath": "$.payload",
+				"ResultSelector": {"echoed.$": "$.greeting"},
+				"ResultPath": "$.result",
+				"OutputPath": "$.result",
+				"End": true
+			}
+		}
+	}`, "echo-fn")
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "task-pipeline", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"payload":{"greeting":"hi"},"noise":"ignore-me"}`)
+
+	if exec.Output != `{"echoed":"hi"}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"echoed":"hi"}`)
+	}
+}
+
+// TestPassStatePipelineAppliesResultAndResultPath mirrors the ASL spec's
+// own worked example: a Pass state's static Result is merged into its
+// input at ResultPath, rather than replacing it outright.
+func TestPassStatePipelineAppliesResultAndResultPath(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "ProvideTestData",
+		"States": {
+			"ProvideTestData": {
+				"Type": "Pass",
+				"Result": {"x-datum": 0.381018, "y-datum": 622.2269926397355},
+				"ResultPath": "$.coords",
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "pass-resultpath", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"georefOf":"Home"}`)
+
+	assertJSONEqual(t, exec.Output, `{"georefOf":"Home","coords":{"x-datum":0.381018,"y-datum":622.2269926397355}}`)
+}
+
+// TestPassStatePipelineDefaultsToPassThrough checks that a Pass state with
+// neither Result nor ResultPath simply copies its input to its output.
+func TestPassStatePipelineDefaultsToPassThrough(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "NoOp",
+		"States": {"NoOp": {"Type": "Pass", "End": true}}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "pass-passthrough", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"a":1}`)
+
+	if exec.Output != `{"a":1}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"a":1}`)
+	}
+}
+
+// TestParallelStatePipelineAppliesResultSelectorAndResultPath checks that a
+// Parallel state's branch-output array passes through ResultSelector
+// (which, per the spec, resolves "$." references against the result, here
+// "$" selecting the whole array) before ResultPath merges it into the
+// state's effective input.
+func TestParallelStatePipelineAppliesResultSelectorAndResultPath(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Fork",
+		"States": {
+			"Fork": {
+				"Type": "Parallel",
+				"Branches": [
+					{"StartAt": "A", "States": {"A": {"Type": "Pass", "Result": {"branch": "a"}, "End": true}}},
+					{"StartAt": "B", "States": {"B": {"Type": "Pass", "Result": {"branch": "b"}, "End": true}}}
+				],
+				"ResultSelector": {"all.$": "$"},
+				"ResultPath": "$.parallelResult",
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "parallel-pipeline", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"seed":1}`)
+
+	assertJSONEqual(t, exec.Output, `{"seed":1,"parallelResult":{"all":[{"branch":"a"},{"branch":"b"}]}}`)
+}
+
+// TestMapStatePipelineAppliesResultSelectorAndResultPath checks the same
+// ResultSelector/ResultPath combination for a Map state, whose ItemsPath
+// resolves against the InputPath-filtered effective input.
+func TestMapStatePipelineAppliesResultSelectorAndResultPath(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemsPath": "$.items",
+				"ItemProcessor": {"StartAt": "Tag", "States": {"Tag": {"Type": "Pass", "Result": {"doubled": true}, "End": true}}},
+				"ResultSelector": {"outputs.$": "$"},
+				"ResultPath": "$.mapResult",
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-pipeline", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"items":[1,2,3]}`)
+
+	assertJSONEqual(t, exec.Output, `{
+		"items": [1, 2, 3],
+		"mapResult": {"outputs": [{"doubled": true}, {"doubled": true}, {"doubled": true}]}
+	}`)
+}
+
+// TestWaitStatePipelineAppliesInputPathAndOutputPath checks that a Wait
+// state resolves its duration against the InputPath-filtered effective
+// input and narrows its (pass-through) output with OutputPath.
+func TestWaitStatePipelineAppliesInputPathAndOutputPath(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "W",
+		"States": {
+			"W": {
+				"Type": "Wait",
+				"InputPath": "$.payload",
+				"Seconds": 0,
+				"OutputPath": "$.value",
+				"Next": "Done"
+			},
+			"Done": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "wait-pipeline", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"payload":{"value":1},"noise":true}`)
+
+	if exec.Output != `1` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `1`)
+	}
+}
+
+// TestChoiceStatePipelineAppliesInputPathAndOutputPath checks that a
+// Choice state's rules are evaluated against the InputPath-filtered
+// effective input, and that OutputPath narrows the (pass-through) output
+// used as the matched Next state's input.
+func TestChoiceStatePipelineAppliesInputPathAndOutputPath(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Decide",
+		"States": {
+			"Decide": {
+				"Type": "Choice",
+				"InputPath": "$.payload",
+				"OutputPath": "$.mode",
+				"Choices": [{"Variable": "$.mode", "StringEquals": "fast", "Next": "Done"}],
+				"Default": "Done"
+			},
+			"Done": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "choice-pipeline", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"payload":{"mode":"fast"},"noise":true}`)
+
+	if exec.Output != `"fast"` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `"fast"`)
+	}
+}
+
+// TestSucceedStateNullInputPathYieldsEmptyObject checks the ASL spec's
+// explicit-null semantics: a null InputPath discards the raw input
+// entirely, yielding an empty JSON object as the effective input/output.
+func TestSucceedStateNullInputPathYieldsEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Done",
+		"States": {
+			"Done": {"Type": "Succeed", "InputPath": null}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "succeed-null-inputpath", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"result":"ok"}`)
+
+	if exec.Output != `{}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{}`)
+	}
+}
+
+// TestTaskResultPathFailureReportsUncatchableStatesRuntime checks
+// requirement: a data-flow field failure that occurs after a Task's own
+// work already succeeded (here, ResultPath cannot apply because the
+// InputPath-filtered effective input is a JSON string rather than an
+// object) reports as States.Runtime and is never caught, even by an
+// explicit States.ALL Catcher -- matching AWS's documented States.Runtime
+// behavior for InputPath/OutputPath/ResultPath failures.
+func TestTaskResultPathFailureReportsUncatchableStatesRuntime(t *testing.T) {
+	t.Parallel()
+
+	server := newEchoLambdaServer(t)
+
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:echo-fn",
+				"InputPath": "$.payload",
+				"ResultPath": "$.x",
+				"Catch": [{"ErrorEquals": ["States.ALL"], "Next": "Fallback"}],
+				"End": true
+			},
+			"Fallback": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "task-resultpath-runtime-error", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{"payload":"just-a-string"}`)
+
+	if exec.Error != errorStatesRuntime {
+		t.Fatalf("execution error: got %q, want %q (States.ALL must not catch a ResultPath failure)", exec.Error, errorStatesRuntime)
+	}
+}
+
+// TestTaskOutputPathFailureReportsStatesRuntime checks that an OutputPath
+// which matches nothing also reports States.Runtime, per AWS's
+// documentation that States.Runtime is often caused by errors such as
+// attempting to apply InputPath or OutputPath on a null JSON payload.
+func TestTaskOutputPathFailureReportsStatesRuntime(t *testing.T) {
+	t.Parallel()
+
+	server := newEchoLambdaServer(t)
+
+	definition := `{
+		"StartAt": "Invoke",
+		"States": {
+			"Invoke": {
+				"Type": "Task",
+				"Resource": "arn:aws:lambda:us-east-1:000000000000:function:echo-fn",
+				"OutputPath": "$.missing",
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "task-outputpath-runtime-error", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{"present":true}`)
+
+	if exec.Error != errorStatesRuntime {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesRuntime)
+	}
+}

--- a/internal/service/sfn/retry.go
+++ b/internal/service/sfn/retry.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 )
 
@@ -30,16 +29,12 @@ type retrier struct {
 }
 
 // catcher is a single entry in a Task/Parallel/Map state's Catch field. See
-// retrier for why its JSON tags are lowerCamelCase.
+// retrier for why its JSON tags are lowerCamelCase, and parsePathField in
+// iodata.go for why ResultPath is left as raw JSON.
 type catcher struct {
-	ErrorEquals []string `json:"errorEquals"`
-	Next        string   `json:"next"`
-
-	// ResultPath is left as raw JSON so an explicit "null" (discard the
-	// Error Output, keep the original input) can be told apart from the
-	// field being absent (default "$", full replacement by the Error
-	// Output); both unmarshal to the same value through a plain *string.
-	ResultPath json.RawMessage `json:"resultPath"`
+	ErrorEquals []string        `json:"errorEquals"`
+	Next        string          `json:"next"`
+	ResultPath  json.RawMessage `json:"resultPath"`
 }
 
 // Retry defaults per the Amazon States Language spec.
@@ -49,29 +44,85 @@ const (
 	defaultRetryBackoffRate     = 2.0
 )
 
-// runWithRetryCatch executes fn (a state's own work for one execution),
-// applying that state's Retry and Catch policy: retries are attempted
-// first, using the matching Retrier's backoff schedule; if retries do not
-// resolve the error, or no Retrier matches, the first matching Catcher
-// routes to its Next state with the Catcher's Error Output as input. The
-// return shape mirrors executeState: nextOverride is non-empty only when a
-// Catcher matched.
-func (e *executionEngine) runWithRetryCatch(ctx context.Context, name string, state *stateDefinition, input string, fn func(context.Context) (string, error)) (string, string, error) {
-	output, err := e.runWithRetry(ctx, state, fn)
-	if err == nil {
-		return output, "", nil
+// runRetryCatchResultPipeline executes work (a state's own work for one
+// execution, already given whatever effective input the caller computed
+// for it -- see executeTaskStateWithPolicy, executeParallelStateWithPolicy,
+// and executeMapStateWithPolicy in executor.go/parallel.go/mapstate.go,
+// which each fold InputPath/Parameters differently), applying that state's
+// Retry and Catch policy: retries are attempted first, using the matching
+// Retrier's backoff schedule; if retries do not resolve the error, or no
+// Retrier matches, the first matching Catcher routes to its Next state
+// with the Catcher's Error Output merged into the state's raw
+// (un-filtered) input via the Catcher's own ResultPath.
+//
+// On success, the result passes through ResultSelector, ResultPath, and
+// OutputPath to produce the effective output (see applyResultPipeline). On
+// a Catch match, only OutputPath applies to the Catcher's output --
+// ResultSelector/ResultPath are skipped, since the Catcher already shaped
+// its own output via its own ResultPath -- because OutputPath is a
+// state-level field that applies to the state's output regardless of
+// which path produced it (see applyCatchResult). An unmatched error
+// propagates unchanged: per AWS, a data-flow failure itself (e.g. an
+// unresolvable ResultPath) reports as States.Runtime, which is never
+// caught (see errorNameMatches), so such failures never reach Retry/Catch
+// in the first place.
+//
+// The return shape mirrors executeState: nextOverride is non-empty only
+// when a Catcher matched.
+func (e *executionEngine) runRetryCatchResultPipeline(
+	ctx context.Context, name string, state *stateDefinition, rawInput, effectiveInput string,
+	work func(context.Context) (string, error),
+) (string, string, error) {
+	result, err := e.runWithRetry(ctx, state, work)
+	if err != nil {
+		return e.applyCatchResult(name, state, rawInput, err)
 	}
 
-	catchOutput, catchNext, matched, buildErr := applyCatch(state, input, err)
+	return e.applyResultPipeline(name, state, effectiveInput, result)
+}
+
+// applyCatchResult scans state's Catchers for a match against workErr,
+// applying OutputPath to the matching Catcher's output. If no Catcher
+// matches, workErr propagates unchanged so the caller fails the state.
+func (e *executionEngine) applyCatchResult(name string, state *stateDefinition, rawInput string, workErr error) (string, string, error) {
+	catchOutput, catchNext, matched, buildErr := applyCatch(state, rawInput, workErr)
 	if buildErr != nil {
 		return "", "", fmt.Errorf("state %q: %w", name, buildErr)
 	}
 
 	if !matched {
-		return "", "", err
+		return "", "", workErr
 	}
 
-	return catchOutput, catchNext, nil
+	out, err := applyOutputPath(state.OutputPath, catchOutput)
+	if err != nil {
+		return "", "", fmt.Errorf("state %q: %w", name, err)
+	}
+
+	return out, catchNext, nil
+}
+
+// applyResultPipeline turns a state's own successful result into its
+// effective output: ResultSelector produces the effective result,
+// ResultPath merges it into effectiveInput, and OutputPath narrows the
+// merged output.
+func (e *executionEngine) applyResultPipeline(name string, state *stateDefinition, effectiveInput, result string) (string, string, error) {
+	effectiveResult, err := applyResultSelector(state.ResultSelector, result)
+	if err != nil {
+		return "", "", fmt.Errorf("state %q: %w", name, err)
+	}
+
+	merged, err := applyResultPath(state.ResultPath, effectiveInput, effectiveResult)
+	if err != nil {
+		return "", "", fmt.Errorf("state %q: %w", name, err)
+	}
+
+	out, err := applyOutputPath(state.OutputPath, merged)
+	if err != nil {
+		return "", "", fmt.Errorf("state %q: %w", name, err)
+	}
+
+	return out, "", nil
 }
 
 // runWithRetry executes fn, applying the state's Retry policy. Per the
@@ -216,84 +267,23 @@ func applyCatch(state *stateDefinition, input string, err error) (output, next s
 }
 
 // buildCatchOutput builds a Catcher's output: the Error Output object
-// {"Error": errName, "Cause": cause}, optionally injected into the state's
-// original input per ResultPath. The default (ResultPath absent) is "$",
-// meaning the output is the Error Output alone; an explicit null ResultPath
-// discards the Error Output and passes the original input through
-// unchanged. Only "$" and single-level "$.field" paths are supported;
-// anything deeper is reported as a plain error, which executionErrorCode
-// surfaces as States.Runtime like any other unsupported definition
-// construct.
+// {"Error": errName, "Cause": cause}, merged into the state's original
+// (raw) input per the Catcher's own ResultPath -- "works exactly like a
+// state's top-level ResultPath" per the spec's JSONPath Catchers section,
+// so it reuses applyResultPath, supporting the same "$", null, and
+// arbitrary-depth "$.a.b.c" semantics.
 func buildCatchOutput(rawResultPath json.RawMessage, input, errName, cause string) (string, error) {
-	path, isNull, err := parseCatcherResultPath(rawResultPath)
-	if err != nil {
-		return "", err
-	}
-
-	if isNull {
-		return input, nil
-	}
-
 	errorOutput := map[string]string{"Error": errName, "Cause": cause}
 
-	if path == "$" {
-		out, err := json.Marshal(errorOutput)
-		if err != nil {
-			return "", fmt.Errorf("marshal error output: %w", err)
-		}
-
-		return string(out), nil
-	}
-
-	return injectCatchResultPath(path, input, errorOutput)
-}
-
-// parseCatcherResultPath interprets a Catcher's raw ResultPath JSON.
-func parseCatcherResultPath(raw json.RawMessage) (path string, isNull bool, err error) {
-	if len(raw) == 0 {
-		return "$", false, nil
-	}
-
-	var value any
-	if err := json.Unmarshal(raw, &value); err != nil {
-		return "", false, fmt.Errorf("parse ResultPath: %w", err)
-	}
-
-	if value == nil {
-		return "", true, nil
-	}
-
-	path, ok := value.(string)
-	if !ok {
-		return "", false, fmt.Errorf("resultPath must be a string or null")
-	}
-
-	return path, false, nil
-}
-
-// injectCatchResultPath injects errorOutput into input at a single-level
-// "$.field" path, replacing or creating that top-level field.
-func injectCatchResultPath(path, input string, errorOutput map[string]string) (string, error) {
-	field, ok := strings.CutPrefix(path, "$.")
-	if !ok || field == "" || strings.Contains(field, ".") {
-		return "", fmt.Errorf("unsupported ResultPath %q: only \"$\" and single-level \"$.field\" are supported", path)
-	}
-
-	var inputData map[string]any
-	if err := json.Unmarshal([]byte(input), &inputData); err != nil {
-		return "", fmt.Errorf("resultPath %q requires an object input: %w", path, err)
-	}
-
-	if inputData == nil {
-		inputData = map[string]any{}
-	}
-
-	inputData[field] = errorOutput
-
-	out, err := json.Marshal(inputData)
+	resultJSON, err := json.Marshal(errorOutput)
 	if err != nil {
-		return "", fmt.Errorf("marshal ResultPath result: %w", err)
+		return "", fmt.Errorf("marshal error output: %w", err)
 	}
 
-	return string(out), nil
+	out, err := applyResultPath(rawResultPath, input, string(resultJSON))
+	if err != nil {
+		return "", fmt.Errorf("catch: %w", err)
+	}
+
+	return out, nil
 }

--- a/internal/service/sfn/validate.go
+++ b/internal/service/sfn/validate.go
@@ -44,6 +44,46 @@ var terminalStateTypes = map[string]bool{
 	"Fail":    true,
 }
 
+// pathFieldTypes, resultFieldTypes, resultSelectorTypes, and
+// retryCatchTypes are the sets of state Types the ASL spec's "Table of
+// State Types and Fields (JSONPath)"
+// (https://states-language.net/spec.html#statetypetable) allows each
+// data-flow field group on:
+//
+//   - InputPath/OutputPath: every state type except Fail.
+//   - ResultPath/Parameters: Task, Parallel, Map, Pass (the states that can
+//     generate a result, plus Pass, which uses Parameters/ResultPath to
+//     shape its Result-or-input).
+//   - ResultSelector: Task, Parallel, Map only (not Pass).
+//   - Retry/Catch: Task, Parallel, Map only.
+var (
+	pathFieldTypes = map[string]bool{
+		"Task": true, "Parallel": true, "Map": true, "Pass": true,
+		"Wait": true, "Choice": true, "Succeed": true,
+	}
+	resultFieldTypes      = map[string]bool{"Task": true, "Parallel": true, "Map": true, "Pass": true}
+	resultSelectorTypes   = map[string]bool{"Task": true, "Parallel": true, "Map": true}
+	retryCatchFieldTypes  = map[string]bool{"Task": true, "Parallel": true, "Map": true}
+	stateDataFlowFieldSet = []stateFieldRule{
+		{"InputPath", func(s *stateDefinition) bool { return len(s.InputPath) > 0 }, pathFieldTypes},
+		{"OutputPath", func(s *stateDefinition) bool { return len(s.OutputPath) > 0 }, pathFieldTypes},
+		{"ResultPath", func(s *stateDefinition) bool { return len(s.ResultPath) > 0 }, resultFieldTypes},
+		{"Parameters", func(s *stateDefinition) bool { return s.Parameters != nil }, resultFieldTypes},
+		{"ResultSelector", func(s *stateDefinition) bool { return s.ResultSelector != nil }, resultSelectorTypes},
+		{"Retry", func(s *stateDefinition) bool { return len(s.Retry) > 0 }, retryCatchFieldTypes},
+		{"Catch", func(s *stateDefinition) bool { return len(s.Catch) > 0 }, retryCatchFieldTypes},
+	}
+)
+
+// stateFieldRule checks one JSON field's applicability across state Types:
+// isSet reports whether the field is present on a given state, and allowed
+// is the set of state Types the spec permits it on.
+type stateFieldRule struct {
+	name    string
+	isSet   func(*stateDefinition) bool
+	allowed map[string]bool
+}
+
 // mapDistributedOnlyFields are Map state fields AWS documents only under
 // Distributed mode (see requireDistributedModeForFields in mapstate.go):
 // they are absent from the Inline Map state field list at
@@ -172,6 +212,7 @@ func (v *definitionValidator) validateState(name string, state *stateDefinition,
 	}
 
 	v.validateCatchers(name, state, states, location)
+	v.validateStateFields(name, state, location)
 
 	switch state.Type {
 	case "Task":
@@ -184,6 +225,24 @@ func (v *definitionValidator) validateState(name string, state *stateDefinition,
 		v.validateMapState(name, state, location)
 	case "Wait":
 		v.validateWaitState(name, state, location)
+	}
+}
+
+// validateStateFields flags any data-flow field (InputPath, OutputPath,
+// ResultPath, Parameters, ResultSelector, Retry, Catch) set on a state Type
+// the spec's field table does not allow it on -- for example, a ResultPath
+// on a Wait state -- so a definition that structurally validates does not
+// still surprise the caller when it runs (the pipeline in iodata.go and
+// retry.go simply never reads a field its state type does not support).
+func (v *definitionValidator) validateStateFields(name string, state *stateDefinition, location string) {
+	for _, rule := range stateDataFlowFieldSet {
+		if !rule.isSet(state) || rule.allowed[state.Type] {
+			continue
+		}
+
+		v.addError(codeSchemaValidationFailed, location+"/"+rule.name, fmt.Sprintf(
+			"state %q: %q is not a supported field for %s states", name, rule.name, state.Type,
+		))
 	}
 }
 

--- a/internal/service/sfn/validate_test.go
+++ b/internal/service/sfn/validate_test.go
@@ -161,6 +161,36 @@ var validateDiagnosticTests = []diagnosticTest{
 		wantLocation: "/States/W",
 	},
 	{
+		name: "ResultPath on Wait is not a supported field",
+		definition: `{
+			"StartAt": "W",
+			"States": {"W": {"Type": "Wait", "Seconds": 1, "ResultPath": "$.x", "End": true}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeSchemaValidationFailed,
+		wantLocation: "/States/W/ResultPath",
+	},
+	{
+		name: "ResultSelector on Pass is not a supported field",
+		definition: `{
+			"StartAt": "P",
+			"States": {"P": {"Type": "Pass", "ResultSelector": {"a": "b"}, "End": true}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeSchemaValidationFailed,
+		wantLocation: "/States/P/ResultSelector",
+	},
+	{
+		name: "OutputPath on Fail is not a supported field",
+		definition: `{
+			"StartAt": "F",
+			"States": {"F": {"Type": "Fail", "OutputPath": "$.x", "Error": "E", "Cause": "C"}}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeSchemaValidationFailed,
+		wantLocation: "/States/F/OutputPath",
+	},
+	{
 		name: "dangling Catch Next",
 		definition: `{
 			"StartAt": "Invoke",

--- a/internal/service/sfn/wait.go
+++ b/internal/service/sfn/wait.go
@@ -8,7 +8,10 @@ import (
 )
 
 // executeWaitState executes a Wait state by sleeping for the duration
-// determined by Seconds, SecondsPath, Timestamp, or TimestampPath.
+// determined by Seconds, SecondsPath, Timestamp, or TimestampPath, resolved
+// against the effective input (InputPath applied to the raw input). Wait
+// has no Parameters/Result/ResultPath: its output is always its (possibly
+// filtered) input, narrowed once more by OutputPath.
 //
 // The wait is not artificially capped: kumo sleeps for the full requested
 // duration but honors ctx cancellation, and every execution already runs
@@ -16,7 +19,12 @@ import (
 // (min(definition TimeoutSeconds, executionTimeoutCap)), which bounds how
 // long any single Wait can actually block.
 func (e *executionEngine) executeWaitState(ctx context.Context, state *stateDefinition, input string) (string, error) {
-	d, err := waitDuration(state, input)
+	effectiveInput, err := applyInputPath(state.InputPath, input)
+	if err != nil {
+		return "", fmt.Errorf("wait state: %w", err)
+	}
+
+	d, err := waitDuration(state, effectiveInput)
 	if err != nil {
 		return "", fmt.Errorf("wait state: %w", err)
 	}
@@ -30,7 +38,12 @@ func (e *executionEngine) executeWaitState(ctx context.Context, state *stateDefi
 	case <-timer.C:
 	}
 
-	return input, nil
+	output, err := applyOutputPath(state.OutputPath, effectiveInput)
+	if err != nil {
+		return "", fmt.Errorf("wait state: %w", err)
+	}
+
+	return output, nil
 }
 
 // waitDuration determines how long a Wait state should sleep from whichever


### PR DESCRIPTION
## Summary
First of three PRs completing the remaining Step Functions gaps.

- Full data-flow pipeline on every state type per the ASL field table: InputPath -> Parameters -> work -> ResultSelector -> ResultPath (arbitrary depth) -> OutputPath, with spec null semantics
- Catch ResultPath generalized from single-level to arbitrary depth, merging into the raw state input per the spec
- Choice gains all *Path comparator variants plus TimestampLessThanEquals/GreaterThanEquals
- Validation errors for data-flow fields on state types that do not allow them
- Data-flow failures surface as States.Runtime and bypass Retry/Catch, matching documented behavior

## Test plan
- [ ] iodata unit tests (paths, null semantics, depth, failures) and per-state pipeline tests against a fake Lambda
- [ ] Choice *Path/Timestamp additions table-driven
- [ ] Live-server TestSFN integration goldens unchanged