### PR TITLE
fix(apigatewayv2): omit the $default stage segment from proxy event paths

### DIFF
--- a/internal/service/execapi/event.go
+++ b/internal/service/execapi/event.go
@@ -8,6 +8,21 @@ import (
 	"github.com/google/uuid"
 )
 
+// defaultStage is the HTTP API catch-all stage, served at the root of the
+// API's invoke URL.
+const defaultStage = "$default"
+
+// stagePath builds the request path delivered to the integration. The
+// $default stage is not part of the invoke URL path on AWS, so only a named
+// stage contributes a path segment.
+func stagePath(stage, resourcePath string) string {
+	if stage == defaultStage {
+		return resourcePath
+	}
+
+	return "/" + stage + resourcePath
+}
+
 // proxyEventV1 is the API Gateway proxy integration input event for REST APIs
 // and HTTP API payload format 1.0.
 type proxyEventV1 struct {
@@ -53,7 +68,7 @@ func buildEventV1(r *http.Request, req *Request, body []byte) ([]byte, error) {
 		RequestContext: requestContextV1{
 			ResourcePath: req.ResourcePath,
 			HTTPMethod:   r.Method,
-			Path:         "/" + req.Stage + req.ResourcePath,
+			Path:         stagePath(req.Stage, req.ResourcePath),
 			APIID:        req.APIID,
 			Stage:        req.Stage,
 			RequestID:    uuid.New().String(),
@@ -117,7 +132,7 @@ func buildEventV2(r *http.Request, req *Request, body []byte) ([]byte, error) {
 	headers, _ := collectHeaders(r)
 	query, _ := collectQuery(r)
 
-	path := "/" + req.Stage + req.ResourcePath
+	path := stagePath(req.Stage, req.ResourcePath)
 
 	event := proxyEventV2{
 		Version:               "2.0",

--- a/internal/service/execapi/event_test.go
+++ b/internal/service/execapi/event_test.go
@@ -142,6 +142,135 @@ func checkBuildEventV2StageVariables(t *testing.T, stageVariables, wantVars map[
 	}
 }
 
+func TestBuildEventV2_StagePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		stage    string
+		wantPath string
+	}{
+		{
+			name:     "$default stage is omitted from the path",
+			stage:    "$default",
+			wantPath: "/items",
+		},
+		{
+			name:     "named stage is retained in the path",
+			stage:    "prod",
+			wantPath: "/prod/items",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checkBuildEventV2StagePath(t, tt.stage, tt.wantPath)
+		})
+	}
+}
+
+func checkBuildEventV2StagePath(t *testing.T, stage, wantPath string) {
+	t.Helper()
+
+	r := httptest.NewRequestWithContext(t.Context(), "GET", wantPath, nil)
+	req := &Request{
+		APIID:        "api1",
+		Stage:        stage,
+		ResourcePath: "/items",
+		RouteKey:     "GET /items",
+	}
+
+	data, err := buildEventV2(r, req, nil)
+	if err != nil {
+		t.Fatalf("buildEventV2() error = %v", err)
+	}
+
+	var decoded struct {
+		RawPath        string `json:"rawPath"`
+		RequestContext struct {
+			Stage string `json:"stage"`
+			HTTP  struct {
+				Path string `json:"path"`
+			} `json:"http"`
+		} `json:"requestContext"`
+	}
+
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+
+	if decoded.RawPath != wantPath {
+		t.Errorf("rawPath = %q, want %q", decoded.RawPath, wantPath)
+	}
+
+	if decoded.RequestContext.HTTP.Path != wantPath {
+		t.Errorf("requestContext.http.path = %q, want %q", decoded.RequestContext.HTTP.Path, wantPath)
+	}
+
+	if decoded.RequestContext.Stage != stage {
+		t.Errorf("requestContext.stage = %q, want %q", decoded.RequestContext.Stage, stage)
+	}
+}
+
+func TestBuildEventV1_StagePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		stage    string
+		wantPath string
+	}{
+		{
+			name:     "$default stage is omitted from the path",
+			stage:    "$default",
+			wantPath: "/items",
+		},
+		{
+			name:     "named stage is retained in the path",
+			stage:    "dev",
+			wantPath: "/dev/items",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequestWithContext(t.Context(), "GET", tt.wantPath, nil)
+			req := &Request{
+				APIID:        "api1",
+				Stage:        tt.stage,
+				ResourcePath: "/items",
+			}
+
+			data, err := buildEventV1(r, req, nil)
+			if err != nil {
+				t.Fatalf("buildEventV1() error = %v", err)
+			}
+
+			var decoded struct {
+				RequestContext struct {
+					Path  string `json:"path"`
+					Stage string `json:"stage"`
+				} `json:"requestContext"`
+			}
+
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal event: %v", err)
+			}
+
+			if decoded.RequestContext.Path != tt.wantPath {
+				t.Errorf("requestContext.path = %q, want %q", decoded.RequestContext.Path, tt.wantPath)
+			}
+
+			if decoded.RequestContext.Stage != tt.stage {
+				t.Errorf("requestContext.stage = %q, want %q", decoded.RequestContext.Stage, tt.stage)
+			}
+		})
+	}
+}
+
 func mapsEqual(a, b map[string]string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary
On AWS the $default stage is served at the root of the invoke URL, so it never appears in `rawPath` or `requestContext` paths — only a named stage does. kumo prefixed the stage name unconditionally, so handlers routing on `rawPath` received `/$default/items` instead of `/items` and returned 404 for every request.

The fix applies to both payload formats: `rawPath` / `requestContext.http.path` (2.0) and `requestContext.path` (1.0, also selectable for HTTP APIs). `requestContext.stage` still reports `$default`. REST APIs cannot have a $default stage, so the 1.0 path is unaffected for them.

Closes #871

## Test plan
- [x] Event-building unit tests: $default stage omits the segment, named stage retains it (both payload formats)
- [x] `make lint` 0 issues, `go test -race -shuffle=on ./...` green