### PR TITLE
feat(sfn): nested executions, MapRun tracking, and remaining Map and Choice features

### DIFF
--- a/internal/service/sfn/choice.go
+++ b/internal/service/sfn/choice.go
@@ -64,8 +64,17 @@ type choiceRule struct {
 	TimestampLessThanEqualsPath    *string `json:"timestampLessThanEqualsPath"`
 	TimestampGreaterThanEqualsPath *string `json:"timestampGreaterThanEqualsPath"`
 
-	IsPresent *bool `json:"isPresent"`
-	IsNull    *bool `json:"isNull"`
+	IsPresent   *bool `json:"isPresent"`
+	IsNull      *bool `json:"isNull"`
+	IsNumeric   *bool `json:"isNumeric"`
+	IsString    *bool `json:"isString"`
+	IsBoolean   *bool `json:"isBoolean"`
+	IsTimestamp *bool `json:"isTimestamp"`
+
+	// StringMatches has no "*Path" variant (the spec lists it as a plain
+	// comparator, unlike every other String*/Numeric*/Boolean*/Timestamp*
+	// operator) -- see evaluateStringMatches.
+	StringMatches *string `json:"stringMatches"`
 
 	And []choiceRule `json:"and"`
 	Or  []choiceRule `json:"or"`
@@ -148,6 +157,10 @@ func evaluateDataTest(rule *choiceRule, input map[string]any) (bool, error) {
 		return (value == nil) == *rule.IsNull, nil
 	}
 
+	if matched, handled := evaluateTypeCheck(rule, value); handled {
+		return matched, nil
+	}
+
 	if matched, handled, err := evaluateStringComparison(rule, value, input); handled {
 		return matched, err
 	}
@@ -168,7 +181,8 @@ func evaluateDataTest(rule *choiceRule, input map[string]any) (bool, error) {
 }
 
 // evaluateStringComparison evaluates the String* comparators, including
-// their "*Path" variants. handled is false if rule sets none of them.
+// their "*Path" variants, and StringMatches (which has no "*Path" variant).
+// handled is false if rule sets none of them.
 func evaluateStringComparison(rule *choiceRule, value any, input map[string]any) (matched, handled bool, err error) {
 	switch {
 	case rule.StringEquals != nil || rule.StringEqualsPath != nil:
@@ -181,9 +195,137 @@ func evaluateStringComparison(rule *choiceRule, value any, input map[string]any)
 		return compareStringWith(value, rule.StringLessThanEquals, rule.StringLessThanEqualsPath, input, func(cmp int) bool { return cmp <= 0 })
 	case rule.StringGreaterThanEquals != nil || rule.StringGreaterThanEqualsPath != nil:
 		return compareStringWith(value, rule.StringGreaterThanEquals, rule.StringGreaterThanEqualsPath, input, func(cmp int) bool { return cmp >= 0 })
+	case rule.StringMatches != nil:
+		return evaluateStringMatches(value, *rule.StringMatches)
 	default:
 		return false, false, nil
 	}
+}
+
+// evaluateStringMatches evaluates StringMatches: value must be a string
+// matching pattern, per states-language.net's wildcard rules -- see
+// parseStringMatchesPattern/stringMatchesGlob.
+func evaluateStringMatches(value any, pattern string) (matched, handled bool, err error) {
+	s, ok := value.(string)
+	if !ok {
+		return false, true, nil
+	}
+
+	segments, err := parseStringMatchesPattern(pattern)
+	if err != nil {
+		return false, true, fmt.Errorf("choice rule: %w", err)
+	}
+
+	return stringMatchesGlob(s, segments), true, nil
+}
+
+// parseStringMatchesPattern splits a StringMatches pattern into the literal
+// segments between its unescaped "*" wildcards, per
+// https://states-language.net/spec.html's StringMatches rules: "*" matches
+// zero or more characters; "\*" is a literal "*"; "\\" is a literal "\";
+// any other use of "\" (including a trailing, unescaped one) is a runtime
+// error.
+func parseStringMatchesPattern(pattern string) ([]string, error) {
+	var (
+		segments []string
+		current  strings.Builder
+	)
+
+	runes := []rune(pattern)
+
+	for i := 0; i < len(runes); i++ {
+		switch runes[i] {
+		case '\\':
+			if i+1 >= len(runes) {
+				return nil, fmt.Errorf("stringMatches pattern %q ends with an unescaped backslash", pattern)
+			}
+
+			next := runes[i+1]
+			if next != '*' && next != '\\' {
+				return nil, fmt.Errorf("stringMatches pattern %q: backslash must escape '*' or '\\', not %q", pattern, next)
+			}
+
+			current.WriteRune(next)
+
+			i++
+		case '*':
+			segments = append(segments, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(runes[i])
+		}
+	}
+
+	segments = append(segments, current.String())
+
+	return segments, nil
+}
+
+// stringMatchesGlob reports whether value matches a StringMatches pattern
+// already split into segments by parseStringMatchesPattern: segments[0]
+// must prefix value and segments[len-1] must suffix it (the sole segment
+// must equal value exactly when there was no wildcard at all), with every
+// segment in between required to appear, in order, somewhere between them.
+func stringMatchesGlob(value string, segments []string) bool {
+	if len(segments) == 1 {
+		return value == segments[0]
+	}
+
+	if !strings.HasPrefix(value, segments[0]) {
+		return false
+	}
+
+	value = value[len(segments[0]):]
+
+	for _, seg := range segments[1 : len(segments)-1] {
+		idx := strings.Index(value, seg)
+		if idx < 0 {
+			return false
+		}
+
+		value = value[idx+len(seg):]
+	}
+
+	return strings.HasSuffix(value, segments[len(segments)-1])
+}
+
+// evaluateTypeCheck evaluates IsNumeric/IsString/IsBoolean/IsTimestamp: each
+// takes a boolean operand and matches when value's type (JSON number/
+// string/boolean, or -- for IsTimestamp -- an RFC3339 string) equals it,
+// mirroring how IsNull compares (value == nil) against its own boolean
+// operand. handled is false if rule sets none of them.
+func evaluateTypeCheck(rule *choiceRule, value any) (matched, handled bool) {
+	switch {
+	case rule.IsNumeric != nil:
+		_, isNumber := value.(float64)
+
+		return isNumber == *rule.IsNumeric, true
+	case rule.IsString != nil:
+		_, isString := value.(string)
+
+		return isString == *rule.IsString, true
+	case rule.IsBoolean != nil:
+		_, isBool := value.(bool)
+
+		return isBool == *rule.IsBoolean, true
+	case rule.IsTimestamp != nil:
+		return isTimestampValue(value) == *rule.IsTimestamp, true
+	default:
+		return false, false
+	}
+}
+
+// isTimestampValue reports whether value is a string parseable as an
+// RFC3339 timestamp, mirroring timestampCompare's own parsing.
+func isTimestampValue(value any) bool {
+	s, ok := value.(string)
+	if !ok {
+		return false
+	}
+
+	_, err := time.Parse(time.RFC3339, s)
+
+	return err == nil
 }
 
 // compareStringWith resolves a String* comparator's operand -- from a

--- a/internal/service/sfn/choice_test.go
+++ b/internal/service/sfn/choice_test.go
@@ -301,6 +301,114 @@ var choiceRuleTests = []struct {
 		want:  true,
 	},
 	{
+		name:  "IsNumeric true for numeric field",
+		rule:  choiceRule{Variable: pathValue, IsNumeric: boolPtr(true)},
+		input: map[string]any{fieldValue: float64(1)},
+		want:  true,
+	},
+	{
+		name:  "IsNumeric false for non-numeric field",
+		rule:  choiceRule{Variable: pathValue, IsNumeric: boolPtr(false)},
+		input: map[string]any{fieldValue: valueFast},
+		want:  true,
+	},
+	{
+		name:  "IsNumeric true expectation fails for non-numeric field",
+		rule:  choiceRule{Variable: pathValue, IsNumeric: boolPtr(true)},
+		input: map[string]any{fieldValue: valueFast},
+		want:  false,
+	},
+	{
+		name:  "IsString true for string field",
+		rule:  choiceRule{Variable: pathValue, IsString: boolPtr(true)},
+		input: map[string]any{fieldValue: valueFast},
+		want:  true,
+	},
+	{
+		name:  "IsString false for non-string field",
+		rule:  choiceRule{Variable: pathValue, IsString: boolPtr(false)},
+		input: map[string]any{fieldValue: float64(1)},
+		want:  true,
+	},
+	{
+		name:  "IsBoolean true for boolean field",
+		rule:  choiceRule{Variable: pathValue, IsBoolean: boolPtr(true)},
+		input: map[string]any{fieldValue: true},
+		want:  true,
+	},
+	{
+		name:  "IsBoolean false for non-boolean field",
+		rule:  choiceRule{Variable: pathValue, IsBoolean: boolPtr(false)},
+		input: map[string]any{fieldValue: valueFast},
+		want:  true,
+	},
+	{
+		name:  "IsTimestamp true for RFC3339 string field",
+		rule:  choiceRule{Variable: pathValue, IsTimestamp: boolPtr(true)},
+		input: map[string]any{fieldValue: "2020-01-01T00:00:00Z"},
+		want:  true,
+	},
+	{
+		name:  "IsTimestamp false for non-timestamp string field",
+		rule:  choiceRule{Variable: pathValue, IsTimestamp: boolPtr(true)},
+		input: map[string]any{fieldValue: valueFast},
+		want:  false,
+	},
+	{
+		name:  "StringMatches exact match with no wildcard",
+		rule:  choiceRule{Variable: pathName, StringMatches: strPtr("alice")},
+		input: map[string]any{fieldName: "alice"},
+		want:  true,
+	},
+	{
+		name:  "StringMatches leading wildcard",
+		rule:  choiceRule{Variable: pathName, StringMatches: strPtr("*.log")},
+		input: map[string]any{fieldName: "zebra.log"},
+		want:  true,
+	},
+	{
+		name:  "StringMatches trailing wildcard",
+		rule:  choiceRule{Variable: pathName, StringMatches: strPtr("foo*")},
+		input: map[string]any{fieldName: "foo23.log"},
+		want:  true,
+	},
+	{
+		name:  "StringMatches wildcard on both ends",
+		rule:  choiceRule{Variable: pathName, StringMatches: strPtr("foo*.*")},
+		input: map[string]any{fieldName: "foobar.zebra"},
+		want:  true,
+	},
+	{
+		name:  "StringMatches no match",
+		rule:  choiceRule{Variable: pathName, StringMatches: strPtr("log-*.txt")},
+		input: map[string]any{fieldName: "log-1.csv"},
+		want:  false,
+	},
+	{
+		name:  "StringMatches escaped wildcard is literal",
+		rule:  choiceRule{Variable: pathName, StringMatches: strPtr(`a\*b`)},
+		input: map[string]any{fieldName: "a*b"},
+		want:  true,
+	},
+	{
+		name:  "StringMatches escaped wildcard does not act as wildcard",
+		rule:  choiceRule{Variable: pathName, StringMatches: strPtr(`a\*b`)},
+		input: map[string]any{fieldName: "aXb"},
+		want:  false,
+	},
+	{
+		name:  "StringMatches escaped backslash is literal",
+		rule:  choiceRule{Variable: pathName, StringMatches: strPtr(`a\\b`)},
+		input: map[string]any{fieldName: `a\b`},
+		want:  true,
+	},
+	{
+		name:  "StringMatches against non-string value does not match",
+		rule:  choiceRule{Variable: pathValue, StringMatches: strPtr("*")},
+		input: map[string]any{fieldValue: float64(1)},
+		want:  false,
+	},
+	{
 		name: "And all match",
 		rule: choiceRule{And: []choiceRule{
 			{Variable: pathValue, IsPresent: boolPtr(true)},
@@ -383,6 +491,28 @@ func TestEvaluateChoiceRulePathComparatorUnresolvableOperandErrors(t *testing.T)
 	_, err := evaluateChoiceRule(&rule, map[string]any{fieldMode: valueFast})
 	if err == nil {
 		t.Fatal("evaluateChoiceRule: want error for unresolvable *Path comparator operand, got nil")
+	}
+}
+
+func TestEvaluateChoiceRuleStringMatchesDanglingBackslashErrors(t *testing.T) {
+	t.Parallel()
+
+	rule := choiceRule{Variable: pathName, StringMatches: strPtr(`a\`)}
+
+	_, err := evaluateChoiceRule(&rule, map[string]any{fieldName: "a"})
+	if err == nil {
+		t.Fatal("evaluateChoiceRule: want error for StringMatches pattern with a dangling backslash, got nil")
+	}
+}
+
+func TestEvaluateChoiceRuleStringMatchesInvalidEscapeErrors(t *testing.T) {
+	t.Parallel()
+
+	rule := choiceRule{Variable: pathName, StringMatches: strPtr(`a\bc`)}
+
+	_, err := evaluateChoiceRule(&rule, map[string]any{fieldName: "abc"})
+	if err == nil {
+		t.Fatal("evaluateChoiceRule: want error for StringMatches pattern escaping a character other than '*' or '\\', got nil")
 	}
 }
 

--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -93,11 +93,16 @@ type stateDefinition struct {
 	// fields require ItemProcessor.ProcessorConfig.Mode "DISTRIBUTED".
 	// MaxItemsPerBatchPath/MaxInputBytesPerBatchPath/MaxConcurrencyPath/
 	// ToleratedFailurePercentagePath/ToleratedFailureCountPath (the dynamic,
-	// reference-path forms of these fields) are not implemented.
+	// reference-path forms of these fields) are resolved against the Map
+	// state's effective input, preferring the Path form when both it and
+	// the static field are set -- see resolveMaxConcurrency in mapstate.go,
+	// resolveMapTolerance in maptolerance.go, and buildProcessorUnits in
+	// itembatcher.go.
 	ItemsPath                  string                  `json:"ItemsPath"`
 	ItemProcessor              *stateMachineDefinition `json:"ItemProcessor"`
 	Iterator                   *stateMachineDefinition `json:"Iterator"`
 	MaxConcurrency             int                     `json:"MaxConcurrency"`
+	MaxConcurrencyPath         string                  `json:"MaxConcurrencyPath"`
 	ItemReader                 json.RawMessage         `json:"ItemReader"`
 	ItemSelector               json.RawMessage         `json:"ItemSelector"`
 	ItemBatcher                json.RawMessage         `json:"ItemBatcher"`
@@ -105,10 +110,8 @@ type stateDefinition struct {
 	ToleratedFailurePercentage *float64                `json:"ToleratedFailurePercentage"`
 	ToleratedFailureCount      *int                    `json:"ToleratedFailureCount"`
 
-	// ToleratedFailurePercentagePath/ToleratedFailureCountPath are decoded
-	// only so validate.go can flag them as unimplemented; the engine never
-	// reads them (see resolveMapTolerance in maptolerance.go, which only
-	// reads the static ToleratedFailurePercentage/ToleratedFailureCount).
+	// ToleratedFailurePercentagePath/ToleratedFailureCountPath: see
+	// resolveMapTolerance in maptolerance.go.
 	ToleratedFailurePercentagePath string `json:"ToleratedFailurePercentagePath"`
 	ToleratedFailureCountPath      string `json:"ToleratedFailureCountPath"`
 
@@ -245,6 +248,22 @@ type executionEngine struct {
 	// activityPollTimeout bounds GetActivityTask's long poll; tests
 	// override this directly to keep runtime bounded.
 	activityPollTimeout time.Duration
+
+	// starter services the states:startExecution Task integration (see
+	// nestedexec.go). It is wired to the same MemoryStorage that owns this
+	// engine (see NewMemoryStorage in storage.go) rather than an HTTP round
+	// trip back to kumo's own server, since it recurses into kumo's own SFN
+	// engine -- see nestedexec.go's executionStarter doc for why. It is nil
+	// for engines built directly via newExecutionEngine in tests that never
+	// exercise states:startExecution.
+	starter executionStarter
+
+	// mapRuns records distributed-mode Map Runs (see maprun.go), wired the
+	// same way as starter and for the same reason: it is storage
+	// bookkeeping, not a real AWS service call. It is nil for engines built
+	// directly via newExecutionEngine in tests that never exercise a
+	// Distributed Map.
+	mapRuns mapRunTracker
 }
 
 // newExecutionEngine creates a new execution engine.
@@ -525,6 +544,8 @@ func (e *executionEngine) executeTaskState(ctx context.Context, name string, sta
 		return wrapTaskResult(e.executeLambdaInvoke(ctx, params))
 	case strings.HasPrefix(resource, "arn:aws:lambda:"):
 		return wrapTaskResult(e.executeLambdaFunctionTask(ctx, name, resource, params, input))
+	case strings.HasPrefix(resource, resourceStartExecutionBase):
+		return wrapTaskResult(e.executeStartExecutionTask(ctx, resource, params))
 	default:
 		return "", fmt.Errorf("unsupported task resource %q", resource)
 	}

--- a/internal/service/sfn/handlers.go
+++ b/internal/service/sfn/handlers.go
@@ -26,6 +26,8 @@ func (s *Service) getActionHandlers() map[string]handlerFunc {
 		"DescribeExecution":    s.DescribeExecution,
 		"ListExecutions":       s.ListExecutions,
 		"GetExecutionHistory":  s.GetExecutionHistory,
+		"DescribeMapRun":       s.DescribeMapRun,
+		"ListMapRuns":          s.ListMapRuns,
 		"SendTaskSuccess":      s.SendTaskSuccess,
 		"SendTaskFailure":      s.SendTaskFailure,
 		"SendTaskHeartbeat":    s.SendTaskHeartbeat,
@@ -352,6 +354,94 @@ func (s *Service) GetExecutionHistory(w http.ResponseWriter, r *http.Request) {
 	writeResponse(w, resp)
 }
 
+// DescribeMapRun handles the DescribeMapRun API.
+func (s *Service) DescribeMapRun(w http.ResponseWriter, r *http.Request) {
+	var req DescribeMapRunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	mr, err := s.storage.DescribeMapRun(r.Context(), req.MapRunArn)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	writeResponse(w, mapRunToDescribeResponse(mr))
+}
+
+// mapRunToDescribeResponse converts a MapRun storage record into its
+// DescribeMapRun wire shape.
+func mapRunToDescribeResponse(mr *MapRun) *DescribeMapRunResponse {
+	resp := &DescribeMapRunResponse{
+		ExecutionArn:    mr.ExecutionArn,
+		ExecutionCounts: mr.ExecutionCounts,
+		ItemCounts:      mr.ItemCounts,
+		MapRunArn:       mr.MapRunArn,
+		MaxConcurrency:  mr.MaxConcurrency,
+		RedriveCount:    mr.RedriveCount,
+		StartDate:       float64(mr.StartDate.Unix()),
+		Status:          mr.Status,
+	}
+
+	if mr.StopDate != nil {
+		resp.StopDate = float64(mr.StopDate.Unix())
+	}
+
+	if mr.RedriveDate != nil {
+		resp.RedriveDate = float64(mr.RedriveDate.Unix())
+	}
+
+	if mr.ToleratedFailureCount != nil {
+		resp.ToleratedFailureCount = int64(*mr.ToleratedFailureCount)
+	}
+
+	if mr.ToleratedFailurePercentage != nil {
+		resp.ToleratedFailurePercentage = *mr.ToleratedFailurePercentage
+	}
+
+	return resp
+}
+
+// ListMapRuns handles the ListMapRuns API.
+func (s *Service) ListMapRuns(w http.ResponseWriter, r *http.Request) {
+	var req ListMapRunsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return
+	}
+
+	mapRuns, nextToken, err := s.storage.ListMapRuns(r.Context(), req.ExecutionArn, req.MaxResults, req.NextToken)
+	if err != nil {
+		handleError(w, err)
+
+		return
+	}
+
+	items := make([]MapRunListItem, len(mapRuns))
+
+	for i, mr := range mapRuns {
+		item := MapRunListItem{
+			ExecutionArn:    mr.ExecutionArn,
+			MapRunArn:       mr.MapRunArn,
+			StartDate:       float64(mr.StartDate.Unix()),
+			StateMachineArn: mr.StateMachineArn,
+		}
+
+		if mr.StopDate != nil {
+			item.StopDate = float64(mr.StopDate.Unix())
+		}
+
+		items[i] = item
+	}
+
+	writeResponse(w, &ListMapRunsResponse{MapRuns: items, NextToken: nextToken})
+}
+
 // writeResponse writes a JSON response.
 func writeResponse(w http.ResponseWriter, resp any) {
 	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
@@ -385,7 +475,7 @@ func getErrorStatus(code string) int {
 		return http.StatusNotFound
 	case errStateMachineAlreadyExists, errExecutionAlreadyExists:
 		return http.StatusConflict
-	case errInvalidArn, errInvalidDefinition:
+	case errInvalidArn, errInvalidDefinition, errResourceNotFound:
 		return http.StatusBadRequest
 	default:
 		return http.StatusBadRequest

--- a/internal/service/sfn/itembatcher.go
+++ b/internal/service/sfn/itembatcher.go
@@ -12,8 +12,8 @@ import (
 //
 // MaxItemsPerBatchPath and MaxInputBytesPerBatchPath (the dynamic,
 // reference-path forms of MaxItemsPerBatch/MaxInputBytesPerBatch) are
-// decoded only so validate.go can flag them as unimplemented; the engine
-// never reads them.
+// resolved against the Map state's input in buildProcessorUnits, preferring
+// the Path form over its static counterpart when both are set.
 type itemBatcherDef struct {
 	MaxItemsPerBatch          *int           `json:"maxItemsPerBatch"`
 	MaxInputBytesPerBatch     *int           `json:"maxInputBytesPerBatch"`
@@ -46,8 +46,18 @@ func buildProcessorUnits(raw json.RawMessage, items []json.RawMessage, mapInput 
 		return nil, fmt.Errorf("parse ItemBatcher: %w", err)
 	}
 
-	if def.MaxItemsPerBatch == nil && def.MaxInputBytesPerBatch == nil {
-		return nil, fmt.Errorf("itemBatcher requires MaxItemsPerBatch or MaxInputBytesPerBatch")
+	maxItemsPerBatch, err := resolveOptionalIntPath(def.MaxItemsPerBatch, def.MaxItemsPerBatchPath, mapInput)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ItemBatcher MaxItemsPerBatchPath: %w", err)
+	}
+
+	maxInputBytesPerBatch, err := resolveOptionalIntPath(def.MaxInputBytesPerBatch, def.MaxInputBytesPerBatchPath, mapInput)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ItemBatcher MaxInputBytesPerBatchPath: %w", err)
+	}
+
+	if maxItemsPerBatch == nil && maxInputBytesPerBatch == nil {
+		return nil, fmt.Errorf("itemBatcher requires MaxItemsPerBatch(Path) or MaxInputBytesPerBatch(Path)")
 	}
 
 	batchInput, err := resolveBatchInput(def.BatchInput, mapInput)
@@ -55,7 +65,7 @@ func buildProcessorUnits(raw json.RawMessage, items []json.RawMessage, mapInput 
 		return nil, err
 	}
 
-	batches := groupIntoBatches(items, def.MaxItemsPerBatch, def.MaxInputBytesPerBatch)
+	batches := groupIntoBatches(items, maxItemsPerBatch, maxInputBytesPerBatch)
 
 	units := make([]mapUnit, len(batches))
 

--- a/internal/service/sfn/itembatcher_test.go
+++ b/internal/service/sfn/itembatcher_test.go
@@ -106,6 +106,74 @@ func TestMapStateItemBatcherResolvesBatchInputFromMapInput(t *testing.T) {
 	}
 }
 
+func TestMapStateItemBatcherMaxItemsPerBatchPathResolvesFromMapInput(t *testing.T) {
+	t.Parallel()
+
+	itemBatcher := `{"MaxItemsPerBatchPath": "$.batchSize"}`
+	definition := fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemsPath": "$.items",
+				"ItemBatcher": %s,
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, itemBatcher, distributedItemProcessorJSON)
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-itembatcher-maxitemsperbatchpath", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"items":[1,2,3,4,5],"batchSize":2}`)
+
+	var envelopes []batchEnvelope
+	if err := json.Unmarshal([]byte(exec.Output), &envelopes); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(envelopes) != 3 {
+		t.Fatalf("batches: got %d, want 3", len(envelopes))
+	}
+}
+
+// TestMapStateItemBatcherMaxItemsPerBatchPathTakesPrecedenceOverStatic
+// checks that, when both MaxItemsPerBatch and MaxItemsPerBatchPath are set,
+// the Path form wins -- the same precedence every other *Path field in this
+// package gives its static counterpart.
+func TestMapStateItemBatcherMaxItemsPerBatchPathTakesPrecedenceOverStatic(t *testing.T) {
+	t.Parallel()
+
+	itemBatcher := `{"MaxItemsPerBatch": 10, "MaxItemsPerBatchPath": "$.batchSize"}`
+	definition := fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemsPath": "$.items",
+				"ItemBatcher": %s,
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, itemBatcher, distributedItemProcessorJSON)
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-itembatcher-maxitemsperbatchpath-precedence", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"items":[1,2,3,4,5],"batchSize":1}`)
+
+	var envelopes []batchEnvelope
+	if err := json.Unmarshal([]byte(exec.Output), &envelopes); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(envelopes) != 5 {
+		t.Fatalf("batches: got %d, want 5 (MaxItemsPerBatchPath=1 must win over MaxItemsPerBatch=10)", len(envelopes))
+	}
+}
+
 // jsonDeepEqual compares two already-decoded JSON values by re-encoding
 // them, avoiding a reflect.DeepEqual dependency on map/slice identity.
 func jsonDeepEqual(a, b any) bool {

--- a/internal/service/sfn/itemreader.go
+++ b/internal/service/sfn/itemreader.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 )
 
 // ItemReader.ReaderConfig.InputType values kumo implements.
@@ -24,12 +27,19 @@ const (
 	csvHeaderLocationGiven    = "GIVEN"
 )
 
-// ItemReader.Resource values. Only s3:getObject is implemented;
-// s3:listObjectsV2 is documented but out of scope (see readItemsFromS3).
+// ItemReader.Resource values.
 const (
 	itemReaderResourceS3GetObject     = "arn:aws:states:::s3:getObject"
 	itemReaderResourceS3ListObjectsV2 = "arn:aws:states:::s3:listObjectsV2"
 )
+
+// itemReaderTransformationLoadAndFlatten is ReaderConfig.Transformation's
+// only non-default value, meaningful only for s3:listObjectsV2: it reads
+// and parses the actual object contents (per InputType) referenced by each
+// listing entry, instead of returning the S3 object metadata itself. kumo
+// does not implement it -- see readItemsFromS3ListObjectsV2 -- since it is
+// effectively a second, nested ItemReader pass per listed object.
+const itemReaderTransformationLoadAndFlatten = "LOAD_AND_FLATTEN"
 
 // itemReaderDef is the decoded ItemReader field. JSON tags are
 // lowerCamelCase; see itemBatcherDef in itembatcher.go for why.
@@ -40,32 +50,28 @@ type itemReaderDef struct {
 }
 
 // itemReaderConfig is ItemReader.ReaderConfig. ItemsPointer and
-// CSVDelimiter are not implemented. MaxItemsPath is decoded only so
-// validate.go can flag it as unimplemented; the engine never reads it (see
-// applyMaxItems, which only reads the static MaxItems).
+// CSVDelimiter are not implemented. MaxItemsPath is resolved against the
+// Map state's input in readItemsFromS3, preferring it over the static
+// MaxItems when both are set.
 type itemReaderConfig struct {
 	InputType         string   `json:"inputType"`
 	CSVHeaderLocation string   `json:"csvHeaderLocation"`
 	CSVHeaders        []string `json:"csvHeaders"`
 	MaxItems          *int     `json:"maxItems"`
 	MaxItemsPath      string   `json:"maxItemsPath"`
+
+	// Transformation only applies to s3:listObjectsV2 -- see
+	// itemReaderTransformationLoadAndFlatten.
+	Transformation string `json:"transformation"`
 }
 
 // readItemsFromS3 resolves a Map state's ItemReader field into the item
-// list it selects, fetching the underlying object from kumo's own S3 over
-// plain HTTP (see (*executionEngine).getS3Object).
+// list it selects, fetching the underlying object(s) from kumo's own S3
+// over plain HTTP (see (*executionEngine).getS3Object/listS3ObjectsV2).
 func readItemsFromS3(ctx context.Context, e *executionEngine, raw json.RawMessage, mapInput string) ([]json.RawMessage, error) {
 	var def itemReaderDef
 	if err := json.Unmarshal(raw, &def); err != nil {
 		return nil, fmt.Errorf("parse ItemReader: %w", err)
-	}
-
-	if def.Resource != itemReaderResourceS3GetObject {
-		if def.Resource == itemReaderResourceS3ListObjectsV2 {
-			return nil, fmt.Errorf("itemReader resource %q is not implemented; only %q is supported", def.Resource, itemReaderResourceS3GetObject)
-		}
-
-		return nil, fmt.Errorf("unsupported ItemReader resource %q", def.Resource)
 	}
 
 	params, err := resolveParameters(def.Parameters, mapInput)
@@ -73,24 +79,72 @@ func readItemsFromS3(ctx context.Context, e *executionEngine, raw json.RawMessag
 		return nil, fmt.Errorf("resolve ItemReader Parameters: %w", err)
 	}
 
+	var items []json.RawMessage
+
+	switch def.Resource {
+	case itemReaderResourceS3GetObject:
+		items, err = readItemsFromS3GetObject(ctx, e, params, &def.ReaderConfig)
+	case itemReaderResourceS3ListObjectsV2:
+		items, err = readItemsFromS3ListObjectsV2(ctx, e, params, &def.ReaderConfig)
+	default:
+		return nil, fmt.Errorf("unsupported ItemReader resource %q", def.Resource)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("itemReader: %w", err)
+	}
+
+	maxItems, err := resolveOptionalIntPath(def.ReaderConfig.MaxItems, def.ReaderConfig.MaxItemsPath, mapInput)
+	if err != nil {
+		return nil, fmt.Errorf("itemReader: resolve ReaderConfig.MaxItemsPath: %w", err)
+	}
+
+	return applyMaxItems(items, maxItems), nil
+}
+
+// readItemsFromS3GetObject implements the s3:getObject ItemReader Resource:
+// fetch one object and parse its body per ReaderConfig.InputType.
+func readItemsFromS3GetObject(ctx context.Context, e *executionEngine, params map[string]any, cfg *itemReaderConfig) ([]json.RawMessage, error) {
 	bucket, _ := params["Bucket"].(string)
 	key, _ := params["Key"].(string)
 
 	if bucket == "" || key == "" {
-		return nil, fmt.Errorf("itemReader s3:getObject requires Parameters.Bucket and Parameters.Key")
+		return nil, fmt.Errorf("s3:getObject requires Parameters.Bucket and Parameters.Key")
 	}
 
 	body, err := e.getS3Object(ctx, bucket, key)
 	if err != nil {
-		return nil, fmt.Errorf("itemReader: %w", err)
+		return nil, err
 	}
 
-	items, err := parseItemReaderBody(body, &def.ReaderConfig)
+	return parseItemReaderBody(body, cfg)
+}
+
+// readItemsFromS3ListObjectsV2 implements the s3:listObjectsV2 ItemReader
+// Resource: items are the object summaries AWS's own ListObjectsV2 API
+// action returns (Etag, Key, LastModified, Size, StorageClass -- see
+// marshalS3ObjectSummaries), not the objects' own contents.
+func readItemsFromS3ListObjectsV2(ctx context.Context, e *executionEngine, params map[string]any, cfg *itemReaderConfig) ([]json.RawMessage, error) {
+	if strings.EqualFold(cfg.Transformation, itemReaderTransformationLoadAndFlatten) {
+		return nil, fmt.Errorf(
+			"readerConfig.Transformation %q is not implemented for %q; only the default object-metadata listing is supported",
+			itemReaderTransformationLoadAndFlatten, itemReaderResourceS3ListObjectsV2,
+		)
+	}
+
+	bucket, _ := params["Bucket"].(string)
+	if bucket == "" {
+		return nil, fmt.Errorf("s3:listObjectsV2 requires Parameters.Bucket")
+	}
+
+	prefix, _ := params["Prefix"].(string)
+
+	objects, err := e.listS3ObjectsV2(ctx, bucket, prefix)
 	if err != nil {
-		return nil, fmt.Errorf("itemReader: %w", err)
+		return nil, err
 	}
 
-	return applyMaxItems(items, def.ReaderConfig.MaxItems), nil
+	return marshalS3ObjectSummaries(objects)
 }
 
 // getS3Object fetches an object from kumo's own S3 service using the same
@@ -121,6 +175,130 @@ func (e *executionEngine) getS3Object(ctx context.Context, bucket, key string) (
 	}
 
 	return body, nil
+}
+
+// s3ListObjectsV2TimeFormat matches kumo's own S3 service's LastModified
+// XML format (see timeFormatISO in internal/service/s3/handlers.go).
+const s3ListObjectsV2TimeFormat = "2006-01-02T15:04:05.000Z"
+
+// s3ListBucketResult mirrors just the fields of kumo's own S3
+// ListObjectsV2 XML response (see ListBucketResult in
+// internal/service/s3/types.go) that the ItemReader s3:listObjectsV2
+// integration needs. It is redefined here rather than imported since kumo
+// services only ever talk to each other over HTTP (see
+// getS3Object/putS3Object), never via direct package imports.
+type s3ListBucketResult struct {
+	XMLName               xml.Name          `xml:"ListBucketResult"`
+	IsTruncated           bool              `xml:"IsTruncated"`
+	Contents              []s3ObjectSummary `xml:"Contents"`
+	NextContinuationToken string            `xml:"NextContinuationToken"`
+}
+
+// s3ObjectSummary is one ListObjectsV2 <Contents> entry.
+type s3ObjectSummary struct {
+	Key          string `xml:"Key"`
+	LastModified string `xml:"LastModified"`
+	ETag         string `xml:"ETag"`
+	Size         int64  `xml:"Size"`
+	StorageClass string `xml:"StorageClass"`
+}
+
+// listS3ObjectsV2 lists every object under prefix in bucket, following
+// kumo's own S3 ListObjectsV2 continuation-token pagination until
+// IsTruncated is false.
+func (e *executionEngine) listS3ObjectsV2(ctx context.Context, bucket, prefix string) ([]s3ObjectSummary, error) {
+	var (
+		all               []s3ObjectSummary
+		continuationToken string
+	)
+
+	for {
+		page, err := e.getS3ListObjectsV2Page(ctx, bucket, prefix, continuationToken)
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, page.Contents...)
+
+		if !page.IsTruncated || page.NextContinuationToken == "" {
+			return all, nil
+		}
+
+		continuationToken = page.NextContinuationToken
+	}
+}
+
+// getS3ListObjectsV2Page fetches a single ListObjectsV2 page from kumo's
+// own S3 service (GET /{bucket}?list-type=2&prefix=...&continuation-token=...).
+func (e *executionEngine) getS3ListObjectsV2Page(ctx context.Context, bucket, prefix, continuationToken string) (*s3ListBucketResult, error) {
+	q := url.Values{"list-type": {"2"}}
+	if prefix != "" {
+		q.Set("prefix", prefix)
+	}
+
+	if continuationToken != "" {
+		q.Set("continuation-token", continuationToken)
+	}
+
+	reqURL := fmt.Sprintf("%s/%s?%s", e.baseURL, bucket, q.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create request for s3://%s (list-type=2): %w", bucket, err)
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list s3://%s: %w", bucket, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read list s3://%s response: %w", bucket, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list s3://%s: unexpected status %d: %s", bucket, resp.StatusCode, string(body))
+	}
+
+	var result s3ListBucketResult
+	if err := xml.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse list s3://%s response: %w", bucket, err)
+	}
+
+	return &result, nil
+}
+
+// marshalS3ObjectSummaries converts S3 object metadata into the item shape
+// AWS documents for s3:listObjectsV2 (without LOAD_AND_FLATTEN): Etag, Key,
+// LastModified (Unix seconds), Size, StorageClass -- see
+// https://docs.aws.amazon.com/step-functions/latest/dg/input-output-itemreader.html.
+func marshalS3ObjectSummaries(objects []s3ObjectSummary) ([]json.RawMessage, error) {
+	items := make([]json.RawMessage, len(objects))
+
+	for i, obj := range objects {
+		lastModified, err := time.Parse(s3ListObjectsV2TimeFormat, obj.LastModified)
+		if err != nil {
+			return nil, fmt.Errorf("parse LastModified %q for key %q: %w", obj.LastModified, obj.Key, err)
+		}
+
+		encoded, err := json.Marshal(map[string]any{
+			"Etag":         obj.ETag,
+			"Key":          obj.Key,
+			"LastModified": lastModified.Unix(),
+			"Size":         obj.Size,
+			"StorageClass": obj.StorageClass,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("marshal object summary for key %q: %w", obj.Key, err)
+		}
+
+		items[i] = encoded
+	}
+
+	return items, nil
 }
 
 // parseItemReaderBody parses an S3 object's body per ReaderConfig.InputType.

--- a/internal/service/sfn/itemreader_test.go
+++ b/internal/service/sfn/itemreader_test.go
@@ -113,6 +113,134 @@ func TestMapStateItemReaderMaxItems(t *testing.T) {
 	}
 }
 
+func TestMapStateItemReaderMaxItemsPathResolvesFromMapInput(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+	server.putObject("src-bucket", "items.dat", `[1,2,3,4,5]`)
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemReader": {
+					"Resource": "arn:aws:states:::s3:getObject",
+					"Parameters": {"Bucket": "src-bucket", "Key": "items.dat"},
+					"ReaderConfig": {"InputType": "JSON", "MaxItemsPath": "$.limit"}
+				},
+				"ItemProcessor": ` + distributedItemProcessorJSON + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-itemreader-maxitemspath", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"limit":2}`)
+
+	if want := `[1,2]`; exec.Output != want {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, want)
+	}
+}
+
+func TestMapStateItemReaderS3ListObjectsV2ReturnsObjectSummaries(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+	server.putObject("listed-bucket", "data/a.json", `{"n":1}`)
+	server.putObject("listed-bucket", "data/b.json", `{"n":22}`)
+	server.putObject("listed-bucket", "other/skip.json", `{"n":999}`)
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemReader": {
+					"Resource": "arn:aws:states:::s3:listObjectsV2",
+					"Parameters": {"Bucket": "listed-bucket", "Prefix": "data/"}
+				},
+				"ItemProcessor": ` + distributedItemProcessorJSON + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-itemreader-listobjectsv2", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{}`)
+
+	// JSON tags are lowerCamelCase (encoding/json matches the wire's
+	// PascalCase case-insensitively; see itemBatcherDef in itembatcher.go
+	// for why).
+	var summaries []struct {
+		Etag         string `json:"etag"`
+		Key          string `json:"key"`
+		LastModified int64  `json:"lastModified"`
+		Size         int64  `json:"size"`
+		StorageClass string `json:"storageClass"`
+	}
+
+	if err := json.Unmarshal([]byte(exec.Output), &summaries); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(summaries) != 2 {
+		t.Fatalf("summaries: got %d, want 2 (only keys under the Prefix): %+v", len(summaries), summaries)
+	}
+
+	if summaries[0].Key != "data/a.json" || summaries[1].Key != "data/b.json" {
+		t.Fatalf("summary keys: got [%q, %q], want [data/a.json, data/b.json]", summaries[0].Key, summaries[1].Key)
+	}
+
+	if summaries[0].Size != int64(len(`{"n":1}`)) {
+		t.Fatalf("summary[0].Size: got %d, want %d", summaries[0].Size, len(`{"n":1}`))
+	}
+
+	if summaries[0].Etag == "" || summaries[0].StorageClass != "STANDARD" || summaries[0].LastModified == 0 {
+		t.Fatalf("summary[0]: got %+v, want non-empty Etag/StorageClass=STANDARD/non-zero LastModified", summaries[0])
+	}
+}
+
+func TestMapStateItemReaderS3ListObjectsV2LoadAndFlattenIsUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+	server.putObject("listed-bucket", "data/a.json", `{"n":1}`)
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemReader": {
+					"Resource": "arn:aws:states:::s3:listObjectsV2",
+					"ReaderConfig": {"InputType": "JSON", "Transformation": "LOAD_AND_FLATTEN"},
+					"Parameters": {"Bucket": "listed-bucket", "Prefix": "data/"}
+				},
+				"ItemProcessor": ` + distributedItemProcessorJSON + `,
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-itemreader-loadandflatten", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesRuntime {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesRuntime)
+	}
+
+	if !strings.Contains(exec.Cause, "LOAD_AND_FLATTEN") {
+		t.Fatalf("execution cause: got %q, want it to mention LOAD_AND_FLATTEN", exec.Cause)
+	}
+}
+
 func TestMapStateItemReaderMissingObjectFails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/sfn/map_test.go
