### PR TITLE
feat(sfn): callback tasks with task tokens and Activity support

### DIFF
--- a/internal/service/sfn/activity.go
+++ b/internal/service/sfn/activity.go
@@ -1,0 +1,112 @@
+package sfn
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// errActivityDoesNotExist matches AWS's DescribeActivity/GetActivityTask
+// error code for an unknown activity ARN.
+const errActivityDoesNotExist = "ActivityDoesNotExist"
+
+// Activity represents a Step Functions activity: a task type hosted and
+// polled for by a worker via GetActivityTask, as opposed to an optimized
+// service integration.
+type Activity struct {
+	ActivityArn  string
+	Name         string
+	CreationDate time.Time
+}
+
+// activityARN builds an activity's ARN, matching the same
+// arn:aws:states:{region}:{account}:{resource-type}:{name} shape
+// CreateStateMachine already uses for state machines (see storage.go).
+func (s *MemoryStorage) activityARN(name string) string {
+	return fmt.Sprintf("arn:aws:states:%s:%s:activity:%s", s.region, s.accountID, name)
+}
+
+// CreateActivity creates an activity. Per AWS documentation, CreateActivity
+// is idempotent on name: a repeated call for a name that already has an
+// activity returns the existing ActivityArn/CreationDate unchanged, and any
+// different Tags on the repeat request are ignored rather than applied.
+func (s *MemoryStorage) CreateActivity(_ context.Context, name string, tags []Tag) (*Activity, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	arn := s.activityARN(name)
+
+	if existing, ok := s.Activities[arn]; ok {
+		return existing, nil
+	}
+
+	activity := &Activity{
+		ActivityArn:  arn,
+		Name:         name,
+		CreationDate: time.Now(),
+	}
+
+	s.Activities[arn] = activity
+
+	if len(tags) > 0 {
+		s.Tags[arn] = append([]Tag{}, tags...)
+	}
+
+	s.saveLocked()
+
+	return activity, nil
+}
+
+// DescribeActivity describes an activity.
+func (s *MemoryStorage) DescribeActivity(_ context.Context, arn string) (*Activity, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	activity, ok := s.Activities[arn]
+	if !ok {
+		return nil, &ServiceError{Code: errActivityDoesNotExist, Message: "Activity does not exist"}
+	}
+
+	return activity, nil
+}
+
+// ListActivities lists all activities, ordered by creation date.
+func (s *MemoryStorage) ListActivities(_ context.Context, maxResults int32, _ string) ([]*Activity, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if maxResults <= 0 {
+		maxResults = 100
+	}
+
+	activities := make([]*Activity, 0, len(s.Activities))
+	for _, a := range s.Activities {
+		activities = append(activities, a)
+	}
+
+	sort.Slice(activities, func(i, j int) bool {
+		return activities[i].CreationDate.Before(activities[j].CreationDate)
+	})
+
+	if limit := int(maxResults); len(activities) > limit {
+		activities = activities[:limit]
+	}
+
+	return activities, "", nil
+}
+
+// DeleteActivity deletes an activity. Per AWS's documented errors for this
+// action (only InvalidArn), deleting an ARN that does not exist is not an
+// error.
+func (s *MemoryStorage) DeleteActivity(_ context.Context, arn string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.Activities, arn)
+	delete(s.Tags, arn)
+
+	s.saveLocked()
+
+	return nil
+}

--- a/internal/service/sfn/activity_queue.go
+++ b/internal/service/sfn/activity_queue.go
@@ -1,0 +1,129 @@
+package sfn
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// activityTask is a single unit of work scheduled for an activity by a Task
+// state, waiting to be handed to a GetActivityTask poller.
+type activityTask struct {
+	token   string
+	input   string
+	pending *pendingCallback
+}
+
+// activityQueueWaiter is a single GetActivityTask long poll blocked waiting
+// for a task. claimed and ch are both guarded by the owning activityQueue's
+// mutex, so enqueue and poll never race over which of them delivers (or
+// fails to deliver) a given task; see activityQueue's own doc comment.
+type activityQueueWaiter struct {
+	ch      chan *activityTask
+	claimed bool
+}
+
+// activityQueue implements one activity's task hand-off: a Task state
+// enqueues a scheduled task, and GetActivityTask pollers dequeue one --
+// each task delivered to exactly one poller, per AWS's GetActivityTask
+// documentation. When a poller is already waiting, enqueue hands the task
+// to it directly; otherwise the task sits in pending until a poller
+// arrives.
+//
+// A poller that times out or whose context is done must still check
+// whether it was claimed after all: enqueue may have already committed to
+// delivering it a task (under waiters's lock) in the same instant the
+// poller decided to give up. Coordinating this through the same mutex
+// enqueue uses to pick a waiter is what makes delivery exactly-once even
+// under that race, without ever silently dropping a scheduled task.
+type activityQueue struct {
+	mu      sync.Mutex
+	pending []*activityTask
+	waiters []*activityQueueWaiter
+}
+
+// newActivityQueue creates an empty activityQueue.
+func newActivityQueue() *activityQueue {
+	return &activityQueue{}
+}
+
+// enqueue schedules task, handing it directly to the longest-waiting poller
+// if one is available, or appending it to pending otherwise.
+func (q *activityQueue) enqueue(task *activityTask) {
+	q.mu.Lock()
+
+	if len(q.waiters) > 0 {
+		w := q.waiters[0]
+		q.waiters = q.waiters[1:]
+		w.claimed = true
+
+		q.mu.Unlock()
+
+		w.ch <- task
+
+		return
+	}
+
+	q.pending = append(q.pending, task)
+
+	q.mu.Unlock()
+}
+
+// poll waits up to timeout (or until ctx is done, if sooner) for a task,
+// returning nil if none arrived in time.
+func (q *activityQueue) poll(ctx context.Context, timeout time.Duration) *activityTask {
+	q.mu.Lock()
+
+	if len(q.pending) > 0 {
+		task := q.pending[0]
+		q.pending = q.pending[1:]
+
+		q.mu.Unlock()
+
+		return task
+	}
+
+	w := &activityQueueWaiter{ch: make(chan *activityTask, 1)}
+	q.waiters = append(q.waiters, w)
+
+	q.mu.Unlock()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case task := <-w.ch:
+		return task
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+
+	return q.giveUpOrClaimed(w)
+}
+
+// giveUpOrClaimed resolves the race between a poller's own timeout/context
+// cancellation and enqueue claiming the same waiter: if enqueue had already
+// claimed w by the time this runs (under the same lock enqueue used), w.ch
+// is guaranteed to have a task ready to read; otherwise w is removed from
+// the queue so no later enqueue can claim it.
+func (q *activityQueue) giveUpOrClaimed(w *activityQueueWaiter) *activityTask {
+	q.mu.Lock()
+
+	if w.claimed {
+		q.mu.Unlock()
+
+		return <-w.ch
+	}
+
+	for i, waiter := range q.waiters {
+		if waiter == w {
+			q.waiters = append(q.waiters[:i], q.waiters[i+1:]...)
+
+			break
+		}
+	}
+
+	q.mu.Unlock()
+
+	return nil
+}

