### PR TITLE
refactor(test): share AWS client setup across integration tests

### DIFF
--- a/test/integration/acm_test.go
+++ b/test/integration/acm_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 	"github.com/aws/aws-sdk-go-v2/service/acm/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newACMClient(t *testing.T) *acm.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return acm.NewFromConfig(cfg, func(o *acm.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return acm.NewFromConfig(awsConfig(t), func(o *acm.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/amp_test.go
+++ b/test/integration/amp_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/amp"
 	"github.com/sivchari/golden"
 )
@@ -16,18 +14,8 @@ import (
 func newAMPClient(t *testing.T) *amp.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return amp.NewFromConfig(cfg, func(o *amp.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return amp.NewFromConfig(awsConfig(t), func(o *amp.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/amplify_test.go
+++ b/test/integration/amplify_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/amplify"
 	"github.com/sivchari/golden"
 )
@@ -15,18 +13,8 @@ import (
 func newAmplifyClient(t *testing.T) *amplify.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return amplify.NewFromConfig(cfg, func(o *amplify.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return amplify.NewFromConfig(awsConfig(t), func(o *amplify.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/apigateway_executeapi_test.go
+++ b/test/integration/apigateway_executeapi_test.go
@@ -13,28 +13,18 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 )
 
-const kumoEndpoint = "http://localhost:4566"
+var kumoEndpoint = testEndpoint()
 
 // executeAPIClient builds an API Gateway client targeting kumoEndpoint, so
 // resources are created on the same server the stage URL is invoked against.
 func executeAPIClient(t *testing.T) *apigateway.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
-	)
-	if err != nil {
-		t.Fatalf("load config: %v", err)
-	}
-
-	return apigateway.NewFromConfig(cfg, func(o *apigateway.Options) {
+	return apigateway.NewFromConfig(awsConfig(t), func(o *apigateway.Options) {
 		o.BaseEndpoint = aws.String(kumoEndpoint + "/apigateway")
 	})
 }

--- a/test/integration/apigateway_test.go
+++ b/test/integration/apigateway_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newAPIGatewayClient(t *testing.T) *apigateway.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return apigateway.NewFromConfig(cfg, func(o *apigateway.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566/apigateway")
+	return apigateway.NewFromConfig(awsConfig(t), func(o *apigateway.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint() + "/apigateway")
 	})
 }
 

--- a/test/integration/apigatewayv2_executeapi_test.go
+++ b/test/integration/apigatewayv2_executeapi_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 )
@@ -19,15 +17,7 @@ import (
 func executeAPIV2Client(t *testing.T) *apigatewayv2.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
-	)
-	if err != nil {
-		t.Fatalf("load config: %v", err)
-	}
-
-	return apigatewayv2.NewFromConfig(cfg, func(o *apigatewayv2.Options) {
+	return apigatewayv2.NewFromConfig(awsConfig(t), func(o *apigatewayv2.Options) {
 		o.BaseEndpoint = aws.String(kumoEndpoint + "/apigatewayv2")
 	})
 }

--- a/test/integration/apigatewayv2_test.go
+++ b/test/integration/apigatewayv2_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newAPIGatewayV2Client(t *testing.T) *apigatewayv2.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return apigatewayv2.NewFromConfig(cfg, func(o *apigatewayv2.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566/apigatewayv2")
+	return apigatewayv2.NewFromConfig(awsConfig(t), func(o *apigatewayv2.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint() + "/apigatewayv2")
 	})
 }
 

--- a/test/integration/appmesh_test.go
+++ b/test/integration/appmesh_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/appmesh"
 	"github.com/aws/aws-sdk-go-v2/service/appmesh/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newAppMeshClient(t *testing.T) *appmesh.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return appmesh.NewFromConfig(cfg, func(o *appmesh.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return appmesh.NewFromConfig(awsConfig(t), func(o *appmesh.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/appsync_test.go
+++ b/test/integration/appsync_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/appsync"
 	"github.com/aws/aws-sdk-go-v2/service/appsync/types"
 	"github.com/sivchari/golden"
@@ -376,17 +374,7 @@ func TestAppSync_StartSchemaCreation(t *testing.T) {
 func createAppSyncClient(t *testing.T) *appsync.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return appsync.NewFromConfig(cfg, func(o *appsync.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566/appsync")
+	return appsync.NewFromConfig(awsConfig(t), func(o *appsync.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint() + "/appsync")
 	})
 }

--- a/test/integration/athena_test.go
+++ b/test/integration/athena_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 	"github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newAthenaClient(t *testing.T) *athena.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return athena.NewFromConfig(cfg, func(o *athena.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return athena.NewFromConfig(awsConfig(t), func(o *athena.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/backup_test.go
+++ b/test/integration/backup_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/backup"
 	"github.com/aws/aws-sdk-go-v2/service/backup/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newBackupClient(t *testing.T) *backup.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return backup.NewFromConfig(cfg, func(o *backup.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return backup.NewFromConfig(awsConfig(t), func(o *backup.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/batch_test.go
+++ b/test/integration/batch_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/batch"
 	"github.com/aws/aws-sdk-go-v2/service/batch/types"
 	"github.com/sivchari/golden"
@@ -461,17 +459,7 @@ func TestBatch_TerminateJob(t *testing.T) {
 func createBatchClient(t *testing.T) *batch.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return batch.NewFromConfig(cfg, func(o *batch.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return batch.NewFromConfig(awsConfig(t), func(o *batch.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }

--- a/test/integration/ce_test.go
+++ b/test/integration/ce_test.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newCostExplorerClient(t *testing.T) *costexplorer.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return costexplorer.NewFromConfig(cfg, func(o *costexplorer.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return costexplorer.NewFromConfig(awsConfig(t), func(o *costexplorer.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/cloudcontrol_test.go
+++ b/test/integration/cloudcontrol_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/sivchari/golden"
@@ -18,18 +16,8 @@ import (
 func newCloudControlClient(t *testing.T) *cloudcontrol.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return cloudcontrol.NewFromConfig(cfg, func(o *cloudcontrol.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return cloudcontrol.NewFromConfig(awsConfig(t), func(o *cloudcontrol.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/cloudformation_test.go
+++ b/test/integration/cloudformation_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/sivchari/golden"
 )
@@ -51,18 +49,8 @@ const (
 func newCloudFormationClient(t *testing.T) *cloudformation.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return cloudformation.NewFromConfig(cfg, func(o *cloudformation.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return cloudformation.NewFromConfig(awsConfig(t), func(o *cloudformation.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/cloudfront_signing_test.go
+++ b/test/integration/cloudfront_signing_test.go
@@ -264,7 +264,7 @@ func TestCloudFront_EdgeSignedCookie(t *testing.T) {
 		})
 	})
 
-	edgeURL := fmt.Sprintf("http://localhost:4566/kumo/cdn/%s/test.txt", distID)
+	edgeURL := fmt.Sprintf("%s/kumo/cdn/%s/test.txt", testEndpoint(), distID)
 
 	t.Run("no_credentials_returns_403", func(t *testing.T) {
 		t.Parallel()

--- a/test/integration/cloudfront_test.go
+++ b/test/integration/cloudfront_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newCloudFrontClient(t *testing.T) *cloudfront.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return cloudfront.NewFromConfig(cfg, func(o *cloudfront.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return cloudfront.NewFromConfig(awsConfig(t), func(o *cloudfront.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/cloudtrail_test.go
+++ b/test/integration/cloudtrail_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
 	"github.com/sivchari/golden"
 )
@@ -16,18 +14,8 @@ import (
 func newCloudTrailClient(t *testing.T) *cloudtrail.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return cloudtrail.NewFromConfig(cfg, func(o *cloudtrail.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return cloudtrail.NewFromConfig(awsConfig(t), func(o *cloudtrail.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/cloudwatch_test.go
+++ b/test/integration/cloudwatch_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/sivchari/golden"
@@ -18,18 +16,8 @@ import (
 func newCloudWatchClient(t *testing.T) *cloudwatch.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return cloudwatch.NewFromConfig(cfg, func(o *cloudwatch.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return cloudwatch.NewFromConfig(awsConfig(t), func(o *cloudwatch.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/cloudwatchlogs_test.go
+++ b/test/integration/cloudwatchlogs_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/sivchari/golden"
@@ -18,18 +16,8 @@ import (
 func newCloudWatchLogsClient(t *testing.T) *cloudwatchlogs.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return cloudwatchlogs.NewFromConfig(cfg, func(o *cloudwatchlogs.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return cloudwatchlogs.NewFromConfig(awsConfig(t), func(o *cloudwatchlogs.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/codeconnections_test.go
+++ b/test/integration/codeconnections_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/codeconnections"
 	"github.com/aws/aws-sdk-go-v2/service/codeconnections/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newCodeConnectionsClient(t *testing.T) *codeconnections.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return codeconnections.NewFromConfig(cfg, func(o *codeconnections.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return codeconnections.NewFromConfig(awsConfig(t), func(o *codeconnections.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/codeguruprofiler_test.go
+++ b/test/integration/codeguruprofiler_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/codeguruprofiler"
 	"github.com/aws/aws-sdk-go-v2/service/codeguruprofiler/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newCodeGuruProfilerClient(t *testing.T) *codeguruprofiler.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return codeguruprofiler.NewFromConfig(cfg, func(o *codeguruprofiler.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return codeguruprofiler.NewFromConfig(awsConfig(t), func(o *codeguruprofiler.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/codegurureviewer_test.go
+++ b/test/integration/codegurureviewer_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/codegurureviewer"
 	"github.com/aws/aws-sdk-go-v2/service/codegurureviewer/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newCodeGuruReviewerClient(t *testing.T) *codegurureviewer.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return codegurureviewer.NewFromConfig(cfg, func(o *codegurureviewer.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return codegurureviewer.NewFromConfig(awsConfig(t), func(o *codegurureviewer.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/cognito_test.go
+++ b/test/integration/cognito_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newCognitoClient(t *testing.T) *cognitoidentityprovider.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return cognitoidentityprovider.NewFromConfig(cfg, func(o *cognitoidentityprovider.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return cognitoidentityprovider.NewFromConfig(awsConfig(t), func(o *cognitoidentityprovider.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/comprehend_test.go
+++ b/test/integration/comprehend_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/comprehend"
 	"github.com/aws/aws-sdk-go-v2/service/comprehend/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newComprehendClient(t *testing.T) *comprehend.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return comprehend.NewFromConfig(cfg, func(o *comprehend.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return comprehend.NewFromConfig(awsConfig(t), func(o *comprehend.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/configservice_test.go
+++ b/test/integration/configservice_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/configservice"
 	"github.com/aws/aws-sdk-go-v2/service/configservice/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newConfigServiceClient(t *testing.T) *configservice.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return configservice.NewFromConfig(cfg, func(o *configservice.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return configservice.NewFromConfig(awsConfig(t), func(o *configservice.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/dataexchange_test.go
+++ b/test/integration/dataexchange_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dataexchange"
 	"github.com/aws/aws-sdk-go-v2/service/dataexchange/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newDataExchangeClient(t *testing.T) *dataexchange.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return dataexchange.NewFromConfig(cfg, func(o *dataexchange.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return dataexchange.NewFromConfig(awsConfig(t), func(o *dataexchange.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/dlm_test.go
+++ b/test/integration/dlm_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dlm"
 	"github.com/aws/aws-sdk-go-v2/service/dlm/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newDLMClient(t *testing.T) *dlm.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return dlm.NewFromConfig(cfg, func(o *dlm.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566/dlm")
+	return dlm.NewFromConfig(awsConfig(t), func(o *dlm.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint() + "/dlm")
 	})
 }
 

--- a/test/integration/documentdb_test.go
+++ b/test/integration/documentdb_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/docdb"
 	"github.com/sivchari/golden"
 )
@@ -16,18 +14,8 @@ import (
 func newDocDBClient(t *testing.T) *docdb.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return docdb.NewFromConfig(cfg, func(o *docdb.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return docdb.NewFromConfig(awsConfig(t), func(o *docdb.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/ds_test.go
+++ b/test/integration/ds_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
 	"github.com/aws/aws-sdk-go-v2/service/directoryservice/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newDSClient(t *testing.T) *directoryservice.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return directoryservice.NewFromConfig(cfg, func(o *directoryservice.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return directoryservice.NewFromConfig(awsConfig(t), func(o *directoryservice.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -14,8 +14,6 @@ import (
 	dynamodbv1 "github.com/aws/aws-sdk-go/service/dynamodb"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/smithy-go"
@@ -25,18 +23,8 @@ import (
 func newDynamoDBClient(t *testing.T) *dynamodb.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return dynamodb.NewFromConfig(awsConfig(t), func(o *dynamodb.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 
@@ -44,8 +32,8 @@ func newDynamoDBV1Client(t *testing.T) *dynamodbv1.DynamoDB {
 	t.Helper()
 
 	sess, err := awsv1session.NewSession(&awsv1.Config{
-		Region:      awsv1.String("us-east-1"),
-		Endpoint:    awsv1.String("http://localhost:4566"),
+		Region:      awsv1.String(testRegion()),
+		Endpoint:    awsv1.String(testEndpoint()),
 		Credentials: awsv1creds.NewStaticCredentials("test", "test", ""),
 	})
 	if err != nil {

--- a/test/integration/dynamodbstreams_test.go
+++ b/test/integration/dynamodbstreams_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodbstreams"
@@ -19,18 +17,8 @@ import (
 func newDynamoDBStreamsClient(t *testing.T) *dynamodbstreams.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return dynamodbstreams.NewFromConfig(cfg, func(o *dynamodbstreams.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return dynamodbstreams.NewFromConfig(awsConfig(t), func(o *dynamodbstreams.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/ebs_test.go
+++ b/test/integration/ebs_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ebs"
 	"github.com/aws/aws-sdk-go-v2/service/ebs/types"
 	"github.com/sivchari/golden"
@@ -20,18 +18,8 @@ import (
 func newEBSClient(t *testing.T) *ebs.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return ebs.NewFromConfig(cfg, func(o *ebs.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return ebs.NewFromConfig(awsConfig(t), func(o *ebs.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/ec2_test.go
+++ b/test/integration/ec2_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newEC2Client(t *testing.T) *ec2.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return ec2.NewFromConfig(cfg, func(o *ec2.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return ec2.NewFromConfig(awsConfig(t), func(o *ec2.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/ecr_test.go
+++ b/test/integration/ecr_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newECRClient(t *testing.T) *ecr.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return ecr.NewFromConfig(cfg, func(o *ecr.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return ecr.NewFromConfig(awsConfig(t), func(o *ecr.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/ecs_test.go
+++ b/test/integration/ecs_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newECSClient(t *testing.T) *ecs.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return ecs.NewFromConfig(cfg, func(o *ecs.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return ecs.NewFromConfig(awsConfig(t), func(o *ecs.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/eks_test.go
+++ b/test/integration/eks_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newEKSClient(t *testing.T) *eks.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return eks.NewFromConfig(cfg, func(o *eks.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566/eks")
+	return eks.NewFromConfig(awsConfig(t), func(o *eks.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint() + "/eks")
 	})
 }
 

--- a/test/integration/elasticache_test.go
+++ b/test/integration/elasticache_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/sivchari/golden"
 )
@@ -16,18 +14,8 @@ import (
 func newElastiCacheClient(t *testing.T) *elasticache.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return elasticache.NewFromConfig(cfg, func(o *elasticache.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return elasticache.NewFromConfig(awsConfig(t), func(o *elasticache.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/elasticbeanstalk_test.go
+++ b/test/integration/elasticbeanstalk_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk"
 	"github.com/sivchari/golden"
 )
@@ -15,18 +13,8 @@ import (
 func newElasticBeanstalkClient(t *testing.T) *elasticbeanstalk.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return elasticbeanstalk.NewFromConfig(cfg, func(o *elasticbeanstalk.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return elasticbeanstalk.NewFromConfig(awsConfig(t), func(o *elasticbeanstalk.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/elbv2_test.go
+++ b/test/integration/elbv2_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newELBv2Client(t *testing.T) *elasticloadbalancingv2.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return elasticloadbalancingv2.NewFromConfig(cfg, func(o *elasticloadbalancingv2.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return elasticloadbalancingv2.NewFromConfig(awsConfig(t), func(o *elasticloadbalancingv2.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/emrserverless_test.go
+++ b/test/integration/emrserverless_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/emrserverless"
 	"github.com/aws/aws-sdk-go-v2/service/emrserverless/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newEMRServerlessClient(t *testing.T) *emrserverless.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return emrserverless.NewFromConfig(cfg, func(o *emrserverless.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return emrserverless.NewFromConfig(awsConfig(t), func(o *emrserverless.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/entityresolution_test.go
+++ b/test/integration/entityresolution_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/entityresolution"
 	"github.com/aws/aws-sdk-go-v2/service/entityresolution/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newEntityResolutionClient(t *testing.T) *entityresolution.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return entityresolution.NewFromConfig(cfg, func(o *entityresolution.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return entityresolution.NewFromConfig(awsConfig(t), func(o *entityresolution.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/eventbridge_test.go
+++ b/test/integration/eventbridge_test.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
@@ -25,18 +23,8 @@ import (
 func newEventBridgeClient(t *testing.T) *eventbridge.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return eventbridge.NewFromConfig(cfg, func(o *eventbridge.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return eventbridge.NewFromConfig(awsConfig(t), func(o *eventbridge.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 
@@ -392,7 +380,7 @@ func TestEventBridge_PutEvents_Delivery(t *testing.T) {
 	}
 
 	// Check delivered events via kumo endpoint.
-	resp, err := http.Get("http://localhost:4566/kumo/eventbridge/delivered-events")
+	resp, err := http.Get(testEndpoint() + "/kumo/eventbridge/delivered-events")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -491,7 +479,7 @@ func TestEventBridge_PutEvents_SQSDelivery(t *testing.T) {
 
 	for range 10 {
 		recvOutput, err = sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
-			QueueUrl:        aws.String("http://localhost:4566/000000000000/" + queueName),
+			QueueUrl:        aws.String(testEndpoint() + "/000000000000/" + queueName),
 			WaitTimeSeconds: 1,
 		})
 		if err != nil {
@@ -583,7 +571,7 @@ func TestEventBridge_PutEvents_InputPath(t *testing.T) {
 
 	for range 10 {
 		recvOutput, err = sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
-			QueueUrl:        aws.String("http://localhost:4566/000000000000/" + queueName),
+			QueueUrl:        aws.String(testEndpoint() + "/000000000000/" + queueName),
 			WaitTimeSeconds: 1,
 		})
 		if err != nil {
@@ -691,7 +679,7 @@ func TestEventBridge_PutEvents_InputTransformer(t *testing.T) {
 			Name: aws.String(busName),
 		})
 		_, _ = sqsClient.DeleteQueue(cleanupCtx, &sqs.DeleteQueueInput{
-			QueueUrl: aws.String("http://localhost:4566/000000000000/" + queueName),
+			QueueUrl: aws.String(testEndpoint() + "/000000000000/" + queueName),
 		})
 	})
 
@@ -717,7 +705,7 @@ func TestEventBridge_PutEvents_InputTransformer(t *testing.T) {
 
 	for range 10 {
 		recvOutput, err = sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
-			QueueUrl:        aws.String("http://localhost:4566/000000000000/" + queueName),
+			QueueUrl:        aws.String(testEndpoint() + "/000000000000/" + queueName),
 			WaitTimeSeconds: 1,
 		})
 		if err != nil {
@@ -874,7 +862,7 @@ func TestEventBridge_PutEvents_LambdaDelivery(t *testing.T) {
 	})
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
-		"http://localhost:4566/lambda/2015-03-31/functions", bytes.NewReader(createReq))
+		testEndpoint()+"/lambda/2015-03-31/functions", bytes.NewReader(createReq))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -889,7 +877,7 @@ func TestEventBridge_PutEvents_LambdaDelivery(t *testing.T) {
 
 	t.Cleanup(func() {
 		delReq, _ := http.NewRequestWithContext(context.Background(), http.MethodDelete,
-			"http://localhost:4566/lambda/2015-03-31/functions/"+functionName, nil)
+			testEndpoint()+"/lambda/2015-03-31/functions/"+functionName, nil)
 
 		delResp, _ := http.DefaultClient.Do(delReq)
 		if delResp != nil {

--- a/test/integration/finspace_test.go
+++ b/test/integration/finspace_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/finspace"
 	"github.com/sivchari/golden"
 )
@@ -15,18 +13,8 @@ import (
 func newFinSpaceClient(t *testing.T) *finspace.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return finspace.NewFromConfig(cfg, func(o *finspace.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return finspace.NewFromConfig(awsConfig(t), func(o *finspace.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/firehose_test.go
+++ b/test/integration/firehose_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/firehose"
 	"github.com/aws/aws-sdk-go-v2/service/firehose/types"
 	"github.com/sivchari/golden"
@@ -269,17 +267,7 @@ func TestFirehose_UpdateDestination(t *testing.T) {
 func createFirehoseClient(t *testing.T) *firehose.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return firehose.NewFromConfig(cfg, func(o *firehose.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return firehose.NewFromConfig(awsConfig(t), func(o *firehose.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }

--- a/test/integration/forecast_test.go
+++ b/test/integration/forecast_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/forecast"
 	"github.com/aws/aws-sdk-go-v2/service/forecast/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newForecastClient(t *testing.T) *forecast.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return forecast.NewFromConfig(cfg, func(o *forecast.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return forecast.NewFromConfig(awsConfig(t), func(o *forecast.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/gamelift_test.go
+++ b/test/integration/gamelift_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/gamelift"
 	"github.com/sivchari/golden"
 )
@@ -16,18 +14,8 @@ import (
 func newGameLiftClient(t *testing.T) *gamelift.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return gamelift.NewFromConfig(cfg, func(o *gamelift.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return gamelift.NewFromConfig(awsConfig(t), func(o *gamelift.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/glacier_test.go
+++ b/test/integration/glacier_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/glacier"
 	"github.com/sivchari/golden"
 )
@@ -15,18 +13,8 @@ import (
 func newGlacierClient(t *testing.T) *glacier.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return glacier.NewFromConfig(cfg, func(o *glacier.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return glacier.NewFromConfig(awsConfig(t), func(o *glacier.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/globalaccelerator_test.go
+++ b/test/integration/globalaccelerator_test.go
@@ -27,7 +27,7 @@ func newGlobalAcceleratorClient(t *testing.T) *globalaccelerator.Client {
 	}
 
 	return globalaccelerator.NewFromConfig(cfg, func(o *globalaccelerator.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/glue_test.go
+++ b/test/integration/glue_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	"github.com/aws/aws-sdk-go-v2/service/glue/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newGlueClient(t *testing.T) *glue.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return glue.NewFromConfig(cfg, func(o *glue.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return glue.NewFromConfig(awsConfig(t), func(o *glue.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestHealthEndpoint(t *testing.T) {
-	resp, err := http.Get("http://localhost:4566/health")
+	resp, err := http.Get(testEndpoint() + "/health")
 	if err != nil {
 		t.Fatalf("failed to get health endpoint: %v", err)
 	}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+)
+
+const (
+	defaultRegion   = "us-east-1"
+	defaultEndpoint = "http://localhost:4566"
+)
+
+// testRegion returns the AWS region integration tests target, overridable
+// via KUMO_TEST_REGION.
+func testRegion() string {
+	if r := os.Getenv("KUMO_TEST_REGION"); r != "" {
+		return r
+	}
+
+	return defaultRegion
+}
+
+// testEndpoint returns the kumo endpoint integration tests target,
+// overridable via KUMO_TEST_ENDPOINT.
+func testEndpoint() string {
+	if e := os.Getenv("KUMO_TEST_ENDPOINT"); e != "" {
+		return e
+	}
+
+	return defaultEndpoint
+}
+
+// awsConfig builds the shared aws-sdk-go-v2 config used by every AWS
+// service client constructed in these integration tests.
+func awsConfig(t *testing.T) aws.Config {
+	t.Helper()
+
+	cfg, err := config.LoadDefaultConfig(t.Context(),
+		config.WithRegion(testRegion()),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"test", "test", "",
+		)),
+	)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	return cfg
+}

--- a/test/integration/iam_test.go
+++ b/test/integration/iam_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newIAMClient(t *testing.T) *iam.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return iam.NewFromConfig(cfg, func(o *iam.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566/iam")
+	return iam.NewFromConfig(awsConfig(t), func(o *iam.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint() + "/iam")
 	})
 }
 

--- a/test/integration/kafka_test.go
+++ b/test/integration/kafka_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
 	"github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newKafkaClient(t *testing.T) *kafka.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return kafka.NewFromConfig(cfg, func(o *kafka.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566/kafka")
+	return kafka.NewFromConfig(awsConfig(t), func(o *kafka.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint() + "/kafka")
 	})
 }
 

--- a/test/integration/kinesis_test.go
+++ b/test/integration/kinesis_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newKinesisClient(t *testing.T) *kinesis.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return kinesis.NewFromConfig(cfg, func(o *kinesis.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return kinesis.NewFromConfig(awsConfig(t), func(o *kinesis.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/kms_test.go
+++ b/test/integration/kms_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/sivchari/golden"
@@ -21,18 +19,8 @@ import (
 func newKMSClient(t *testing.T) *kms.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return kms.NewFromConfig(cfg, func(o *kms.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return kms.NewFromConfig(awsConfig(t), func(o *kms.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/lambda_async_test.go
+++ b/test/integration/lambda_async_test.go
@@ -59,7 +59,7 @@ func TestLambda_AsyncInvokeRetriesUntilEndpointUp(t *testing.T) {
 	createBody, _ := json.Marshal(createReq)
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
-		"http://localhost:4566/lambda/2015-03-31/functions", bytes.NewReader(createBody))
+		testEndpoint()+"/lambda/2015-03-31/functions", bytes.NewReader(createBody))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)

--- a/test/integration/lambda_runtime_test.go
+++ b/test/integration/lambda_runtime_test.go
@@ -18,7 +18,7 @@ import (
 
 // lambdaRuntimeAPIHost is the host:port a handler uses to reach kumo's
 // Runtime API (AWS_LAMBDA_RUNTIME_API=<host>/_runtime/{functionName}).
-const lambdaRuntimeAPIHost = "localhost:4566"
+var lambdaRuntimeAPIHost = strings.TrimPrefix(testEndpoint(), "http://")
 
 // TestLambdaRuntime_Invoke proves that an unmodified lambda.Start binary runs
 // against kumo via the Runtime API (no external RIE): the binary is started

--- a/test/integration/lambda_test.go
+++ b/test/integration/lambda_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/sivchari/golden"
@@ -22,18 +20,8 @@ import (
 func newLambdaClient(t *testing.T) *lambda.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return lambda.NewFromConfig(cfg, func(o *lambda.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566/lambda")
+	return lambda.NewFromConfig(awsConfig(t), func(o *lambda.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint() + "/lambda")
 	})
 }
 
@@ -218,7 +206,7 @@ func TestLambda_InvokeWithEndpoint(t *testing.T) {
 	createBody, _ := json.Marshal(createReq)
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
-		"http://localhost:4566/lambda/2015-03-31/functions", bytes.NewReader(createBody))
+		testEndpoint()+"/lambda/2015-03-31/functions", bytes.NewReader(createBody))
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -233,7 +221,7 @@ func TestLambda_InvokeWithEndpoint(t *testing.T) {
 
 	t.Cleanup(func() {
 		delReq, _ := http.NewRequestWithContext(context.Background(), http.MethodDelete,
-			"http://localhost:4566/lambda/2015-03-31/functions/"+functionName, nil)
+			testEndpoint()+"/lambda/2015-03-31/functions/"+functionName, nil)
 		delResp, _ := http.DefaultClient.Do(delReq)
 		if delResp != nil {
 			delResp.Body.Close()
@@ -243,7 +231,7 @@ func TestLambda_InvokeWithEndpoint(t *testing.T) {
 	// Invoke function.
 	payload := []byte(`{"key": "value"}`)
 	invokeReq, _ := http.NewRequestWithContext(ctx, http.MethodPost,
-		"http://localhost:4566/lambda/2015-03-31/functions/"+functionName+"/invocations",
+		testEndpoint()+"/lambda/2015-03-31/functions/"+functionName+"/invocations",
 		bytes.NewReader(payload))
 	invokeReq.Header.Set("Content-Type", "application/json")
 

--- a/test/integration/location_test.go
+++ b/test/integration/location_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/location"
 	"github.com/aws/aws-sdk-go-v2/service/location/types"
 	smithymiddleware "github.com/aws/smithy-go/middleware"
@@ -19,18 +17,8 @@ import (
 func newLocationClient(t *testing.T) *location.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return location.NewFromConfig(cfg, func(o *location.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return location.NewFromConfig(awsConfig(t), func(o *location.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 		// Disable host prefix (e.g., "cp.maps.") to route requests to localhost.
 		o.APIOptions = append(o.APIOptions, func(stack *smithymiddleware.Stack) error {
 			return stack.Serialize.Add(smithymiddleware.SerializeMiddlewareFunc(

--- a/test/integration/macie2_test.go
+++ b/test/integration/macie2_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/macie2"
 	"github.com/aws/aws-sdk-go-v2/service/macie2/types"
 	smithymiddleware "github.com/aws/smithy-go/middleware"
@@ -19,18 +17,8 @@ import (
 func newMacie2Client(t *testing.T) *macie2.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return macie2.NewFromConfig(cfg, func(o *macie2.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return macie2.NewFromConfig(awsConfig(t), func(o *macie2.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 		// Disable host prefix to route requests to localhost.
 		o.APIOptions = append(o.APIOptions, func(stack *smithymiddleware.Stack) error {
 			return stack.Serialize.Add(smithymiddleware.SerializeMiddlewareFunc(

--- a/test/integration/memorydb_test.go
+++ b/test/integration/memorydb_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/memorydb"
 	"github.com/aws/aws-sdk-go-v2/service/memorydb/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newMemoryDBClient(t *testing.T) *memorydb.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return memorydb.NewFromConfig(cfg, func(o *memorydb.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return memorydb.NewFromConfig(awsConfig(t), func(o *memorydb.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/mq_test.go
+++ b/test/integration/mq_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/mq"
 	"github.com/aws/aws-sdk-go-v2/service/mq/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newMQClient(t *testing.T) *mq.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return mq.NewFromConfig(cfg, func(o *mq.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return mq.NewFromConfig(awsConfig(t), func(o *mq.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/neptune_test.go
+++ b/test/integration/neptune_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/neptune"
 	"github.com/sivchari/golden"
 )
@@ -16,18 +14,8 @@ import (
 func newNeptuneClient(t *testing.T) *neptune.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return neptune.NewFromConfig(cfg, func(o *neptune.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return neptune.NewFromConfig(awsConfig(t), func(o *neptune.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/organizations_test.go
+++ b/test/integration/organizations_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newOrganizationsClient(t *testing.T) *organizations.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return organizations.NewFromConfig(cfg, func(o *organizations.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return organizations.NewFromConfig(awsConfig(t), func(o *organizations.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/pinpointsmsvoicev2_test.go
+++ b/test/integration/pinpointsmsvoicev2_test.go
@@ -9,26 +9,14 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2"
 )
 
 func newPinpointSMSVoiceV2Client(t *testing.T) *pinpointsmsvoicev2.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return pinpointsmsvoicev2.NewFromConfig(cfg, func(o *pinpointsmsvoicev2.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return pinpointsmsvoicev2.NewFromConfig(awsConfig(t), func(o *pinpointsmsvoicev2.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 
@@ -67,7 +55,7 @@ func TestPinpointSMSVoiceV2_GetSentTextMessages(t *testing.T) {
 	}
 
 	// Get sent messages via kumo-specific endpoint.
-	resp, err := http.Get("http://localhost:4566/kumo/pinpointsmsvoicev2/sent-messages")
+	resp, err := http.Get(testEndpoint() + "/kumo/pinpointsmsvoicev2/sent-messages")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/pipes_test.go
+++ b/test/integration/pipes_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/pipes"
 	"github.com/aws/aws-sdk-go-v2/service/pipes/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newPipesClient(t *testing.T) *pipes.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return pipes.NewFromConfig(cfg, func(o *pipes.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return pipes.NewFromConfig(awsConfig(t), func(o *pipes.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/rds_test.go
+++ b/test/integration/rds_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/sivchari/golden"
 )
@@ -16,18 +14,8 @@ import (
 func newRDSClient(t *testing.T) *rds.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return rds.NewFromConfig(cfg, func(o *rds.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return rds.NewFromConfig(awsConfig(t), func(o *rds.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/redshift_test.go
+++ b/test/integration/redshift_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/sivchari/golden"
 )
@@ -16,18 +14,8 @@ import (
 func newRedshiftClient(t *testing.T) *redshift.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return redshift.NewFromConfig(cfg, func(o *redshift.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return redshift.NewFromConfig(awsConfig(t), func(o *redshift.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/rekognition_test.go
+++ b/test/integration/rekognition_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newRekognitionClient(t *testing.T) *rekognition.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return rekognition.NewFromConfig(cfg, func(o *rekognition.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return rekognition.NewFromConfig(awsConfig(t), func(o *rekognition.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/resiliencehub_test.go
+++ b/test/integration/resiliencehub_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/resiliencehub"
 	"github.com/aws/aws-sdk-go-v2/service/resiliencehub/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newResilienceHubClient(t *testing.T) *resiliencehub.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return resiliencehub.NewFromConfig(cfg, func(o *resiliencehub.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return resiliencehub.NewFromConfig(awsConfig(t), func(o *resiliencehub.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/route53_test.go
+++ b/test/integration/route53_test.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/sivchari/golden"
@@ -21,18 +19,8 @@ import (
 func newRoute53Client(t *testing.T) *route53.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return route53.NewFromConfig(cfg, func(o *route53.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return route53.NewFromConfig(awsConfig(t), func(o *route53.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/route53resolver_test.go
+++ b/test/integration/route53resolver_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/route53resolver"
 	"github.com/aws/aws-sdk-go-v2/service/route53resolver/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newRoute53ResolverClient(t *testing.T) *route53resolver.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return route53resolver.NewFromConfig(cfg, func(o *route53resolver.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return route53resolver.NewFromConfig(awsConfig(t), func(o *route53resolver.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/s3_cors_test.go
+++ b/test/integration/s3_cors_test.go
@@ -39,7 +39,7 @@ func TestS3_CORS(t *testing.T) {
 	</CORSConfiguration>`
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
-		"http://localhost:4566/"+bucketName+"?cors",
+		testEndpoint()+"/"+bucketName+"?cors",
 		bytes.NewReader([]byte(corsXML)))
 	if err != nil {
 		t.Fatal(err)
@@ -69,7 +69,7 @@ func TestS3_CORS(t *testing.T) {
 
 	// 4. GET with matching Origin - should have CORS headers.
 	getReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		"http://localhost:4566/"+bucketName+"/test.txt", nil)
+		testEndpoint()+"/"+bucketName+"/test.txt", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestS3_CORS(t *testing.T) {
 
 	// 5. GET with non-matching Origin - should NOT have CORS headers.
 	getReq2, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		"http://localhost:4566/"+bucketName+"/test.txt", nil)
+		testEndpoint()+"/"+bucketName+"/test.txt", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestS3_CORS(t *testing.T) {
 
 	// 6. OPTIONS preflight with matching Origin.
 	optReq, err := http.NewRequestWithContext(ctx, http.MethodOptions,
-		"http://localhost:4566/"+bucketName+"/test.txt", nil)
+		testEndpoint()+"/"+bucketName+"/test.txt", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestS3_CORS(t *testing.T) {
 
 	// 7. GET without Origin - should NOT have CORS headers.
 	getReq3, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		"http://localhost:4566/"+bucketName+"/test.txt", nil)
+		testEndpoint()+"/"+bucketName+"/test.txt", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/s3_eventbridge_test.go
+++ b/test/integration/s3_eventbridge_test.go
@@ -42,7 +42,7 @@ func TestS3_EventBridgeNotification(t *testing.T) {
 	notifXML := `<NotificationConfiguration><EventBridgeConfiguration></EventBridgeConfiguration></NotificationConfiguration>`
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
-		"http://localhost:4566/"+bucketName+"?notification",
+		testEndpoint()+"/"+bucketName+"?notification",
 		bytes.NewReader([]byte(notifXML)))
 	if err != nil {
 		t.Fatal(err)
@@ -207,7 +207,7 @@ func TestS3_NotificationToSQS(t *testing.T) {
 		`</NotificationConfiguration>`
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
-		"http://localhost:4566/"+bucketName+"?notification",
+		testEndpoint()+"/"+bucketName+"?notification",
 		bytes.NewReader([]byte(notifXML)))
 	if err != nil {
 		t.Fatal(err)
@@ -356,7 +356,7 @@ func TestS3_NotificationToLambda(t *testing.T) {
 		`</NotificationConfiguration>`
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
-		"http://localhost:4566/"+bucketName+"?notification",
+		testEndpoint()+"/"+bucketName+"?notification",
 		bytes.NewReader([]byte(notifXML)))
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/s3_test.go
+++ b/test/integration/s3_test.go
@@ -15,8 +15,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/sivchari/golden"
@@ -25,18 +23,8 @@ import (
 func newS3Client(t *testing.T) *s3.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return s3.NewFromConfig(cfg, func(o *s3.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return s3.NewFromConfig(awsConfig(t), func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 		o.UsePathStyle = true
 	})
 }

--- a/test/integration/s3control_test.go
+++ b/test/integration/s3control_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3control"
 	"github.com/aws/aws-sdk-go-v2/service/s3control/types"
 	smithyendpoints "github.com/aws/smithy-go/endpoints"
@@ -21,7 +19,7 @@ import (
 type s3ControlEndpointResolver struct{}
 
 func (r *s3ControlEndpointResolver) ResolveEndpoint(_ context.Context, params s3control.EndpointParameters) (smithyendpoints.Endpoint, error) {
-	u, _ := url.Parse("http://localhost:4566")
+	u, _ := url.Parse(testEndpoint())
 
 	return smithyendpoints.Endpoint{URI: *u}, nil
 }
@@ -29,17 +27,7 @@ func (r *s3ControlEndpointResolver) ResolveEndpoint(_ context.Context, params s3
 func newS3ControlClient(t *testing.T) *s3control.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return s3control.NewFromConfig(cfg, func(o *s3control.Options) {
+	return s3control.NewFromConfig(awsConfig(t), func(o *s3control.Options) {
 		o.EndpointResolverV2 = &s3ControlEndpointResolver{}
 	})
 }

--- a/test/integration/s3tables_test.go
+++ b/test/integration/s3tables_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3tables"
 	"github.com/sivchari/golden"
 )
@@ -16,18 +14,8 @@ import (
 func newS3TablesClient(t *testing.T) *s3tables.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return s3tables.NewFromConfig(cfg, func(o *s3tables.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return s3tables.NewFromConfig(awsConfig(t), func(o *s3tables.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/sagemaker_test.go
+++ b/test/integration/sagemaker_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newSageMakerClient(t *testing.T) *sagemaker.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return sagemaker.NewFromConfig(cfg, func(o *sagemaker.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return sagemaker.NewFromConfig(awsConfig(t), func(o *sagemaker.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/scheduler"
 	"github.com/aws/aws-sdk-go-v2/service/scheduler/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newSchedulerClient(t *testing.T) *scheduler.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return scheduler.NewFromConfig(cfg, func(o *scheduler.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566/scheduler")
+	return scheduler.NewFromConfig(awsConfig(t), func(o *scheduler.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint() + "/scheduler")
 	})
 }
 

--- a/test/integration/secretsmanager_test.go
+++ b/test/integration/secretsmanager_test.go
@@ -10,8 +10,6 @@ import (
 	"unicode"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/sivchari/golden"
 )
@@ -19,18 +17,8 @@ import (
 func newSecretsManagerClient(t *testing.T) *secretsmanager.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return secretsmanager.NewFromConfig(awsConfig(t), func(o *secretsmanager.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/securitylake_test.go
+++ b/test/integration/securitylake_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/securitylake"
 	"github.com/aws/aws-sdk-go-v2/service/securitylake/types"
 	"github.com/sivchari/golden"
@@ -16,18 +14,8 @@ import (
 func newSecurityLakeClient(t *testing.T) *securitylake.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return securitylake.NewFromConfig(cfg, func(o *securitylake.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return securitylake.NewFromConfig(awsConfig(t), func(o *securitylake.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/servicequotas_test.go
+++ b/test/integration/servicequotas_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	"github.com/sivchari/golden"
 )
@@ -15,18 +13,8 @@ import (
 func newServiceQuotasClient(t *testing.T) *servicequotas.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return servicequotas.NewFromConfig(cfg, func(o *servicequotas.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return servicequotas.NewFromConfig(awsConfig(t), func(o *servicequotas.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/ses_test.go
+++ b/test/integration/ses_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ses"
 	"github.com/aws/aws-sdk-go-v2/service/ses/types"
 	"github.com/sivchari/golden"
@@ -19,18 +17,8 @@ import (
 func newSESClient(t *testing.T) *ses.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return ses.NewFromConfig(cfg, func(o *ses.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return ses.NewFromConfig(awsConfig(t), func(o *ses.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 
@@ -289,7 +277,7 @@ func TestSES_Mailbox(t *testing.T) {
 	}
 
 	// Check mailbox via kumo-specific endpoint.
-	resp, err := http.Get("http://localhost:4566/_aws/ses?email=" + source)
+	resp, err := http.Get(testEndpoint() + "/_aws/ses?email=" + source)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/sesv2_test.go
+++ b/test/integration/sesv2_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/sivchari/golden"
@@ -20,18 +18,8 @@ import (
 func newSESv2Client(t *testing.T) *sesv2.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return sesv2.NewFromConfig(cfg, func(o *sesv2.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566/ses")
+	return sesv2.NewFromConfig(awsConfig(t), func(o *sesv2.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint() + "/ses")
 	})
 }
 
@@ -304,7 +292,7 @@ func TestSESv2_SendRawEmail(t *testing.T) {
 	}
 
 	// Verify sent email via kumo-specific endpoint.
-	resp, err := http.Get("http://localhost:4566/kumo/ses/v2/sent-emails")
+	resp, err := http.Get(testEndpoint() + "/kumo/ses/v2/sent-emails")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -355,7 +343,7 @@ func TestSESv2_SendRawEmailWithoutDestination(t *testing.T) {
 	}
 
 	// Verify sent email via kumo-specific endpoint.
-	resp, err := http.Get("http://localhost:4566/kumo/ses/v2/sent-emails")
+	resp, err := http.Get(testEndpoint() + "/kumo/ses/v2/sent-emails")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,7 +410,7 @@ func TestSESv2_GetSentEmails(t *testing.T) {
 	}
 
 	// Get sent emails via kumo-specific endpoint.
-	resp, err := http.Get("http://localhost:4566/kumo/ses/v2/sent-emails")
+	resp, err := http.Get(testEndpoint() + "/kumo/ses/v2/sent-emails")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/sfn_test.go
+++ b/test/integration/sfn_test.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
 	"github.com/sivchari/golden"
@@ -20,18 +18,8 @@ import (
 func newSFNClient(t *testing.T) *sfn.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return sfn.NewFromConfig(cfg, func(o *sfn.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return sfn.NewFromConfig(awsConfig(t), func(o *sfn.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/sns_test.go
+++ b/test/integration/sns_test.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
@@ -19,18 +17,8 @@ import (
 func newSNSClient(t *testing.T) *sns.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return sns.NewFromConfig(cfg, func(o *sns.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return sns.NewFromConfig(awsConfig(t), func(o *sns.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/sqs_test.go
+++ b/test/integration/sqs_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/sivchari/golden"
@@ -19,18 +17,8 @@ import (
 func newSQSClient(t *testing.T) *sqs.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return sqs.NewFromConfig(cfg, func(o *sqs.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return sqs.NewFromConfig(awsConfig(t), func(o *sqs.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/ssm_test.go
+++ b/test/integration/ssm_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/sivchari/golden"
@@ -17,18 +15,8 @@ import (
 func newSSMClient(t *testing.T) *ssm.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return ssm.NewFromConfig(cfg, func(o *ssm.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return ssm.NewFromConfig(awsConfig(t), func(o *ssm.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/sts_test.go
+++ b/test/integration/sts_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/sivchari/golden"
 )
@@ -15,18 +13,8 @@ import (
 func newSTSClient(t *testing.T) *sts.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return sts.NewFromConfig(cfg, func(o *sts.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return sts.NewFromConfig(awsConfig(t), func(o *sts.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }
 

--- a/test/integration/xray_test.go
+++ b/test/integration/xray_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/xray"
 	"github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/sivchari/golden"
@@ -283,17 +281,7 @@ func TestXRay_DeleteGroup(t *testing.T) {
 func createXRayClient(t *testing.T, _ context.Context) *xray.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(t.Context(),
-		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			"test", "test", "",
-		)),
-	)
-	if err != nil {
-		t.Fatalf("failed to load config: %v", err)
-	}
-
-	return xray.NewFromConfig(cfg, func(o *xray.Options) {
-		o.BaseEndpoint = aws.String("http://localhost:4566")
+	return xray.NewFromConfig(awsConfig(t), func(o *xray.Options) {
+		o.BaseEndpoint = aws.String(testEndpoint())
 	})
 }


### PR DESCRIPTION
## Summary
78 of 90 integration test files carried an identical 10-line AWS config block, and the region/endpoint literals were hardcoded in ~85 files. This adds `test/integration/helpers_test.go` with a shared `awsConfig(t)` plus `testRegion()`/`testEndpoint()` accessors (overridable via KUMO_TEST_REGION / KUMO_TEST_ENDPOINT) and routes every client constructor through it: net -937 lines.

Per-service quirks are preserved verbatim (s3 UsePathStyle, dynamodb v1 SDK client, globalaccelerator us-west-2 pin, location/macie2/s3control custom resolvers). ARN and other asserted-value literals keep their hardcoded region on purpose.

## Test plan
- [x] `go build -tags=integration` / `go vet -tags=integration` clean, golden testdata untouched
- [x] Spot-ran SQS / S3 / GlobalAccelerator / EventBridge / ExecuteAPI / DynamoDB suites against a live kumo server, all pass
- [ ] Full integration suite runs in CI