+++ b/internal/service/sfn/map_test.go
@@ -11,6 +11,11 @@ import (
 
 const echoItemProcessorJSON = `{"StartAt": "Echo", "States": {"Echo": {"Type": "Pass", "End": true}}}`
 
+// threeItemArrayJSON is the "[1,2,3]" Map input/output literal shared by
+// several tests across this package (goconst flags it once repeated three
+// or more times).
+const threeItemArrayJSON = `[1,2,3]`
+
 func TestMapStateProcessesItemsInOrder(t *testing.T) {
 	t.Parallel()
 
@@ -28,10 +33,10 @@ func TestMapStateProcessesItemsInOrder(t *testing.T) {
 	store := NewMemoryStorage()
 	sm := createExecutionTestStateMachine(t, store, "map-order", definition)
 
-	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `[1,2,3]`)
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, threeItemArrayJSON)
 
-	if exec.Output != `[1,2,3]` {
-		t.Fatalf("execution output: got %q, want %q", exec.Output, `[1,2,3]`)
+	if exec.Output != threeItemArrayJSON {
+		t.Fatalf("execution output: got %q, want %q", exec.Output, threeItemArrayJSON)
 	}
 }
 
@@ -114,7 +119,7 @@ func TestMapStateItemFailureFailsTheMap(t *testing.T) {
 	store := NewMemoryStorage(WithBaseURL("http://127.0.0.1:1"))
 	sm := createExecutionTestStateMachine(t, store, "map-item-fails", definition)
 
-	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `[1,2,3]`)
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, threeItemArrayJSON)
 
 	if exec.Error != errorStatesTaskFailed {
 		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesTaskFailed)