--- a/internal/service/sfn/activity_task.go
+++ b/internal/service/sfn/activity_task.go
@@ -1,0 +1,137 @@
+package sfn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// isActivityResource reports whether resource is an activity ARN created
+// via CreateActivity (arn:aws:states:{region}:{account}:activity:{name}),
+// as opposed to the arn:aws:states:::service:action shape optimized
+// integrations use, which always leaves the region/account segments empty.
+func isActivityResource(resource string) bool {
+	return strings.HasPrefix(resource, "arn:aws:states:") && strings.Contains(resource, ":activity:")
+}
+
+// activityQueueRegistry lazily creates one activityQueue per activity ARN,
+// so each activity's pending tasks and waiting pollers are independent of
+// every other activity's.
+type activityQueueRegistry struct {
+	mu     sync.Mutex
+	queues map[string]*activityQueue
+}
+
+// newActivityQueueRegistry creates an empty activityQueueRegistry.
+func newActivityQueueRegistry() *activityQueueRegistry {
+	return &activityQueueRegistry{queues: make(map[string]*activityQueue)}
+}
+
+// get returns arn's activityQueue, creating it on first use.
+func (r *activityQueueRegistry) get(arn string) *activityQueue {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	q, ok := r.queues[arn]
+	if !ok {
+		q = newActivityQueue()
+		r.queues[arn] = q
+	}
+
+	return q
+}
+
+// executeActivityTask executes a Task state whose Resource references an
+// activity created via CreateActivity: it resolves the task's input
+// (resolved Parameters if set, else the effective input verbatim -- the
+// same fallback executeLambdaFunctionTask in executor.go uses for the
+// directly-specified-function integration), enqueues it for a
+// GetActivityTask poller, and then waits for SendTaskSuccess/SendTaskFailure
+// exactly like a callback Task state (see awaitTaskToken in
+// callback_task.go), honoring the same TimeoutSeconds/HeartbeatSeconds
+// semantics.
+func (e *executionEngine) executeActivityTask(ctx context.Context, name string, state *stateDefinition, resource, input string) (string, error) {
+	taskInput := input
+
+	if len(state.Parameters) > 0 {
+		params, err := resolveParameters(state.Parameters, input)
+		if err != nil {
+			return "", fmt.Errorf("resolve parameters for state %q: %w", name, err)
+		}
+
+		marshaled, err := json.Marshal(params)
+		if err != nil {
+			return "", fmt.Errorf("marshal parameters for state %q: %w", name, err)
+		}
+
+		taskInput = string(marshaled)
+	}
+
+	token, pending := e.tokens.register()
+
+	e.activityQueues.get(resource).enqueue(&activityTask{token: token, input: taskInput, pending: pending})
+
+	return e.awaitTaskToken(ctx, name, token, state, pending)
+}
+
+// activityPollTimeout bounds GetActivityTask's long poll; AWS documents 60
+// seconds as the maximum time the service holds the request open.
+const activityPollTimeout = 60 * time.Second
+
+// GetActivityTask long-polls for a task scheduled against activityArn,
+// returning an empty taskToken if none arrives within the poll window --
+// per AWS's documented behavior of responding with "a taskToken with a
+// null string" once the 60-second poll elapses.
+func (s *MemoryStorage) GetActivityTask(ctx context.Context, activityArn, _ string) (string, string, error) {
+	s.mu.RLock()
+	_, exists := s.Activities[activityArn]
+	s.mu.RUnlock()
+
+	if !exists {
+		return "", "", &ServiceError{Code: errActivityDoesNotExist, Message: "Activity does not exist"}
+	}
+
+	task := s.engine.activityQueues.get(activityArn).poll(ctx, s.engine.activityPollTimeout)
+	if task == nil {
+		return "", "", nil
+	}
+
+	return task.token, task.input, nil
+}
+
+// SendTaskSuccess resolves taskToken with output, resuming the callback or
+// activity Task state waiting on it.
+func (s *MemoryStorage) SendTaskSuccess(_ context.Context, taskToken, output string) error {
+	return tokenServiceError(s.engine.tokens.resolve(taskToken, callbackResult{output: output}))
+}
+
+// SendTaskFailure resolves taskToken with a failure, which the waiting
+// state's Retry/Catch can match like any other named error.
+func (s *MemoryStorage) SendTaskFailure(_ context.Context, taskToken, errorName, cause string) error {
+	result := callbackResult{err: &failStateError{errorName: errorName, cause: cause}}
+
+	return tokenServiceError(s.engine.tokens.resolve(taskToken, result))
+}
+
+// SendTaskHeartbeat resets taskToken's HeartbeatSeconds deadline.
+func (s *MemoryStorage) SendTaskHeartbeat(_ context.Context, taskToken string) error {
+	return tokenServiceError(s.engine.tokens.heartbeatToken(taskToken))
+}
+
+// tokenServiceError turns a tokenRegistry result code (tokenErrDoesNotExist,
+// tokenErrTimedOut, or "" for success) into the ServiceError handlers.go
+// expects, matching AWS's documented SendTaskSuccess/SendTaskFailure/
+// SendTaskHeartbeat error messages.
+func tokenServiceError(code string) error {
+	switch code {
+	case "":
+		return nil
+	case tokenErrTimedOut:
+		return &ServiceError{Code: code, Message: "The task token has either expired or the task associated with the token has already been closed"}
+	default:
+		return &ServiceError{Code: code, Message: "The activity does not exist"}
+	}
+}

