### PR TITLE
refactor(sfn): unify the duplicate JSONPath resolvers

### DIFF
--- a/internal/service/sfn/choice.go
+++ b/internal/service/sfn/choice.go
@@ -143,12 +143,12 @@ func evaluateDataTest(rule *choiceRule, input map[string]any) (bool, error) {
 	}
 
 	if rule.IsPresent != nil {
-		_, err := resolveJSONPath(input, rule.Variable)
+		_, err := resolveAnyJSONPath(rule.Variable, input)
 
 		return (err == nil) == *rule.IsPresent, nil
 	}
 
-	value, err := resolveJSONPath(input, rule.Variable)
+	value, err := resolveAnyJSONPath(rule.Variable, input)
 	if err != nil {
 		return false, fmt.Errorf("choice rule: resolve Variable %q: %w", rule.Variable, err)
 	}
@@ -356,7 +356,7 @@ func resolveStringOperand(static, path *string, input map[string]any) (want stri
 		return *static, true, nil
 	}
 
-	resolved, err := resolveJSONPath(input, *path)
+	resolved, err := resolveAnyJSONPath(*path, input)
 	if err != nil {
 		return "", false, fmt.Errorf("resolve comparator path %q: %w", *path, err)
 	}
@@ -411,7 +411,7 @@ func resolveNumericOperand(static *float64, path *string, input map[string]any) 
 		return *static, true, nil
 	}
 
-	resolved, err := resolveJSONPath(input, *path)
+	resolved, err := resolveAnyJSONPath(*path, input)
 	if err != nil {
 		return 0, false, fmt.Errorf("resolve comparator path %q: %w", *path, err)
 	}
@@ -450,7 +450,7 @@ func resolveBooleanOperand(static *bool, path *string, input map[string]any) (wa
 		return *static, true, nil
 	}
 
-	resolved, err := resolveJSONPath(input, *path)
+	resolved, err := resolveAnyJSONPath(*path, input)
 	if err != nil {
 		return false, false, fmt.Errorf("resolve comparator path %q: %w", *path, err)
 	}

--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -639,9 +639,7 @@ func resolveParametersWithContext(params map[string]any, input string, contextDa
 // the lazily-parsed input (nil until first use); the possibly newly parsed
 // value is returned so the caller can reuse it for later references,
 // keeping the input JSON unmarshaled at most once per resolveParameters
-// call. inputData -- and therefore the path resolution against it -- uses
-// resolveAnyJSONPath rather than resolveJSONPath, since the input is not
-// always a JSON object (see resolveParametersWithContext).
+// call.
 func resolveJSONPathRef(key string, value any, input string, inputData any, contextData map[string]any) (any, any, error) {
 	pathStr, ok := value.(string)
 	if !ok {
@@ -653,7 +651,7 @@ func resolveJSONPathRef(key string, value any, input string, inputData any, cont
 			return nil, inputData, fmt.Errorf("jsonPath reference for key %q uses the Context object (%q), which is only available in ItemSelector", key, pathStr)
 		}
 
-		resolvedValue, err := resolveJSONPath(contextData, "$"+strings.TrimPrefix(pathStr, "$$"))
+		resolvedValue, err := resolveAnyJSONPath("$"+strings.TrimPrefix(pathStr, "$$"), contextData)
 		if err != nil {
 			return nil, inputData, fmt.Errorf("resolve Context object path %q for key %q: %w", pathStr, key, err)
 		}
@@ -684,41 +682,6 @@ func resolveStaticValue(value any, input string, contextData map[string]any) (an
 	}
 
 	return resolveParametersWithContext(subMap, input, contextData)
-}
-
-// resolveJSONPath resolves a simple JSONPath expression ("$" or "$.field") against the input data.
-// Only single-level field access is supported (e.g., "$.message"), plus "$" for the whole input.
-func resolveJSONPath(data map[string]any, path string) (any, error) {
-	if path == "$" {
-		return data, nil
-	}
-
-	if !strings.HasPrefix(path, "$.") {
-		return nil, fmt.Errorf("unsupported JSONPath %q: must start with $", path)
-	}
-
-	field := strings.TrimPrefix(path, "$.")
-
-	// Support nested field access like "$.a.b.c".
-	parts := strings.Split(field, ".")
-
-	var current any = data
-
-	for _, part := range parts {
-		m, ok := current.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("jsonPath %q: cannot access field %q on non-object", path, part)
-		}
-
-		val, exists := m[part]
-		if !exists {
-			return nil, fmt.Errorf("jsonPath %q: field %q not found", path, part)
-		}
-
-		current = val
-	}
-
-	return current, nil
 }
 
 // executeSQSSendMessage sends a message to SQS via HTTP.

--- a/internal/service/sfn/jsonpath.go
+++ b/internal/service/sfn/jsonpath.go
@@ -1,0 +1,40 @@
+package sfn
+
+import (
+	"fmt"
+	"strings"
+)
+
+// resolveAnyJSONPath resolves "$" or "$.field[.field...]" against an
+// already-decoded JSON value of any shape. Only single-level field access
+// is supported per path segment (e.g., "$.message"), plus "$" for the
+// whole input. It does not require the root value to be a JSON object, so
+// e.g. Map state's ItemsPath can select the entire input when the input
+// itself is a JSON array.
+func resolveAnyJSONPath(path string, data any) (any, error) {
+	if path == "$" {
+		return data, nil
+	}
+
+	if !strings.HasPrefix(path, "$.") {
+		return nil, fmt.Errorf("unsupported JSONPath %q: must start with $", path)
+	}
+
+	current := data
+
+	for _, part := range strings.Split(strings.TrimPrefix(path, "$."), ".") {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("jsonPath %q: cannot access field %q on non-object", path, part)
+		}
+
+		val, exists := m[part]
+		if !exists {
+			return nil, fmt.Errorf("jsonPath %q: field %q not found", path, part)
+		}
+
+		current = val
+	}
+
+	return current, nil
+}