@@ -183,7 +188,7 @@ func TestMapStateMaxConcurrencyOneSerializesItems(t *testing.T) {
 	store := NewMemoryStorage(WithBaseURL(server.URL))
 	sm := createExecutionTestStateMachine(t, store, "map-max-concurrency", definition)
 
-	startAndAwaitSuccess(t, store, sm.StateMachineArn, `[1,2,3]`)
+	startAndAwaitSuccess(t, store, sm.StateMachineArn, threeItemArrayJSON)
 
 	if got := atomic.LoadInt32(maxSeen); got != 1 {
 		t.Fatalf("max observed concurrent item invocations: got %d, want 1", got)

--- a/internal/service/sfn/mapfakeaws_test.go
+++ b/internal/service/sfn/mapfakeaws_test.go
@@ -1,9 +1,12 @@
 package sfn
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -40,6 +43,7 @@ func newFakeAWSServer(t *testing.T) *fakeAWSServer {
 
 	s.mux.HandleFunc("GET /{bucket}/{key...}", s.handleGet)
 	s.mux.HandleFunc("PUT /{bucket}/{key...}", s.handlePut)
+	s.mux.HandleFunc("GET /{bucket}", s.handleListObjectsV2)
 
 	s.Server = httptest.NewServer(s.mux)
 	t.Cleanup(s.Close)
@@ -96,6 +100,55 @@ func (s *fakeAWSServer) handlePut(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// handleListObjectsV2 handles GET /{bucket}?list-type=2&prefix=...: a
+// minimal single-page ListObjectsV2 XML response over whatever objects were
+// seeded via putObject, synthesizing ETag/LastModified/StorageClass the way
+// kumo's own S3 service would (see ListObjects in
+// internal/service/s3/handlers.go). Test keys are expected to be simple
+// (no XML-special characters), so no escaping is done.
+func (s *fakeAWSServer) handleListObjectsV2(w http.ResponseWriter, r *http.Request) {
+	bucket := r.PathValue("bucket")
+	prefix := r.URL.Query().Get("prefix")
+
+	s.mu.Lock()
+
+	sizes := make(map[string]int, len(s.objects))
+
+	for objectKey, body := range s.objects {
+		b, k, ok := strings.Cut(objectKey, "/")
+		if !ok || b != bucket || !strings.HasPrefix(k, prefix) {
+			continue
+		}
+
+		sizes[k] = len(body)
+	}
+
+	s.mu.Unlock()
+
+	keys := make([]string, 0, len(sizes))
+	for k := range sizes {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	var buf strings.Builder
+
+	buf.WriteString(`<?xml version="1.0" encoding="UTF-8"?><ListBucketResult>`)
+
+	for _, k := range keys {
+		fmt.Fprintf(&buf,
+			`<Contents><Key>%s</Key><LastModified>2024-01-02T03:04:05.000Z</LastModified><ETag>&quot;etag-%s&quot;</ETag><Size>%d</Size><StorageClass>STANDARD</StorageClass></Contents>`,
+			k, k, sizes[k],
+		)
+	}
+
+	buf.WriteString(`<IsTruncated>false</IsTruncated></ListBucketResult>`)
+
+	w.Header().Set("Content-Type", "application/xml")
+	_, _ = io.WriteString(w, buf.String())
 }
 
 // putObject pre-seeds an object for a test's ItemReader to read.

--- a/internal/service/sfn/maprun.go
+++ b/internal/service/sfn/maprun.go
@@ -1,0 +1,214 @@
+package sfn
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Map Run status values, matching AWS's documented DescribeMapRun "status".
+const (
+	mapRunStatusRunning   = "RUNNING"
+	mapRunStatusSucceeded = "SUCCEEDED"
+	mapRunStatusFailed    = "FAILED"
+)
+
+// executionArnContextKey is the context.Context key carrying the current
+// (top-level or nested) execution's ARN through its own synchronous call
+// graph, the same way nestedExecutionDepthKey carries nesting depth (see
+// nestedexec.go) -- set once in MemoryStorage.runExecution and read back by
+// executionEngine.startMapRunIfDistributed, which needs it to attribute a
+// new Map Run to the execution that started it.
+type executionArnContextKey struct{}
+
+// withExecutionArn returns a context carrying executionArn as the execution
+// currently running.
+func withExecutionArn(ctx context.Context, executionArn string) context.Context {
+	return context.WithValue(ctx, executionArnContextKey{}, executionArn)
+}
+
+// executionArnFromContext reads the current execution's ARN from ctx,
+// returning "" if none was installed (e.g. a test engine exercised without
+// going through MemoryStorage.runExecution).
+func executionArnFromContext(ctx context.Context) string {
+	arn, _ := ctx.Value(executionArnContextKey{}).(string)
+
+	return arn
+}
+
+// mapRunTracker is the subset of Storage a Distributed Map state uses to
+// record its Map Run (see startMapRunIfDistributed/finishMapRunIfDistributed
+// below). Like executionStarter (nestedexec.go), executionEngine calls back
+// into the same MemoryStorage that constructed it rather than an HTTP round
+// trip: recording a Map Run is storage bookkeeping local to this process,
+// not a call to another emulated AWS service.
+type mapRunTracker interface {
+	startMapRun(ctx context.Context, executionArn, mapStateName string, maxConcurrency int, tolerance mapTolerance) (mapRunArn string, err error)
+	finishMapRun(mapRunArn, status string, itemCounts, executionCounts *MapRunCounts)
+}
+
+// startMapRunIfDistributed records a new Map Run for a Distributed-mode Map
+// state (isDistributedMode(processor)), returning "" for an Inline-mode Map
+// (Map Runs are a Distributed-mode-only AWS concept -- see
+// https://docs.aws.amazon.com/step-functions/latest/dg/concepts-state-machine-executions.html#concepts-map-run)
+// or when e.mapRuns/the current execution ARN is unavailable (an engine
+// built directly via newExecutionEngine in tests, bypassing
+// MemoryStorage.runExecution). Bookkeeping failures are logged and
+// otherwise ignored -- see finishMapRunIfDistributed -- so the Map state
+// itself still completes normally even if Map Run tracking could not.
+func (e *executionEngine) startMapRunIfDistributed(ctx context.Context, name string, processor *stateMachineDefinition, maxConcurrency int, tolerance mapTolerance) string {
+	if e.mapRuns == nil || !isDistributedMode(processor) {
+		return ""
+	}
+
+	executionArn := executionArnFromContext(ctx)
+	if executionArn == "" {
+		return ""
+	}
+
+	mapRunArn, err := e.mapRuns.startMapRun(ctx, executionArn, name, maxConcurrency, tolerance)
+	if err != nil {
+		slog.Debug("SFN executor: failed to record Map Run", "state", name, "error", err)
+
+		return ""
+	}
+
+	return mapRunArn
+}
+
+// finishMapRunIfDistributed finalizes the Map Run started by
+// startMapRunIfDistributed, computing its item/execution counts from the
+// processed units. results is nil when runMapUnits itself returned an error
+// (the non-tolerant fast-fail path, which cancels and discards the
+// remaining units' outcomes -- see mapRunCountsFromResults).
+func (e *executionEngine) finishMapRunIfDistributed(mapRunArn, status string, units []mapUnit, results []mapUnitResult, totalItems int) {
+	if e.mapRuns == nil || mapRunArn == "" {
+		return
+	}
+
+	itemCounts, executionCounts := mapRunCountsFromResults(units, results, totalItems)
+	e.mapRuns.finishMapRun(mapRunArn, status, &itemCounts, &executionCounts)
+}
+
+// mapRunCountsFromResults derives a finished Map Run's itemCounts (dataset
+// items, weighted by each unit's itemCount -- see mapUnit in itembatcher.go
+// for why a unit can represent more than one item under ItemBatcher) and
+// executionCounts (processor invocations, one per unit) from its units'
+// outcomes. kumo runs every unit in-process rather than as a real child
+// *execution* (see mapstate.go), so Pending/Running/Aborted/TimedOut/
+// ResultsWritten/FailuresNotRedrivable/PendingRedrive are always reported as
+// 0 rather than fabricated -- kumo's Map processing has no notion of any of
+// those states.
+func mapRunCountsFromResults(units []mapUnit, results []mapUnitResult, totalItems int) (itemCounts, executionCounts MapRunCounts) {
+	executionCounts.Total = int64(len(units))
+	itemCounts.Total = int64(totalItems)
+
+	if results == nil {
+		// The non-tolerant fast-fail path (see runMapUnits in
+		// mapconcurrency.go) cancels and discards the remaining units'
+		// results once the first failure occurs, so kumo cannot attribute
+		// success/failure per unit here; report the whole run as failed,
+		// matching the Map state's own outcome.
+		executionCounts.Failed = executionCounts.Total
+		itemCounts.Failed = itemCounts.Total
+
+		return itemCounts, executionCounts
+	}
+
+	for i, r := range results {
+		if r.err != nil {
+			executionCounts.Failed++
+			itemCounts.Failed += int64(units[i].itemCount)
+
+			continue
+		}
+
+		executionCounts.Succeeded++
+		itemCounts.Succeeded += int64(units[i].itemCount)
+	}
+
+	return itemCounts, executionCounts
+}
+
+// startMapRun implements mapRunTracker: it looks up executionArn's state
+// machine (for the Map Run ARN's name segment and the record's own
+// StateMachineArn) and records a new RUNNING Map Run.
+func (s *MemoryStorage) startMapRun(_ context.Context, executionArn, mapStateName string, maxConcurrency int, tolerance mapTolerance) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ed, exists := s.Executions[executionArn]
+	if !exists {
+		return "", fmt.Errorf("map run: execution %q not found", executionArn)
+	}
+
+	stateMachineArn := ed.Execution.StateMachineArn
+	stateMachineName := stateMachineArn
+
+	if sm, ok := s.StateMachines[stateMachineArn]; ok {
+		stateMachineName = sm.Name
+	}
+
+	mapRunArn := buildMapRunArn(s.region, s.accountID, stateMachineName, mapStateName)
+
+	s.MapRuns[mapRunArn] = &MapRun{
+		MapRunArn:                  mapRunArn,
+		ExecutionArn:               executionArn,
+		StateMachineArn:            stateMachineArn,
+		Status:                     mapRunStatusRunning,
+		StartDate:                  time.Now(),
+		MaxConcurrency:             maxConcurrency,
+		ToleratedFailureCount:      tolerance.count,
+		ToleratedFailurePercentage: tolerance.percentage,
+	}
+
+	s.saveLocked()
+
+	return mapRunArn, nil
+}
+
+// finishMapRun implements mapRunTracker: it records status and the final
+// item/execution counts on an existing Map Run. A mapRunArn kumo does not
+// recognize is silently ignored -- startMapRunIfDistributed already logs
+// the failure that would cause this.
+func (s *MemoryStorage) finishMapRun(mapRunArn, status string, itemCounts, executionCounts *MapRunCounts) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	mr, exists := s.MapRuns[mapRunArn]
+	if !exists {
+		return
+	}
+
+	now := time.Now()
+	mr.Status = status
+	mr.StopDate = &now
+	mr.ItemCounts = *itemCounts
+	mr.ExecutionCounts = *executionCounts
+
+	s.saveLocked()
+}
+
+// buildMapRunArn builds a Map Run ARN in AWS's documented format
+// arn:aws:states:{region}:{account}:mapRun:{stateMachineName}/{label}:{uuid}
+// (see
+// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-distributed.html#state-map-distributed-nested-workflow).
+// AWS's {label} segment is either a user-supplied Map state "Label" field or
+// an auto-generated one; kumo does not model the "Label" field, so it uses
+// the Map state's own name instead -- more useful for debugging than a
+// random value, and, unlike AWS's auto-generated label, deterministic given
+// the same definition.
+func buildMapRunArn(region, accountID, stateMachineName, mapStateName string) string {
+	return fmt.Sprintf("arn:aws:states:%s:%s:mapRun:%s/%s:%s", region, accountID, stateMachineName, mapStateName, uuid.New().String())
+}
+
+// copyMapRun returns a shallow copy of mr so callers never hold a pointer
+// into MemoryStorage's own map (mirrors copyExecution in storage.go).
+func copyMapRun(mr *MapRun) *MapRun {
+	c := *mr
+
+	return &c
+}

--- a/internal/service/sfn/maprun_test.go
+++ b/internal/service/sfn/maprun_test.go
@@ -1,0 +1,175 @@
+package sfn
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// distributedMapDefinitionForMapRun builds a single distributed-mode Map
+// state using conditionalFailProcessorJSON (see toleratedfailure_test.go),
+// with tolerance/name given verbatim so tests can control both the Map
+// Run's recorded tolerance fields and whether it ends up FAILED or
+// SUCCEEDED.
+func distributedMapDefinitionForMapRun(mapStateName, toleranceField string) string {
+	extra := ""
+	if toleranceField != "" {
+		extra = toleranceField + ","
+	}
+
+	return `{
+		"StartAt": "` + mapStateName + `",
+		"States": {
+			"` + mapStateName + `": {
+				"Type": "Map",
+				` + extra + `
+				"ItemProcessor": ` + conditionalFailProcessorJSON + `,
+				"End": true
+			}
+		}
+	}`
+}
+
+func TestDistributedMapRecordsSucceededMapRun(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "maprun-succeeded",
+		distributedMapDefinitionForMapRun("Each", `"ToleratedFailurePercentage": 100`))
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, oneOfFourFailsInput)
+
+	mapRuns, _, err := store.ListMapRuns(context.Background(), exec.ExecutionArn, 0, "")
+	if err != nil {
+		t.Fatalf("ListMapRuns: %v", err)
+	}
+
+	if len(mapRuns) != 1 {
+		t.Fatalf("mapRuns: got %d, want 1", len(mapRuns))
+	}
+
+	mr := mapRuns[0]
+
+	if mr.ExecutionArn != exec.ExecutionArn {
+		t.Fatalf("ListMapRuns item ExecutionArn: got %q, want %q", mr.ExecutionArn, exec.ExecutionArn)
+	}
+
+	if mr.StateMachineArn != sm.StateMachineArn {
+		t.Fatalf("ListMapRuns item StateMachineArn: got %q, want %q", mr.StateMachineArn, sm.StateMachineArn)
+	}
+
+	if !strings.Contains(mr.MapRunArn, ":mapRun:"+sm.Name+"/Each:") {
+		t.Fatalf("MapRunArn %q: want it to contain %q", mr.MapRunArn, ":mapRun:"+sm.Name+"/Each:")
+	}
+
+	described, err := store.DescribeMapRun(context.Background(), mr.MapRunArn)
+	if err != nil {
+		t.Fatalf("DescribeMapRun: %v", err)
+	}
+
+	if described.Status != mapRunStatusSucceeded {
+		t.Fatalf("DescribeMapRun Status: got %q, want %q", described.Status, mapRunStatusSucceeded)
+	}
+
+	if described.ItemCounts.Total != 4 || described.ItemCounts.Succeeded != 3 || described.ItemCounts.Failed != 1 {
+		t.Fatalf("DescribeMapRun ItemCounts: got %+v, want {Total:4 Succeeded:3 Failed:1 ...}", described.ItemCounts)
+	}
+
+	if described.ExecutionCounts.Total != 4 {
+		t.Fatalf("DescribeMapRun ExecutionCounts.Total: got %d, want 4", described.ExecutionCounts.Total)
+	}
+
+	if described.ToleratedFailurePercentage == nil || *described.ToleratedFailurePercentage != 100 {
+		t.Fatalf("DescribeMapRun ToleratedFailurePercentage: got %v, want 100", described.ToleratedFailurePercentage)
+	}
+
+	if described.StopDate == nil {
+		t.Fatal("DescribeMapRun StopDate: want non-nil for a finished Map Run")
+	}
+}
+
+func TestDistributedMapRecordsFailedMapRunWhenToleranceExceeded(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "maprun-failed",
+		distributedMapDefinitionForMapRun("Each", `"ToleratedFailureCount": 0`))
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, oneOfFourFailsInput)
+
+	mapRuns, _, err := store.ListMapRuns(context.Background(), exec.ExecutionArn, 0, "")
+	if err != nil {
+		t.Fatalf("ListMapRuns: %v", err)
+	}
+
+	if len(mapRuns) != 1 {
+		t.Fatalf("mapRuns: got %d, want 1", len(mapRuns))
+	}
+
+	described, err := store.DescribeMapRun(context.Background(), mapRuns[0].MapRunArn)
+	if err != nil {
+		t.Fatalf("DescribeMapRun: %v", err)
+	}
+
+	if described.Status != mapRunStatusFailed {
+		t.Fatalf("DescribeMapRun Status: got %q, want %q", described.Status, mapRunStatusFailed)
+	}
+}
+
+func TestInlineMapDoesNotRecordAMapRun(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Each",
+		"States": {
+			"Each": {"Type": "Map", "ItemProcessor": ` + echoItemProcessorJSON + `, "End": true}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "maprun-inline", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `[1,2]`)
+
+	mapRuns, _, err := store.ListMapRuns(context.Background(), exec.ExecutionArn, 0, "")
+	if err != nil {
+		t.Fatalf("ListMapRuns: %v", err)
+	}
+
+	if len(mapRuns) != 0 {
+		t.Fatalf("mapRuns for an Inline-mode Map: got %d, want 0: %+v", len(mapRuns), mapRuns)
+	}
+}
+
+func TestDescribeMapRunUnknownArnReportsResourceNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+
+	_, err := store.DescribeMapRun(context.Background(), "arn:aws:states:us-east-1:000000000000:mapRun:missing/x:00000000-0000-0000-0000-000000000000")
+	if err == nil {
+		t.Fatal("DescribeMapRun: want error for an unknown mapRunArn, got nil")
+	}
+
+	var svcErr *ServiceError
+	if !errors.As(err, &svcErr) || svcErr.Code != errResourceNotFound {
+		t.Fatalf("DescribeMapRun error: got %v, want ServiceError code %q", err, errResourceNotFound)
+	}
+}
+
+func TestListMapRunsUnknownExecutionArnReportsExecutionDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+
+	_, _, err := store.ListMapRuns(context.Background(), "arn:aws:states:us-east-1:000000000000:execution:missing:x", 0, "")
+	if err == nil {
+		t.Fatal("ListMapRuns: want error for an unknown executionArn, got nil")
+	}
+
+	var svcErr *ServiceError
+	if !errors.As(err, &svcErr) || svcErr.Code != errExecutionDoesNotExist {
+		t.Fatalf("ListMapRuns error: got %v, want ServiceError code %q", err, errExecutionDoesNotExist)
+	}
+}