--- a/internal/service/sfn/activity_test.go
+++ b/internal/service/sfn/activity_test.go
@@ -1,0 +1,315 @@
+package sfn
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestActivityCRUDRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	ctx := context.Background()
+
+	created, err := store.CreateActivity(ctx, "my-activity", nil)
+	if err != nil {
+		t.Fatalf("CreateActivity: %v", err)
+	}
+
+	described, err := store.DescribeActivity(ctx, created.ActivityArn)
+	if err != nil {
+		t.Fatalf("DescribeActivity: %v", err)
+	}
+
+	if described.Name != "my-activity" {
+		t.Fatalf("DescribeActivity Name: got %q, want %q", described.Name, "my-activity")
+	}
+
+	activities, _, err := store.ListActivities(ctx, 100, "")
+	if err != nil {
+		t.Fatalf("ListActivities: %v", err)
+	}
+
+	found := false
+
+	for _, a := range activities {
+		if a.ActivityArn == created.ActivityArn {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("ListActivities: created activity %q not found in %+v", created.ActivityArn, activities)
+	}
+
+	if err := store.DeleteActivity(ctx, created.ActivityArn); err != nil {
+		t.Fatalf("DeleteActivity: %v", err)
+	}
+
+	if _, err := store.DescribeActivity(ctx, created.ActivityArn); err == nil {
+		t.Fatal("DescribeActivity after DeleteActivity: expected error")
+	}
+}
+
+func TestCreateActivityIsIdempotentByName(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	ctx := context.Background()
+
+	first, err := store.CreateActivity(ctx, "dup-activity", []Tag{{Key: "k", Value: "v1"}})
+	if err != nil {
+		t.Fatalf("first CreateActivity: %v", err)
+	}
+
+	second, err := store.CreateActivity(ctx, "dup-activity", []Tag{{Key: "k", Value: "v2"}})
+	if err != nil {
+		t.Fatalf("second CreateActivity: %v", err)
+	}
+
+	if first.ActivityArn != second.ActivityArn {
+		t.Fatalf("ActivityArn changed across idempotent CreateActivity calls: %q vs %q", first.ActivityArn, second.ActivityArn)
+	}
+
+	if !first.CreationDate.Equal(second.CreationDate) {
+		t.Fatalf("CreationDate changed across idempotent CreateActivity calls: %v vs %v", first.CreationDate, second.CreationDate)
+	}
+
+	tags, err := store.ListTagsForResource(ctx, first.ActivityArn)
+	if err != nil {
+		t.Fatalf("ListTagsForResource: %v", err)
+	}
+
+	if len(tags) != 1 || tags[0].Value != "v1" {
+		t.Fatalf("tags after idempotent re-create: got %+v, want the original [{k v1}] unchanged", tags)
+	}
+}
+
+func TestDescribeActivityNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+
+	_, err := store.DescribeActivity(context.Background(), "arn:aws:states:us-east-1:000000000000:activity:nonexistent")
+
+	var svcErr *ServiceError
+	if !errors.As(err, &svcErr) || svcErr.Code != errActivityDoesNotExist {
+		t.Fatalf("DescribeActivity error: got %v, want ServiceError code %q", err, errActivityDoesNotExist)
+	}
+}
+
+func TestGetActivityTaskDeliversExactlyOneTaskToOneOfTwoPollers(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	store.engine.activityPollTimeout = 300 * time.Millisecond
+
+	ctx := context.Background()
+
+	activity, err := store.CreateActivity(ctx, "poll-activity", nil)
+	if err != nil {
+		t.Fatalf("CreateActivity: %v", err)
+	}
+
+	results := make(chan string, 2)
+
+	var wg sync.WaitGroup
+
+	for range 2 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			token, _, err := store.GetActivityTask(ctx, activity.ActivityArn, "")
+			if err != nil {
+				t.Errorf("GetActivityTask: %v", err)
+
+				return
+			}
+
+			results <- token
+		}()
+	}
+
+	// Give both pollers time to register as waiters before scheduling the
+	// only task; otherwise enqueue could hand it to whichever poller
+	// happened to register first, defeating the "two concurrent pollers"
+	// setup this test is for.
+	time.Sleep(50 * time.Millisecond)
+
+	q := store.engine.activityQueues.get(activity.ActivityArn)
+	q.enqueue(&activityTask{token: "the-only-task", input: "{}", pending: &pendingCallback{
+		done:      make(chan callbackResult, 1),
+		heartbeat: make(chan struct{}, 1),
+	}})
+
+	wg.Wait()
+	close(results)
+
+	var delivered []string
+
+	for token := range results {
+		if token != "" {
+			delivered = append(delivered, token)
+		}
+	}
+
+	if len(delivered) != 1 || delivered[0] != "the-only-task" {
+		t.Fatalf("delivered tokens: got %v, want exactly one delivery of %q", delivered, "the-only-task")
+	}
+}
+
+func TestGetActivityTaskReturnsEmptyTaskTokenOnPollTimeout(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	store.engine.activityPollTimeout = 50 * time.Millisecond
+
+	activity, err := store.CreateActivity(context.Background(), "idle-activity", nil)
+	if err != nil {
+		t.Fatalf("CreateActivity: %v", err)
+	}
+
+	token, input, err := store.GetActivityTask(context.Background(), activity.ActivityArn, "")
+	if err != nil {
+		t.Fatalf("GetActivityTask: %v", err)
+	}
+
+	if token != "" || input != "" {
+		t.Fatalf("GetActivityTask on idle activity: got taskToken=%q input=%q, want both empty", token, input)
+	}
+}
+
+func TestGetActivityTaskUnknownActivityReportsActivityDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+
+	_, _, err := store.GetActivityTask(context.Background(), "arn:aws:states:us-east-1:000000000000:activity:nonexistent", "")
+
+	var svcErr *ServiceError
+	if !errors.As(err, &svcErr) || svcErr.Code != errActivityDoesNotExist {
+		t.Fatalf("GetActivityTask error: got %v, want ServiceError code %q", err, errActivityDoesNotExist)
+	}
+}
+
+func TestActivityTaskStateEndToEndWorkerPollsAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	store.engine.activityPollTimeout = 2 * time.Second
+
+	ctx := context.Background()
+
+	activity, err := store.CreateActivity(ctx, "worker-activity", nil)
+	if err != nil {
+		t.Fatalf("CreateActivity: %v", err)
+	}
+
+	definition := `{
+		"StartAt": "DoWork",
+		"States": {
+			"DoWork": {
+				"Type": "Task",
+				"Resource": "` + activity.ActivityArn + `",
+				"End": true
+			}
+		}
+	}`
+
+	sm := createExecutionTestStateMachine(t, store, "activity-task", definition)
+
+	started, err := store.StartExecution(ctx, sm.StateMachineArn, "", `{"n":1}`, "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	token, input, err := store.GetActivityTask(ctx, activity.ActivityArn, "worker-1")
+	if err != nil {
+		t.Fatalf("GetActivityTask: %v", err)
+	}
+
+	if token == "" {
+		t.Fatal("GetActivityTask: expected a task token")
+	}
+
+	if input != `{"n":1}` {
+		t.Fatalf("GetActivityTask input: got %q, want %q", input, `{"n":1}`)
+	}
+
+	if err := store.SendTaskSuccess(ctx, token, `{"n":2}`); err != nil {
+		t.Fatalf("SendTaskSuccess: %v", err)
+	}
+
+	exec := pollExecutionUntilTerminal(t, store, started.ExecutionArn)
+	if exec.Status != ExecutionStatusSucceeded {
+		t.Fatalf("execution status: got %q, want SUCCEEDED (error: %s, cause: %s)", exec.Status, exec.Error, exec.Cause)
+	}
+
+	if exec.Output != `{"n":2}` {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, `{"n":2}`)
+	}
+}
+
+func TestActivityTaskStateRetriesAfterSendTaskFailure(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	store.engine.activityPollTimeout = 2 * time.Second
+
+	ctx := context.Background()
+
+	activity, err := store.CreateActivity(ctx, "retry-activity", nil)
+	if err != nil {
+		t.Fatalf("CreateActivity: %v", err)
+	}
+
+	definition := `{
+		"StartAt": "DoWork",
+		"States": {
+			"DoWork": {
+				"Type": "Task",
+				"Resource": "` + activity.ActivityArn + `",
+				"Retry": [{"ErrorEquals": ["States.ALL"], "MaxAttempts": 1, "IntervalSeconds": 0}],
+				"End": true
+			}
+		}
+	}`
+
+	sm := createExecutionTestStateMachine(t, store, "activity-task-retry", definition)
+
+	started, err := store.StartExecution(ctx, sm.StateMachineArn, "", `{}`, "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	// First attempt: fail it, expecting the Retry policy to schedule the
+	// task again.
+	firstToken, _, err := store.GetActivityTask(ctx, activity.ActivityArn, "")
+	if err != nil {
+		t.Fatalf("GetActivityTask (attempt 1): %v", err)
+	}
+
+	if err := store.SendTaskFailure(ctx, firstToken, "TransientError", "try again"); err != nil {
+		t.Fatalf("SendTaskFailure: %v", err)
+	}
+
+	// Second attempt: succeed it.
+	secondToken, _, err := store.GetActivityTask(ctx, activity.ActivityArn, "")
+	if err != nil {
+		t.Fatalf("GetActivityTask (attempt 2): %v", err)
+	}
+
+	if err := store.SendTaskSuccess(ctx, secondToken, `{"done":true}`); err != nil {
+		t.Fatalf("SendTaskSuccess: %v", err)
+	}
+
+	exec := pollExecutionUntilTerminal(t, store, started.ExecutionArn)
+	if exec.Status != ExecutionStatusSucceeded {
+		t.Fatalf("execution status: got %q, want SUCCEEDED (error: %s, cause: %s)", exec.Status, exec.Error, exec.Cause)
+	}
+}

--- a/internal/service/sfn/callback.go
+++ b/internal/service/sfn/callback.go
@@ -1,0 +1,160 @@
+package sfn
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// Task token error codes, matching AWS's documented SendTaskSuccess/
+// SendTaskFailure/SendTaskHeartbeat errors: TaskDoesNotExist ("the activity
+// does not exist") is a token kumo has never seen; TaskTimedOut ("the task
+// token has either expired or the task associated with the token has
+// already been closed") is a token that was valid but has since resolved
+// (success, failure, or its own timeout) or already been reported on.
+const (
+	tokenErrDoesNotExist = "TaskDoesNotExist"
+	tokenErrTimedOut     = "TaskTimedOut"
+)
+
+// callbackResult carries the outcome delivered by SendTaskSuccess or
+// SendTaskFailure for a single waiting task token. err is nil for a
+// success; for a failure it is a failStateError carrying the reported
+// Error/Cause, so it flows through Retry/Catch exactly like any other named
+// error.
+type callbackResult struct {
+	output string
+	err    error
+}
+
+// pendingCallback is a single task token's wait state, shared between the
+// executor goroutine blocked on it (see awaitTaskToken in callback_task.go
+// and executeActivityTask in activity_task.go) and the SendTaskSuccess/
+// SendTaskFailure/SendTaskHeartbeat handlers that resolve it. done and
+// heartbeat are both buffered so a resolving call never blocks on a waiter
+// that has already stopped listening (e.g. TimeoutSeconds expired first).
+type pendingCallback struct {
+	done      chan callbackResult
+	heartbeat chan struct{}
+}
+
+// tokenRegistry tracks every task token currently awaited by a callback
+// Task state (.waitForTaskToken) or an activity Task state, and the
+// executor goroutines waiting on them. It is entirely in-memory: waiting
+// tokens do not need to survive a kumo restart, since the execution
+// goroutine SendTaskSuccess/Failure ultimately resumes does not survive one
+// either.
+//
+// The registry's own mutex is intentionally separate from
+// MemoryStorage.mu: an executor goroutine blocks on pendingCallback.done
+// without holding any lock (see awaitTaskToken), and every registry method
+// below only ever holds this mutex for the duration of a single map
+// operation, so SendTaskSuccess/Failure/Heartbeat requests are never
+// blocked behind a long-running execution.
+type tokenRegistry struct {
+	mu     sync.Mutex
+	active map[string]*pendingCallback
+	// closed records every token that has ever left active, so a late
+	// SendTaskSuccess/Failure/Heartbeat for it reports TaskTimedOut instead
+	// of TaskDoesNotExist, which AWS reserves for a token that never
+	// existed.
+	closed map[string]bool
+}
+
+// newTokenRegistry creates an empty tokenRegistry.
+func newTokenRegistry() *tokenRegistry {
+	return &tokenRegistry{
+		active: make(map[string]*pendingCallback),
+		closed: make(map[string]bool),
+	}
+}
+
+// register creates a new task token and its pendingCallback, returning both
+// for the caller to inject the token into the integration's request payload
+// (or GetActivityTaskResponse) and then wait on the pendingCallback.
+func (r *tokenRegistry) register() (string, *pendingCallback) {
+	token := uuid.New().String()
+	pending := &pendingCallback{
+		done:      make(chan callbackResult, 1),
+		heartbeat: make(chan struct{}, 1),
+	}
+
+	r.mu.Lock()
+	r.active[token] = pending
+	r.mu.Unlock()
+
+	return token, pending
+}
+
+// release removes token from the active set without resolving it, moving it
+// to closed. Callers use this when they abandon a token before any
+// SendTaskSuccess/Failure resolves it (a callback integration call that
+// itself failed, or the wait timing out), so a late SendTaskSuccess/Failure
+// for that token correctly reports TaskTimedOut rather than succeeding.
+func (r *tokenRegistry) release(token string) {
+	r.mu.Lock()
+	delete(r.active, token)
+	r.closed[token] = true
+	r.mu.Unlock()
+}
+
+// resolve delivers result to token's waiter and marks the token closed. It
+// returns "" on success, or tokenErrDoesNotExist/tokenErrTimedOut if token
+// is not currently active.
+func (r *tokenRegistry) resolve(token string, result callbackResult) string {
+	r.mu.Lock()
+
+	pending, ok := r.active[token]
+	if !ok {
+		code := r.notActiveCodeLocked(token)
+
+		r.mu.Unlock()
+
+		return code
+	}
+
+	delete(r.active, token)
+	r.closed[token] = true
+
+	r.mu.Unlock()
+
+	pending.done <- result
+
+	return ""
+}
+
+// heartbeatToken signals token's waiter to reset its heartbeat deadline. It
+// reports tokenErrDoesNotExist/tokenErrTimedOut the same way resolve does.
+func (r *tokenRegistry) heartbeatToken(token string) string {
+	r.mu.Lock()
+
+	pending, ok := r.active[token]
+	if !ok {
+		code := r.notActiveCodeLocked(token)
+
+		r.mu.Unlock()
+
+		return code
+	}
+
+	r.mu.Unlock()
+
+	// If a heartbeat is already pending delivery, the waiter will observe it
+	// and reset its timer, so this one is redundant.
+	select {
+	case pending.heartbeat <- struct{}{}:
+	default:
+	}
+
+	return ""
+}
+
+// notActiveCodeLocked reports which error a token not currently in active
+// should surface. Callers must hold r.mu.
+func (r *tokenRegistry) notActiveCodeLocked(token string) string {
+	if r.closed[token] {
+		return tokenErrTimedOut
+	}
+
+	return tokenErrDoesNotExist
+}

--- a/internal/service/sfn/callback_task.go
+++ b/internal/service/sfn/callback_task.go
@@ -1,0 +1,164 @@
+package sfn
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// callbackResourceSuffix marks a Task state's Resource as using the "Wait
+// for a Callback with Task Token" service integration pattern
+// (.waitForTaskToken), per
+// https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html.
+const callbackResourceSuffix = ".waitForTaskToken"
+
+// callbackIntegrations are the optimized service integrations kumo supports
+// with .waitForTaskToken appended. AWS documents Lambda and SQS (among
+// others) as supporting the "Wait for a Callback with Task Token" pattern;
+// kumo implements the two integrations it already supports without the
+// suffix (see executeTaskState in executor.go).
+var callbackIntegrations = map[string]bool{
+	"arn:aws:states:::lambda:invoke":   true,
+	"arn:aws:states:::sqs:sendMessage": true,
+}
+
+// isCallbackResource reports whether resource uses the .waitForTaskToken
+// integration pattern, returning the base resource (the integration ARN
+// with the suffix stripped) when it does.
+func isCallbackResource(resource string) (baseResource string, ok bool) {
+	if len(resource) <= len(callbackResourceSuffix) {
+		return "", false
+	}
+
+	suffixStart := len(resource) - len(callbackResourceSuffix)
+	if resource[suffixStart:] != callbackResourceSuffix {
+		return "", false
+	}
+
+	return resource[:suffixStart], true
+}
+
+// executeCallbackTask executes a Task state whose Resource uses the "Wait
+// for a Callback with Task Token" pattern: it generates a task token,
+// injects it into the resolved Parameters via the Context object
+// ($$.Task.Token), fires the underlying integration once, and then blocks
+// until SendTaskSuccess/SendTaskFailure resolves the token or the wait
+// times out. TimeoutSeconds bounds the whole wait; HeartbeatSeconds, if
+// set, must see a SendTaskHeartbeat within every interval or the wait times
+// out early -- both report States.Timeout, per AWS's documentation for this
+// pattern.
+func (e *executionEngine) executeCallbackTask(ctx context.Context, name string, state *stateDefinition, baseResource, input string) (string, error) {
+	if !callbackIntegrations[baseResource] {
+		return "", fmt.Errorf("unsupported %s resource %q", callbackResourceSuffix, baseResource)
+	}
+
+	token, pending := e.tokens.register()
+
+	params, err := resolveParametersWithContext(state.Parameters, input, taskTokenContext(token))
+	if err != nil {
+		e.tokens.release(token)
+
+		return "", fmt.Errorf("resolve parameters: %w", err)
+	}
+
+	if err := e.fireCallbackIntegration(ctx, baseResource, params); err != nil {
+		e.tokens.release(token)
+
+		return "", err
+	}
+
+	return e.awaitTaskToken(ctx, name, token, state, pending)
+}
+
+// taskTokenContext builds the Context object subset ($$.Task.Token) a
+// callback/activity Task state's Parameters may reference via
+// resolveParametersWithContext. kumo does not model the rest of the
+// Context object ($$.Execution, $$.State, ...); see mapItemContext in
+// itemselector.go for the only other place the Context object is built.
+func taskTokenContext(token string) map[string]any {
+	return map[string]any{
+		"Task": map[string]any{"Token": token},
+	}
+}
+
+// fireCallbackIntegration performs the "fire" half of a callback task: the
+// underlying integration call itself, discarding its response, since a
+// callback task's real output comes from SendTaskSuccess, not the
+// integration's own response.
+func (e *executionEngine) fireCallbackIntegration(ctx context.Context, baseResource string, params map[string]any) error {
+	switch baseResource {
+	case "arn:aws:states:::sqs:sendMessage":
+		_, err := e.executeSQSSendMessage(ctx, params)
+
+		return err
+	case "arn:aws:states:::lambda:invoke":
+		_, err := e.executeLambdaInvoke(ctx, params)
+
+		return err
+	default:
+		return fmt.Errorf("unsupported %s resource %q", callbackResourceSuffix, baseResource)
+	}
+}
+
+// awaitTaskToken blocks until token is resolved by SendTaskSuccess/
+// SendTaskFailure, a HeartbeatSeconds interval elapses with no
+// SendTaskHeartbeat, or ctx is done (TimeoutSeconds, or an outer
+// execution-level deadline). All three timeout paths report the same
+// taskTimeoutError (see timeout.go), which executionErrorCode surfaces as
+// States.Timeout; on any of them, token is released so a
+// SendTaskSuccess/Failure that arrives afterward correctly reports
+// TaskTimedOut instead of resolving a state that has already failed.
+func (e *executionEngine) awaitTaskToken(ctx context.Context, name, token string, state *stateDefinition, pending *pendingCallback) (string, error) {
+	heartbeat := heartbeatInterval(state)
+
+	var heartbeatTimer *time.Timer
+
+	var heartbeatC <-chan time.Time
+
+	if heartbeat > 0 {
+		heartbeatTimer = time.NewTimer(heartbeat)
+		defer heartbeatTimer.Stop()
+
+		heartbeatC = heartbeatTimer.C
+	}
+
+	for {
+		select {
+		case result := <-pending.done:
+			return result.output, result.err
+		case <-pending.heartbeat:
+			heartbeatTimer.Reset(heartbeat)
+		case <-ctx.Done():
+			return e.timeoutOrLateResult(name, token, pending)
+		case <-heartbeatC:
+			return e.timeoutOrLateResult(name, token, pending)
+		}
+	}
+}
+
+// timeoutOrLateResult favors a callbackResult that arrived in the same
+// instant a timeout fired -- select does not prioritize ready cases -- over
+// reporting a spurious States.Timeout, then releases token.
+func (e *executionEngine) timeoutOrLateResult(name, token string, pending *pendingCallback) (string, error) {
+	select {
+	case result := <-pending.done:
+		return result.output, result.err
+	default:
+	}
+
+	e.tokens.release(token)
+
+	return "", &taskTimeoutError{state: name}
+}
+
+// heartbeatInterval resolves a Task state's HeartbeatSeconds, returning
+// zero if unset. HeartbeatSecondsPath is decoded (see stateDefinition in
+// retry.go) but not implemented -- it is a dynamic reference-path form AWS
+// documents far less prominently than the static field.
+func heartbeatInterval(state *stateDefinition) time.Duration {
+	if state.HeartbeatSeconds == nil {
+		return 0
+	}
+
+	return time.Duration(*state.HeartbeatSeconds) * time.Second
+}

--- a/internal/service/sfn/callback_task_test.go
+++ b/internal/service/sfn/callback_task_test.go
@@ -1,0 +1,380 @@
+package sfn
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newTaskTokenCapturingLambdaServer returns an httptest server standing in
+// for kumo's Lambda invoke endpoint: it extracts the callback task token
+// from the request payload's "taskToken" field and sends it on tokenCh,
+// then responds with an empty object (a callback task's own integration
+// response is discarded -- see fireCallbackIntegration).
+func newTaskTokenCapturingLambdaServer(t *testing.T, tokenCh chan<- string) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
+
+		// executeLambdaInvoke posts the resolved Payload map verbatim as the
+		// request body (no outer envelope), so the token sits directly at
+		// the top level here.
+		var payload struct {
+			TaskToken string `json:"taskToken"`
+		}
+
+		if err := json.Unmarshal(body, &payload); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
+
+		tokenCh <- payload.TaskToken
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// recvTaskToken waits for a token on tokenCh, failing the test if none
+// arrives within a bounded deadline.
+func recvTaskToken(t *testing.T, tokenCh <-chan string) string {
+	t.Helper()
+
+	select {
+	case token := <-tokenCh:
+		if token == "" {
+			t.Fatal("captured task token is empty")
+		}
+
+		return token
+	case <-time.After(5 * time.Second):
+		t.Fatal("did not receive a task token in time")
+
+		return ""
+	}
+}
+
+// pollExecutionUntilTerminal polls DescribeExecution for executionArn until
+// it leaves RUNNING, failing the test if it does not terminate in time.
+func pollExecutionUntilTerminal(t *testing.T, store *MemoryStorage, executionArn string) *Execution {
+	t.Helper()
+
+	ctx := context.Background()
+	deadline := time.Now().Add(10 * time.Second)
+
+	for time.Now().Before(deadline) {
+		exec, err := store.DescribeExecution(ctx, executionArn)
+		if err != nil {
+			t.Fatalf("DescribeExecution: %v", err)
+		}
+
+		if exec.Status != ExecutionStatusRunning {
+			return exec
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("execution did not terminate within the deadline")
+
+	return nil
+}
+
+const callbackTaskDefinition = `{
+	"StartAt": "Notify",
+	"States": {
+		"Notify": {
+			"Type": "Task",
+			"Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+			"Parameters": {
+				"FunctionName": "notify-fn",
+				"Payload": {"taskToken.$": "$$.Task.Token"}
+			},
+			"ResultPath": "$.callback",
+			"End": true
+		}
+	}
+}`
+
+func TestCallbackTaskPausesUntilSendTaskSuccessThenFlowsThroughResultPath(t *testing.T) {
+	t.Parallel()
+
+	tokenCh := make(chan string, 1)
+	server := newTaskTokenCapturingLambdaServer(t, tokenCh)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "callback-success", callbackTaskDefinition)
+
+	started, err := store.StartExecution(context.Background(), sm.StateMachineArn, "", `{"x":1}`, "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	token := recvTaskToken(t, tokenCh)
+
+	// The execution must still be paused, waiting on the token.
+	time.Sleep(50 * time.Millisecond)
+
+	running, err := store.DescribeExecution(context.Background(), started.ExecutionArn)
+	if err != nil {
+		t.Fatalf("DescribeExecution: %v", err)
+	}
+
+	if running.Status != ExecutionStatusRunning {
+		t.Fatalf("execution status before SendTaskSuccess: got %q, want RUNNING", running.Status)
+	}
+
+	if err := store.SendTaskSuccess(context.Background(), token, `{"ok":true}`); err != nil {
+		t.Fatalf("SendTaskSuccess: %v", err)
+	}
+
+	exec := pollExecutionUntilTerminal(t, store, started.ExecutionArn)
+	if exec.Status != ExecutionStatusSucceeded {
+		t.Fatalf("execution status: got %q, want SUCCEEDED (error: %s, cause: %s)", exec.Status, exec.Error, exec.Cause)
+	}
+
+	var output map[string]any
+	if err := json.Unmarshal([]byte(exec.Output), &output); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if output["callback"] == nil {
+		t.Fatalf("execution output %q: missing \"callback\" from ResultPath", exec.Output)
+	}
+}
+
+func TestCallbackTaskSendTaskFailureTriggersCatch(t *testing.T) {
+	t.Parallel()
+
+	tokenCh := make(chan string, 1)
+	server := newTaskTokenCapturingLambdaServer(t, tokenCh)
+
+	definition := `{
+		"StartAt": "Notify",
+		"States": {
+			"Notify": {
+				"Type": "Task",
+				"Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+				"Parameters": {"FunctionName": "notify-fn", "Payload": {"taskToken.$": "$$.Task.Token"}},
+				"Catch": [{"ErrorEquals": ["States.ALL"], "Next": "Fallback"}],
+				"End": true
+			},
+			"Fallback": {"Type": "Pass", "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "callback-failure", definition)
+
+	started, err := store.StartExecution(context.Background(), sm.StateMachineArn, "", `{}`, "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	token := recvTaskToken(t, tokenCh)
+
+	if err := store.SendTaskFailure(context.Background(), token, "CustomError", "custom cause"); err != nil {
+		t.Fatalf("SendTaskFailure: %v", err)
+	}
+
+	exec := pollExecutionUntilTerminal(t, store, started.ExecutionArn)
+	if exec.Status != ExecutionStatusSucceeded {
+		t.Fatalf("execution status: got %q, want SUCCEEDED via Catch (error: %s, cause: %s)", exec.Status, exec.Error, exec.Cause)
+	}
+
+	var errorOutput map[string]string
+	if err := json.Unmarshal([]byte(exec.Output), &errorOutput); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if errorOutput["Error"] != "CustomError" || errorOutput["Cause"] != "custom cause" {
+		t.Fatalf("caught error output: got %+v, want Error=CustomError Cause=custom cause", errorOutput)
+	}
+}
+
+func TestSendTaskSuccessUnknownTokenReportsTaskDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+
+	err := store.SendTaskSuccess(context.Background(), "does-not-exist", `{}`)
+
+	var svcErr *ServiceError
+	if !errors.As(err, &svcErr) || svcErr.Code != tokenErrDoesNotExist {
+		t.Fatalf("SendTaskSuccess error: got %v, want ServiceError code %q", err, tokenErrDoesNotExist)
+	}
+}
+
+func TestSendTaskSuccessAlreadyResolvedTokenReportsTaskTimedOut(t *testing.T) {
+	t.Parallel()
+
+	tokenCh := make(chan string, 1)
+	server := newTaskTokenCapturingLambdaServer(t, tokenCh)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "callback-double-resolve", callbackTaskDefinition)
+
+	_, err := store.StartExecution(context.Background(), sm.StateMachineArn, "", `{}`, "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	token := recvTaskToken(t, tokenCh)
+
+	if err := store.SendTaskSuccess(context.Background(), token, `{}`); err != nil {
+		t.Fatalf("first SendTaskSuccess: %v", err)
+	}
+
+	err = store.SendTaskSuccess(context.Background(), token, `{}`)
+
+	var svcErr *ServiceError
+	if !errors.As(err, &svcErr) || svcErr.Code != tokenErrTimedOut {
+		t.Fatalf("second SendTaskSuccess error: got %v, want ServiceError code %q", err, tokenErrTimedOut)
+	}
+}
+
+func TestCallbackTaskTimeoutSecondsFailsExecutionWithStatesTimeout(t *testing.T) {
+	t.Parallel()
+
+	tokenCh := make(chan string, 1)
+	server := newTaskTokenCapturingLambdaServer(t, tokenCh)
+
+	definition := `{
+		"StartAt": "Notify",
+		"States": {
+			"Notify": {
+				"Type": "Task",
+				"Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+				"TimeoutSeconds": 1,
+				"Parameters": {"FunctionName": "notify-fn", "Payload": {"taskToken.$": "$$.Task.Token"}},
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "callback-timeout", definition)
+
+	started, err := store.StartExecution(context.Background(), sm.StateMachineArn, "", `{}`, "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	recvTaskToken(t, tokenCh)
+
+	exec := pollExecutionUntilTerminal(t, store, started.ExecutionArn)
+	if exec.Status != ExecutionStatusFailed {
+		t.Fatalf("execution status: got %q, want FAILED", exec.Status)
+	}
+
+	if exec.Error != errorStatesTimeout {
+		t.Fatalf("execution error: got %q, want %q (cause: %s)", exec.Error, errorStatesTimeout, exec.Cause)
+	}
+}
+
+func TestCallbackTaskHeartbeatExpiryFailsExecutionWithStatesTimeout(t *testing.T) {
+	t.Parallel()
+
+	tokenCh := make(chan string, 1)
+	server := newTaskTokenCapturingLambdaServer(t, tokenCh)
+
+	definition := `{
+		"StartAt": "Notify",
+		"States": {
+			"Notify": {
+				"Type": "Task",
+				"Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+				"HeartbeatSeconds": 1,
+				"Parameters": {"FunctionName": "notify-fn", "Payload": {"taskToken.$": "$$.Task.Token"}},
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "callback-heartbeat-timeout", definition)
+
+	started, err := store.StartExecution(context.Background(), sm.StateMachineArn, "", `{}`, "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	recvTaskToken(t, tokenCh)
+
+	// No SendTaskHeartbeat is ever sent, so the 1-second HeartbeatSeconds
+	// interval must expire and fail the state.
+	exec := pollExecutionUntilTerminal(t, store, started.ExecutionArn)
+	if exec.Status != ExecutionStatusFailed {
+		t.Fatalf("execution status: got %q, want FAILED", exec.Status)
+	}
+
+	if exec.Error != errorStatesTimeout {
+		t.Fatalf("execution error: got %q, want %q (cause: %s)", exec.Error, errorStatesTimeout, exec.Cause)
+	}
+}
+
+func TestCallbackTaskHeartbeatsKeepWaitAlivePastTheInterval(t *testing.T) {
+	t.Parallel()
+
+	tokenCh := make(chan string, 1)
+	server := newTaskTokenCapturingLambdaServer(t, tokenCh)
+
+	definition := `{
+		"StartAt": "Notify",
+		"States": {
+			"Notify": {
+				"Type": "Task",
+				"Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+				"HeartbeatSeconds": 1,
+				"Parameters": {"FunctionName": "notify-fn", "Payload": {"taskToken.$": "$$.Task.Token"}},
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "callback-heartbeat-alive", definition)
+
+	started, err := store.StartExecution(context.Background(), sm.StateMachineArn, "", `{}`, "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	token := recvTaskToken(t, tokenCh)
+
+	// Send three heartbeats, each well inside the 1-second interval, for a
+	// total elapsed time well past it, proving each heartbeat resets the
+	// deadline rather than the wait timing out after the first interval.
+	for range 3 {
+		time.Sleep(600 * time.Millisecond)
+
+		if err := store.SendTaskHeartbeat(context.Background(), token); err != nil {
+			t.Fatalf("SendTaskHeartbeat: %v", err)
+		}
+	}
+
+	if err := store.SendTaskSuccess(context.Background(), token, `{"done":true}`); err != nil {
+		t.Fatalf("SendTaskSuccess: %v", err)
+	}
+
+	exec := pollExecutionUntilTerminal(t, store, started.ExecutionArn)
+	if exec.Status != ExecutionStatusSucceeded {
+		t.Fatalf("execution status: got %q, want SUCCEEDED (error: %s, cause: %s)", exec.Status, exec.Error, exec.Cause)
+	}
+}

--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -120,11 +120,15 @@ type stateDefinition struct {
 	TimeoutSeconds     *int   `json:"TimeoutSeconds"`
 	TimeoutSecondsPath string `json:"TimeoutSecondsPath"`
 
-	// HeartbeatSeconds/HeartbeatSecondsPath are decoded but intentionally
-	// never enforced: kumo has no activity/callback (.waitForTaskToken) task
-	// token support, so a task can never send a heartbeat. Enforcing this
-	// field would fail every task that sets it, for a reason kumo can never
-	// satisfy.
+	// HeartbeatSeconds is enforced only for callback (.waitForTaskToken) and
+	// activity Task states (see heartbeatInterval and awaitTaskToken in
+	// callback_task.go, and executeActivityTask in activity_task.go): those
+	// are the only Task states that can ever receive a SendTaskHeartbeat.
+	// For every other (ordinary HTTP) Task state it is decoded but not
+	// enforced, since such a task can never send a heartbeat -- enforcing it
+	// there would fail every task that sets it, for a reason kumo can never
+	// satisfy. HeartbeatSecondsPath is decoded but not implemented at all
+	// (see heartbeatInterval).
 	HeartbeatSeconds     *int   `json:"HeartbeatSeconds"`
 	HeartbeatSecondsPath string `json:"HeartbeatSecondsPath"`
 }
@@ -228,6 +232,19 @@ func executionErrorCause(err error) string {
 type executionEngine struct {
 	baseURL string
 	client  *http.Client
+
+	// tokens tracks task tokens for callback (.waitForTaskToken) and
+	// activity Task states (see callback.go, callback_task.go,
+	// activity_task.go).
+	tokens *tokenRegistry
+
+	// activityQueues holds each activity's pending tasks and waiting
+	// GetActivityTask pollers (see activity_task.go).
+	activityQueues *activityQueueRegistry
+
+	// activityPollTimeout bounds GetActivityTask's long poll; tests
+	// override this directly to keep runtime bounded.
+	activityPollTimeout time.Duration
 }
 
 // newExecutionEngine creates a new execution engine.
@@ -237,6 +254,9 @@ func newExecutionEngine(baseURL string) *executionEngine {
 		client: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		tokens:              newTokenRegistry(),
+		activityQueues:      newActivityQueueRegistry(),
+		activityPollTimeout: activityPollTimeout,
 	}
 }
 
@@ -471,11 +491,25 @@ func (e *executionEngine) executeFailState(state *stateDefinition) error {
 	return &failStateError{errorName: state.Error, cause: state.Cause}
 }
 
-// executeTaskState executes a Task state by calling the appropriate service.
+// executeTaskState executes a Task state by calling the appropriate
+// service. Callback (.waitForTaskToken) and activity resources are
+// dispatched before the ordinary integrations below, since both pause the
+// state on a task token rather than completing from the integration call's
+// own response; wrapCallbackTaskResult -- not wrapTaskResult -- wraps their
+// result, so a taskTimeoutError from a HeartbeatSeconds/TimeoutSeconds
+// expiry reaches executionErrorCode unwrapped (see wrapCallbackTaskResult).
 func (e *executionEngine) executeTaskState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
 	resource := state.Resource
 	if resource == "" {
 		return "", fmt.Errorf("task state %q has no Resource", name)
+	}
+
+	if isActivityResource(resource) {
+		return wrapCallbackTaskResult(e.executeActivityTask(ctx, name, state, resource, input))
+	}
+
+	if baseResource, ok := isCallbackResource(resource); ok {
+		return wrapCallbackTaskResult(e.executeCallbackTask(ctx, name, state, baseResource, input))
 	}
 
 	// Resolve parameters with JSONPath references from input.
@@ -504,6 +538,31 @@ func wrapTaskResult(output string, err error) (string, error) {
 	}
 
 	return output, nil
+}
+
+// wrapCallbackTaskResult is wrapTaskResult's counterpart for callback and
+// activity Task states: a taskTimeoutError (HeartbeatSeconds/TimeoutSeconds
+// expiry, or a SendTaskFailure's own reported error via failStateError) must
+// reach executionErrorCode unwrapped, since executionErrorCode checks for
+// *taskFailedError before *taskTimeoutError/*failStateError -- wrapping
+// either in *taskFailedError here would misreport a real States.Timeout or
+// SendTaskFailure error as States.TaskFailed instead.
+func wrapCallbackTaskResult(output string, err error) (string, error) {
+	if err == nil {
+		return output, nil
+	}
+
+	var timeoutErr *taskTimeoutError
+	if errors.As(err, &timeoutErr) {
+		return "", err
+	}
+
+	var failErr *failStateError
+	if errors.As(err, &failErr) {
+		return "", err
+	}
+
+	return "", &taskFailedError{err: err}
 }
 
 // resolveParameters resolves parameter values, handling JSONPath references

--- a/internal/service/sfn/handlers.go
+++ b/internal/service/sfn/handlers.go
@@ -29,6 +29,12 @@ func (s *Service) getActionHandlers() map[string]handlerFunc {
 		"SendTaskSuccess":      s.SendTaskSuccess,
 		"SendTaskFailure":      s.SendTaskFailure,
 		"SendTaskHeartbeat":    s.SendTaskHeartbeat,
+		// Activity operations.
+		"CreateActivity":   s.CreateActivity,
+		"DescribeActivity": s.DescribeActivity,
+		"ListActivities":   s.ListActivities,
+		"DeleteActivity":   s.DeleteActivity,
+		"GetActivityTask":  s.GetActivityTask,
 		// Tag, validation, version and alias operations.
 		"ValidateStateMachineDefinition": s.ValidateStateMachineDefinition,
 		"ListStateMachineVersions":       s.ListStateMachineVersions,
@@ -387,21 +393,176 @@ func getErrorStatus(code string) int {
 }
 
 // SendTaskSuccess handles the SendTaskSuccess API.
-// Since kumo does not manage task tokens, it always returns InvalidToken.
-func (s *Service) SendTaskSuccess(w http.ResponseWriter, _ *http.Request) {
-	writeError(w, "InvalidToken", "Invalid token", http.StatusBadRequest)
+func (s *Service) SendTaskSuccess(w http.ResponseWriter, r *http.Request) {
+	var req SendTaskSuccessRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.SendTaskSuccess(r.Context(), req.TaskToken, req.Output); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &SendTaskSuccessResponse{})
 }
 
 // SendTaskFailure handles the SendTaskFailure API.
-// Since kumo does not manage task tokens, it always returns InvalidToken.
-func (s *Service) SendTaskFailure(w http.ResponseWriter, _ *http.Request) {
-	writeError(w, "InvalidToken", "Invalid token", http.StatusBadRequest)
+func (s *Service) SendTaskFailure(w http.ResponseWriter, r *http.Request) {
+	var req SendTaskFailureRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.SendTaskFailure(r.Context(), req.TaskToken, req.Error, req.Cause); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &SendTaskFailureResponse{})
 }
 
 // SendTaskHeartbeat handles the SendTaskHeartbeat API.
-// Since kumo does not manage task tokens, it always returns InvalidToken.
-func (s *Service) SendTaskHeartbeat(w http.ResponseWriter, _ *http.Request) {
-	writeError(w, "InvalidToken", "Invalid token", http.StatusBadRequest)
+func (s *Service) SendTaskHeartbeat(w http.ResponseWriter, r *http.Request) {
+	var req SendTaskHeartbeatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.SendTaskHeartbeat(r.Context(), req.TaskToken); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &SendTaskHeartbeatResponse{})
+}
+
+// CreateActivity handles the CreateActivity API.
+func (s *Service) CreateActivity(w http.ResponseWriter, r *http.Request) {
+	var req CreateActivityRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	activity, err := s.storage.CreateActivity(r.Context(), req.Name, req.Tags)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &CreateActivityResponse{
+		ActivityArn:  activity.ActivityArn,
+		CreationDate: float64(activity.CreationDate.Unix()),
+	})
+}
+
+// DescribeActivity handles the DescribeActivity API.
+func (s *Service) DescribeActivity(w http.ResponseWriter, r *http.Request) {
+	var req DescribeActivityRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	activity, err := s.storage.DescribeActivity(r.Context(), req.ActivityArn)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DescribeActivityResponse{
+		ActivityArn:  activity.ActivityArn,
+		Name:         activity.Name,
+		CreationDate: float64(activity.CreationDate.Unix()),
+	})
+}
+
+// ListActivities handles the ListActivities API.
+func (s *Service) ListActivities(w http.ResponseWriter, r *http.Request) {
+	var req ListActivitiesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	activities, nextToken, err := s.storage.ListActivities(r.Context(), req.MaxResults, req.NextToken)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	items := make([]ActivityListItem, len(activities))
+	for i, a := range activities {
+		items[i] = ActivityListItem{
+			ActivityArn:  a.ActivityArn,
+			Name:         a.Name,
+			CreationDate: float64(a.CreationDate.Unix()),
+		}
+	}
+
+	writeResponse(w, &ListActivitiesResponse{
+		Activities: items,
+		NextToken:  nextToken,
+	})
+}
+
+// DeleteActivity handles the DeleteActivity API.
+func (s *Service) DeleteActivity(w http.ResponseWriter, r *http.Request) {
+	var req DeleteActivityRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.storage.DeleteActivity(r.Context(), req.ActivityArn); err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &DeleteActivityResponse{})
+}
+
+// GetActivityTask handles the GetActivityTask API: a worker's long poll for
+// a scheduled task. It blocks for up to activityPollTimeout inside
+// s.storage.GetActivityTask, so the HTTP response itself is only written
+// once a task arrives or the poll window elapses.
+func (s *Service) GetActivityTask(w http.ResponseWriter, r *http.Request) {
+	var req GetActivityTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	taskToken, input, err := s.storage.GetActivityTask(r.Context(), req.ActivityArn, req.WorkerName)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, &GetActivityTaskResponse{
+		TaskToken: taskToken,
+		Input:     input,
+	})
 }
 
 // ValidateStateMachineDefinition runs kumo's structural checks against the

--- a/internal/service/sfn/storage.go
+++ b/internal/service/sfn/storage.go
@@ -50,6 +50,19 @@ type Storage interface {
 	ListStateMachineVersions(ctx context.Context, stateMachineArn string, maxResults int32, nextToken string) ([]map[string]string, string, error)
 	ListStateMachineAliases(ctx context.Context, stateMachineArn string, maxResults int32, nextToken string) ([]map[string]string, string, error)
 
+	// Activity operations.
+	CreateActivity(ctx context.Context, name string, tags []Tag) (*Activity, error)
+	DescribeActivity(ctx context.Context, arn string) (*Activity, error)
+	ListActivities(ctx context.Context, maxResults int32, nextToken string) ([]*Activity, string, error)
+	DeleteActivity(ctx context.Context, arn string) error
+	GetActivityTask(ctx context.Context, activityArn, workerName string) (taskToken, input string, err error)
+
+	// Task token operations, shared by callback (.waitForTaskToken) Task
+	// states and activity Task states.
+	SendTaskSuccess(ctx context.Context, taskToken, output string) error
+	SendTaskFailure(ctx context.Context, taskToken, errorName, cause string) error
+	SendTaskHeartbeat(ctx context.Context, taskToken string) error
+
 	// DispatchAction dispatches the request to the appropriate handler.
 	DispatchAction(action string) bool
 }
@@ -82,6 +95,7 @@ type MemoryStorage struct {
 	mu            sync.RWMutex              `json:"-"`
 	StateMachines map[string]*StateMachine  `json:"stateMachines"`
 	Executions    map[string]*ExecutionData `json:"executions"`
+	Activities    map[string]*Activity      `json:"activities"`
 	Tags          map[string][]Tag          `json:"tags"`
 	region        string
 	accountID     string
@@ -107,6 +121,7 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	s := &MemoryStorage{
 		StateMachines: make(map[string]*StateMachine),
 		Executions:    make(map[string]*ExecutionData),
+		Activities:    make(map[string]*Activity),
 		Tags:          make(map[string][]Tag),
 		region:        region,
 		accountID:     "000000000000",
@@ -159,6 +174,10 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 
 	if s.Executions == nil {
 		s.Executions = make(map[string]*ExecutionData)
+	}
+
+	if s.Activities == nil {
+		s.Activities = make(map[string]*Activity)
 	}
 
 	if s.Tags == nil {

--- a/internal/service/sfn/types.go
+++ b/internal/service/sfn/types.go
@@ -432,3 +432,94 @@ type validateDiagnostic struct {
 	Message  string `json:"message"`
 	Location string `json:"location,omitempty"`
 }
+
+// CreateActivityRequest is the request for CreateActivity.
+type CreateActivityRequest struct {
+	Name string `json:"name"`
+	Tags []Tag  `json:"tags,omitempty"`
+}
+
+// CreateActivityResponse is the response for CreateActivity.
+type CreateActivityResponse struct {
+	ActivityArn  string  `json:"activityArn"`
+	CreationDate float64 `json:"creationDate"`
+}
+
+// DescribeActivityRequest is the request for DescribeActivity.
+type DescribeActivityRequest struct {
+	ActivityArn string `json:"activityArn"`
+}
+
+// DescribeActivityResponse is the response for DescribeActivity.
+type DescribeActivityResponse struct {
+	ActivityArn  string  `json:"activityArn"`
+	Name         string  `json:"name"`
+	CreationDate float64 `json:"creationDate"`
+}
+
+// ListActivitiesRequest is the request for ListActivities.
+type ListActivitiesRequest struct {
+	MaxResults int32  `json:"maxResults,omitempty"`
+	NextToken  string `json:"nextToken,omitempty"`
+}
+
+// ListActivitiesResponse is the response for ListActivities.
+type ListActivitiesResponse struct {
+	Activities []ActivityListItem `json:"activities"`
+	NextToken  string             `json:"nextToken,omitempty"`
+}
+
+// ActivityListItem represents an activity in a list.
+type ActivityListItem struct {
+	ActivityArn  string  `json:"activityArn"`
+	Name         string  `json:"name"`
+	CreationDate float64 `json:"creationDate"`
+}
+
+// DeleteActivityRequest is the request for DeleteActivity.
+type DeleteActivityRequest struct {
+	ActivityArn string `json:"activityArn"`
+}
+
+// DeleteActivityResponse is the response for DeleteActivity.
+type DeleteActivityResponse struct{}
+
+// GetActivityTaskRequest is the request for GetActivityTask.
+type GetActivityTaskRequest struct {
+	ActivityArn string `json:"activityArn"`
+	WorkerName  string `json:"workerName,omitempty"`
+}
+
+// GetActivityTaskResponse is the response for GetActivityTask. TaskToken is
+// an empty string when the long poll elapsed with no task scheduled.
+type GetActivityTaskResponse struct {
+	TaskToken string `json:"taskToken"`
+	Input     string `json:"input,omitempty"`
+}
+
+// SendTaskSuccessRequest is the request for SendTaskSuccess.
+type SendTaskSuccessRequest struct {
+	TaskToken string `json:"taskToken"`
+	Output    string `json:"output"`
+}
+
+// SendTaskSuccessResponse is the response for SendTaskSuccess.
+type SendTaskSuccessResponse struct{}
+
+// SendTaskFailureRequest is the request for SendTaskFailure.
+type SendTaskFailureRequest struct {
+	TaskToken string `json:"taskToken"`
+	Error     string `json:"error,omitempty"`
+	Cause     string `json:"cause,omitempty"`
+}
+
+// SendTaskFailureResponse is the response for SendTaskFailure.
+type SendTaskFailureResponse struct{}
+
+// SendTaskHeartbeatRequest is the request for SendTaskHeartbeat.
+type SendTaskHeartbeatRequest struct {
+	TaskToken string `json:"taskToken"`
+}
+
+// SendTaskHeartbeatResponse is the response for SendTaskHeartbeat.
+type SendTaskHeartbeatResponse struct{}

--- a/internal/service/sfn/validate.go
+++ b/internal/service/sfn/validate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // Diagnostic severities and validation results, matching the exact wire
@@ -267,11 +268,40 @@ func (v *definitionValidator) validateCatchers(name string, state *stateDefiniti
 	}
 }
 
-// validateTaskState checks a Task state's required Resource field.
+// validateTaskState checks a Task state's required Resource field, and, for
+// the .waitForTaskToken integration pattern, that Parameters actually
+// references the task token ($$.Task.Token) -- otherwise the integration
+// fires but no caller can ever resolve the token, so the state can only
+// ever fail with States.Timeout. AWS rejects this at CreateStateMachine
+// time.
 func (v *definitionValidator) validateTaskState(name string, state *stateDefinition, location string) {
 	if state.Resource == "" {
 		v.addError(codeInvalidResource, location+"/Resource", fmt.Sprintf("Task state %q is missing required field \"Resource\"", name))
+
+		return
 	}
+
+	if _, ok := isCallbackResource(state.Resource); ok && !hasTaskTokenReference(state.Parameters) {
+		v.addError(codeSchemaValidationFailed, location+"/Parameters", fmt.Sprintf(
+			"Task state %q uses %q, so \"Parameters\" must reference the task token via \"$$.Task.Token\"", name, callbackResourceSuffix,
+		))
+	}
+}
+
+// hasTaskTokenReference reports whether params contains a "$$.Task.Token"
+// JSONPath reference anywhere, including nested Payload Template objects.
+func hasTaskTokenReference(params map[string]any) bool {
+	for key, value := range params {
+		if strings.HasSuffix(key, ".$") && value == "$$.Task.Token" {
+			return true
+		}
+
+		if sub, ok := value.(map[string]any); ok && hasTaskTokenReference(sub) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // validateChoiceState checks a Choice state's Choices (non-empty, each with

--- a/internal/service/sfn/validate_test.go
+++ b/internal/service/sfn/validate_test.go
@@ -40,13 +40,46 @@ const comprehensiveValidDefinition = `{
 	}
 }`
 
+// validCallbackDefinition is a Task state using the .waitForTaskToken
+// integration pattern with a properly nested $$.Task.Token reference in
+// Parameters, which must validate with no ERROR diagnostics.
+const validCallbackDefinition = `{
+	"StartAt": "Notify",
+	"States": {
+		"Notify": {
+			"Type": "Task",
+			"Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+			"Parameters": {
+				"QueueUrl": "https://sqs.us-east-1.amazonaws.com/000000000000/q",
+				"MessageBody": {"TaskToken.$": "$$.Task.Token"}
+			},
+			"End": true
+		}
+	}
+}`
+
+// validActivityTaskDefinition is a Task state whose Resource is an activity
+// ARN, which must validate with no ERROR diagnostics.
+const validActivityTaskDefinition = `{
+	"StartAt": "DoWork",
+	"States": {
+		"DoWork": {
+			"Type": "Task",
+			"Resource": "arn:aws:states:us-east-1:000000000000:activity:my-activity",
+			"End": true
+		}
+	}
+}`
+
 func TestValidateStateMachineDefinitionExistingDefinitionsStillOK(t *testing.T) {
 	t.Parallel()
 
 	for name, definition := range map[string]string{
-		"comprehensive":  comprehensiveValidDefinition,
-		"execution test": executionTestDefinition,
-		"choice repro":   choiceReproDefinition,
+		"comprehensive":     comprehensiveValidDefinition,
+		"execution test":    executionTestDefinition,
+		"choice repro":      choiceReproDefinition,
+		"waitForTaskToken":  validCallbackDefinition,
+		"activity resource": validActivityTaskDefinition,
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -261,6 +294,23 @@ var validateDiagnosticTests = []diagnosticTest{
 		wantSeverity: diagnosticSeverityError,
 		wantCode:     codeInvalidJSONDescription,
 		wantLocation: "",
+	},
+	{
+		name: "waitForTaskToken without $$.Task.Token reference",
+		definition: `{
+			"StartAt": "Notify",
+			"States": {
+				"Notify": {
+					"Type": "Task",
+					"Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+					"Parameters": {"FunctionName": "notify-fn"},
+					"End": true
+				}
+			}
+		}`,
+		wantSeverity: diagnosticSeverityError,
+		wantCode:     codeSchemaValidationFailed,
+		wantLocation: "/States/Notify/Parameters",
 	},
 }
 

--- a/test/integration/sfn_test.go
+++ b/test/integration/sfn_test.go
@@ -374,3 +374,86 @@ func TestSFN_TagOperations(t *testing.T) {
 	}
 	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_after_untag", listOutput2)
 }
+
+func TestSFN_ActivityCRUD(t *testing.T) {
+	client := newSFNClient(t)
+	ctx := t.Context()
+
+	name := "test-activity"
+
+	// CreateActivity.
+	createOutput, err := client.CreateActivity(ctx, &sfn.CreateActivityInput{
+		Name: aws.String(name),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ActivityArn", "CreationDate", "ResultMetadata")).Assert(t.Name()+"_create", createOutput)
+
+	activityArn := *createOutput.ActivityArn
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteActivity(context.Background(), &sfn.DeleteActivityInput{
+			ActivityArn: aws.String(activityArn),
+		})
+	})
+
+	// CreateActivity again with the same name: idempotent, same ARN.
+	secondCreateOutput, err := client.CreateActivity(ctx, &sfn.CreateActivityInput{
+		Name: aws.String(name),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *secondCreateOutput.ActivityArn != activityArn {
+		t.Fatalf("CreateActivity is not idempotent: got %q, want %q", *secondCreateOutput.ActivityArn, activityArn)
+	}
+
+	// DescribeActivity.
+	describeOutput, err := client.DescribeActivity(ctx, &sfn.DescribeActivityInput{
+		ActivityArn: aws.String(activityArn),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ActivityArn", "CreationDate", "ResultMetadata")).Assert(t.Name()+"_describe", describeOutput)
+
+	// ListActivities.
+	listOutput, err := client.ListActivities(ctx, &sfn.ListActivitiesInput{
+		MaxResults: 100,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+
+	for _, a := range listOutput.Activities {
+		if *a.Name == name {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Error("created activity not found in list")
+	}
+
+	// DeleteActivity.
+	_, err = client.DeleteActivity(ctx, &sfn.DeleteActivityInput{
+		ActivityArn: aws.String(activityArn),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify deletion.
+	_, err = client.DescribeActivity(ctx, &sfn.DescribeActivityInput{
+		ActivityArn: aws.String(activityArn),
+	})
+	if err == nil {
+		t.Fatal("expected error for deleted activity")
+	}
+}

--- a/test/integration/testdata/sfn_test_TestSFN_ActivityCRUD_TestSFN_ActivityCRUD_create.golden.go
+++ b/test/integration/testdata/sfn_test_TestSFN_ActivityCRUD_TestSFN_ActivityCRUD_create.golden.go
@@ -1,0 +1,5 @@
+{
+  "ActivityArn": "arn:aws:states:us-east-1:000000000000:activity:test-activity",
+  "CreationDate": "2026-07-30T04:58:18Z",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/sfn_test_TestSFN_ActivityCRUD_TestSFN_ActivityCRUD_describe.golden.go
+++ b/test/integration/testdata/sfn_test_TestSFN_ActivityCRUD_TestSFN_ActivityCRUD_describe.golden.go
@@ -1,0 +1,7 @@
+{
+  "ActivityArn": "arn:aws:states:us-east-1:000000000000:activity:test-activity",
+  "CreationDate": "2026-07-30T04:58:18Z",
+  "Name": "test-activity",
+  "EncryptionConfiguration": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
Second of three PRs completing the remaining Step Functions gaps: the callback pattern and Activities.

- .waitForTaskToken on lambda:invoke / sqs:sendMessage: the integration fires with $$.Task.Token injected, the execution pauses, and SendTaskSuccess / SendTaskFailure resolve it (output flows through the data-flow pipeline; failures hit the state's Retry/Catch)
- HeartbeatSeconds becomes enforceable for callback tasks via SendTaskHeartbeat; both heartbeat and TimeoutSeconds expiry surface as States.Timeout per AWS docs
- SendTaskSuccess/SendTaskFailure/SendTaskHeartbeat APIs with TaskDoesNotExist / TaskTimedOut semantics
- Activities: CRUD (CreateActivity idempotent by name), GetActivityTask long-poll with exactly-once FIFO hand-off, and Task states targeting activity ARNs
- Validation errors for .waitForTaskToken resources whose Parameters never reference $$.Task.Token

## Test plan
- [ ] Callback pause/resume, failure-to-Catch, unknown token, timeout and heartbeat expiry
- [ ] Activity CRUD golden test; concurrent pollers receive each task exactly once; end-to-end worker flow
- [ ] Full sfn suite race-clean