--- a/internal/service/sfn/mapstate.go
+++ b/internal/service/sfn/mapstate.go
@@ -307,36 +307,3 @@ func marshalItems(items []any) ([]json.RawMessage, error) {
 
 	return raw, nil
 }
-
-// resolveAnyJSONPath resolves "$" or "$.field[.field...]" against an
-// already-decoded JSON value of any shape. It mirrors resolveJSONPath's
-// supported subset but, unlike resolveJSONPath, does not require the root
-// value to be a JSON object, so ItemsPath can select the entire input when
-// the input itself is a JSON array.
-func resolveAnyJSONPath(path string, data any) (any, error) {
-	if path == "$" {
-		return data, nil
-	}
-
-	if !strings.HasPrefix(path, "$.") {
-		return nil, fmt.Errorf("unsupported JSONPath %q: must start with $", path)
-	}
-
-	current := data
-
-	for _, part := range strings.Split(strings.TrimPrefix(path, "$."), ".") {
-		m, ok := current.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("jsonPath %q: cannot access field %q on non-object", path, part)
-		}
-
-		val, exists := m[part]
-		if !exists {
-			return nil, fmt.Errorf("jsonPath %q: field %q not found", path, part)
-		}
-
-		current = val
-	}
-
-	return current, nil
-}

--- a/internal/service/sfn/wait.go
+++ b/internal/service/sfn/wait.go
@@ -137,7 +137,7 @@ func resolvePath(path, input string) (any, error) {
 		return nil, fmt.Errorf("parse input: %w", err)
 	}
 
-	value, err := resolveJSONPath(data, path)
+	value, err := resolveAnyJSONPath(path, data)
 	if err != nil {
 		return nil, fmt.Errorf("resolve JSONPath %q: %w", path, err)
 	}


### PR DESCRIPTION
## Summary
sfn had two byte-identical single-field JSONPath resolvers (`resolveJSONPath` in executor.go and `resolveAnyJSONPath` in mapstate.go) differing only in parameter type and argument order. This keeps the more general one, moves it to a new `jsonpath.go`, and updates the 7 call sites. Behavior preserving: error messages and "$" handling are identical, verified line by line.

## Test plan
- [x] `go test -race ./...` green
- [x] `make lint` 0 issues