--- a/internal/service/sfn/mapstate.go
+++ b/internal/service/sfn/mapstate.go
@@ -46,10 +46,10 @@ func (e *executionEngine) executeMapStateWithPolicy(ctx context.Context, name st
 // through the state's ItemProcessor (or its legacy alias, Iterator),
 // bounding concurrency at MaxConcurrency when it is positive.
 //
-// Both Inline and Distributed mode run in-process in kumo: kumo has no
-// child-execution or Map Run resource, so DescribeMapRun/ListMapRuns and
-// child-execution tracking are out of scope (see the ResultWriter
-// simplification documented in resultwriter.go for the same reason).
+// Both Inline and Distributed mode run each unit in-process in kumo, rather
+// than as a real child *execution* (see maprun.go's mapRunCountsFromResults
+// doc for the consequences of that simplification); a Distributed-mode run
+// is still recorded as a queryable Map Run (see runMapProcessorUnits).
 func (e *executionEngine) executeMapState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
 	processor, err := itemProcessorDefinition(state)
 	if err != nil {
@@ -81,21 +81,38 @@ func (e *executionEngine) executeMapState(ctx context.Context, name string, stat
 // runMapProcessorUnits runs every processor unit and shapes the Map
 // state's output: the ExceedToleratedFailureThreshold check, the plain
 // item-output array, or -- when ResultWriter is set -- the
-// ResultWriterDetails{Bucket, Key} shape (see resultwriter.go).
+// ResultWriterDetails{Bucket, Key} shape (see resultwriter.go). For a
+// Distributed-mode processor it also records the run as a Map Run (see
+// maprun.go), whose ARN (when recorded) is included in the ResultWriter
+// output.
 func (e *executionEngine) runMapProcessorUnits(ctx context.Context, name string, state *stateDefinition, processor *stateMachineDefinition, units []mapUnit, totalItems int, input string) (string, error) {
-	tolerance := resolveMapTolerance(state)
+	tolerance, err := resolveMapTolerance(state, input)
+	if err != nil {
+		return "", fmt.Errorf("map state %q: %w", name, err)
+	}
+
+	maxConcurrency, err := resolveMaxConcurrency(state, input)
+	if err != nil {
+		return "", fmt.Errorf("map state %q: %w", name, err)
+	}
 
 	itemCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	results, err := runMapUnits(itemCtx, e, processor, units, state.MaxConcurrency, tolerance.enabled(), cancel)
+	mapRunArn := e.startMapRunIfDistributed(ctx, name, processor, maxConcurrency, tolerance)
+
+	results, err := runMapUnits(itemCtx, e, processor, units, maxConcurrency, tolerance.enabled(), cancel)
 	if err != nil {
+		e.finishMapRunIfDistributed(mapRunArn, mapRunStatusFailed, units, nil, totalItems)
+
 		return "", fmt.Errorf("map state %q: %w", name, err)
 	}
 
 	outputs, failedItems := collectMapResults(units, results)
 
 	if tolerance.enabled() && tolerance.exceeds(failedItems, totalItems) {
+		e.finishMapRunIfDistributed(mapRunArn, mapRunStatusFailed, units, results, totalItems)
+
 		return "", &failStateError{
 			errorName: errorStatesExceedToleratedFailureThreshold,
 			cause: fmt.Sprintf(
@@ -105,8 +122,10 @@ func (e *executionEngine) runMapProcessorUnits(ctx context.Context, name string,
 		}
 	}
 
+	e.finishMapRunIfDistributed(mapRunArn, mapRunStatusSucceeded, units, results, totalItems)
+
 	if len(state.ResultWriter) > 0 {
-		written, err := writeMapResultToS3(ctx, e, state.ResultWriter, outputs, input)
+		written, err := writeMapResultToS3(ctx, e, state.ResultWriter, outputs, input, mapRunArn)
 		if err != nil {
 			return "", fmt.Errorf("map state %q: %w", name, err)
 		}
@@ -120,6 +139,23 @@ func (e *executionEngine) runMapProcessorUnits(ctx context.Context, name string,
 	}
 
 	return string(result), nil
+}
+
+// resolveMaxConcurrency resolves a Map state's MaxConcurrency, preferring
+// MaxConcurrencyPath when set (the same precedence every other *Path field
+// in this package gives its static counterpart -- see taskTimeout in
+// timeout.go).
+func resolveMaxConcurrency(state *stateDefinition, input string) (int, error) {
+	if state.MaxConcurrencyPath == "" {
+		return state.MaxConcurrency, nil
+	}
+
+	n, err := resolveNumberPath(state.MaxConcurrencyPath, input)
+	if err != nil {
+		return 0, fmt.Errorf("resolve MaxConcurrencyPath: %w", err)
+	}
+
+	return int(n), nil
 }
 
 // collectMapResults turns per-unit results into the Map state's output

--- a/internal/service/sfn/maptolerance.go
+++ b/internal/service/sfn/maptolerance.go
@@ -1,24 +1,34 @@
 package sfn
 
+import "fmt"
+
 // mapTolerance is a Map state's resolved ToleratedFailurePercentage/
 // ToleratedFailureCount (see
 // https://docs.aws.amazon.com/step-functions/latest/dg/state-map-distributed.html#state-map-fields-failure-tolerance).
-// ToleratedFailurePercentagePath/ToleratedFailureCountPath (the dynamic,
-// reference-path forms of these fields) are not implemented.
 type mapTolerance struct {
 	percentage *float64
 	count      *int
 }
 
-// resolveMapTolerance reads a Map state's tolerance fields. Only
-// requireDistributedModeForFields lets these fields take effect at all
-// (they are Distributed-mode-only), so resolveMapTolerance itself does not
-// need to check mode.
-func resolveMapTolerance(state *stateDefinition) mapTolerance {
-	return mapTolerance{
-		percentage: state.ToleratedFailurePercentage,
-		count:      state.ToleratedFailureCount,
+// resolveMapTolerance reads a Map state's tolerance fields, resolving
+// ToleratedFailurePercentagePath/ToleratedFailureCountPath against input
+// (the Map state's effective input) when set, preferring the Path form over
+// its static counterpart -- see resolveOptionalFloatPath/
+// resolveOptionalIntPath in wait.go. Only requireDistributedModeForFields
+// lets these fields take effect at all (they are Distributed-mode-only), so
+// resolveMapTolerance itself does not need to check mode.
+func resolveMapTolerance(state *stateDefinition, input string) (mapTolerance, error) {
+	percentage, err := resolveOptionalFloatPath(state.ToleratedFailurePercentage, state.ToleratedFailurePercentagePath, input)
+	if err != nil {
+		return mapTolerance{}, fmt.Errorf("resolve ToleratedFailurePercentagePath: %w", err)
 	}
+
+	count, err := resolveOptionalIntPath(state.ToleratedFailureCount, state.ToleratedFailureCountPath, input)
+	if err != nil {
+		return mapTolerance{}, fmt.Errorf("resolve ToleratedFailureCountPath: %w", err)
+	}
+
+	return mapTolerance{percentage: percentage, count: count}, nil
 }
 
 // enabled reports whether either threshold was configured. When neither is

--- a/internal/service/sfn/nestedexec.go
+++ b/internal/service/sfn/nestedexec.go
@@ -1,0 +1,318 @@
+package sfn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// resourceStartExecutionBase is the Task Resource for the "AWS Step
+// Functions integrates with its own API" service integration
+// (https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html):
+// starting a nested execution of another (or the same) state machine.
+// startExecutionSyncSuffix/startExecutionSyncV2Suffix are its "Run a Job"
+// (.sync) variants; unlike most other optimized integrations, startExecution
+// does NOT support .waitForTaskToken -- see classifyStartExecutionResource.
+const (
+	resourceStartExecutionBase  = "arn:aws:states:::states:startExecution"
+	startExecutionSyncSuffix    = ".sync"
+	startExecutionSyncV2Suffix  = ".sync:2"
+	resourceStartExecutionSync  = resourceStartExecutionBase + startExecutionSyncSuffix
+	resourceStartExecutionSync2 = resourceStartExecutionBase + startExecutionSyncV2Suffix
+)
+
+// nestedExecutionMaxDepth caps how many states:startExecution calls may
+// nest before kumo reports a States.Runtime error. This guards against a
+// state machine starting itself (directly, or via a cycle of state
+// machines) and running forever; real AWS instead bounds this indirectly
+// via account-level running-execution quotas, which kumo does not model, so
+// this fixed depth cap is a documented emulator-only bound.
+const nestedExecutionMaxDepth = 5
+
+// nestedExecutionPollInterval is how often a .sync/.sync:2 Task polls the
+// child execution's status via DescribeExecution while waiting for it to
+// complete.
+const nestedExecutionPollInterval = 20 * time.Millisecond
+
+// startExecutionVariant identifies which of the three
+// arn:aws:states:::states:startExecution* integration patterns a Task
+// Resource selects.
+type startExecutionVariant int
+
+const (
+	// startExecutionAsync is the plain (fire-and-forget) integration: the
+	// Task's output is {ExecutionArn, StartDate} and the Task completes as
+	// soon as the child execution starts, without waiting for it.
+	startExecutionAsync startExecutionVariant = iota
+	// startExecutionSync is the .sync ("Run a Job") variant: the Task waits
+	// for the child execution to complete, and its output mirrors
+	// DescribeExecution with Output left as a JSON string.
+	startExecutionSync
+	// startExecutionSyncV2 is the .sync:2 variant: identical to
+	// startExecutionSync except Output is parsed JSON rather than a string.
+	startExecutionSyncV2
+)
+
+// classifyStartExecutionResource identifies which
+// arn:aws:states:::states:startExecution* variant resource selects. ok is
+// false for any other suffix (including .waitForTaskToken, which AWS does
+// not document as supported for this integration -- see
+// https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html's
+// "Optimized integrations in Step Functions" table, which lists AWS Step
+// Functions as supporting only Request Response and Run a Job), so callers
+// reject it with a clear "unsupported task resource" error instead of
+// silently treating it as fire-and-forget.
+func classifyStartExecutionResource(resource string) (variant startExecutionVariant, ok bool) {
+	switch resource {
+	case resourceStartExecutionBase:
+		return startExecutionAsync, true
+	case resourceStartExecutionSync:
+		return startExecutionSync, true
+	case resourceStartExecutionSync2:
+		return startExecutionSyncV2, true
+	default:
+		return startExecutionAsync, false
+	}
+}
+
+// nestedExecutionDepthKey is the context.Context key carrying the current
+// nesting depth through one execution's own synchronous call graph (see
+// withNestedExecutionDepth). It does not, and cannot, cross the boundary
+// into a child execution's own background goroutine -- MemoryStorage.
+// StartExecution intentionally ignores its caller's context, since an
+// execution must outlive the request that started it -- so the depth for a
+// child execution is instead passed explicitly to
+// MemoryStorage.startExecutionAtDepth/runExecution (see storage.go) and
+// re-installed into that child's own context there.
+type nestedExecutionDepthKey struct{}
+
+// withNestedExecutionDepth returns a context carrying depth as the current
+// nesting depth for states:startExecution calls made within it.
+func withNestedExecutionDepth(ctx context.Context, depth int) context.Context {
+	return context.WithValue(ctx, nestedExecutionDepthKey{}, depth)
+}
+
+// nestedExecutionDepthFromContext reads the current nesting depth from ctx,
+// defaulting to 0 (a top-level execution) if none was installed.
+func nestedExecutionDepthFromContext(ctx context.Context) int {
+	depth, _ := ctx.Value(nestedExecutionDepthKey{}).(int)
+
+	return depth
+}
+
+// executionStarter is the subset of Storage the states:startExecution
+// integration needs. executionEngine calls back into the same MemoryStorage
+// that constructed it (see the storage field wiring in NewMemoryStorage,
+// storage.go) rather than looping an HTTP request back to kumo's own
+// server, the way the SQS/Lambda/S3 integrations address those (separate)
+// services: this integration recurses into kumo's own SFN engine, and the
+// recursion-depth guard above needs to travel with the Go call stack via
+// context.Context. A real HTTP round trip could still carry that via a
+// custom header, but real AWS's StartExecution API has no such field, and
+// kumo already has a direct reference to the very storage object that would
+// answer that HTTP call -- looping back out over HTTP to reach code in the
+// same process is unnecessary indirection with its own failure modes (e.g.
+// exhausting the shared http.Client's connections under deep nesting).
+type executionStarter interface {
+	// startNestedExecution is StartExecution's counterpart for a nested
+	// (states:startExecution-originated) call: depth is the nesting depth
+	// the new execution runs at, threaded explicitly since context values
+	// do not survive StartExecution's intentional context detachment (see
+	// nestedExecutionDepthKey).
+	startNestedExecution(ctx context.Context, stateMachineArn, name, input string, depth int) (*Execution, error)
+	DescribeExecution(ctx context.Context, executionArn string) (*Execution, error)
+}
+
+// executeStartExecutionTask executes a Task state whose Resource is
+// arn:aws:states:::states:startExecution (optionally suffixed .sync or
+// .sync:2): it starts a child execution of Parameters.StateMachineArn with
+// Parameters.Input (default "{}") and Parameters.Name, then -- for the
+// .sync/.sync:2 variants -- waits for it to finish and reports a child
+// failure as this Task's own failure (wrapTaskResult then reports
+// States.TaskFailed, matching every other Task integration's failure
+// mapping; see AWS's own documented behavior for nested workflow
+// executions).
+func (e *executionEngine) executeStartExecutionTask(ctx context.Context, resource string, params map[string]any) (string, error) {
+	variant, ok := classifyStartExecutionResource(resource)
+	if !ok {
+		return "", fmt.Errorf("unsupported task resource %q", resource)
+	}
+
+	if e.starter == nil {
+		return "", fmt.Errorf("states:startExecution: nested execution support is not available")
+	}
+
+	stateMachineArn, _ := params["StateMachineArn"].(string)
+	if stateMachineArn == "" {
+		return "", fmt.Errorf("states:startExecution: Parameters.StateMachineArn is required")
+	}
+
+	childInput, err := marshalStartExecutionInput(params["Input"])
+	if err != nil {
+		return "", fmt.Errorf("states:startExecution: %w", err)
+	}
+
+	execName, _ := params["Name"].(string)
+
+	depth := nestedExecutionDepthFromContext(ctx)
+	if depth >= nestedExecutionMaxDepth {
+		return "", fmt.Errorf(
+			"states:startExecution: nesting depth exceeded kumo's emulator-only bound of %d; this guards against a state machine recursively starting itself (real AWS instead limits this indirectly via account running-execution quotas)",
+			nestedExecutionMaxDepth,
+		)
+	}
+
+	child, err := e.starter.startNestedExecution(ctx, stateMachineArn, execName, childInput, depth+1)
+	if err != nil {
+		return "", fmt.Errorf("states:startExecution: %w", err)
+	}
+
+	if variant == startExecutionAsync {
+		return marshalStartExecutionAsyncOutput(child)
+	}
+
+	completed, err := e.awaitChildExecution(ctx, child.ExecutionArn)
+	if err != nil {
+		return "", fmt.Errorf("states:startExecution%s: %w", startExecutionSuffixFor(variant), err)
+	}
+
+	if completed.Status != ExecutionStatusSucceeded {
+		return "", fmt.Errorf(
+			"child execution %q ended with status %s: %s: %s",
+			completed.ExecutionArn, completed.Status, completed.Error, completed.Cause,
+		)
+	}
+
+	if variant == startExecutionSyncV2 {
+		return marshalSyncV2ExecutionOutput(completed)
+	}
+
+	return marshalSyncExecutionOutput(completed)
+}
+
+// startExecutionSuffixFor returns the Resource suffix for variant, for
+// error messages.
+func startExecutionSuffixFor(variant startExecutionVariant) string {
+	if variant == startExecutionSyncV2 {
+		return startExecutionSyncV2Suffix
+	}
+
+	return startExecutionSyncSuffix
+}
+
+// awaitChildExecution polls DescribeExecution until executionArn leaves
+// RUNNING, or ctx is done (the Task's own TimeoutSeconds, Retry/Catch
+// context, or the outer execution's own deadline all apply here exactly as
+// they would to any other Task invocation).
+func (e *executionEngine) awaitChildExecution(ctx context.Context, executionArn string) (*Execution, error) {
+	ticker := time.NewTicker(nestedExecutionPollInterval)
+	defer ticker.Stop()
+
+	for {
+		exec, err := e.starter.DescribeExecution(ctx, executionArn)
+		if err != nil {
+			return nil, fmt.Errorf("describe child execution %q: %w", executionArn, err)
+		}
+
+		if exec.Status != ExecutionStatusRunning {
+			return exec, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("wait for child execution %q: %w", executionArn, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// marshalStartExecutionInput builds a child execution's input JSON from a
+// startExecution Task's resolved Parameters.Input: absent input defaults to
+// "{}", matching AWS's own StartExecution requirement that input always be
+// at least an empty JSON object.
+func marshalStartExecutionInput(v any) (string, error) {
+	if v == nil {
+		return "{}", nil
+	}
+
+	encoded, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("marshal Input: %w", err)
+	}
+
+	return string(encoded), nil
+}
+
+// marshalStartExecutionAsyncOutput builds the plain (fire-and-forget)
+// startExecution Task's output: {executionArn, startDate}, matching AWS's
+// documented StartExecution API response shape exactly (see
+// https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html).
+func marshalStartExecutionAsyncOutput(exec *Execution) (string, error) {
+	encoded, err := json.Marshal(map[string]any{
+		"executionArn": exec.ExecutionArn,
+		"startDate":    float64(exec.StartDate.Unix()),
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal states:startExecution output: %w", err)
+	}
+
+	return string(encoded), nil
+}
+
+// describeExecutionEnvelope builds the DescribeExecution-shaped fields
+// shared by both .sync and .sync:2 output (everything except "output",
+// which differs -- see marshalSyncExecutionOutput/marshalSyncV2ExecutionOutput),
+// using AWS's documented DescribeExecution response field names (see
+// https://docs.aws.amazon.com/step-functions/latest/apireference/API_DescribeExecution.html).
+func describeExecutionEnvelope(exec *Execution) map[string]any {
+	env := map[string]any{
+		"executionArn":    exec.ExecutionArn,
+		"stateMachineArn": exec.StateMachineArn,
+		"name":            exec.Name,
+		"status":          string(exec.Status),
+		"startDate":       float64(exec.StartDate.Unix()),
+		"input":           exec.Input,
+	}
+
+	if exec.StopDate != nil {
+		env["stopDate"] = float64(exec.StopDate.Unix())
+	}
+
+	return env
+}
+
+// marshalSyncExecutionOutput builds the .sync Task's output: the
+// DescribeExecution-style envelope with "output" left as a JSON string,
+// exactly as the child execution itself reports it -- see AWS's documented
+// "Nested state machines return the following" table at
+// https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html.
+func marshalSyncExecutionOutput(exec *Execution) (string, error) {
+	env := describeExecutionEnvelope(exec)
+	env["output"] = exec.Output
+
+	encoded, err := json.Marshal(env)
+	if err != nil {
+		return "", fmt.Errorf("marshal states:startExecution.sync output: %w", err)
+	}
+
+	return string(encoded), nil
+}
+
+// marshalSyncV2ExecutionOutput is marshalSyncExecutionOutput's .sync:2
+// counterpart: "output" holds the child execution's output as parsed JSON
+// rather than a string.
+func marshalSyncV2ExecutionOutput(exec *Execution) (string, error) {
+	env := describeExecutionEnvelope(exec)
+
+	if exec.Output != "" {
+		env["output"] = json.RawMessage(exec.Output)
+	}
+
+	encoded, err := json.Marshal(env)
+	if err != nil {
+		return "", fmt.Errorf("marshal states:startExecution.sync:2 output: %w", err)
+	}
+
+	return string(encoded), nil
+}

--- a/internal/service/sfn/nestedexec_test.go
+++ b/internal/service/sfn/nestedexec_test.go
@@ -1,0 +1,306 @@
+package sfn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// childStateMachineArn computes the deterministic ARN CreateStateMachine
+// assigns a state machine named name, matching storage.go's own
+// "arn:aws:states:%s:%s:stateMachine:%s" format with NewMemoryStorage's
+// default region/account -- so a test can reference a child (or its own)
+// state machine's ARN in a Parameters.StateMachineArn literal before ever
+// calling CreateStateMachine.
+func childStateMachineArn(name string) string {
+	return fmt.Sprintf("arn:aws:states:us-east-1:000000000000:stateMachine:%s", name)
+}
+
+// startExecutionParentDefinition builds a single-Task state machine whose
+// Task uses resource (one of the arn:aws:states:::states:startExecution*
+// variants) to start childArn.
+func startExecutionParentDefinition(resource, childArn, inputJSON string) string {
+	return fmt.Sprintf(`{
+		"StartAt": "Nested",
+		"States": {
+			"Nested": {
+				"Type": "Task",
+				"Resource": %q,
+				"Parameters": {"StateMachineArn": %q, "Input": %s},
+				"End": true
+			}
+		}
+	}`, resource, childArn, inputJSON)
+}
+
+func TestStartExecutionFireAndForgetOutputShapeAndDispatchesChild(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+
+	child := createExecutionTestStateMachine(t, store, "nested-child-async", `{
+		"StartAt": "Echo", "States": {"Echo": {"Type": "Pass", "End": true}}
+	}`)
+
+	parentDef := startExecutionParentDefinition(resourceStartExecutionBase, child.StateMachineArn, `{"greeting":"hi"}`)
+	parent := createExecutionTestStateMachine(t, store, "nested-parent-async", parentDef)
+
+	exec := startAndAwaitSuccess(t, store, parent.StateMachineArn, `{}`)
+
+	var output struct {
+		ExecutionArn string  `json:"executionArn"`
+		StartDate    float64 `json:"startDate"`
+	}
+
+	if err := json.Unmarshal([]byte(exec.Output), &output); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if output.ExecutionArn == "" || !strings.Contains(output.ExecutionArn, ":execution:") {
+		t.Fatalf("output.executionArn: got %q, want a non-empty execution ARN", output.ExecutionArn)
+	}
+
+	if output.StartDate == 0 {
+		t.Fatalf("output.startDate: got 0, want a non-zero Unix timestamp")
+	}
+
+	// The fire-and-forget Task must not have waited for the child, but the
+	// child must actually have been dispatched.
+	childExec := waitForExecutionTerminal(t, store, output.ExecutionArn)
+	if childExec.Status != ExecutionStatusSucceeded {
+		t.Fatalf("child execution status: got %q, want SUCCEEDED", childExec.Status)
+	}
+}
+
+func TestStartExecutionSyncWaitsAndReturnsOutputAsString(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+
+	child := createExecutionTestStateMachine(t, store, "nested-child-sync", `{
+		"StartAt": "Build",
+		"States": {"Build": {"Type": "Pass", "Result": {"MyKey": "MyValue"}, "End": true}}
+	}`)
+
+	parentDef := startExecutionParentDefinition(resourceStartExecutionSync, child.StateMachineArn, `{}`)
+	parent := createExecutionTestStateMachine(t, store, "nested-parent-sync", parentDef)
+
+	exec := startAndAwaitSuccess(t, store, parent.StateMachineArn, `{}`)
+
+	var output struct {
+		Status string `json:"status"`
+		Output string `json:"output"`
+	}
+
+	if err := json.Unmarshal([]byte(exec.Output), &output); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if output.Status != string(ExecutionStatusSucceeded) {
+		t.Fatalf("output.status: got %q, want %q", output.Status, ExecutionStatusSucceeded)
+	}
+
+	if want := `{"MyKey":"MyValue"}`; output.Output != want {
+		t.Fatalf(".sync output.output: got %q, want the child's own output as a JSON string %q", output.Output, want)
+	}
+}
+
+func TestStartExecutionSyncV2ParsesOutputAsJSON(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+
+	child := createExecutionTestStateMachine(t, store, "nested-child-syncv2", `{
+		"StartAt": "Build",
+		"States": {"Build": {"Type": "Pass", "Result": {"MyKey": "MyValue"}, "End": true}}
+	}`)
+
+	parentDef := startExecutionParentDefinition(resourceStartExecutionSync2, child.StateMachineArn, `{}`)
+	parent := createExecutionTestStateMachine(t, store, "nested-parent-syncv2", parentDef)
+
+	exec := startAndAwaitSuccess(t, store, parent.StateMachineArn, `{}`)
+
+	var output struct {
+		Output map[string]any `json:"output"`
+	}
+
+	if err := json.Unmarshal([]byte(exec.Output), &output); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if output.Output["MyKey"] != "MyValue" {
+		t.Fatalf(".sync:2 output.output: got %v, want parsed JSON {\"MyKey\":\"MyValue\"}", output.Output)
+	}
+}
+
+func TestStartExecutionSyncChildFailureReportsTaskFailed(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+
+	child := createExecutionTestStateMachine(t, store, "nested-child-fails", `{
+		"StartAt": "Boom",
+		"States": {"Boom": {"Type": "Fail", "Error": "ChildBroke", "Cause": "it broke"}}
+	}`)
+
+	parentDef := startExecutionParentDefinition(resourceStartExecutionSync, child.StateMachineArn, `{}`)
+	parent := createExecutionTestStateMachine(t, store, "nested-parent-child-fails", parentDef)
+
+	exec := startAndAwaitFailure(t, store, parent.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesTaskFailed {
+		t.Fatalf("execution error: got %q, want %q (cause: %s)", exec.Error, errorStatesTaskFailed, exec.Cause)
+	}
+
+	if !strings.Contains(exec.Cause, "ChildBroke") {
+		t.Fatalf("execution cause: got %q, want it to mention the child's Error %q", exec.Cause, "ChildBroke")
+	}
+}
+
+func TestStartExecutionWaitForTaskTokenSuffixIsRejected(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+
+	child := createExecutionTestStateMachine(t, store, "nested-child-wftt", `{
+		"StartAt": "Echo", "States": {"Echo": {"Type": "Pass", "End": true}}
+	}`)
+
+	parentDef := startExecutionParentDefinition(resourceStartExecutionBase+callbackResourceSuffix, child.StateMachineArn, `{}`)
+	parent := createExecutionTestStateMachine(t, store, "nested-parent-wftt", parentDef)
+
+	exec := startAndAwaitFailure(t, store, parent.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesTaskFailed {
+		t.Fatalf("execution error: got %q, want %q (cause: %s)", exec.Error, errorStatesTaskFailed, exec.Cause)
+	}
+
+	if !strings.Contains(exec.Cause, callbackResourceSuffix) {
+		t.Fatalf("execution cause: got %q, want it to mention %q as unsupported", exec.Cause, callbackResourceSuffix)
+	}
+}
+
+func TestStartExecutionMissingStateMachineArnFailsCleanly(t *testing.T) {
+	t.Parallel()
+
+	definition := `{
+		"StartAt": "Nested",
+		"States": {
+			"Nested": {
+				"Type": "Task",
+				"Resource": "arn:aws:states:::states:startExecution",
+				"Parameters": {},
+				"End": true
+			}
+		}
+	}`
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "nested-missing-arn", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, `{}`)
+
+	if exec.Error != errorStatesTaskFailed {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesTaskFailed)
+	}
+
+	if !strings.Contains(exec.Cause, "StateMachineArn") {
+		t.Fatalf("execution cause: got %q, want it to mention the missing StateMachineArn", exec.Cause)
+	}
+}
+
+// TestStartExecutionSelfRecursionHitsDepthCap builds a state machine whose
+// only Task calls states:startExecution.sync against its own ARN, so every
+// level waits for the next: the innermost execution to actually run (at
+// nestedExecutionMaxDepth) refuses to recurse further and fails, and that
+// failure -- via each level's own States.TaskFailed -- eventually
+// propagates all the way back up to the top-level execution.
+func TestStartExecutionSelfRecursionHitsDepthCap(t *testing.T) {
+	t.Parallel()
+
+	const name = "self-recursing"
+
+	selfArn := childStateMachineArn(name)
+	definition := startExecutionParentDefinition(resourceStartExecutionSync, selfArn, `{}`)
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, name, definition)
+
+	exec := startAndAwaitFailureWithin(t, store, sm.StateMachineArn, `{}`, 15*time.Second)
+
+	if exec.Error != errorStatesTaskFailed {
+		t.Fatalf("execution error: got %q, want %q (cause: %s)", exec.Error, errorStatesTaskFailed, exec.Cause)
+	}
+
+	if !strings.Contains(exec.Cause, "nesting depth exceeded") {
+		t.Fatalf("execution cause: got %q, want it to mention kumo's nesting depth cap", exec.Cause)
+	}
+}
+
+// waitForExecutionTerminal polls DescribeExecution for executionArn until it
+// leaves RUNNING, failing the test if it does not terminate in time. Unlike
+// startAndAwaitTerminal (execution_error_test.go), it takes an already
+// existing execution ARN rather than starting a new execution itself.
+func waitForExecutionTerminal(t *testing.T, store *MemoryStorage, executionArn string) *Execution {
+	t.Helper()
+
+	ctx := context.Background()
+	deadline := time.Now().Add(10 * time.Second)
+
+	for time.Now().Before(deadline) {
+		exec, err := store.DescribeExecution(ctx, executionArn)
+		if err != nil {
+			t.Fatalf("DescribeExecution: %v", err)
+		}
+
+		if exec.Status != ExecutionStatusRunning {
+			return exec
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("execution %q did not terminate within the deadline", executionArn)
+
+	return nil
+}
+
+// startAndAwaitFailureWithin is startAndAwaitFailure with a caller-supplied
+// deadline, for tests (like deep self-recursion) that need more time than
+// startAndAwaitTerminal's fixed 10 seconds.
+func startAndAwaitFailureWithin(t *testing.T, store *MemoryStorage, stateMachineArn, input string, timeout time.Duration) *Execution {
+	t.Helper()
+
+	ctx := context.Background()
+
+	started, err := store.StartExecution(ctx, stateMachineArn, "", input, "")
+	if err != nil {
+		t.Fatalf("StartExecution: %v", err)
+	}
+
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		exec, err := store.DescribeExecution(ctx, started.ExecutionArn)
+		if err != nil {
+			t.Fatalf("DescribeExecution: %v", err)
+		}
+
+		if exec.Status == ExecutionStatusFailed {
+			return exec
+		}
+
+		if exec.Status != ExecutionStatusRunning {
+			t.Fatalf("execution ended with status %q, want FAILED", exec.Status)
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("execution did not terminate within the deadline")
+
+	return nil
+}

--- a/internal/service/sfn/resultwriter.go
+++ b/internal/service/sfn/resultwriter.go
@@ -18,32 +18,50 @@ const resultWriterResourceS3PutObject = "arn:aws:states:::s3:putObject"
 // real multi-file layout).
 const resultWriterFileName = "result.json"
 
+// ResultWriter.WriterConfig.OutputType values.
+const (
+	resultWriterOutputTypeJSON  = "JSON"
+	resultWriterOutputTypeJSONL = "JSONL"
+)
+
+// ResultWriter.WriterConfig.Transformation values.
+const (
+	resultWriterTransformationCompact = "COMPACT"
+	resultWriterTransformationFlatten = "FLATTEN"
+	resultWriterTransformationNone    = "NONE"
+)
+
 // resultWriterDef is the decoded ResultWriter field. JSON tags are
 // lowerCamelCase; see itemBatcherDef in itembatcher.go for why.
-//
-// WriterConfig (Transformation/OutputType) is not implemented: kumo always
-// writes the plain JSON array of item outputs, equivalent to AWS's
-// Transformation "COMPACT" with OutputType "JSON". It is decoded only so
-// validate.go can flag it as unimplemented.
 type resultWriterDef struct {
 	Resource     string          `json:"resource"`
 	Parameters   map[string]any  `json:"parameters"`
 	WriterConfig json.RawMessage `json:"writerConfig"`
 }
 
+// resultWriterConfig is the decoded ResultWriter.WriterConfig field (see
+// applyResultWriterTransformation/marshalResultWriterBody for how each
+// value is applied).
+type resultWriterConfig struct {
+	OutputType     string `json:"outputType"`
+	Transformation string `json:"transformation"`
+}
+
 // writeMapResultToS3 uploads outputs -- the Map state's would-be plain-array
-// result -- as a single JSON file to kumo's S3 under Parameters.Prefix, and
-// returns the Map state's output in AWS's documented
-// ResultWriterDetails{Bucket, Key} shape (see
+// result, reshaped per WriterConfig.Transformation and serialized per
+// WriterConfig.OutputType -- as a single file to kumo's S3 under
+// Parameters.Prefix, and returns the Map state's output in AWS's documented
+// {MapRunArn, ResultWriterDetails: {Bucket, Key}} shape (see
 // https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultwriter.html#export-s3).
+// mapRunArn is "" when the Map Run could not be recorded (see
+// startMapRunIfDistributed in maprun.go), in which case the field is
+// omitted entirely rather than sent empty.
 //
 // This is a deliberate emulator simplification of AWS's real behavior: AWS
 // partitions results into a manifest.json plus per-status
-// SUCCEEDED_n.json/FAILED_n.json files, and the top-level result also
-// carries a MapRunArn. kumo has no Map Run resource (DescribeMapRun/
-// ListMapRuns and child-execution tracking are out of scope, see
-// mapstate.go), so it writes one combined result file and omits MapRunArn.
-func writeMapResultToS3(ctx context.Context, e *executionEngine, raw json.RawMessage, outputs []json.RawMessage, mapInput string) (string, error) {
+// SUCCEEDED_n.json/FAILED_n.json files; kumo writes one combined result
+// file instead.
+func writeMapResultToS3(ctx context.Context, e *executionEngine, raw json.RawMessage, outputs []json.RawMessage, mapInput, mapRunArn string) (string, error) {
 	var def resultWriterDef
 	if err := json.Unmarshal(raw, &def); err != nil {
 		return "", fmt.Errorf("parse ResultWriter: %w", err)
@@ -65,18 +83,108 @@ func writeMapResultToS3(ctx context.Context, e *executionEngine, raw json.RawMes
 		return "", fmt.Errorf("resultWriter s3:putObject requires Parameters.Bucket")
 	}
 
-	key := resultWriterKey(prefix)
-
-	body, err := json.Marshal(outputs)
-	if err != nil {
-		return "", fmt.Errorf("marshal ResultWriter output: %w", err)
+	var cfg resultWriterConfig
+	if len(def.WriterConfig) > 0 {
+		if err := json.Unmarshal(def.WriterConfig, &cfg); err != nil {
+			return "", fmt.Errorf("parse ResultWriter WriterConfig: %w", err)
+		}
 	}
+
+	transformed, err := applyResultWriterTransformation(outputs, cfg.Transformation)
+	if err != nil {
+		return "", fmt.Errorf("resultWriter: %w", err)
+	}
+
+	body, err := marshalResultWriterBody(transformed, cfg.OutputType)
+	if err != nil {
+		return "", fmt.Errorf("resultWriter: %w", err)
+	}
+
+	key := resultWriterKey(prefix)
 
 	if err := e.putS3Object(ctx, bucket, key, body); err != nil {
 		return "", fmt.Errorf("resultWriter: %w", err)
 	}
 
-	return marshalResultWriterOutput(bucket, key)
+	return marshalResultWriterOutput(bucket, key, mapRunArn)
+}
+
+// applyResultWriterTransformation reshapes outputs (one entry per processor
+// unit) per WriterConfig.Transformation:
+//
+//   - "" or COMPACT (kumo's default, matching AWS's own documented default
+//     "when ResultWriter is not specified"): outputs unchanged, each entry
+//     keeping whatever shape its own unit produced.
+//   - FLATTEN: any entry that is itself a JSON array has its elements
+//     spliced into the result in place of the array; other entries pass
+//     through unchanged.
+//   - NONE: rejected. AWS's NONE wraps each entry in a DescribeExecution-
+//     style envelope (ExecutionArn, Status, StartDate, ...) describing the
+//     real child *execution* that produced it; kumo runs every Map unit
+//     in-process rather than as one (see mapstate.go), so it has none of
+//     that data to report and would have to fabricate it.
+func applyResultWriterTransformation(outputs []json.RawMessage, transformation string) ([]json.RawMessage, error) {
+	switch strings.ToUpper(transformation) {
+	case "", resultWriterTransformationCompact:
+		return outputs, nil
+	case resultWriterTransformationFlatten:
+		return flattenResultWriterOutputs(outputs), nil
+	case resultWriterTransformationNone:
+		return nil, fmt.Errorf(
+			"writerConfig.Transformation %q is not implemented: it requires per-item child-execution metadata kumo does not track for Map units; use COMPACT or FLATTEN instead",
+			resultWriterTransformationNone,
+		)
+	default:
+		return nil, fmt.Errorf("unsupported WriterConfig.Transformation %q", transformation)
+	}
+}
+
+// flattenResultWriterOutputs implements Transformation FLATTEN: an entry
+// that unmarshals as a JSON array contributes its own elements instead of
+// itself (dropping a JSON null this way too, matching a failed unit
+// contributing nothing to the flattened success list); every other entry
+// passes through unchanged.
+func flattenResultWriterOutputs(outputs []json.RawMessage) []json.RawMessage {
+	flattened := make([]json.RawMessage, 0, len(outputs))
+
+	for _, out := range outputs {
+		var elems []json.RawMessage
+		if json.Unmarshal(out, &elems) == nil {
+			flattened = append(flattened, elems...)
+
+			continue
+		}
+
+		flattened = append(flattened, out)
+	}
+
+	return flattened
+}
+
+// marshalResultWriterBody serializes outputs per WriterConfig.OutputType:
+// "" or JSON (the default) as a single JSON array document; JSONL as
+// newline-delimited JSON documents, one per entry.
+func marshalResultWriterBody(outputs []json.RawMessage, outputType string) ([]byte, error) {
+	switch strings.ToUpper(outputType) {
+	case "", resultWriterOutputTypeJSON:
+		body, err := json.Marshal(outputs)
+		if err != nil {
+			return nil, fmt.Errorf("marshal ResultWriter output: %w", err)
+		}
+
+		return body, nil
+	case resultWriterOutputTypeJSONL:
+		var buf bytes.Buffer
+
+		for _, out := range outputs {
+			buf.Write(out)
+			buf.WriteByte('\n')
+		}
+
+		return buf.Bytes(), nil
+	default:
+		return nil, fmt.Errorf("unsupported WriterConfig.OutputType %q", outputType)
+	}
 }
 
 // resultWriterKey builds the combined result file's object key under Prefix.
@@ -89,14 +197,19 @@ func resultWriterKey(prefix string) string {
 }
 
 // marshalResultWriterOutput builds the Map state's output when ResultWriter
-// exported to S3: {"ResultWriterDetails": {"Bucket": ..., "Key": ...}}. A
-// plain map is used so the wire keys need not be exempted from tagliatelle.
-func marshalResultWriterOutput(bucket, key string) (string, error) {
+// exported to S3: {"MapRunArn": ..., "ResultWriterDetails": {"Bucket": ...,
+// "Key": ...}}. A plain map is used so the wire keys need not be exempted
+// from tagliatelle.
+func marshalResultWriterOutput(bucket, key, mapRunArn string) (string, error) {
 	result := map[string]any{
 		"ResultWriterDetails": map[string]any{
 			"Bucket": bucket,
 			"Key":    key,
 		},
+	}
+
+	if mapRunArn != "" {
+		result["MapRunArn"] = mapRunArn
 	}
 
 	encoded, err := json.Marshal(result)

--- a/internal/service/sfn/resultwriter_test.go
+++ b/internal/service/sfn/resultwriter_test.go
@@ -3,6 +3,7 @@ package sfn
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -31,7 +32,7 @@ func TestMapStateResultWriterExportsToS3(t *testing.T) {
 	store := NewMemoryStorage(WithBaseURL(server.URL))
 	sm := createExecutionTestStateMachine(t, store, "map-resultwriter", definition)
 
-	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `[1,2,3]`)
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, threeItemArrayJSON)
 
 	// JSON tags are lowerCamelCase (encoding/json matches the wire's
 	// PascalCase case-insensitively; see itemBatcherDef in itembatcher.go
@@ -60,7 +61,159 @@ func TestMapStateResultWriterExportsToS3(t *testing.T) {
 		t.Fatalf("PUT target: got bucket=%q key=%q, want bucket=%q key=%q", put.bucket, put.key, "dst-bucket", "out/result.json")
 	}
 
-	if want := `[1,2,3]`; string(put.body) != want {
+	if want := threeItemArrayJSON; string(put.body) != want {
 		t.Fatalf("PUT body: got %q, want %q", string(put.body), want)
+	}
+}
+
+// resultWriterWriterConfigDefinition builds a Map state exporting to S3
+// with resultWriterExtra (a WriterConfig JSON fragment, or "") added to
+// ResultWriter, using a plain echo ItemProcessor: each item is itself
+// already a one-element JSON array (see resultWriterWriterConfigInput), so
+// each unit's own output is an array -- exactly the shape
+// Transformation FLATTEN needs something to flatten.
+func resultWriterWriterConfigDefinition(resultWriterExtra string) string {
+	resultWriter := fmt.Sprintf(`{
+		"Resource": "arn:aws:states:::s3:putObject",
+		"Parameters": {"Bucket": "dst-bucket", "Prefix": "out"}
+		%s
+	}`, resultWriterExtra)
+
+	return fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ResultWriter": %s,
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, resultWriter, distributedItemProcessorJSON)
+}
+
+// resultWriterWriterConfigInput is resultWriterWriterConfigDefinition's Map
+// input: three one-element arrays, one per item/unit.
+const resultWriterWriterConfigInput = `[[1],[2],[3]]`
+
+func TestMapStateResultWriterOutputIncludesMapRunArn(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+
+	resultWriter := `{
+		"Resource": "arn:aws:states:::s3:putObject",
+		"Parameters": {"Bucket": "dst-bucket", "Prefix": "out"}
+	}`
+
+	definition := fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ResultWriter": %s,
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, resultWriter, distributedItemProcessorJSON)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-resultwriter-maprunarn", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `[1,2]`)
+
+	var output struct {
+		MapRunArn string `json:"mapRunArn"`
+	}
+
+	if err := json.Unmarshal([]byte(exec.Output), &output); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if output.MapRunArn == "" {
+		t.Fatalf("execution output %q: want a non-empty MapRunArn", exec.Output)
+	}
+
+	if !strings.Contains(output.MapRunArn, ":mapRun:") {
+		t.Fatalf("MapRunArn %q: want it to contain the \":mapRun:\" ARN segment", output.MapRunArn)
+	}
+}
+
+func TestMapStateResultWriterWriterConfigJSONLOutputType(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+
+	definition := resultWriterWriterConfigDefinition(`, "WriterConfig": {"OutputType": "JSONL"}`)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-resultwriter-jsonl", definition)
+
+	startAndAwaitSuccess(t, store, sm.StateMachineArn, resultWriterWriterConfigInput)
+
+	put := server.lastPut(t)
+
+	if want := "[1]\n[2]\n[3]\n"; string(put.body) != want {
+		t.Fatalf("PUT body (JSONL): got %q, want %q", string(put.body), want)
+	}
+}
+
+func TestMapStateResultWriterWriterConfigFlatten(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+
+	definition := resultWriterWriterConfigDefinition(`, "WriterConfig": {"Transformation": "FLATTEN"}`)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-resultwriter-flatten", definition)
+
+	startAndAwaitSuccess(t, store, sm.StateMachineArn, resultWriterWriterConfigInput)
+
+	put := server.lastPut(t)
+
+	if want := threeItemArrayJSON; string(put.body) != want {
+		t.Fatalf("PUT body (FLATTEN): got %q, want %q", string(put.body), want)
+	}
+}
+
+func TestMapStateResultWriterWriterConfigCompactIsDefaultAndUnflattened(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+
+	definition := resultWriterWriterConfigDefinition("")
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-resultwriter-compact-default", definition)
+
+	startAndAwaitSuccess(t, store, sm.StateMachineArn, resultWriterWriterConfigInput)
+
+	put := server.lastPut(t)
+
+	if want := `[[1],[2],[3]]`; string(put.body) != want {
+		t.Fatalf("PUT body (default/COMPACT): got %q, want %q", string(put.body), want)
+	}
+}
+
+func TestMapStateResultWriterWriterConfigTransformationNoneIsUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeAWSServer(t)
+
+	definition := resultWriterWriterConfigDefinition(`, "WriterConfig": {"Transformation": "NONE"}`)
+
+	store := NewMemoryStorage(WithBaseURL(server.URL))
+	sm := createExecutionTestStateMachine(t, store, "map-resultwriter-none", definition)
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn, resultWriterWriterConfigInput)
+
+	if exec.Error != errorStatesRuntime {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesRuntime)
+	}
+
+	if !strings.Contains(exec.Cause, "NONE") {
+		t.Fatalf("execution cause: got %q, want it to mention NONE", exec.Cause)
 	}
 }

--- a/internal/service/sfn/storage.go
+++ b/internal/service/sfn/storage.go
@@ -24,6 +24,9 @@ const (
 	errExecutionAlreadyExists    = "ExecutionAlreadyExists"
 	errInvalidArn                = "InvalidArn"
 	errInvalidDefinition         = "InvalidDefinition"
+	// errResourceNotFound is DescribeMapRun's documented error for a
+	// mapRunArn kumo has never recorded.
+	errResourceNotFound = "ResourceNotFound"
 )
 
 // Storage defines the Step Functions storage interface.
@@ -40,6 +43,12 @@ type Storage interface {
 	DescribeExecution(ctx context.Context, executionArn string) (*Execution, error)
 	ListExecutions(ctx context.Context, stateMachineArn, statusFilter string, maxResults int32, nextToken string) ([]*Execution, string, error)
 	GetExecutionHistory(ctx context.Context, executionArn string, maxResults int32, nextToken string, reverseOrder bool) ([]*HistoryEvent, string, error)
+
+	// Map Run operations (see maprun.go): distributed-mode Map states each
+	// create a Map Run record, queryable the same way real AWS's own
+	// DescribeMapRun/ListMapRuns are.
+	DescribeMapRun(ctx context.Context, mapRunArn string) (*MapRun, error)
+	ListMapRuns(ctx context.Context, executionArn string, maxResults int32, nextToken string) ([]*MapRun, string, error)
 
 	// Tag operations.
 	TagResource(ctx context.Context, resourceArn string, tags []Tag) error
@@ -97,6 +106,7 @@ type MemoryStorage struct {
 	Executions    map[string]*ExecutionData `json:"executions"`
 	Activities    map[string]*Activity      `json:"activities"`
 	Tags          map[string][]Tag          `json:"tags"`
+	MapRuns       map[string]*MapRun        `json:"mapRuns"`
 	region        string
 	accountID     string
 	EventCounter  int64 `json:"eventCounter"`
@@ -123,6 +133,7 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 		Executions:    make(map[string]*ExecutionData),
 		Activities:    make(map[string]*Activity),
 		Tags:          make(map[string][]Tag),
+		MapRuns:       make(map[string]*MapRun),
 		region:        region,
 		accountID:     "000000000000",
 		baseURL:       defaultBaseURL,
@@ -132,6 +143,12 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	}
 
 	s.engine = newExecutionEngine(s.baseURL)
+	// Wire the engine's states:startExecution and Map Run bookkeeping back
+	// to this same storage -- see executionStarter in nestedexec.go and
+	// mapRunTracker in maprun.go for why this is a direct reference rather
+	// than an HTTP round trip.
+	s.engine.starter = s
+	s.engine.mapRuns = s
 
 	if s.dataDir != "" {
 		_ = storage.Load(s.dataDir, "states", s)
@@ -182,6 +199,10 @@ func (s *MemoryStorage) UnmarshalJSON(data []byte) error {
 
 	if s.Tags == nil {
 		s.Tags = make(map[string][]Tag)
+	}
+
+	if s.MapRuns == nil {
+		s.MapRuns = make(map[string]*MapRun)
 	}
 
 	return nil
@@ -307,7 +328,22 @@ func (s *MemoryStorage) ListStateMachines(_ context.Context, maxResults int32, _
 }
 
 // StartExecution starts a new execution.
-func (s *MemoryStorage) StartExecution(_ context.Context, stateMachineArn, name, input, traceHeader string) (*Execution, error) {
+func (s *MemoryStorage) StartExecution(ctx context.Context, stateMachineArn, name, input, traceHeader string) (*Execution, error) {
+	return s.startExecutionAtDepth(ctx, stateMachineArn, name, input, traceHeader, 0)
+}
+
+// startNestedExecution implements executionStarter (see nestedexec.go) for
+// a states:startExecution Task: identical to StartExecution except it
+// carries the caller's nesting depth through to the child's own runExecution
+// goroutine, since StartExecution's own ctx parameter cannot (see
+// nestedExecutionDepthKey's doc in nestedexec.go).
+func (s *MemoryStorage) startNestedExecution(ctx context.Context, stateMachineArn, name, input string, depth int) (*Execution, error) {
+	return s.startExecutionAtDepth(ctx, stateMachineArn, name, input, "", depth)
+}
+
+// startExecutionAtDepth is StartExecution/startNestedExecution's shared
+// implementation.
+func (s *MemoryStorage) startExecutionAtDepth(_ context.Context, stateMachineArn, name, input, traceHeader string, depth int) (*Execution, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -348,7 +384,7 @@ func (s *MemoryStorage) StartExecution(_ context.Context, stateMachineArn, name,
 	// Parse the definition and run the state machine asynchronously.
 	definition := sm.Definition
 
-	go s.runExecution(ed, definition, input, startID)
+	go s.runExecution(ed, definition, input, startID, depth)
 
 	return copyExecution(exec), nil
 }
@@ -362,8 +398,10 @@ func (s *MemoryStorage) StartExecution(_ context.Context, stateMachineArn, name,
 const executionTimeoutCap = 5 * time.Minute
 
 // runExecution executes the state machine in a background goroutine, bounded
-// by min(definition TimeoutSeconds, executionTimeoutCap).
-func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string, lastEventID int64) {
+// by min(definition TimeoutSeconds, executionTimeoutCap). depth is this
+// execution's states:startExecution nesting depth (0 for a top-level
+// execution reached via StartExecution; see startNestedExecution).
+func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string, lastEventID int64, depth int) {
 	def, err := parseDefinition(definition)
 	if err != nil {
 		s.failExecution(ed, lastEventID, errorStatesRuntime, fmt.Sprintf("Failed to parse definition: %v", err))
@@ -373,6 +411,9 @@ func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string
 
 	ctx, cancel, definitionTimeoutApplies := executionContext(def)
 	defer cancel()
+
+	ctx = withNestedExecutionDepth(ctx, depth)
+	ctx = withExecutionArn(ctx, ed.Execution.ExecutionArn)
 
 	output, err := s.engine.execute(ctx, def, input)
 	if err != nil {
@@ -584,6 +625,53 @@ func (s *MemoryStorage) ListExecutions(_ context.Context, stateMachineArn, statu
 	}
 
 	return executions, "", nil
+}
+
+// DescribeMapRun describes a Map Run (see maprun.go).
+func (s *MemoryStorage) DescribeMapRun(_ context.Context, mapRunArn string) (*MapRun, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	mr, exists := s.MapRuns[mapRunArn]
+	if !exists {
+		return nil, &ServiceError{Code: errResourceNotFound, Message: "Map Run does not exist"}
+	}
+
+	return copyMapRun(mr), nil
+}
+
+// ListMapRuns lists the Map Runs started by a given execution.
+func (s *MemoryStorage) ListMapRuns(_ context.Context, executionArn string, maxResults int32, _ string) ([]*MapRun, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if _, exists := s.Executions[executionArn]; !exists {
+		return nil, "", &ServiceError{Code: errExecutionDoesNotExist, Message: "Execution does not exist"}
+	}
+
+	if maxResults <= 0 {
+		maxResults = 100
+	}
+
+	var mapRuns []*MapRun
+
+	for _, mr := range s.MapRuns {
+		if mr.ExecutionArn != executionArn {
+			continue
+		}
+
+		mapRuns = append(mapRuns, copyMapRun(mr))
+	}
+
+	sort.Slice(mapRuns, func(i, j int) bool {
+		return mapRuns[i].StartDate.Before(mapRuns[j].StartDate)
+	})
+
+	if len(mapRuns) > int(maxResults) {
+		mapRuns = mapRuns[:int(maxResults)]
+	}
+
+	return mapRuns, "", nil
 }
 
 // GetExecutionHistory gets the history of an execution.

--- a/internal/service/sfn/toleratedfailure_test.go
+++ b/internal/service/sfn/toleratedfailure_test.go
@@ -103,3 +103,87 @@ func TestMapStateToleratedFailureCountExceedingToleranceFails(t *testing.T) {
 		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesExceedToleratedFailureThreshold)
 	}
 }
+
+// toleratedFailurePathMapDefinition builds a Map state whose tolerance
+// field(s) are resolved dynamically from the Map state's own input, rather
+// than the static literal toleratedFailureMapDefinition uses.
+func toleratedFailurePathMapDefinition(toleranceField string) string {
+	return fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemsPath": "$.items",
+				%s,
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, toleranceField, conditionalFailProcessorJSON)
+}
+
+func TestMapStateToleratedFailurePercentagePathResolvesFromMapInput(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-tolerated-pct-path",
+		toleratedFailurePathMapDefinition(`"ToleratedFailurePercentagePath": "$.tolerance"`))
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn,
+		`{"items":[{"ok":true},{"ok":true},{"ok":false},{"ok":true}],"tolerance":50}`)
+
+	var outputs []json.RawMessage
+	if err := json.Unmarshal([]byte(exec.Output), &outputs); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(outputs) != 4 {
+		t.Fatalf("outputs: got %d entries, want 4", len(outputs))
+	}
+}
+
+func TestMapStateToleratedFailureCountPathResolvesFromMapInput(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-tolerated-count-path",
+		toleratedFailurePathMapDefinition(`"ToleratedFailureCountPath": "$.tolerance"`))
+
+	exec := startAndAwaitFailure(t, store, sm.StateMachineArn,
+		`{"items":[{"ok":true},{"ok":true},{"ok":false},{"ok":true}],"tolerance":0}`)
+
+	if exec.Error != errorStatesExceedToleratedFailureThreshold {
+		t.Fatalf("execution error: got %q, want %q", exec.Error, errorStatesExceedToleratedFailureThreshold)
+	}
+}
+
+func TestMapStateMaxConcurrencyPathResolvesFromMapInput(t *testing.T) {
+	t.Parallel()
+
+	definition := fmt.Sprintf(`{
+		"StartAt": "Each",
+		"States": {
+			"Each": {
+				"Type": "Map",
+				"ItemsPath": "$.items",
+				"MaxConcurrencyPath": "$.concurrency",
+				"ItemProcessor": %s,
+				"End": true
+			}
+		}
+	}`, distributedItemProcessorJSON)
+
+	store := NewMemoryStorage()
+	sm := createExecutionTestStateMachine(t, store, "map-maxconcurrencypath", definition)
+
+	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"items":[{"ok":true},{"ok":true}],"concurrency":1}`)
+
+	var outputs []json.RawMessage
+	if err := json.Unmarshal([]byte(exec.Output), &outputs); err != nil {
+		t.Fatalf("unmarshal execution output %q: %v", exec.Output, err)
+	}
+
+	if len(outputs) != 2 {
+		t.Fatalf("outputs: got %d entries, want 2", len(outputs))
+	}
+}

--- a/internal/service/sfn/types.go
+++ b/internal/service/sfn/types.go
@@ -115,6 +115,88 @@ type CloudWatchEventsExecutionDataDetails struct {
 	Included bool `json:"included,omitempty"`
 }
 
+// MapRun represents a Distributed-mode Map state's Map Run (see maprun.go).
+type MapRun struct {
+	MapRunArn                  string
+	ExecutionArn               string
+	StateMachineArn            string
+	Status                     string
+	StartDate                  time.Time
+	StopDate                   *time.Time
+	MaxConcurrency             int
+	ToleratedFailureCount      *int
+	ToleratedFailurePercentage *float64
+	RedriveCount               int32
+	RedriveDate                *time.Time
+	ItemCounts                 MapRunCounts
+	ExecutionCounts            MapRunCounts
+}
+
+// MapRunCounts is DescribeMapRun's documented MapRunExecutionCounts/
+// MapRunItemCounts shape (both share the same fields; see
+// https://docs.aws.amazon.com/step-functions/latest/apireference/API_MapRunExecutionCounts.html
+// and .../API_MapRunItemCounts.html), reused directly as both MapRun's own
+// storage field type and (embedded in DescribeMapRunResponse) the wire type,
+// the same way Tag and LoggingConfiguration double as both elsewhere in this
+// file. Every field except FailuresNotRedrivable/PendingRedrive is
+// documented "Required: Yes", so none but those two get "omitempty" -- a
+// legitimate 0 count must still be sent, not omitted.
+type MapRunCounts struct {
+	Total                 int64 `json:"total"`
+	Succeeded             int64 `json:"succeeded"`
+	Failed                int64 `json:"failed"`
+	Pending               int64 `json:"pending"`
+	Running               int64 `json:"running"`
+	Aborted               int64 `json:"aborted"`
+	TimedOut              int64 `json:"timedOut"`
+	ResultsWritten        int64 `json:"resultsWritten"`
+	FailuresNotRedrivable int64 `json:"failuresNotRedrivable,omitempty"`
+	PendingRedrive        int64 `json:"pendingRedrive,omitempty"`
+}
+
+// DescribeMapRunRequest is the request for DescribeMapRun.
+type DescribeMapRunRequest struct {
+	MapRunArn string `json:"mapRunArn"`
+}
+
+// DescribeMapRunResponse is the response for DescribeMapRun.
+type DescribeMapRunResponse struct {
+	ExecutionArn               string       `json:"executionArn"`
+	ExecutionCounts            MapRunCounts `json:"executionCounts"`
+	ItemCounts                 MapRunCounts `json:"itemCounts"`
+	MapRunArn                  string       `json:"mapRunArn"`
+	MaxConcurrency             int          `json:"maxConcurrency"`
+	RedriveCount               int32        `json:"redriveCount,omitempty"`
+	RedriveDate                float64      `json:"redriveDate,omitempty"`
+	StartDate                  float64      `json:"startDate"`
+	Status                     string       `json:"status"`
+	StopDate                   float64      `json:"stopDate,omitempty"`
+	ToleratedFailureCount      int64        `json:"toleratedFailureCount,omitempty"`
+	ToleratedFailurePercentage float64      `json:"toleratedFailurePercentage,omitempty"`
+}
+
+// ListMapRunsRequest is the request for ListMapRuns.
+type ListMapRunsRequest struct {
+	ExecutionArn string `json:"executionArn"`
+	MaxResults   int32  `json:"maxResults,omitempty"`
+	NextToken    string `json:"nextToken,omitempty"`
+}
+
+// ListMapRunsResponse is the response for ListMapRuns.
+type ListMapRunsResponse struct {
+	MapRuns   []MapRunListItem `json:"mapRuns"`
+	NextToken string           `json:"nextToken,omitempty"`
+}
+
+// MapRunListItem represents a Map Run in a ListMapRuns response.
+type MapRunListItem struct {
+	ExecutionArn    string  `json:"executionArn"`
+	MapRunArn       string  `json:"mapRunArn"`
+	StartDate       float64 `json:"startDate"`
+	StateMachineArn string  `json:"stateMachineArn"`
+	StopDate        float64 `json:"stopDate,omitempty"`
+}
+
 // HistoryEvent represents a history event in an execution.
 type HistoryEvent struct {
 	Timestamp                      time.Time

--- a/internal/service/sfn/validate.go
+++ b/internal/service/sfn/validate.go
@@ -416,78 +416,68 @@ func (v *definitionValidator) warnDistributedOnlyFields(name string, state *stat
 	}
 }
 
-// warnUnimplementedMapConstructs flags Map/ItemReader/ItemBatcher/
-// ResultWriter constructs kumo's engine does not implement at all (see
-// itemreader.go, itembatcher.go, resultwriter.go), so a definition that
-// structurally validates does not still surprise the caller when it runs.
+// warnUnimplementedMapConstructs flags Map/ItemReader/ResultWriter
+// constructs kumo's engine still does not implement at all (see
+// itemreader.go, resultwriter.go), so a definition that structurally
+// validates does not still surprise the caller when it runs. ItemBatcher's
+// MaxItemsPerBatchPath/MaxInputBytesPerBatchPath and the Map state's own
+// ToleratedFailurePercentagePath/ToleratedFailureCountPath are implemented
+// (see buildProcessorUnits in itembatcher.go and resolveMapTolerance in
+// maptolerance.go), so neither warns anymore.
 func (v *definitionValidator) warnUnimplementedMapConstructs(name string, state *stateDefinition, location string) {
 	v.warnUnimplementedItemReaderConstructs(name, state.ItemReader, location)
-	v.warnUnimplementedItemBatcherConstructs(name, state.ItemBatcher, location)
 	v.warnUnimplementedResultWriterConstructs(name, state.ResultWriter, location)
-
-	if state.ToleratedFailurePercentagePath != "" {
-		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ToleratedFailurePercentagePath",
-			fmt.Sprintf("Map state %q: ToleratedFailurePercentagePath is not implemented; use the static ToleratedFailurePercentage instead", name))
-	}
-
-	if state.ToleratedFailureCountPath != "" {
-		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ToleratedFailureCountPath",
-			fmt.Sprintf("Map state %q: ToleratedFailureCountPath is not implemented; use the static ToleratedFailureCount instead", name))
-	}
 }
 
 // warnUnimplementedItemReaderConstructs flags an ItemReader Resource kumo
-// does not implement (only s3:getObject is supported) and the unimplemented
-// ReaderConfig.MaxItemsPath field.
+// does not implement: only s3:getObject and s3:listObjectsV2 are supported
+// (see itemreader.go).
 func (v *definitionValidator) warnUnimplementedItemReaderConstructs(name string, raw json.RawMessage, location string) {
 	var def itemReaderDef
 	if len(raw) == 0 || json.Unmarshal(raw, &def) != nil {
 		return
 	}
 
-	if def.Resource != "" && def.Resource != itemReaderResourceS3GetObject {
+	if def.Resource != "" && def.Resource != itemReaderResourceS3GetObject && def.Resource != itemReaderResourceS3ListObjectsV2 {
 		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ItemReader/Resource", fmt.Sprintf(
-			"Map state %q: ItemReader Resource %q is not implemented; only %q is supported", name, def.Resource, itemReaderResourceS3GetObject,
+			"Map state %q: ItemReader Resource %q is not implemented; only %q and %q are supported",
+			name, def.Resource, itemReaderResourceS3GetObject, itemReaderResourceS3ListObjectsV2,
 		))
 	}
 
-	if def.ReaderConfig.MaxItemsPath != "" {
-		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ItemReader/ReaderConfig/MaxItemsPath",
-			fmt.Sprintf("Map state %q: ItemReader ReaderConfig.MaxItemsPath is not implemented; use the static MaxItems instead", name))
+	if strings.EqualFold(def.ReaderConfig.Transformation, itemReaderTransformationLoadAndFlatten) {
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ItemReader/ReaderConfig/Transformation", fmt.Sprintf(
+			"Map state %q: ItemReader ReaderConfig.Transformation %q is not implemented", name, itemReaderTransformationLoadAndFlatten,
+		))
 	}
 }
 
-// warnUnimplementedItemBatcherConstructs flags ItemBatcher's unimplemented
-// reference-path sub-fields.
-func (v *definitionValidator) warnUnimplementedItemBatcherConstructs(name string, raw json.RawMessage, location string) {
-	var def itemBatcherDef
-	if len(raw) == 0 || json.Unmarshal(raw, &def) != nil {
-		return
-	}
-
-	if def.MaxItemsPerBatchPath != "" {
-		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ItemBatcher/MaxItemsPerBatchPath",
-			fmt.Sprintf("Map state %q: ItemBatcher MaxItemsPerBatchPath is not implemented; use the static MaxItemsPerBatch instead", name))
-	}
-
-	if def.MaxInputBytesPerBatchPath != "" {
-		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ItemBatcher/MaxInputBytesPerBatchPath",
-			fmt.Sprintf("Map state %q: ItemBatcher MaxInputBytesPerBatchPath is not implemented; use the static MaxInputBytesPerBatch instead", name))
-	}
-}
-
-// warnUnimplementedResultWriterConstructs flags ResultWriter.WriterConfig,
-// which kumo does not implement (kumo always writes the plain item-output
-// array; see resultwriter.go).
+// warnUnimplementedResultWriterConstructs flags the ResultWriter
+// combinations kumo still does not implement: WriterConfig.Transformation
+// "NONE", and WriterConfig used without Resource/Parameters ("preview"
+// mode, which AWS documents as valid but kumo does not implement -- see
+// writeMapResultToS3 in resultwriter.go).
 func (v *definitionValidator) warnUnimplementedResultWriterConstructs(name string, raw json.RawMessage, location string) {
 	var def resultWriterDef
-	if len(raw) == 0 || json.Unmarshal(raw, &def) != nil {
+	if len(raw) == 0 || json.Unmarshal(raw, &def) != nil || len(def.WriterConfig) == 0 {
 		return
 	}
 
-	if len(def.WriterConfig) > 0 {
-		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ResultWriter/WriterConfig",
-			fmt.Sprintf("Map state %q: ResultWriter WriterConfig is not implemented; kumo always writes the plain item-output array", name))
+	var cfg resultWriterConfig
+	if json.Unmarshal(def.WriterConfig, &cfg) != nil {
+		return
+	}
+
+	if strings.EqualFold(cfg.Transformation, resultWriterTransformationNone) {
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ResultWriter/WriterConfig/Transformation", fmt.Sprintf(
+			"Map state %q: ResultWriter WriterConfig.Transformation %q is not implemented; use COMPACT or FLATTEN instead", name, resultWriterTransformationNone,
+		))
+	}
+
+	if def.Resource == "" {
+		v.addWarning(codeUnsupportedRuntimeConstruct, location+"/ResultWriter/WriterConfig", fmt.Sprintf(
+			"Map state %q: ResultWriter WriterConfig without Resource/Parameters (preview mode) is not implemented", name,
+		))
 	}
 }
 

--- a/internal/service/sfn/validate_test.go
+++ b/internal/service/sfn/validate_test.go
@@ -271,6 +271,61 @@ var validateDiagnosticTests = []diagnosticTest{
 		wantLocation: "/States/Items/ResultWriter",
 	},
 	{
+		name: "ItemReader Resource kumo does not implement",
+		definition: `{
+			"StartAt": "Items",
+			"States": {
+				"Items": {
+					"Type": "Map",
+					"ItemProcessor": ` + distributedItemProcessorJSON + `,
+					"ItemReader": {"Resource": "arn:aws:states:::s3:getObjectRange", "Parameters": {"Bucket": "b", "Key": "k"}},
+					"End": true
+				}
+			}
+		}`,
+		wantSeverity: diagnosticSeverityWarning,
+		wantCode:     codeUnsupportedRuntimeConstruct,
+		wantLocation: "/States/Items/ItemReader/Resource",
+	},
+	{
+		name: "ResultWriter WriterConfig Transformation NONE",
+		definition: `{
+			"StartAt": "Items",
+			"States": {
+				"Items": {
+					"Type": "Map",
+					"ItemProcessor": ` + distributedItemProcessorJSON + `,
+					"ResultWriter": {
+						"Resource": "arn:aws:states:::s3:putObject",
+						"Parameters": {"Bucket": "b", "Prefix": "p"},
+						"WriterConfig": {"Transformation": "NONE"}
+					},
+					"End": true
+				}
+			}
+		}`,
+		wantSeverity: diagnosticSeverityWarning,
+		wantCode:     codeUnsupportedRuntimeConstruct,
+		wantLocation: "/States/Items/ResultWriter/WriterConfig/Transformation",
+	},
+	{
+		name: "ResultWriter WriterConfig preview mode without Resource",
+		definition: `{
+			"StartAt": "Items",
+			"States": {
+				"Items": {
+					"Type": "Map",
+					"ItemProcessor": ` + distributedItemProcessorJSON + `,
+					"ResultWriter": {"WriterConfig": {"OutputType": "JSON"}},
+					"End": true
+				}
+			}
+		}`,
+		wantSeverity: diagnosticSeverityWarning,
+		wantCode:     codeUnsupportedRuntimeConstruct,
+		wantLocation: "/States/Items/ResultWriter/WriterConfig",
+	},
+	{
 		name: "nested branch dangling Next",
 		definition: `{
 			"StartAt": "Fork",

--- a/internal/service/sfn/wait.go
+++ b/internal/service/sfn/wait.go
@@ -144,3 +144,41 @@ func resolvePath(path, input string) (any, error) {
 
 	return value, nil
 }
+
+// resolveOptionalIntPath resolves the dynamic "*Path" variant of an
+// otherwise-static optional integer field, preferring path over static when
+// both are set -- the same precedence taskTimeout gives
+// TimeoutSecondsPath/TimeoutSeconds. It returns static unchanged (possibly
+// nil) when path is empty. Shared by the several Map/ItemReader/ItemBatcher
+// fields with this exact shape: ReaderConfig.MaxItems(Path),
+// ItemBatcher.MaxItemsPerBatch(Path)/MaxInputBytesPerBatch(Path), and
+// ToleratedFailureCount(Path).
+func resolveOptionalIntPath(static *int, path, input string) (*int, error) {
+	if path == "" {
+		return static, nil
+	}
+
+	n, err := resolveNumberPath(path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved := int(n)
+
+	return &resolved, nil
+}
+
+// resolveOptionalFloatPath is resolveOptionalIntPath's float64 counterpart,
+// used by ToleratedFailurePercentage(Path).
+func resolveOptionalFloatPath(static *float64, path, input string) (*float64, error) {
+	if path == "" {
+		return static, nil
+	}
+
+	n, err := resolveNumberPath(path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return &n, nil
+}

--- a/test/integration/sfn_test.go
+++ b/test/integration/sfn_test.go
@@ -4,7 +4,10 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -455,5 +458,119 @@ func TestSFN_ActivityCRUD(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for deleted activity")
+	}
+}
+
+// waitForSFNExecutionTerminal polls DescribeExecution until executionArn
+// leaves RUNNING: unlike every other state machine in this file (a single
+// Pass state, which completes essentially instantly), a
+// states:startExecution.sync/.sync:2 Task's own execution can still be
+// RUNNING by the time the test calls DescribeExecution, since it waits on
+// its child execution in the background.
+func waitForSFNExecutionTerminal(t *testing.T, client *sfn.Client, executionArn string) *sfn.DescribeExecutionOutput {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+
+	for {
+		out, err := client.DescribeExecution(context.Background(), &sfn.DescribeExecutionInput{
+			ExecutionArn: aws.String(executionArn),
+		})
+		if err != nil {
+			t.Fatalf("DescribeExecution: %v", err)
+		}
+
+		if out.Status != sfntypes.ExecutionStatusRunning {
+			return out
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("execution %q did not terminate within the deadline", executionArn)
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestSFN_NestedExecution exercises the states:startExecution.sync:2
+// integration end to end: a parent state machine's Task starts a child
+// state machine and waits for it, and the Task's own output (the whole
+// parent execution's Output here, since the Task is also the parent's only
+// state) mirrors DescribeExecution with the child's own Output parsed as
+// JSON rather than left as a string -- see
+// https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html.
+func TestSFN_NestedExecution(t *testing.T) {
+	client := newSFNClient(t)
+	ctx := t.Context()
+
+	roleArn := "arn:aws:iam::000000000000:role/test-role"
+
+	childDefinition := `{
+		"StartAt": "Build",
+		"States": {"Build": {"Type": "Pass", "Result": {"MyKey": "MyValue"}, "End": true}}
+	}`
+
+	childOutput, err := client.CreateStateMachine(ctx, &sfn.CreateStateMachineInput{
+		Name:       aws.String("test-nested-child"),
+		Definition: aws.String(childDefinition),
+		RoleArn:    aws.String(roleArn),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parentDefinition := fmt.Sprintf(`{
+		"StartAt": "Nested",
+		"States": {
+			"Nested": {
+				"Type": "Task",
+				"Resource": "arn:aws:states:::states:startExecution.sync:2",
+				"Parameters": {"StateMachineArn": %q, "Input": {}},
+				"End": true
+			}
+		}
+	}`, *childOutput.StateMachineArn)
+
+	parentOutput, err := client.CreateStateMachine(ctx, &sfn.CreateStateMachineInput{
+		Name:       aws.String("test-nested-parent"),
+		Definition: aws.String(parentDefinition),
+		RoleArn:    aws.String(roleArn),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	startOutput, err := client.StartExecution(ctx, &sfn.StartExecutionInput{
+		StateMachineArn: parentOutput.StateMachineArn,
+		Input:           aws.String("{}"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	describeOutput := waitForSFNExecutionTerminal(t, client, *startOutput.ExecutionArn)
+
+	golden.New(t, golden.WithIgnoreFields(
+		"ExecutionArn", "StateMachineArn", "StartDate", "StopDate", "Name", "Output", "ResultMetadata",
+	)).Assert(t.Name()+"_describe", describeOutput)
+
+	if describeOutput.Status != sfntypes.ExecutionStatusSucceeded {
+		t.Fatalf("parent execution status: got %s, want %s (output: %s)", describeOutput.Status, sfntypes.ExecutionStatusSucceeded, aws.ToString(describeOutput.Output))
+	}
+
+	var taskOutput struct {
+		Status string         `json:"status"`
+		Output map[string]any `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(aws.ToString(describeOutput.Output)), &taskOutput); err != nil {
+		t.Fatalf("unmarshal parent execution Output %q: %v", aws.ToString(describeOutput.Output), err)
+	}
+
+	if taskOutput.Status != string(sfntypes.ExecutionStatusSucceeded) {
+		t.Fatalf(".sync:2 nested output.status: got %q, want %q", taskOutput.Status, sfntypes.ExecutionStatusSucceeded)
+	}
+
+	if taskOutput.Output["MyKey"] != "MyValue" {
+		t.Fatalf(".sync:2 nested output.output: got %v, want parsed JSON {\"MyKey\":\"MyValue\"}", taskOutput.Output)
 	}
 }

--- a/test/integration/testdata/sfn_test_TestSFN_NestedExecution_TestSFN_NestedExecution_describe.golden.go
+++ b/test/integration/testdata/sfn_test_TestSFN_NestedExecution_TestSFN_NestedExecution_describe.golden.go
@@ -1,0 +1,27 @@
+{
+  "ExecutionArn": "arn:aws:states:us-east-1:000000000000:execution:test-nested-parent:1d32e2fb-5355-4283-a9e1-797cc861d862",
+  "StartDate": "2026-07-30T06:01:43Z",
+  "StateMachineArn": "arn:aws:states:us-east-1:000000000000:stateMachine:test-nested-parent",
+  "Status": "SUCCEEDED",
+  "Cause": null,
+  "Error": null,
+  "Input": "{}",
+  "InputDetails": {
+    "Included": true
+  },
+  "MapRunArn": null,
+  "Name": "1d32e2fb-5355-4283-a9e1-797cc861d862",
+  "Output": "{\"executionArn\":\"arn:aws:states:us-east-1:000000000000:execution:test-nested-child:2c105781-9f85-477d-82cb-2b7e2196a78d\",\"input\":\"{}\",\"name\":\"2c105781-9f85-477d-82cb-2b7e2196a78d\",\"output\":{\"MyKey\":\"MyValue\"},\"startDate\":1785391303,\"stateMachineArn\":\"arn:aws:states:us-east-1:000000000000:stateMachine:test-nested-child\",\"status\":\"SUCCEEDED\",\"stopDate\":1785391303}",
+  "OutputDetails": {
+    "Included": true
+  },
+  "RedriveCount": null,
+  "RedriveDate": null,
+  "RedriveStatus": "",
+  "RedriveStatusReason": null,
+  "StateMachineAliasArn": null,
+  "StateMachineVersionArn": null,
+  "StopDate": "2026-07-30T06:01:43Z",
+  "TraceHeader": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
Final PR of the Step Functions completion series (#874, #875).

- states:startExecution / .sync / .sync:2 with verified output shapes, running child executions in-process with a nesting-depth cap of 5 (documented emulator bound)
- MapRun tracking for distributed Maps plus DescribeMapRun / ListMapRuns; ResultWriter output now carries MapRunArn
- ItemReader s3:listObjectsV2, all *Path reference-form Map fields, WriterConfig (JSON/JSONL, COMPACT/FLATTEN)
- Choice gains StringMatches (wildcard + escape rules per the ASL spec) and the Is* type-test operators

Remaining documented gaps are narrow: LOAD_AND_FLATTEN for listObjectsV2, Transformation NONE, ResultWriter preview mode, JitterStrategy (deterministic emulator).

## Test plan
- [ ] 124 sfn unit tests race-clean, including nested-exec depth cap and MapRun shapes
- [ ] Live-server integration suite incl. new TestSFN_NestedExecution golden