### PR TITLE
refactor: drop comments that restate the code

### DIFF
--- a/internal/server/awsquery.go
+++ b/internal/server/awsquery.go
@@ -60,14 +60,12 @@ func (d *QueryProtocolDispatcher) RegisterAction(action, servicePrefix, serviceI
 
 // ServeHTTP implements http.Handler and dispatches to the appropriate service.
 func (d *QueryProtocolDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Parse form data.
 	if err := r.ParseForm(); err != nil {
 		writeQueryError(w, "InvalidParameterValue", "Failed to parse form data")
 
 		return
 	}
 
-	// Get Action parameter.
 	action := r.FormValue("Action")
 	if action == "" {
 		writeQueryError(w, "MissingAction", "Action parameter is required")
@@ -75,7 +73,6 @@ func (d *QueryProtocolDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Identify the target service from User-Agent header.
 	svcID := parseServiceFromUserAgent(r.Header.Get("User-Agent"))
 
 	entry, err := d.resolveHandler(svcID, action)
@@ -256,17 +253,14 @@ func formToJSON(form map[string][]string) []byte {
 // parseFormValue converts a form value string to appropriate JSON type.
 // Numeric strings are converted to numbers for proper JSON unmarshaling.
 func parseFormValue(s string) any {
-	// Try to parse as integer.
 	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
 		return i
 	}
 
-	// Try to parse as boolean.
 	if b, err := strconv.ParseBool(s); err == nil {
 		return b
 	}
 
-	// Return as string.
 	return s
 }
 

--- a/internal/server/cbor_dispatcher.go
+++ b/internal/server/cbor_dispatcher.go
@@ -72,7 +72,6 @@ func (d *CBORProtocolDispatcher) Register(serviceName string, handler CBORServic
 // ServeHTTP implements http.Handler and dispatches to the appropriate service.
 // It handles requests to /service/{serviceName}/operation/{operationName}.
 func (d *CBORProtocolDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Parse URL: /service/{serviceName}/operation/{operationName}
 	path := r.URL.Path
 	if !strings.HasPrefix(path, "/service/") {
 		WriteCBORError(w, "InvalidPath", "Path must start with /service/", http.StatusBadRequest)
@@ -80,7 +79,6 @@ func (d *CBORProtocolDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Remove "/service/" prefix
 	remaining := strings.TrimPrefix(path, "/service/")
 	parts := strings.Split(remaining, "/operation/")
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -133,11 +133,9 @@ func (r *Router) wrapHandler(method, pattern string, handler http.HandlerFunc) h
 		start := time.Now()
 		requestID := uuid.New().String()
 
-		// Add AWS-style headers
 		w.Header().Set("x-amz-request-id", requestID)
 		w.Header().Set("x-amzn-RequestId", requestID)
 
-		// Capture request body for debug logging.
 		var requestBody string
 
 		if r.logger.Enabled(req.Context(), slog.LevelDebug) && req.Body != nil {
@@ -148,13 +146,10 @@ func (r *Router) wrapHandler(method, pattern string, handler http.HandlerFunc) h
 			}
 		}
 
-		// Wrap response writer to capture status code
 		wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 
-		// Call the actual handler
 		handler(wrapped, req)
 
-		// Build log attributes.
 		attrs := []any{
 			"method", method,
 			"path", req.URL.Path,
@@ -179,7 +174,6 @@ func (r *Router) wrapHandler(method, pattern string, handler http.HandlerFunc) h
 
 		r.logger.Info("request", attrs...)
 
-		// Log request body at debug level.
 		if requestBody != "" {
 			r.logger.Debug("request body", "request_id", requestID, "body", requestBody)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,7 +105,6 @@ func New(config Config) *Server {
 		logger:          logger,
 	}
 
-	// Auto-register services from global registry
 	for _, svc := range service.Services() {
 		srv.RegisterService(svc)
 	}
@@ -116,7 +115,6 @@ func New(config Config) *Server {
 	wireS3toLambda(registry)
 	wireCloudWatchToSNS(registry)
 
-	// Register unified protocol dispatcher for POST /
 	hasJSONServices := len(jsonDispatcher.handlers) > 0
 	hasQueryServices := len(queryDispatcher.handlers) > 0
 
@@ -125,7 +123,6 @@ func New(config Config) *Server {
 		logger.Debug("registered unified protocol dispatcher for POST /")
 	}
 
-	// Register CBOR protocol dispatcher for /service/{serviceName}/operation/{operationName}
 	hasCBORServices := len(cborDispatcher.handlers) > 0
 	if hasCBORServices {
 		router.HandleFunc("POST", "/service/{serviceName}/operation/{operationName}", srv.cborDispatcher.ServeHTTP)
@@ -166,23 +163,19 @@ func (s *Server) RegisterService(svc service.Service) {
 	s.registry.Register(svc)
 	svc.RegisterRoutes(s.router)
 
-	// Check if service implements JSON protocol.
 	if jsonSvc, ok := svc.(service.JSONProtocolService); ok {
 		s.jsonDispatcher.Register(jsonSvc.TargetPrefix(), jsonSvc.DispatchAction)
 		s.logger.Debug("registered JSON protocol service", "name", svc.Name(), "prefix", jsonSvc.TargetPrefix())
 	}
 
-	// Check if service exposes an execute-api invoke surface.
 	if execSvc, ok := svc.(service.ExecuteAPIHandler); ok {
 		s.router.AddExecuteAPIHandler(execSvc.HandleExecuteAPI)
 		s.logger.Debug("registered execute-api handler", "name", svc.Name())
 	}
 
-	// Check if service implements Query protocol.
 	if querySvc, ok := svc.(service.QueryProtocolService); ok {
 		s.queryDispatcher.Register(querySvc.TargetPrefix(), querySvc.DispatchAction)
 
-		// Register each action for proper routing.
 		for _, action := range querySvc.Actions() {
 			s.queryDispatcher.RegisterAction(action, querySvc.TargetPrefix(), querySvc.ServiceIdentifier(), querySvc.DispatchAction)
 		}
@@ -194,7 +187,6 @@ func (s *Server) RegisterService(svc service.Service) {
 		)
 	}
 
-	// Check if service implements CBOR protocol.
 	if cborSvc, ok := svc.(service.CBORProtocolService); ok {
 		s.cborDispatcher.Register(cborSvc.ServiceName(), cborSvc.DispatchCBORAction)
 		s.logger.Debug("registered CBOR protocol service", "name", svc.Name(), "serviceName", cborSvc.ServiceName())
@@ -227,7 +219,6 @@ func (s *Server) Start(readyCh ...chan struct{}) error {
 	// Optional pprof endpoint (KUMO_PPROF=1).
 	startPprofServer(s.logger)
 
-	// List registered services
 	for _, name := range s.registry.Names() {
 		s.logger.Info("service available", "name", name)
 	}
@@ -260,7 +251,6 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		return fmt.Errorf("failed to shutdown server: %w", err)
 	}
 
-	// Save final snapshots for services that implement io.Closer.
 	for _, svc := range s.registry.All() {
 		if c, ok := svc.(io.Closer); ok {
 			if err := c.Close(); err != nil {
@@ -274,24 +264,19 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 // Run starts the server and handles graceful shutdown.
 func (s *Server) Run() error {
-	// Channel to receive OS signals
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
-	// Channel to receive server errors
 	errChan := make(chan error, 1)
 
-	// Channel to signal server readiness
 	readyCh := make(chan struct{})
 
-	// Start server in a goroutine
 	go func() {
 		if err := s.Start(readyCh); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errChan <- err
 		}
 	}()
 
-	// Wait for server to be ready, then execute init scripts
 	select {
 	case <-readyCh:
 		s.runInitScripts()
@@ -299,7 +284,6 @@ func (s *Server) Run() error {
 		return fmt.Errorf("server error: %w", err)
 	}
 
-	// Wait for signal or error
 	select {
 	case sig := <-sigChan:
 		s.logger.Info("received signal", "signal", sig)
@@ -307,7 +291,6 @@ func (s *Server) Run() error {
 		return fmt.Errorf("server error: %w", err)
 	}
 
-	// Graceful shutdown with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/internal/service/acm/handlers.go
+++ b/internal/service/acm/handlers.go
@@ -140,13 +140,11 @@ func (s *Service) ListCertificates(w http.ResponseWriter, r *http.Request) {
 	summaries := make([]CertificateSummary, 0, len(certs))
 
 	for _, cert := range certs {
-		// Convert KeyUsages to string slice
 		keyUsages := make([]string, 0, len(cert.KeyUsages))
 		for _, ku := range cert.KeyUsages {
 			keyUsages = append(keyUsages, ku.Name)
 		}
 
-		// Convert ExtendedKeyUsages to string slice
 		extendedKeyUsages := make([]string, 0, len(cert.ExtendedKeyUsages))
 		for _, eku := range cert.ExtendedKeyUsages {
 			extendedKeyUsages = append(extendedKeyUsages, eku.Name)

--- a/internal/service/acm/storage.go
+++ b/internal/service/acm/storage.go
@@ -239,7 +239,6 @@ func (s *MemoryStorage) ListCertificates(_ context.Context, statuses []string, m
 	certs := make([]*Certificate, 0, len(s.Certificates))
 
 	for _, cert := range s.Certificates {
-		// Filter by status if specified.
 		if len(statuses) > 0 && !slices.Contains(statuses, cert.Status) {
 			continue
 		}
@@ -247,7 +246,6 @@ func (s *MemoryStorage) ListCertificates(_ context.Context, statuses []string, m
 		certs = append(certs, cert)
 	}
 
-	// Apply pagination.
 	if len(certs) > int(maxItems) {
 		certs = certs[:maxItems]
 	}
@@ -319,12 +317,10 @@ func (s *MemoryStorage) ImportCertificate(_ context.Context, req *ImportCertific
 
 	arn := req.CertificateArn
 	if arn == "" {
-		// Generate new ARN.
 		certID := uuid.New().String()
 		arn = fmt.Sprintf("arn:aws:acm:us-east-1:000000000000:certificate/%s", certID)
 	}
 
-	// Generate serial number.
 	serialBytes := make([]byte, 16)
 	if _, err := rand.Read(serialBytes); err != nil {
 		return nil, fmt.Errorf("failed to generate serial: %w", err)

--- a/internal/service/apigateway/storage.go
+++ b/internal/service/apigateway/storage.go
@@ -178,7 +178,6 @@ func (s *MemoryStorage) CreateRestAPI(_ context.Context, req *CreateRestAPIReque
 		RootResourceID:         rootResourceID,
 	}
 
-	// Create root resource.
 	rootResource := &Resource{
 		ID:              rootResourceID,
 		Path:            "/",
@@ -341,7 +340,6 @@ func (s *MemoryStorage) DeleteResource(_ context.Context, restAPIID, resourceID 
 		return &ServiceError{Code: errResourceNotFound, Message: "Invalid resource identifier specified"}
 	}
 
-	// Cannot delete root resource.
 	if resource.Path == "/" {
 		return &ServiceError{Code: errBadRequest, Message: "Cannot delete root resource"}
 	}
@@ -522,7 +520,6 @@ func (s *MemoryStorage) CreateDeployment(_ context.Context, restAPIID string, re
 
 	data.Deployments[id] = deployment
 
-	// If stage name is specified, create or update the stage.
 	if req.StageName != "" {
 		stage := &Stage{
 			StageName:       req.StageName,
@@ -614,7 +611,6 @@ func (s *MemoryStorage) CreateStage(_ context.Context, restAPIID string, req *Cr
 		return nil, &ServiceError{Code: errRestAPINotFound, Message: "Invalid REST API identifier specified"}
 	}
 
-	// Verify deployment exists.
 	if _, exists := data.Deployments[req.DeploymentID]; !exists {
 		return nil, &ServiceError{Code: errDeploymentNotFound, Message: "Invalid deployment identifier specified"}
 	}

--- a/internal/service/appmesh/handlers.go
+++ b/internal/service/appmesh/handlers.go
@@ -724,7 +724,6 @@ func extractMeshName(path string) string {
 
 	remainder := strings.TrimPrefix(path, meshPathPrefix)
 
-	// Remove any trailing path segments.
 	if idx := strings.Index(remainder, "/"); idx != -1 {
 		remainder = remainder[:idx]
 	}

--- a/internal/service/appmesh/storage.go
+++ b/internal/service/appmesh/storage.go
@@ -851,7 +851,6 @@ func (m *MemoryStorage) DeleteVirtualRouter(_ context.Context, meshName, virtual
 		}
 	}
 
-	// Check if router has any routes.
 	if len(m.Routes[meshName][virtualRouterName]) > 0 {
 		return nil, &Error{
 			Code:    errResourceInUseException,

--- a/internal/service/appsync/handlers.go
+++ b/internal/service/appsync/handlers.go
@@ -241,8 +241,6 @@ func (s *Service) StartSchemaCreation(w http.ResponseWriter, r *http.Request) {
 
 // extractPathParam extracts a path parameter from the request URL.
 func extractPathParam(r *http.Request, param string) string {
-	// The server router should set path parameters.
-	// For now, we'll parse them from the URL path.
 	// Expected paths:
 	// - /apis/{apiId}
 	// - /apis/{apiId}/datasources

--- a/internal/service/appsync/storage.go
+++ b/internal/service/appsync/storage.go
@@ -242,12 +242,10 @@ func (s *MemoryStorage) ListGraphqlAPIs(_ context.Context, input *ListGraphqlAPI
 	allAPIs := make([]GraphqlAPI, 0, len(s.APIs))
 
 	for _, data := range s.APIs {
-		// Filter by API type if specified.
 		if input.APIType != "" && data.API.APIType != input.APIType {
 			continue
 		}
 
-		// Filter by owner if specified.
 		if input.Owner != "" && data.API.Owner != input.Owner {
 			continue
 		}
@@ -255,12 +253,10 @@ func (s *MemoryStorage) ListGraphqlAPIs(_ context.Context, input *ListGraphqlAPI
 		allAPIs = append(allAPIs, *data.API)
 	}
 
-	// Sort by API ID for consistent pagination.
 	sort.Slice(allAPIs, func(i, j int) bool {
 		return allAPIs[i].APIId < allAPIs[j].APIId
 	})
 
-	// Determine start index from nextToken.
 	startIndex := 0
 
 	if input.NextToken != "" {
@@ -272,13 +268,11 @@ func (s *MemoryStorage) ListGraphqlAPIs(_ context.Context, input *ListGraphqlAPI
 		}
 	}
 
-	// Determine max results.
 	maxResults := int(input.MaxResults)
 	if maxResults <= 0 {
 		maxResults = defaultMaxResults
 	}
 
-	// Apply pagination.
 	endIndex := startIndex + maxResults
 	if endIndex > len(allAPIs) {
 		endIndex = len(allAPIs)
@@ -286,7 +280,6 @@ func (s *MemoryStorage) ListGraphqlAPIs(_ context.Context, input *ListGraphqlAPI
 
 	result := allAPIs[startIndex:endIndex]
 
-	// Generate next token if there are more results.
 	var nextToken string
 	if endIndex < len(allAPIs) {
 		nextToken = base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(endIndex)))

--- a/internal/service/athena/storage.go
+++ b/internal/service/athena/storage.go
@@ -61,7 +61,6 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 		QueryResults:    make(map[string]*ResultSet),
 	}
 
-	// Create the default "primary" workgroup.
 	s.WorkGroups["primary"] = &WorkGroup{
 		Name:         "primary",
 		State:        WorkGroupStateEnabled,
@@ -153,7 +152,6 @@ func (s *MemoryStorage) StartQueryExecution(_ context.Context, query, workGroup 
 		workGroup = "primary"
 	}
 
-	// Verify workgroup exists.
 	if _, ok := s.WorkGroups[workGroup]; !ok {
 		return nil, &ServiceError{
 			Code:    errInvalidRequestException,
@@ -279,7 +277,6 @@ func (s *MemoryStorage) GetQueryResults(_ context.Context, queryExecutionID, _ s
 
 	rs, ok := s.QueryResults[queryExecutionID]
 	if !ok {
-		// Return empty result set.
 		return &ResultSet{
 			Rows:              []Row{},
 			ResultSetMetadata: &ResultSetMetadata{ColumnInfo: []ColumnInfo{}},
@@ -361,7 +358,6 @@ func (s *MemoryStorage) DeleteWorkGroup(_ context.Context, name string, recursiv
 		}
 	}
 
-	// Check if there are any query executions in this workgroup.
 	if !recursiveDelete {
 		for _, qe := range s.QueryExecutions {
 			if qe.WorkGroup == name {
@@ -373,7 +369,6 @@ func (s *MemoryStorage) DeleteWorkGroup(_ context.Context, name string, recursiv
 		}
 	}
 
-	// Delete query executions if recursive delete.
 	if recursiveDelete {
 		for id, qe := range s.QueryExecutions {
 			if qe.WorkGroup == name {

--- a/internal/service/batch/handlers.go
+++ b/internal/service/batch/handlers.go
@@ -57,7 +57,6 @@ func (s *Service) DeleteComputeEnvironment(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Extract name from ARN if provided.
 	name := extractResourceName(req.ComputeEnvironment)
 
 	if err := s.storage.DeleteComputeEnvironment(r.Context(), name); err != nil {
@@ -78,7 +77,6 @@ func (s *Service) DescribeComputeEnvironments(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Extract names from ARNs if provided.
 	names := make([]string, 0, len(req.ComputeEnvironments))
 
 	for _, ce := range req.ComputeEnvironments {

--- a/internal/service/batch/storage.go
+++ b/internal/service/batch/storage.go
@@ -225,12 +225,10 @@ func (s *MemoryStorage) DescribeComputeEnvironments(_ context.Context, names []s
 	var result []ComputeEnvironment
 
 	if len(names) == 0 {
-		// Return all compute environments.
 		for _, ce := range s.ComputeEnvironments {
 			result = append(result, *ce)
 		}
 	} else {
-		// Return specified compute environments.
 		for _, name := range names {
 			if ce, exists := s.ComputeEnvironments[name]; exists {
 				result = append(result, *ce)
@@ -313,12 +311,10 @@ func (s *MemoryStorage) DescribeJobQueues(_ context.Context, names []string) ([]
 	var result []JobQueue
 
 	if len(names) == 0 {
-		// Return all job queues.
 		for _, jq := range s.JobQueues {
 			result = append(result, *jq)
 		}
 	} else {
-		// Return specified job queues.
 		for _, name := range names {
 			if jq, exists := s.JobQueues[name]; exists {
 				result = append(result, *jq)
@@ -348,7 +344,6 @@ func (s *MemoryStorage) RegisterJobDefinition(_ context.Context, input *Register
 		}
 	}
 
-	// Increment revision.
 	revision := s.JobDefRevisions[input.JobDefinitionName] + 1
 	s.JobDefRevisions[input.JobDefinitionName] = revision
 

--- a/internal/service/ce/storage.go
+++ b/internal/service/ce/storage.go
@@ -270,7 +270,6 @@ func (s *MemoryStorage) CreateCostCategoryDefinition(_ context.Context, req *Cre
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check for duplicate name
 	for _, cc := range s.CostCategories {
 		if cc.Name == req.Name {
 			return nil, &ServiceError{
@@ -498,7 +497,6 @@ func getMockTags(tagKey, searchString string) []string {
 	}
 
 	if tagKey != "" {
-		// Return tag values for specific key
 		tagValues := map[string][]string{
 			"Environment": {"production", "staging", "development"},
 			"Project":     {"project-a", "project-b", "project-c"},

--- a/internal/service/cloudformation/storage.go
+++ b/internal/service/cloudformation/storage.go
@@ -141,7 +141,6 @@ func (m *MemoryStorage) CreateStack(_ context.Context, req *CreateStackRequest) 
 	stackID := generateStackID(req.StackName)
 	now := time.Now()
 
-	// Parse template to extract resources.
 	resources := parseTemplateResources(req.TemplateBody, stackID, req.StackName)
 
 	stack := &Stack{
@@ -172,7 +171,6 @@ func (m *MemoryStorage) DeleteStack(_ context.Context, stackName string) error {
 		return &Error{Code: "StackNotFoundException", Message: "Stack not found"}
 	}
 
-	// Mark stack as deleted.
 	stack.StackStatus = StackStatusDeleteComplete
 	stack.DeletionTime = time.Now()
 
@@ -198,7 +196,6 @@ func (m *MemoryStorage) DescribeStacks(_ context.Context, stackName string) ([]*
 		return []*Stack{stack}, nil
 	}
 
-	// Return all stacks.
 	result := make([]*Stack, 0, len(m.Stacks))
 	for _, stack := range m.Stacks {
 		result = append(result, stack)
@@ -250,7 +247,6 @@ func (m *MemoryStorage) UpdateStack(_ context.Context, req *UpdateStackRequest) 
 		stack.Parameters = req.Parameters
 	}
 
-	// Re-parse resources from new template.
 	stack.Resources = parseTemplateResources(req.TemplateBody, stack.StackID, stack.StackName)
 
 	m.saveLocked()
@@ -305,7 +301,6 @@ func (m *MemoryStorage) ValidateTemplate(_ context.Context, templateBody string)
 		return nil, &Error{Code: "ValidationError", Message: "TemplateBody is required"}
 	}
 
-	// Try to parse as JSON.
 	var template map[string]any
 	if err := json.Unmarshal([]byte(templateBody), &template); err != nil {
 		return nil, &Error{Code: "ValidationError", Message: "Template format error: " + err.Error()}
@@ -316,12 +311,10 @@ func (m *MemoryStorage) ValidateTemplate(_ context.Context, templateBody string)
 		Capabilities: []string{},
 	}
 
-	// Extract description.
 	if desc, ok := template["Description"].(string); ok {
 		result.Description = desc
 	}
 
-	// Extract parameters.
 	if params, ok := template["Parameters"].(map[string]any); ok {
 		for key, value := range params {
 			param := parseTemplateParameter(key, value)

--- a/internal/service/cloudfront/storage.go
+++ b/internal/service/cloudfront/storage.go
@@ -159,7 +159,6 @@ func (s *MemoryStorage) CreateDistribution(_ context.Context, config *CreateDist
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check for duplicate caller reference.
 	for _, d := range s.Distributions {
 		if d.DistributionConfig != nil && d.DistributionConfig.CallerReference == config.CallerReference {
 			return nil, &Error{
@@ -169,7 +168,6 @@ func (s *MemoryStorage) CreateDistribution(_ context.Context, config *CreateDist
 		}
 	}
 
-	// Generate distribution ID.
 	id := generateDistributionID()
 	etag := generateETag()
 	now := time.Now()
@@ -235,10 +233,8 @@ func (s *MemoryStorage) ListDistributions(_ context.Context, marker string, maxI
 		dists = append(dists, d)
 	}
 
-	// Sort by ID for consistent ordering.
 	sortDistributionsByID(dists)
 
-	// Apply marker-based pagination.
 	startIdx := 0
 
 	if marker != "" {
@@ -251,12 +247,10 @@ func (s *MemoryStorage) ListDistributions(_ context.Context, marker string, maxI
 		}
 	}
 
-	// Slice the results.
 	endIdx := min(startIdx+maxItems, len(dists))
 
 	result := dists[startIdx:endIdx]
 
-	// Determine next marker.
 	var nextMarker string
 	if endIdx < len(dists) {
 		nextMarker = dists[endIdx-1].ID
@@ -278,7 +272,6 @@ func (s *MemoryStorage) UpdateDistribution(_ context.Context, id string, config 
 		}
 	}
 
-	// Validate ETag.
 	if dist.ETag != etag {
 		return nil, &Error{
 			Code:    errInvalidIfMatchVersion,
@@ -286,7 +279,6 @@ func (s *MemoryStorage) UpdateDistribution(_ context.Context, id string, config 
 		}
 	}
 
-	// Update distribution.
 	newETag := generateETag()
 	dist.ETag = newETag
 	dist.LastModifiedTime = time.Now()
@@ -323,7 +315,6 @@ func (s *MemoryStorage) DeleteDistribution(_ context.Context, id, etag string) e
 		}
 	}
 
-	// Validate ETag.
 	if dist.ETag != etag {
 		return &Error{
 			Code:    errInvalidIfMatchVersion,
@@ -344,7 +335,6 @@ func (s *MemoryStorage) CreateInvalidation(_ context.Context, distributionID str
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check if distribution exists.
 	if _, exists := s.Distributions[distributionID]; !exists {
 		return nil, &Error{
 			Code:    errDistributionNotFound,
@@ -352,7 +342,6 @@ func (s *MemoryStorage) CreateInvalidation(_ context.Context, distributionID str
 		}
 	}
 
-	// Generate invalidation ID.
 	id := generateInvalidationID()
 	now := time.Now()
 
@@ -366,7 +355,6 @@ func (s *MemoryStorage) CreateInvalidation(_ context.Context, distributionID str
 		},
 	}
 
-	// Store invalidation.
 	if s.Invalidations[distributionID] == nil {
 		s.Invalidations[distributionID] = make(map[string]*Invalidation)
 	}
@@ -383,7 +371,6 @@ func (s *MemoryStorage) GetInvalidation(_ context.Context, distributionID, inval
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Check if distribution exists.
 	if _, exists := s.Distributions[distributionID]; !exists {
 		return nil, &Error{
 			Code:    errDistributionNotFound,
@@ -415,7 +402,6 @@ func (s *MemoryStorage) ListInvalidations(_ context.Context, distributionID, mar
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Check if distribution exists.
 	if _, exists := s.Distributions[distributionID]; !exists {
 		return nil, "", &Error{
 			Code:    errDistributionNotFound,
@@ -437,10 +423,8 @@ func (s *MemoryStorage) ListInvalidations(_ context.Context, distributionID, mar
 		invs = append(invs, inv)
 	}
 
-	// Sort by ID for consistent ordering.
 	sortInvalidationsByID(invs)
 
-	// Apply marker-based pagination.
 	startIdx := 0
 
 	if marker != "" {
@@ -453,12 +437,10 @@ func (s *MemoryStorage) ListInvalidations(_ context.Context, distributionID, mar
 		}
 	}
 
-	// Slice the results.
 	endIdx := min(startIdx+maxItems, len(invs))
 
 	result := invs[startIdx:endIdx]
 
-	// Determine next marker.
 	var nextMarker string
 	if endIdx < len(invs) {
 		nextMarker = invs[endIdx-1].ID

--- a/internal/service/cloudtrail/storage.go
+++ b/internal/service/cloudtrail/storage.go
@@ -235,7 +235,6 @@ func (m *MemoryStorage) DescribeTrails(_ context.Context, names []string) ([]*Tr
 	defer m.mu.RUnlock()
 
 	if len(names) == 0 {
-		// Return all trails.
 		result := make([]*Trail, 0, len(m.Trails))
 		for _, trail := range m.Trails {
 			result = append(result, trail)
@@ -244,7 +243,6 @@ func (m *MemoryStorage) DescribeTrails(_ context.Context, names []string) ([]*Tr
 		return result, nil
 	}
 
-	// Return specified trails.
 	result := make([]*Trail, 0, len(names))
 
 	for _, name := range names {
@@ -293,7 +291,6 @@ func (m *MemoryStorage) StopLogging(_ context.Context, name string) error {
 // LookupEvents looks up events.
 // For MVP, this returns an empty list as we don't capture actual events.
 func (m *MemoryStorage) LookupEvents(_ context.Context, _ *LookupEventsRequest) ([]*Event, string, error) {
-	// Return empty events list for MVP.
 	return []*Event{}, "", nil
 }
 

--- a/internal/service/cloudwatch/handlers.go
+++ b/internal/service/cloudwatch/handlers.go
@@ -49,7 +49,6 @@ func (s *Service) PutMetricData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// PutMetricData returns an empty response on success.
 	writeJSONResponse(w, struct{}{})
 }
 
@@ -463,7 +462,6 @@ func (s *Service) GetMetricDataCBOR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Convert CBOR request to storage request
 	storageReq := &GetMetricDataRequest{
 		MetricDataQueries: req.MetricDataQueries,
 		StartTime:         req.StartTime.Format(time.RFC3339),
@@ -479,7 +477,6 @@ func (s *Service) GetMetricDataCBOR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Convert result to CBOR response
 	cborResults := make([]MetricDataCBORResult, len(result.MetricDataResults))
 
 	for i := range result.MetricDataResults {
@@ -527,7 +524,6 @@ func (s *Service) GetMetricStatisticsCBOR(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Convert CBOR request to storage request
 	storageReq := &GetMetricStatisticsRequest{
 		Namespace:  req.Namespace,
 		MetricName: req.MetricName,
@@ -546,7 +542,6 @@ func (s *Service) GetMetricStatisticsCBOR(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Convert result to CBOR response
 	cborDatapoints := make([]CBORDatapoint, len(result.Datapoints))
 
 	for i := range result.Datapoints {
@@ -631,7 +626,6 @@ func (s *Service) PutMetricAlarmCBOR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// PutMetricAlarm returns an empty response on success.
 	server.WriteCBORResponse(w, struct{}{})
 }
 
@@ -656,7 +650,6 @@ func (s *Service) DeleteAlarmsCBOR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// DeleteAlarms returns an empty response on success.
 	server.WriteCBORResponse(w, struct{}{})
 }
 
@@ -676,7 +669,6 @@ func (s *Service) DescribeAlarmsCBOR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Convert result to CBOR response
 	cborAlarms := make([]MetricAlarmCBOR, len(result.MetricAlarms))
 
 	for i := range result.MetricAlarms {
@@ -833,12 +825,10 @@ func parseTimestamp(s string) (time.Time, error) {
 		return time.Time{}, nil
 	}
 
-	// Try RFC3339 first
 	if t, err := time.Parse(time.RFC3339, s); err == nil {
 		return t, nil
 	}
 
-	// Try RFC3339Nano
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, nil
 	}

--- a/internal/service/cloudwatch/storage.go
+++ b/internal/service/cloudwatch/storage.go
@@ -304,7 +304,6 @@ func (s *MemoryStorage) GetMetricData(_ context.Context, req *GetMetricDataReque
 			continue
 		}
 
-		// Filter datapoints by time range.
 		timestamps := make([]string, 0)
 		values := make([]float64, 0)
 
@@ -349,7 +348,6 @@ func (s *MemoryStorage) GetMetricStatistics(_ context.Context, req *GetMetricSta
 		}, nil
 	}
 
-	// Collect datapoints in time range.
 	var filteredPoints []MetricDatapoint
 
 	for _, dp := range metric.Datapoints {
@@ -365,7 +363,6 @@ func (s *MemoryStorage) GetMetricStatistics(_ context.Context, req *GetMetricSta
 		}, nil
 	}
 
-	// Calculate statistics.
 	datapoints := s.calculateStatistics(filteredPoints, req.Statistics, req.Period)
 
 	return &GetMetricStatisticsResult{
@@ -382,17 +379,14 @@ func (s *MemoryStorage) ListMetrics(_ context.Context, req *ListMetricsRequest) 
 	metrics := make([]Metric, 0)
 
 	for _, m := range s.Metrics {
-		// Filter by namespace.
 		if req.Namespace != "" && m.Namespace != req.Namespace {
 			continue
 		}
 
-		// Filter by metric name.
 		if req.MetricName != "" && m.MetricName != req.MetricName {
 			continue
 		}
 
-		// Filter by dimensions.
 		if !s.matchesDimensionFilters(m.Dimensions, req.Dimensions) {
 			continue
 		}
@@ -404,7 +398,6 @@ func (s *MemoryStorage) ListMetrics(_ context.Context, req *ListMetricsRequest) 
 		})
 	}
 
-	// Sort metrics for consistent output.
 	sort.Slice(metrics, func(i, j int) bool {
 		if metrics[i].Namespace != metrics[j].Namespace {
 			return metrics[i].Namespace < metrics[j].Namespace
@@ -622,12 +615,10 @@ func (s *MemoryStorage) DescribeAlarms(_ context.Context, req *DescribeAlarmsReq
 		alarms = append(alarms, convertAlarmToJSON(alarm))
 	}
 
-	// Sort alarms by name.
 	sort.Slice(alarms, func(i, j int) bool {
 		return alarms[i].AlarmName < alarms[j].AlarmName
 	})
 
-	// Apply MaxRecords limit.
 	maxRecords := 50
 	if req.MaxRecords != nil && *req.MaxRecords > 0 {
 		maxRecords = int(*req.MaxRecords)
@@ -685,7 +676,6 @@ func convertAlarmToJSON(alarm *Alarm) MetricAlarm {
 
 // makeMetricKey creates a unique key for a metric.
 func (s *MemoryStorage) makeMetricKey(namespace, metricName string, dimensions []Dimension) MetricKey {
-	// Sort dimensions for consistent key generation.
 	sorted := make([]Dimension, len(dimensions))
 	copy(sorted, dimensions)
 	sort.Slice(sorted, func(i, j int) bool {
@@ -789,7 +779,6 @@ func (s *MemoryStorage) calculateStatistics(points []MetricDatapoint, statistics
 		Unit:      unit,
 	}
 
-	// Include requested statistics.
 	for _, stat := range statistics {
 		switch stat {
 		case "SampleCount":
@@ -805,7 +794,6 @@ func (s *MemoryStorage) calculateStatistics(points []MetricDatapoint, statistics
 		}
 	}
 
-	// If no specific statistics requested, include all.
 	if len(statistics) == 0 {
 		dp.SampleCount = &count
 		dp.Average = &average

--- a/internal/service/cloudwatchlogs/storage.go
+++ b/internal/service/cloudwatchlogs/storage.go
@@ -300,7 +300,6 @@ func (m *MemoryStorage) PutLogEvents(_ context.Context, groupName, streamName st
 		}
 		streamData.Events = append(streamData.Events, logEvent)
 
-		// Update stream timestamps
 		if streamData.Stream.FirstEventTimestamp == nil {
 			streamData.Stream.FirstEventTimestamp = &event.Timestamp
 		}
@@ -310,10 +309,8 @@ func (m *MemoryStorage) PutLogEvents(_ context.Context, groupName, streamName st
 		streamData.Stream.StoredBytes += int64(len(event.Message))
 	}
 
-	// Update group stored bytes
 	groupData.Group.StoredBytes += sumEventBytes(events)
 
-	// Generate new sequence token
 	newToken := uuid.New().String()
 	streamData.Stream.UploadSequenceToken = newToken
 
@@ -350,10 +347,8 @@ func (m *MemoryStorage) GetLogEvents(_ context.Context, req *GetLogEventsRequest
 		limit = min(int(*req.Limit), maxLimit)
 	}
 
-	// Filter events by time range
 	filteredEvents := filterEventsByTime(streamData.Events, req.StartTime, req.EndTime)
 
-	// Sort events
 	startFromHead := req.StartFromHead != nil && *req.StartFromHead
 	if startFromHead {
 		sort.Slice(filteredEvents, func(i, j int) bool {
@@ -365,12 +360,10 @@ func (m *MemoryStorage) GetLogEvents(_ context.Context, req *GetLogEventsRequest
 		})
 	}
 
-	// Apply limit
 	if len(filteredEvents) > limit {
 		filteredEvents = filteredEvents[:limit]
 	}
 
-	// Convert to output format
 	outputEvents := make([]OutputLogEvent, 0, len(filteredEvents))
 	now := time.Now().UnixMilli()
 
@@ -410,12 +403,10 @@ func (m *MemoryStorage) FilterLogEvents(_ context.Context, req *FilterLogEventsR
 	limit := getLimit(req.Limit)
 	allEvents, searchedStreams := m.filterEventsFromStreams(groupData, req)
 
-	// Sort by timestamp
 	sort.Slice(allEvents, func(i, j int) bool {
 		return allEvents[i].Timestamp < allEvents[j].Timestamp
 	})
 
-	// Apply limit
 	if len(allEvents) > limit {
 		allEvents = allEvents[:limit]
 	}
@@ -517,7 +508,6 @@ func (m *MemoryStorage) DescribeLogGroups(_ context.Context, req *DescribeLogGro
 	limit := getLimit(req.Limit)
 	groups := m.filterLogGroups(req)
 
-	// Sort by name
 	sort.Slice(groups, func(i, j int) bool {
 		return groups[i].LogGroupName < groups[j].LogGroupName
 	})

--- a/internal/service/codeconnections/storage.go
+++ b/internal/service/codeconnections/storage.go
@@ -322,7 +322,6 @@ func (s *MemoryStorage) DeleteHost(_ context.Context, hostArn string) error {
 		}
 	}
 
-	// Check if any connection uses this host
 	for _, conn := range s.Connections {
 		if conn.HostArn == hostArn {
 			return &ServiceError{
@@ -392,7 +391,6 @@ func (s *MemoryStorage) CreateRepositoryLink(_ context.Context, connectionArn, o
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Verify connection exists
 	conn, ok := s.Connections[connectionArn]
 	if !ok {
 		return nil, &ServiceError{
@@ -499,7 +497,6 @@ func (s *MemoryStorage) UpdateRepositoryLink(_ context.Context, repositoryLinkID
 	}
 
 	if connectionArn != "" {
-		// Verify new connection exists
 		conn, ok := s.Connections[connectionArn]
 		if !ok {
 			return nil, &ServiceError{
@@ -528,13 +525,11 @@ func (s *MemoryStorage) ListTagsForResource(_ context.Context, resourceArn strin
 
 	var tagMap map[string]string
 
-	// Check connections
 	if conn, ok := s.Connections[resourceArn]; ok {
 		tagMap = conn.Tags
 	} else if host, ok := s.Hosts[resourceArn]; ok {
 		tagMap = host.Tags
 	} else {
-		// Check repository links by ARN
 		for _, link := range s.RepositoryLinks {
 			if link.RepositoryLinkArn == resourceArn {
 				tagMap = link.Tags
@@ -566,13 +561,11 @@ func (s *MemoryStorage) TagResource(_ context.Context, resourceArn string, tags 
 
 	var tagMap map[string]string
 
-	// Check connections
 	if conn, ok := s.Connections[resourceArn]; ok {
 		tagMap = conn.Tags
 	} else if host, ok := s.Hosts[resourceArn]; ok {
 		tagMap = host.Tags
 	} else {
-		// Check repository links by ARN
 		for _, link := range s.RepositoryLinks {
 			if link.RepositoryLinkArn == resourceArn {
 				tagMap = link.Tags
@@ -605,13 +598,11 @@ func (s *MemoryStorage) UntagResource(_ context.Context, resourceArn string, tag
 
 	var tagMap map[string]string
 
-	// Check connections
 	if conn, ok := s.Connections[resourceArn]; ok {
 		tagMap = conn.Tags
 	} else if host, ok := s.Hosts[resourceArn]; ok {
 		tagMap = host.Tags
 	} else {
-		// Check repository links by ARN
 		for _, link := range s.RepositoryLinks {
 			if link.RepositoryLinkArn == resourceArn {
 				tagMap = link.Tags

--- a/internal/service/codegurureviewer/storage.go
+++ b/internal/service/codegurureviewer/storage.go
@@ -256,7 +256,6 @@ func (m *MemoryStorage) CreateCodeReview(input *CreateCodeReviewInput) (*CodeRev
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Find the association.
 	assoc, ok := m.Associations[input.RepositoryAssociationArn]
 	if !ok {
 		return nil, fmt.Errorf("NotFoundException: repository association %s not found", input.RepositoryAssociationArn)

--- a/internal/service/cognito/handlers.go
+++ b/internal/service/cognito/handlers.go
@@ -365,7 +365,6 @@ func (s *Service) SignUp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get user sub from attributes.
 	userSub := uuid.New().String()
 
 	for _, attr := range user.Attributes {

--- a/internal/service/cognito/storage.go
+++ b/internal/service/cognito/storage.go
@@ -285,14 +285,12 @@ func (s *MemoryStorage) DeleteUserPool(_ context.Context, userPoolID string) err
 		return &ServiceError{Code: errUserPoolNotFound, Message: "User pool not found"}
 	}
 
-	// Delete associated clients.
 	for clientID, client := range s.UserPoolClients {
 		if client.UserPoolID == userPoolID {
 			delete(s.UserPoolClients, clientID)
 		}
 	}
 
-	// Delete associated users.
 	delete(s.Users, userPoolID)
 	delete(s.UserPools, userPoolID)
 
@@ -335,7 +333,6 @@ func (s *MemoryStorage) CreateUserPoolClient(_ context.Context, req *CreateUserP
 		client.ClientSecret = generateSecret()
 	}
 
-	// Set defaults.
 	if client.RefreshTokenValidity == 0 {
 		client.RefreshTokenValidity = 30
 	}
@@ -519,7 +516,6 @@ func (s *MemoryStorage) SignUp(_ context.Context, req *SignUpRequest) (*User, er
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Find user pool by client ID.
 	var userPoolID string
 
 	for _, client := range s.UserPoolClients {
@@ -559,7 +555,6 @@ func (s *MemoryStorage) SignUp(_ context.Context, req *SignUpRequest) (*User, er
 
 	s.Users[userPoolID][req.Username] = user
 
-	// Generate confirmation code (simulated).
 	s.ConfirmationCodes[req.Username] = "123456"
 
 	s.saveLocked()
@@ -572,7 +567,6 @@ func (s *MemoryStorage) ConfirmSignUp(_ context.Context, clientID, username, cod
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Find user pool by client ID.
 	var userPoolID string
 
 	for _, client := range s.UserPoolClients {
@@ -614,7 +608,6 @@ func (s *MemoryStorage) InitiateAuth(_ context.Context, req *InitiateAuthRequest
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Find user pool by client ID.
 	var userPoolID string
 
 	for _, client := range s.UserPoolClients {
@@ -645,7 +638,6 @@ func (s *MemoryStorage) InitiateAuth(_ context.Context, req *InitiateAuthRequest
 		return nil, &ServiceError{Code: errNotAuthorized, Message: "User is not confirmed"}
 	}
 
-	// Generate tokens.
 	accessToken := generateToken()
 	idToken := generateToken()
 	refreshToken := generateToken()

--- a/internal/service/comprehend/storage.go
+++ b/internal/service/comprehend/storage.go
@@ -237,7 +237,6 @@ func (a *Analyzer) extractKeyPhrases(text string) []KeyPhrase {
 	keyPhrases := []KeyPhrase{}
 
 	// Simple approach: extract noun phrases (sequences of capitalized words or quoted text).
-	// Find quoted strings.
 	quotePattern := regexp.MustCompile(`"([^"]+)"`)
 	matches := quotePattern.FindAllStringSubmatchIndex(text, -1)
 
@@ -253,7 +252,6 @@ func (a *Analyzer) extractKeyPhrases(text string) []KeyPhrase {
 		}
 	}
 
-	// Find sequences of capitalized words.
 	capPattern := regexp.MustCompile(`\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b`)
 	capMatches := capPattern.FindAllStringSubmatchIndex(text, -1)
 
@@ -276,7 +274,6 @@ func (a *Analyzer) extractKeyPhrases(text string) []KeyPhrase {
 func (a *Analyzer) extractPiiEntities(text string) []PiiEntity {
 	piiEntities := make([]PiiEntity, 0) //nolint:prealloc // Capacity unknown as we check multiple patterns.
 
-	// Email pattern.
 	emailPattern := regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`)
 	emailMatches := emailPattern.FindAllStringIndex(text, -1)
 
@@ -289,7 +286,6 @@ func (a *Analyzer) extractPiiEntities(text string) []PiiEntity {
 		})
 	}
 
-	// Phone pattern (simple US format).
 	phonePattern := regexp.MustCompile(`\b(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b`)
 	phoneMatches := phonePattern.FindAllStringIndex(text, -1)
 
@@ -302,7 +298,6 @@ func (a *Analyzer) extractPiiEntities(text string) []PiiEntity {
 		})
 	}
 
-	// SSN pattern.
 	ssnPattern := regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`)
 	ssnMatches := ssnPattern.FindAllStringIndex(text, -1)
 
@@ -315,7 +310,6 @@ func (a *Analyzer) extractPiiEntities(text string) []PiiEntity {
 		})
 	}
 
-	// Credit card pattern (simple).
 	ccPattern := regexp.MustCompile(`\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b`)
 	ccMatches := ccPattern.FindAllStringIndex(text, -1)
 
@@ -371,7 +365,6 @@ func (a *Analyzer) tokenize(text string) []SyntaxToken {
 func (a *Analyzer) detectPiiLabels(text string) []EntityLabel {
 	labels := []EntityLabel{}
 
-	// Check for email.
 	emailPattern := regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`)
 	if emailPattern.MatchString(text) {
 		labels = append(labels, EntityLabel{
@@ -380,7 +373,6 @@ func (a *Analyzer) detectPiiLabels(text string) []EntityLabel {
 		})
 	}
 
-	// Check for phone.
 	phonePattern := regexp.MustCompile(`\b(\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b`)
 	if phonePattern.MatchString(text) {
 		labels = append(labels, EntityLabel{
@@ -389,7 +381,6 @@ func (a *Analyzer) detectPiiLabels(text string) []EntityLabel {
 		})
 	}
 
-	// Check for SSN.
 	ssnPattern := regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`)
 	if ssnPattern.MatchString(text) {
 		labels = append(labels, EntityLabel{
@@ -415,7 +406,6 @@ func isCommonWord(word string) bool {
 
 // guessEntityType guesses the entity type based on simple heuristics.
 func guessEntityType(word string) EntityType {
-	// Simple heuristics for entity type detection.
 	locationSuffixes := []string{"City", "State", "Country", "Island", "Mountain", "River", "Lake", "Street", "Avenue", "Road"}
 
 	for _, suffix := range locationSuffixes {
@@ -432,7 +422,6 @@ func guessEntityType(word string) EntityType {
 		}
 	}
 
-	// Default to person for capitalized words.
 	return EntityTypePerson
 }
 
@@ -459,32 +448,26 @@ var (
 func guessPartOfSpeech(word string) SyntaxTokenType {
 	lowerWord := strings.ToLower(word)
 
-	// Check word-based POS.
 	if pos, ok := posWordMap[lowerWord]; ok {
 		return pos
 	}
 
-	// Check for punctuation.
 	if len(word) == 1 && strings.ContainsAny(word, ".,!?;:'\"") {
 		return SyntaxTokenPunct
 	}
 
-	// Check for proper nouns (capitalized words).
 	if word != "" && unicode.IsUpper(rune(word[0])) {
 		return SyntaxTokenPropn
 	}
 
-	// Check verb suffixes.
 	if hasSuffix(lowerWord, verbSuffixes) {
 		return SyntaxTokenVerb
 	}
 
-	// Check adverb suffix.
 	if strings.HasSuffix(lowerWord, "ly") {
 		return SyntaxTokenAdv
 	}
 
-	// Check adjective suffixes.
 	if hasSuffix(lowerWord, adjSuffixes) {
 		return SyntaxTokenAdj
 	}

--- a/internal/service/configservice/storage.go
+++ b/internal/service/configservice/storage.go
@@ -202,7 +202,6 @@ func (m *MemoryStorage) PutConfigurationRecorder(_ context.Context, req *PutConf
 
 	m.Recorders[input.Name] = recorder
 
-	// Initialize status if not exists
 	if _, exists := m.RecorderStatuses[input.Name]; !exists {
 		m.RecorderStatuses[input.Name] = &ConfigurationRecorderStatus{
 			Name:       input.Name,
@@ -239,7 +238,6 @@ func (m *MemoryStorage) DescribeConfigurationRecorders(_ context.Context, names 
 	defer m.mu.RUnlock()
 
 	if len(names) == 0 {
-		// Return all recorders
 		result := make([]*ConfigurationRecorder, 0, len(m.Recorders))
 		for _, recorder := range m.Recorders {
 			result = append(result, recorder)
@@ -248,7 +246,6 @@ func (m *MemoryStorage) DescribeConfigurationRecorders(_ context.Context, names 
 		return result, nil
 	}
 
-	// Return specified recorders
 	result := make([]*ConfigurationRecorder, 0, len(names))
 
 	for _, name := range names {
@@ -382,7 +379,6 @@ func (m *MemoryStorage) DescribeConfigRules(_ context.Context, names []string) (
 	defer m.mu.RUnlock()
 
 	if len(names) == 0 {
-		// Return all rules
 		result := make([]*ConfigRule, 0, len(m.Rules))
 		for _, rule := range m.Rules {
 			result = append(result, rule)
@@ -391,7 +387,6 @@ func (m *MemoryStorage) DescribeConfigRules(_ context.Context, names []string) (
 		return result, nil
 	}
 
-	// Return specified rules
 	result := make([]*ConfigRule, 0, len(names))
 
 	for _, name := range names {
@@ -413,7 +408,6 @@ func (m *MemoryStorage) GetComplianceDetailsByConfigRule(_ context.Context, req 
 		return nil, "", &Error{Code: errNoSuchConfigRule, Message: "Config rule not found"}
 	}
 
-	// Return empty results for MVP
 	return []*EvaluationResult{}, "", nil
 }
 

--- a/internal/service/documentdb/storage.go
+++ b/internal/service/documentdb/storage.go
@@ -303,7 +303,6 @@ func (m *MemoryStorage) CreateDBInstance(_ context.Context, input *CreateDBInsta
 
 	m.Instances[input.DBInstanceIdentifier] = instance
 
-	// Add instance to cluster's DBClusterMembers if associated with a cluster.
 	if input.DBClusterIdentifier != "" {
 		if cluster, exists := m.Clusters[input.DBClusterIdentifier]; exists {
 			isWriter := len(cluster.DBClusterMembers) == 0
@@ -335,7 +334,6 @@ func (m *MemoryStorage) DeleteDBInstance(_ context.Context, identifier string, _
 
 	instance.DBInstanceStatus = DBInstanceStatusDeleting
 
-	// Remove instance from cluster's DBClusterMembers.
 	if instance.DBClusterIdentifier != "" {
 		if cluster, clusterExists := m.Clusters[instance.DBClusterIdentifier]; clusterExists {
 			members := make([]DBClusterMember, 0, len(cluster.DBClusterMembers))

--- a/internal/service/ds/storage.go
+++ b/internal/service/ds/storage.go
@@ -143,7 +143,6 @@ func (s *MemoryStorage) CreateDirectory(_ context.Context, req *CreateDirectoryR
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check for duplicate directory name.
 	for _, d := range s.Directories {
 		if d.Name == req.Name {
 			return nil, &Error{
@@ -207,25 +206,21 @@ func (s *MemoryStorage) DescribeDirectories(_ context.Context, directoryIDs []st
 	var directories []*Directory
 
 	if len(directoryIDs) > 0 {
-		// Return specific directories.
 		for _, id := range directoryIDs {
 			if d, exists := s.Directories[id]; exists {
 				directories = append(directories, d)
 			}
 		}
 	} else {
-		// Return all directories.
 		for _, d := range s.Directories {
 			directories = append(directories, d)
 		}
 	}
 
-	// Sort by directory ID for consistent pagination.
 	sort.Slice(directories, func(i, j int) bool {
 		return directories[i].DirectoryID < directories[j].DirectoryID
 	})
 
-	// Handle pagination.
 	start := 0
 
 	if nextToken != "" {
@@ -311,7 +306,6 @@ func (s *MemoryStorage) DescribeSnapshots(_ context.Context, directoryID string,
 	var snapshots []*Snapshot
 
 	if len(snapshotIDs) > 0 {
-		// Return specific snapshots.
 		for _, id := range snapshotIDs {
 			snap, exists := s.Snapshots[id]
 			if !exists {
@@ -325,7 +319,6 @@ func (s *MemoryStorage) DescribeSnapshots(_ context.Context, directoryID string,
 			snapshots = append(snapshots, snap)
 		}
 	} else {
-		// Return all snapshots.
 		for _, snap := range s.Snapshots {
 			if directoryID != "" && snap.DirectoryID != directoryID {
 				continue
@@ -335,12 +328,10 @@ func (s *MemoryStorage) DescribeSnapshots(_ context.Context, directoryID string,
 		}
 	}
 
-	// Sort by snapshot ID for consistent pagination.
 	sort.Slice(snapshots, func(i, j int) bool {
 		return snapshots[i].SnapshotID < snapshots[j].SnapshotID
 	})
 
-	// Handle pagination.
 	start := 0
 
 	if nextToken != "" {

--- a/internal/service/dynamodb/condition.go
+++ b/internal/service/dynamodb/condition.go
@@ -110,7 +110,6 @@ func parseNotExpr(expr string, item Item, values map[string]AttributeValue) (boo
 func parsePrimary(expr string, item Item, values map[string]AttributeValue) (bool, string, error) {
 	trimmed := strings.TrimSpace(expr)
 
-	// Parenthesized expression.
 	if strings.HasPrefix(trimmed, "(") {
 		inner := trimmed[1:]
 
@@ -141,12 +140,10 @@ func parsePrimary(expr string, item Item, values map[string]AttributeValue) (boo
 		}
 	}
 
-	// size() function used in comparison: size(path) op value
 	if strings.HasPrefix(trimmed, "size(") {
 		return parseSizeComparison(trimmed, item, values)
 	}
 
-	// Comparison: operand op operand
 	return parseComparison(trimmed, item, values)
 }
 
@@ -289,12 +286,10 @@ func evalContainsFunc(args []string, item Item, values map[string]AttributeValue
 //
 //nolint:gocritic // hugeParam: AttributeValue passed by value intentionally.
 func evalContains(av AttributeValue, operand AttributeValue) bool {
-	// String contains substring.
 	if av.S != nil && operand.S != nil {
 		return strings.Contains(*av.S, *operand.S)
 	}
 
-	// String set contains value.
 	if av.SS != nil && operand.S != nil {
 		for _, s := range av.SS {
 			if s == *operand.S {
@@ -305,7 +300,6 @@ func evalContains(av AttributeValue, operand AttributeValue) bool {
 		return false
 	}
 
-	// Number set contains value.
 	if av.NS != nil && operand.N != nil {
 		for _, n := range av.NS {
 			if n == *operand.N {
@@ -316,7 +310,6 @@ func evalContains(av AttributeValue, operand AttributeValue) bool {
 		return false
 	}
 
-	// List contains value.
 	if av.L != nil {
 		for _, elem := range av.L {
 			if elem == nil {
@@ -336,7 +329,6 @@ func evalContains(av AttributeValue, operand AttributeValue) bool {
 
 // parseSizeComparison parses size(path) op value.
 func parseSizeComparison(expr string, item Item, values map[string]AttributeValue) (bool, string, error) {
-	// Extract path from size(...).
 	inner := expr[5:] // skip "size("
 
 	parenDepth := 1
@@ -428,12 +420,10 @@ func parseComparison(expr string, item Item, values map[string]AttributeValue) (
 
 	rest = strings.TrimSpace(rest)
 
-	// Handle BETWEEN: operand BETWEEN operand AND operand
 	if startsWithKeyword(rest, "BETWEEN") {
 		return parseBetween(leftToken, strings.TrimSpace(rest[7:]), item, values)
 	}
 
-	// Handle IN: operand IN (operand, operand, ...)
 	if startsWithKeyword(rest, "IN") {
 		return parseIn(leftToken, strings.TrimSpace(rest[2:]), item, values)
 	}
@@ -514,7 +504,6 @@ func parseBetween(leftToken, rest string, item Item, values map[string]Attribute
 	lo := resolveOperand(loToken, item, values)
 	hi := resolveOperand(hiToken, item, values)
 
-	// val >= lo AND val <= hi
 	result := compareAttributeValues(val, lo, ">=") && compareAttributeValues(val, hi, "<=")
 
 	return result, finalRest, nil
@@ -653,12 +642,10 @@ func equalityOnly(equal bool, op string) bool {
 
 //nolint:gocritic // hugeParam: AttributeValue passed by value for comparison.
 func compareAttributeValues(a, b AttributeValue, op string) bool {
-	// String comparison.
 	if a.S != nil && b.S != nil {
 		return compareStrings(*a.S, *b.S, op)
 	}
 
-	// Number comparison.
 	if a.N != nil && b.N != nil {
 		aNum, err1 := strconv.ParseFloat(*a.N, 64)
 		bNum, err2 := strconv.ParseFloat(*b.N, 64)

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -305,7 +305,6 @@ func (s *Service) UpdateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Convert legacy AttributeUpdates to UpdateExpression if needed.
 	if req.UpdateExpression == "" && len(req.AttributeUpdates) > 0 {
 		convertAttributeUpdates(&req)
 	}
@@ -361,7 +360,6 @@ func (s *Service) Query(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Convert legacy KeyConditions to KeyConditionExpression if needed.
 	applyLegacyKeyConditions(&req)
 
 	scanForward := true

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -346,7 +346,6 @@ func (m *MemoryStorage) ListTables(_ context.Context, exclusiveStartTableName st
 
 	sort.Strings(names)
 
-	// Apply exclusive start.
 	startIdx := 0
 
 	if exclusiveStartTableName != "" {
@@ -359,7 +358,6 @@ func (m *MemoryStorage) ListTables(_ context.Context, exclusiveStartTableName st
 		}
 	}
 
-	// Apply limit.
 	endIdx := startIdx + limit
 	if endIdx > len(names) {
 		endIdx = len(names)
@@ -388,7 +386,6 @@ func (m *MemoryStorage) DescribeTable(_ context.Context, tableName string) (*Tab
 		}
 	}
 
-	// Update item count.
 	td.Table.ItemCount = int64(len(td.Items))
 
 	return td.Table, nil
@@ -413,7 +410,6 @@ func (m *MemoryStorage) PutItem(_ context.Context, tableName string, item Item, 
 
 	key := m.serializeKey(td.Table, item)
 
-	// Evaluate condition against existing item (nil if not exists).
 	var existingItem Item
 	if existing, ok := td.Items[key]; ok {
 		existingItem = existing
@@ -439,7 +435,6 @@ func (m *MemoryStorage) PutItem(_ context.Context, tableName string, item Item, 
 
 	td.Items[key] = m.copyItem(item)
 
-	// Emit stream event if streams are enabled for this table.
 	if td.Table.StreamEnabled && td.Table.LatestStreamArn != "" {
 		eventName := streams.OperationTypeInsert
 		if existingItem != nil {
@@ -499,7 +494,6 @@ func (m *MemoryStorage) DeleteItem(_ context.Context, tableName string, key Item
 
 	keyStr := m.serializeKey(td.Table, key)
 
-	// Evaluate condition against existing item.
 	var existingItem Item
 	if existing, ok := td.Items[keyStr]; ok {
 		existingItem = existing
@@ -526,7 +520,6 @@ func (m *MemoryStorage) DeleteItem(_ context.Context, tableName string, key Item
 
 		delete(td.Items, keyStr)
 
-		// Emit stream event if streams are enabled for this table.
 		if td.Table.StreamEnabled && td.Table.LatestStreamArn != "" {
 			m.emitStreamEvent(td.Table, streams.OperationTypeRemove, key, existingItem, nil)
 		}
@@ -557,7 +550,6 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 	keyStr := m.serializeKey(td.Table, key)
 	item, itemExists := td.Items[keyStr]
 
-	// Evaluate condition against the existing item (nil for a new item).
 	var condItem Item
 	if itemExists {
 		condItem = item
@@ -571,11 +563,9 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 	if itemExists {
 		oldItem = m.copyItem(item)
 	} else {
-		// Create new item with key attributes.
 		item = m.copyItem(key)
 	}
 
-	// Parse and apply update expression.
 	if updateExpr != "" {
 		updated, err := m.applyValidatedUpdateExpression(td.Table, item, updateExpr, exprNames, exprValues)
 		if err != nil {
@@ -587,7 +577,6 @@ func (m *MemoryStorage) UpdateItem(_ context.Context, tableName string, key Item
 
 	td.Items[keyStr] = item
 
-	// Emit stream event if streams are enabled for this table.
 	if td.Table.StreamEnabled && td.Table.LatestStreamArn != "" {
 		eventName := streams.OperationTypeInsert
 		if itemExists {
@@ -677,7 +666,6 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 		}
 	}
 
-	// Determine key schema to use (table, GSI, or LSI).
 	keySchema, err := resolveKeySchema(td.Table, indexName)
 	if err != nil {
 		return nil, nil, 0, err
@@ -686,7 +674,6 @@ func (m *MemoryStorage) Query(_ context.Context, tableName, indexName, keyCondEx
 	partitionKeyName := keyAttrName(keySchema, "HASH")
 	partitionKeyValue := m.extractPartitionKeyValue(keyCondExpr, partitionKeyName, exprNames, exprValues)
 
-	// Resolve expression attribute names in key condition.
 	resolvedKeyCondExpr := keyCondExpr
 	for placeholder, name := range exprNames {
 		resolvedKeyCondExpr = strings.ReplaceAll(resolvedKeyCondExpr, placeholder, name)
@@ -1203,13 +1190,11 @@ func (m *MemoryStorage) extractPartitionKeyValue(keyCondExpr, partitionKeyName s
 	}
 
 	// Simple parsing: look for "attrName = :value" pattern.
-	// Replace expression attribute names.
 	expr := keyCondExpr
 	for placeholder, name := range exprNames {
 		expr = strings.ReplaceAll(expr, placeholder, name)
 	}
 
-	// Look for partition key equality.
 	parts := strings.Split(expr, " AND ")
 
 	for _, part := range parts {
@@ -1305,13 +1290,11 @@ func (m *MemoryStorage) attributeValuesEqual(a, b AttributeValue) bool {
 // applyUpdateExpression applies an update expression to an item.
 // Supports SET, ADD, DELETE, and REMOVE clauses.
 func (m *MemoryStorage) applyUpdateExpression(item Item, updateExpr string, exprNames map[string]string, exprValues map[string]AttributeValue) Item {
-	// Replace expression attribute names.
 	expr := updateExpr
 	for placeholder, name := range exprNames {
 		expr = strings.ReplaceAll(expr, placeholder, name)
 	}
 
-	// Split expression into clauses (SET, ADD, DELETE, REMOVE).
 	clauses := parseUpdateClauses(expr)
 
 	for _, clause := range clauses {
@@ -1434,9 +1417,7 @@ func parseUpdateClauses(expr string) []updateClause {
 
 			absIdx := idx + found
 
-			// Ensure it's a keyword boundary (start of string or preceded by space).
 			if absIdx == 0 || upper[absIdx-1] == ' ' {
-				// Ensure it's followed by a space or end of string.
 				endIdx := absIdx + len(kw)
 				if endIdx >= len(upper) || upper[endIdx] == ' ' {
 					positions = append(positions, pos{idx: absIdx, action: kw})
@@ -1447,7 +1428,6 @@ func parseUpdateClauses(expr string) []updateClause {
 		}
 	}
 
-	// Sort by position.
 	sort.Slice(positions, func(i, j int) bool {
 		return positions[i].idx < positions[j].idx
 	})
@@ -1603,7 +1583,6 @@ func evaluateSetArithmetic(item Item, expr string, exprValues map[string]Attribu
 // resolveSetOperand resolves a token to an AttributeValue for SET expressions.
 // Supports: :placeholder, path, and if_not_exists(path, :default).
 func resolveSetOperand(item Item, token string, exprValues map[string]AttributeValue) AttributeValue {
-	// Handle if_not_exists(path, :default)
 	if strings.HasPrefix(token, "if_not_exists(") {
 		return resolveIfNotExists(item, token, exprValues)
 	}
@@ -1801,7 +1780,6 @@ func addNumbers(a, b string) string {
 
 	result := fa + fb
 
-	// Return integer format if result is a whole number.
 	if result == float64(int64(result)) {
 		return strconv.FormatInt(int64(result), 10)
 	}
@@ -2342,7 +2320,6 @@ func (m *MemoryStorage) TagResource(_ context.Context, resourceArn string, tags 
 
 	existing := m.Tags[resourceArn]
 
-	// Build a map of existing tags for efficient lookup.
 	tagMap := make(map[string]int, len(existing))
 	for i, tag := range existing {
 		tagMap[tag.Key] = i

--- a/internal/service/dynamodbstreams/storage.go
+++ b/internal/service/dynamodbstreams/storage.go
@@ -87,7 +87,6 @@ func (m *MemoryStorage) DescribeStream(streamARN string, _ int32, _ string) (*St
 
 // GetShardIterator creates a shard iterator for reading stream records.
 func (m *MemoryStorage) GetShardIterator(streamARN, shardID, iteratorType, _ string) (string, error) {
-	// Verify the stream and shard exist.
 	_, shards, err := m.store.DescribeStream(streamARN)
 	if err != nil {
 		return "", fmt.Errorf("get-shard-iterator failed: %w", err)
@@ -168,13 +167,11 @@ func (m *MemoryStorage) GetRecords(shardIterator string, limit int32) ([]RecordO
 		return nil, nil, fmt.Errorf("get-records failed: %w", err)
 	}
 
-	// Convert stream records to output format.
 	outputs := make([]RecordOutput, len(records))
 	for i, rec := range records {
 		outputs[i] = convertStreamRecord(rec)
 	}
 
-	// Create next iterator.
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/service/ebs/handlers.go
+++ b/internal/service/ebs/handlers.go
@@ -117,7 +117,6 @@ func (s *Service) PutSnapshotBlockHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Compute SHA256 checksum of the block data.
 	sum := sha256.Sum256(data)
 	computedChecksum := base64.StdEncoding.EncodeToString(sum[:])
 

--- a/internal/service/ec2/handlers.go
+++ b/internal/service/ec2/handlers.go
@@ -1664,8 +1664,7 @@ func convertToXMLRouteTable(rt *RouteTable) XMLRouteTable {
 // RevokeSecurityGroupIngress removes the requested rules / CIDRs
 // from the SG's ingress list. terraform aws_security_group calls this
 // on every Update where cidr_blocks shrinks, so the side effect must
-// reach storage — earlier this was a no-op stub which left stale
-// rules behind for the audit-style consumers to trip over.
+// reach storage.
 //
 // The form-converter dotted-key issue applies here too: re-parse the
 // form so IpPermissions.N.* lands in the request.

--- a/internal/service/ec2/storage.go
+++ b/internal/service/ec2/storage.go
@@ -1183,7 +1183,6 @@ func (m *MemoryStorage) AttachInternetGateway(_ context.Context, igwID, vpcID st
 		}
 	}
 
-	// Check if already attached
 	for _, attachment := range igw.Attachments {
 		if attachment.VpcID == vpcID {
 			return &Error{
@@ -1336,7 +1335,6 @@ func (m *MemoryStorage) CreateRoute(_ context.Context, req *CreateRouteRequest) 
 		}
 	}
 
-	// Check for duplicate route
 	for _, route := range rt.Routes {
 		if route.DestinationCidrBlock == req.DestinationCidrBlock {
 			return &Error{

--- a/internal/service/ecr/storage.go
+++ b/internal/service/ecr/storage.go
@@ -260,13 +260,11 @@ func (s *MemoryStorage) ListImages(_ context.Context, repositoryName string, max
 		maxResults = 100
 	}
 
-	// Collect all images into a slice for sorting
 	images := make([]*Image, 0, len(rd.Images))
 	for _, img := range rd.Images {
 		images = append(images, img)
 	}
 
-	// Sort by push date (descending - newest first)
 	sort.Slice(images, func(i, j int) bool {
 		return images[i].PushedAt.After(images[j].PushedAt)
 	})
@@ -284,7 +282,6 @@ func (s *MemoryStorage) ListImages(_ context.Context, repositoryName string, max
 		}
 	}
 
-	// Build the result slice with pagination
 	var imageIDs []*ImageIdentifier
 
 	var newNextToken string

--- a/internal/service/ecs/handlers.go
+++ b/internal/service/ecs/handlers.go
@@ -138,7 +138,6 @@ func (s *Service) ListClusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate maxResults: must be between 1 and 100 if specified
 	if req.MaxResults != 0 && (req.MaxResults < 1 || req.MaxResults > 100) {
 		writeECSError(w, "InvalidParameterException", "maxResults must be between 1 and 100", http.StatusBadRequest)
 

--- a/internal/service/ecs/storage.go
+++ b/internal/service/ecs/storage.go
@@ -210,7 +210,6 @@ func (m *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 
 	arn := m.clusterArn(name)
 
-	// Check if cluster already exists.
 	if existing, ok := m.Clusters[arn]; ok {
 		return existing, nil
 	}
@@ -244,7 +243,6 @@ func (m *MemoryStorage) DeleteCluster(_ context.Context, cluster string) (*Clust
 		}
 	}
 
-	// Check if cluster has active services or tasks.
 	if existing.ActiveServicesCount > 0 {
 		return nil, &Error{
 			Code:    "ClusterContainsServicesException",
@@ -278,7 +276,6 @@ func (m *MemoryStorage) DescribeClusters(_ context.Context, clusters []string) (
 		failures []Failure
 	)
 
-	// If no clusters specified, return all.
 	if len(clusters) == 0 {
 		for _, c := range m.Clusters {
 			result = append(result, *c)
@@ -321,7 +318,6 @@ func (m *MemoryStorage) RegisterTaskDefinition(_ context.Context, req *RegisterT
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Determine revision number.
 	revision := 1
 	if existing, ok := m.TaskDefFamilies[req.Family]; ok {
 		revision = len(existing) + 1
@@ -530,7 +526,6 @@ func (m *MemoryStorage) StopTask(_ context.Context, cluster, taskID, reason stri
 		task.Containers[i].LastStatus = statusStopped
 	}
 
-	// Update cluster task count.
 	if c, ok := m.Clusters[task.ClusterArn]; ok && c.RunningTasksCount > 0 {
 		c.RunningTasksCount--
 	}
@@ -597,7 +592,6 @@ func (m *MemoryStorage) CreateService(_ context.Context, req *CreateServiceReque
 	clusterName := extractClusterName(clusterArn)
 	arn := m.serviceArn(clusterName, req.ServiceName)
 
-	// Check if service already exists.
 	if _, ok := m.Services[arn]; ok {
 		return nil, &Error{
 			Code:    "ServiceAlreadyExistsException",
@@ -679,7 +673,6 @@ func (m *MemoryStorage) DeleteService(_ context.Context, cluster, service string
 
 	delete(m.Services, svcArn)
 
-	// Update cluster service count.
 	if c, ok := m.Clusters[svc.ClusterArn]; ok && c.ActiveServicesCount > 0 {
 		c.ActiveServicesCount--
 	}
@@ -719,7 +712,6 @@ func (m *MemoryStorage) UpdateService(_ context.Context, req *UpdateServiceReque
 		svc.PendingCount = max(*req.DesiredCount-svc.RunningCount, 0)
 	}
 
-	// Update deployment.
 	if len(svc.Deployments) > 0 {
 		svc.Deployments[0].TaskDefinition = svc.TaskDefinition
 		svc.Deployments[0].DesiredCount = svc.DesiredCount

--- a/internal/service/eks/handlers.go
+++ b/internal/service/eks/handlers.go
@@ -256,7 +256,6 @@ func (s *Service) ListNodegroups(w http.ResponseWriter, r *http.Request) {
 // extractClusterName extracts the cluster name from the URL path.
 // Expected paths: /eks/clusters/{name} or /eks/clusters/{name}/node-groups...
 func extractClusterName(path string) string {
-	// Remove leading slash and split.
 	path = strings.TrimPrefix(path, "/")
 	parts := strings.Split(path, "/")
 

--- a/internal/service/eks/storage.go
+++ b/internal/service/eks/storage.go
@@ -259,7 +259,6 @@ func (s *MemoryStorage) DeleteCluster(_ context.Context, name string) (*Cluster,
 		}
 	}
 
-	// Check if there are any nodegroups.
 	if nodegroups, ok := s.Nodegroups[name]; ok && len(nodegroups) > 0 {
 		return nil, &Error{
 			Code:    "ResourceInUseException",

--- a/internal/service/elasticache/storage.go
+++ b/internal/service/elasticache/storage.go
@@ -421,7 +421,6 @@ func (m *MemoryStorage) buildNodeGroups(input *CreateReplicationGroupInput, port
 }
 
 func (m *MemoryStorage) buildNodeGroupMembers(rgID, ngID string, replicas, port int32) []NodeGroupMember {
-	// Primary + replicas
 	totalNodes := 1 + replicas
 	members := make([]NodeGroupMember, 0, totalNodes)
 

--- a/internal/service/elbv2/storage.go
+++ b/internal/service/elbv2/storage.go
@@ -278,7 +278,6 @@ func (m *MemoryStorage) DeleteLoadBalancer(_ context.Context, loadBalancerArn st
 		}
 	}
 
-	// Delete associated listeners.
 	for arn, listener := range m.Listeners {
 		if listener.LoadBalancerArn == loadBalancerArn {
 			delete(m.Listeners, arn)
@@ -300,7 +299,6 @@ func (m *MemoryStorage) DescribeLoadBalancers(_ context.Context, arns, names []s
 	result := make([]*LoadBalancer, 0)
 
 	if len(arns) == 0 && len(names) == 0 {
-		// Return all load balancers.
 		for _, lb := range m.LoadBalancers {
 			result = append(result, lb)
 		}
@@ -308,13 +306,11 @@ func (m *MemoryStorage) DescribeLoadBalancers(_ context.Context, arns, names []s
 		return result, nil
 	}
 
-	// Filter by ARNs.
 	arnSet := make(map[string]bool)
 	for _, arn := range arns {
 		arnSet[arn] = true
 	}
 
-	// Filter by names.
 	nameSet := make(map[string]bool)
 	for _, name := range names {
 		nameSet[name] = true
@@ -484,7 +480,6 @@ func (m *MemoryStorage) DescribeTargetGroups(_ context.Context, arns, names []st
 	result := make([]*TargetGroup, 0)
 
 	if len(arns) == 0 && len(names) == 0 && lbArn == "" {
-		// Return all target groups.
 		for _, tg := range m.TargetGroups {
 			result = append(result, tg)
 		}
@@ -492,13 +487,11 @@ func (m *MemoryStorage) DescribeTargetGroups(_ context.Context, arns, names []st
 		return result, nil
 	}
 
-	// Filter by ARNs.
 	arnSet := make(map[string]bool)
 	for _, arn := range arns {
 		arnSet[arn] = true
 	}
 
-	// Filter by names.
 	nameSet := make(map[string]bool)
 	for _, name := range names {
 		nameSet[name] = true
@@ -605,11 +598,9 @@ func (m *MemoryStorage) CreateListener(_ context.Context, req *CreateListenerReq
 
 	listenerID := uuid.New().String()[:17]
 
-	// Parse load balancer ID from ARN for listener ARN.
 	lbIDStart := len(req.LoadBalancerArn) - 17
 	lbID := req.LoadBalancerArn[lbIDStart:]
 
-	// Get load balancer type from the ARN.
 	lbType := lb.Type[:3]
 
 	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:%s:%s:listener/%s/%s/%s/%s",

--- a/internal/service/emrserverless/handlers.go
+++ b/internal/service/emrserverless/handlers.go
@@ -331,7 +331,6 @@ func extractApplicationID(path string) string {
 
 	remainder := strings.TrimPrefix(path, prefix)
 
-	// Remove any trailing path segments.
 	if idx := strings.Index(remainder, "/"); idx != -1 {
 		remainder = remainder[:idx]
 	}
@@ -367,7 +366,6 @@ func extractApplicationIDFromJobRuns(path string) string {
 
 	remainder := strings.TrimPrefix(path, prefix)
 
-	// Find the /jobruns part.
 	idx := strings.Index(remainder, "/jobruns")
 	if idx == -1 {
 		return ""
@@ -386,7 +384,6 @@ func extractApplicationAndJobRunID(path string) (string, string) {
 
 	remainder := strings.TrimPrefix(path, prefix)
 
-	// Split by /jobruns/.
 	parts := strings.Split(remainder, "/jobruns/")
 	if len(parts) != 2 {
 		return "", ""
@@ -395,7 +392,6 @@ func extractApplicationAndJobRunID(path string) (string, string) {
 	applicationID := parts[0]
 	jobRunID := parts[1]
 
-	// Remove any trailing path segments from jobRunID.
 	if idx := strings.Index(jobRunID, "/"); idx != -1 {
 		jobRunID = jobRunID[:idx]
 	}

--- a/internal/service/emrserverless/storage.go
+++ b/internal/service/emrserverless/storage.go
@@ -275,7 +275,6 @@ func (m *MemoryStorage) ListApplications(_ context.Context, req *ListApplication
 	var summaries []*ApplicationSummary
 
 	for _, app := range m.Applications {
-		// Apply state filter.
 		if len(stateFilter) > 0 && !stateFilter[app.State] {
 			continue
 		}
@@ -326,7 +325,6 @@ func (m *MemoryStorage) UpdateApplication(_ context.Context, req *UpdateApplicat
 		}
 	}
 
-	// Update fields.
 	if req.Architecture != "" {
 		app.Architecture = req.Architecture
 	}
@@ -387,7 +385,6 @@ func (m *MemoryStorage) DeleteApplication(_ context.Context, applicationID strin
 		}
 	}
 
-	// Check for running job runs.
 	for _, jr := range m.JobRuns[applicationID] {
 		if jr.State == JobRunStateRunning || jr.State == JobRunStatePending || jr.State == JobRunStateScheduled {
 			return &Error{
@@ -397,7 +394,6 @@ func (m *MemoryStorage) DeleteApplication(_ context.Context, applicationID strin
 		}
 	}
 
-	// Mark as terminated and delete.
 	app.State = ApplicationStateTerminated
 	app.UpdatedAt = AWSTimestamp{Time: time.Now()}
 
@@ -597,12 +593,10 @@ func (m *MemoryStorage) ListJobRuns(_ context.Context, req *ListJobRunsInput) (*
 	var summaries []*JobRunSummary
 
 	for _, jr := range m.JobRuns[req.ApplicationID] {
-		// Apply state filter.
 		if len(stateFilter) > 0 && !stateFilter[jr.State] {
 			continue
 		}
 
-		// Apply mode filter.
 		if req.Mode != "" && jr.Mode != req.Mode {
 			continue
 		}

--- a/internal/service/eventbridge/storage.go
+++ b/internal/service/eventbridge/storage.go
@@ -155,7 +155,6 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 		_ = storage.Load(s.dataDir, "eventbridge", s)
 	}
 
-	// Create default event bus if not present.
 	if _, exists := s.EventBuses[defaultEventBusName]; !exists {
 		now := time.Now()
 		s.EventBuses[defaultEventBusName] = &EventBus{
@@ -285,7 +284,6 @@ func (s *MemoryStorage) DeleteEventBus(_ context.Context, name string) error {
 	delete(s.EventBuses, name)
 	delete(s.Rules, name)
 
-	// Delete all targets for rules on this event bus.
 	for key := range s.Targets {
 		if strings.HasPrefix(key, name+":") {
 			delete(s.Targets, key)
@@ -407,7 +405,6 @@ func (s *MemoryStorage) DeleteRule(_ context.Context, eventBusName, ruleName str
 
 	delete(rules, ruleName)
 
-	// Delete targets for this rule.
 	targetKey := eventBusName + ":" + ruleName
 	delete(s.Targets, targetKey)
 
@@ -674,17 +671,14 @@ func (s *MemoryStorage) matchAndDeliver(eventID, eventBusName string, entry *Put
 
 			payload := s.buildEventPayload(eventID, eventBusName, target, entry)
 
-			// Deliver to API Destination via HTTP if the target ARN is an API destination.
 			if dest := s.resolveAPIDestination(target.Arn); dest != nil {
 				go s.deliverToHTTP(dest, target, payload)
 			}
 
-			// Deliver to SQS if the target ARN is an SQS queue.
 			if isSQSArn(target.Arn) {
 				go s.deliverToSQS(target, payload)
 			}
 
-			// Deliver to Lambda if the target ARN is a Lambda function.
 			if isLambdaArn(target.Arn) {
 				go s.deliverToLambda(target, payload)
 			}
@@ -726,14 +720,12 @@ func (s *MemoryStorage) buildEventPayload(eventID, eventBusName string, target *
 		return nil
 	}
 
-	// Apply InputTransformer if set on the target.
 	if target.InputTransformer != nil {
 		if transformed := applyInputTransformer(body, target.InputTransformer); transformed != nil {
 			return transformed
 		}
 	}
 
-	// Apply InputPath if set on the target.
 	if target.InputPath != "" {
 		if resolved := resolveInputPath(body, target.InputPath); resolved != nil {
 			return resolved
@@ -787,7 +779,6 @@ func applyInputTransformer(payload []byte, transformer *InputTransformer) []byte
 		return nil
 	}
 
-	// Extract values using InputPathsMap.
 	values := make(map[string]any, len(transformer.InputPathsMap))
 	for key, path := range transformer.InputPathsMap {
 		values[key] = extractJSONPath(event, path)

--- a/internal/service/finspace/storage.go
+++ b/internal/service/finspace/storage.go
@@ -180,7 +180,6 @@ func (s *MemoryStorage) CreateKxEnvironment(_ context.Context, req *CreateKxEnvi
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check for duplicate name
 	for _, env := range s.Environments {
 		if env.Name == req.Name {
 			return nil, &Error{
@@ -350,7 +349,6 @@ func (s *MemoryStorage) CreateKxDatabase(_ context.Context, req *CreateKxDatabas
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check if environment exists
 	if _, exists := s.Environments[req.EnvironmentID]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -360,7 +358,6 @@ func (s *MemoryStorage) CreateKxDatabase(_ context.Context, req *CreateKxDatabas
 
 	key := fmt.Sprintf("%s/%s", req.EnvironmentID, req.DatabaseName)
 
-	// Check for duplicate
 	if _, exists := s.Databases[key]; exists {
 		return nil, &Error{
 			Code:    errConflict,
@@ -514,7 +511,6 @@ func (s *MemoryStorage) CreateKxUser(_ context.Context, req *CreateKxUserRequest
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check if environment exists
 	if _, exists := s.Environments[req.EnvironmentID]; !exists {
 		return nil, &Error{
 			Code:    errResourceNotFound,
@@ -524,7 +520,6 @@ func (s *MemoryStorage) CreateKxUser(_ context.Context, req *CreateKxUserRequest
 
 	key := fmt.Sprintf("%s/%s", req.EnvironmentID, req.UserName)
 
-	// Check for duplicate
 	if _, exists := s.Users[key]; exists {
 		return nil, &Error{
 			Code:    errConflict,
@@ -617,7 +612,6 @@ func (s *MemoryStorage) ListKxUsers(_ context.Context, environmentID string, max
 	users := make([]*KxUser, 0)
 
 	for key, user := range s.Users {
-		// Check if the key starts with the environmentID
 		if len(key) > len(environmentID) && key[:len(environmentID)] == environmentID && key[len(environmentID)] == '/' {
 			users = append(users, user)
 

--- a/internal/service/firehose/storage.go
+++ b/internal/service/firehose/storage.go
@@ -233,7 +233,6 @@ func (s *MemoryStorage) buildDestinations(input *CreateDeliveryStreamInput) []De
 		destinations = append(destinations, dest)
 	}
 
-	// If no destination is provided, create a default.
 	if len(destinations) == 0 {
 		destinations = append(destinations, DestinationDescription{
 			DestinationID: destID,

--- a/internal/service/forecast/storage.go
+++ b/internal/service/forecast/storage.go
@@ -175,7 +175,6 @@ func (m *MemoryStorage) CreateDataset(_ context.Context, req *CreateDatasetInput
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Check for duplicate name.
 	for _, ds := range m.Datasets {
 		if ds.DatasetName == req.DatasetName {
 			return "", &Error{
@@ -185,7 +184,6 @@ func (m *MemoryStorage) CreateDataset(_ context.Context, req *CreateDatasetInput
 		}
 	}
 
-	// Validate dataset type.
 	if !isValidDatasetType(req.DatasetType) {
 		return "", &Error{
 			Code:    errInvalidInputException,
@@ -193,7 +191,6 @@ func (m *MemoryStorage) CreateDataset(_ context.Context, req *CreateDatasetInput
 		}
 	}
 
-	// Validate domain.
 	if !isValidDomain(req.Domain) {
 		return "", &Error{
 			Code:    errInvalidInputException,
@@ -282,7 +279,6 @@ func (m *MemoryStorage) DeleteDataset(_ context.Context, datasetArn string) erro
 		}
 	}
 
-	// Check if dataset is in use by any dataset group.
 	for _, dg := range m.DatasetGroups {
 		if slices.Contains(dg.DatasetArns, datasetArn) {
 			return &Error{
@@ -306,7 +302,6 @@ func (m *MemoryStorage) CreateDatasetGroup(_ context.Context, req *CreateDataset
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Check for duplicate name.
 	for _, dg := range m.DatasetGroups {
 		if dg.DatasetGroupName == req.DatasetGroupName {
 			return "", &Error{
@@ -316,7 +311,6 @@ func (m *MemoryStorage) CreateDatasetGroup(_ context.Context, req *CreateDataset
 		}
 	}
 
-	// Validate domain.
 	if !isValidDomain(req.Domain) {
 		return "", &Error{
 			Code:    errInvalidInputException,
@@ -324,7 +318,6 @@ func (m *MemoryStorage) CreateDatasetGroup(_ context.Context, req *CreateDataset
 		}
 	}
 
-	// Validate dataset ARNs exist and have matching domain.
 	for _, dsArn := range req.DatasetArns {
 		ds, exists := m.Datasets[dsArn]
 		if !exists {
@@ -418,7 +411,6 @@ func (m *MemoryStorage) DeleteDatasetGroup(_ context.Context, datasetGroupArn st
 		}
 	}
 
-	// Check if dataset group is in use by any predictor.
 	for _, p := range m.Predictors {
 		if p.InputDataConfig != nil && p.InputDataConfig.DatasetGroupArn == datasetGroupArn {
 			return &Error{
@@ -448,7 +440,6 @@ func (m *MemoryStorage) UpdateDatasetGroup(_ context.Context, datasetGroupArn st
 		}
 	}
 
-	// Validate dataset ARNs exist and have matching domain.
 	for _, dsArn := range datasetArns {
 		ds, dsExists := m.Datasets[dsArn]
 		if !dsExists {
@@ -520,7 +511,6 @@ func (m *MemoryStorage) CreatePredictor(_ context.Context, req *CreatePredictorI
 // validateCreatePredictor validates a CreatePredictor request and returns the
 // resolved dataset group. It must be called with m.mu held.
 func (m *MemoryStorage) validateCreatePredictor(req *CreatePredictorInput) (*DatasetGroup, *Error) {
-	// Check for duplicate name.
 	for _, p := range m.Predictors {
 		if p.PredictorName == req.PredictorName {
 			return nil, &Error{
@@ -588,7 +578,6 @@ func (m *MemoryStorage) ListPredictors(_ context.Context, maxResults *int32, _ s
 			break
 		}
 
-		// Apply filters.
 		if !matchesFilters(p, filters) {
 			continue
 		}
@@ -624,7 +613,6 @@ func (m *MemoryStorage) DeletePredictor(_ context.Context, predictorArn string) 
 		}
 	}
 
-	// Check if predictor is in use by any forecast.
 	for _, f := range m.Forecasts {
 		if f.PredictorArn == predictorArn {
 			return &Error{
@@ -648,7 +636,6 @@ func (m *MemoryStorage) CreateForecast(_ context.Context, req *CreateForecastInp
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Check for duplicate name.
 	for _, f := range m.Forecasts {
 		if f.ForecastName == req.ForecastName {
 			return "", &Error{
@@ -658,7 +645,6 @@ func (m *MemoryStorage) CreateForecast(_ context.Context, req *CreateForecastInp
 		}
 	}
 
-	// Validate predictor exists.
 	predictor, exists := m.Predictors[req.PredictorArn]
 	if !exists {
 		return "", &Error{
@@ -732,7 +718,6 @@ func (m *MemoryStorage) ListForecasts(_ context.Context, maxResults *int32, _ st
 			break
 		}
 
-		// Apply filters.
 		if !matchesForecastFilters(f, filters) {
 			continue
 		}

--- a/internal/service/gamelift/storage.go
+++ b/internal/service/gamelift/storage.go
@@ -319,7 +319,6 @@ func (m *MemoryStorage) DescribeFleetAttributes(_ context.Context, fleetIDs []st
 	defer m.mu.RUnlock()
 
 	if len(fleetIDs) == 0 {
-		// Return all fleets
 		result := make([]*Fleet, 0, len(m.Fleets))
 		for _, fleet := range m.Fleets {
 			result = append(result, fleet)
@@ -328,7 +327,6 @@ func (m *MemoryStorage) DescribeFleetAttributes(_ context.Context, fleetIDs []st
 		return result, nil
 	}
 
-	// Return specified fleets
 	result := make([]*Fleet, 0, len(fleetIDs))
 
 	for _, fleetID := range fleetIDs {

--- a/internal/service/globalaccelerator/storage.go
+++ b/internal/service/globalaccelerator/storage.go
@@ -173,7 +173,6 @@ func (s *MemoryStorage) CreateAccelerator(_ context.Context, req *CreateAccelera
 		ipAddressType = IPAddressType(req.IPAddressType)
 	}
 
-	// Generate static IP addresses.
 	ipSets := []IPSet{
 		{
 			IPFamily:        "IPv4",
@@ -245,7 +244,6 @@ func (s *MemoryStorage) ListAccelerators(_ context.Context, maxResults int32, ne
 
 	sort.Strings(arns)
 
-	// Find starting index based on nextToken.
 	startIdx := 0
 
 	if nextToken != "" {
@@ -258,13 +256,11 @@ func (s *MemoryStorage) ListAccelerators(_ context.Context, maxResults int32, ne
 		}
 	}
 
-	// Collect accelerators from startIdx up to maxResults.
 	accelerators := make([]*Accelerator, 0, maxResults)
 	for i := startIdx; i < len(arns) && len(accelerators) < int(maxResults); i++ {
 		accelerators = append(accelerators, s.Accelerators[arns[i]])
 	}
 
-	// Determine next token.
 	var newNextToken string
 	if startIdx+int(maxResults) < len(arns) {
 		newNextToken = arns[startIdx+int(maxResults)]
@@ -316,10 +312,8 @@ func (s *MemoryStorage) DeleteAccelerator(_ context.Context, arn string) error {
 		return &ServiceError{Code: errAcceleratorEnabled, Message: "Accelerator must be disabled before deletion"}
 	}
 
-	// Delete associated listeners and endpoint groups.
 	for listenerArn, listener := range s.Listeners {
 		if listener.AcceleratorArn == arn {
-			// Delete endpoint groups for this listener.
 			for egArn, eg := range s.EndpointGroups {
 				if eg.ListenerArn == listenerArn {
 					delete(s.EndpointGroups, egArn)
@@ -342,7 +336,6 @@ func (s *MemoryStorage) CreateListener(_ context.Context, req *CreateListenerReq
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Verify accelerator exists.
 	if _, ok := s.Accelerators[req.AcceleratorArn]; !ok {
 		return nil, &ServiceError{Code: errNotFound, Message: "Accelerator not found"}
 	}
@@ -452,7 +445,6 @@ func (s *MemoryStorage) DeleteListener(_ context.Context, arn string) error {
 		return &ServiceError{Code: errListenerNotFound, Message: "Listener not found"}
 	}
 
-	// Delete associated endpoint groups.
 	for egArn, eg := range s.EndpointGroups {
 		if eg.ListenerArn == arn {
 			delete(s.EndpointGroups, egArn)
@@ -471,7 +463,6 @@ func (s *MemoryStorage) CreateEndpointGroup(_ context.Context, req *CreateEndpoi
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Verify listener exists.
 	if _, ok := s.Listeners[req.ListenerArn]; !ok {
 		return nil, &ServiceError{Code: errListenerNotFound, Message: "Listener not found"}
 	}

--- a/internal/service/glue/storage.go
+++ b/internal/service/glue/storage.go
@@ -296,7 +296,6 @@ func (s *MemoryStorage) CreateTable(_ context.Context, catalogID, databaseName s
 		}
 	}
 
-	// Check if database exists.
 	dbKey := databaseKey(catalogID, databaseName)
 	if _, exists := s.Databases[dbKey]; !exists {
 		return &Error{

--- a/internal/service/iam/handlers.go
+++ b/internal/service/iam/handlers.go
@@ -1016,13 +1016,11 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // getFormValue extracts a form value from the request.
 // It tries JSON body first, then form values.
 func getFormValue(r *http.Request, key string) string {
-	// Try to read from JSON body if content type is JSON.
 	contentType := r.Header.Get("Content-Type")
 	if strings.Contains(contentType, "application/json") || strings.Contains(contentType, "application/x-amz-json") {
 		return getJSONValue(r, key)
 	}
 
-	// Parse form if not already parsed.
 	if r.Form == nil {
 		_ = r.ParseForm()
 	}

--- a/internal/service/kafka/storage.go
+++ b/internal/service/kafka/storage.go
@@ -171,7 +171,6 @@ func (s *MemoryStorage) CreateCluster(_ context.Context, req *CreateClusterReque
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check for duplicate cluster name.
 	for _, c := range s.Clusters {
 		if c.ClusterName == req.ClusterName {
 			return nil, &Error{
@@ -325,7 +324,6 @@ func (s *MemoryStorage) UpdateClusterConfiguration(_ context.Context, clusterArn
 		}
 	}
 
-	// Update version.
 	cluster.CurrentVersion = "K2" + uuid.New().String()[:8]
 
 	s.saveLocked()

--- a/internal/service/kinesis/handlers.go
+++ b/internal/service/kinesis/handlers.go
@@ -75,7 +75,6 @@ func (s *Service) DeleteStream(w http.ResponseWriter, r *http.Request) {
 
 	streamName := req.StreamName
 	if streamName == "" && req.StreamARN != "" {
-		// Extract stream name from ARN.
 		parts := strings.Split(req.StreamARN, "/")
 		if len(parts) >= 2 {
 			streamName = parts[len(parts)-1]
@@ -231,7 +230,6 @@ func (s *Service) ListStreams(w http.ResponseWriter, r *http.Request) {
 		StreamSummaries: streamSummaries,
 	}
 
-	// Set NextToken for pagination if there are more streams.
 	if hasMoreStreams && len(streamNames) > 0 {
 		resp.NextToken = streamNames[len(streamNames)-1]
 	}

--- a/internal/service/kinesis/storage.go
+++ b/internal/service/kinesis/storage.go
@@ -325,7 +325,6 @@ func (s *MemoryStorage) DescribeStream(_ context.Context, streamName string, lim
 		return nil, nil, false, &ServiceError{Code: errResourceNotFound, Message: "Stream not found"}
 	}
 
-	// Collect and sort shards.
 	shards := make([]*Shard, 0, len(sd.Shards))
 	for _, shardData := range sd.Shards {
 		shards = append(shards, shardData.Shard)
@@ -335,7 +334,6 @@ func (s *MemoryStorage) DescribeStream(_ context.Context, streamName string, lim
 		return shards[i].ShardID < shards[j].ShardID
 	})
 
-	// Apply pagination.
 	startIndex := 0
 
 	if exclusiveStartShardID != "" {
@@ -373,7 +371,6 @@ func (s *MemoryStorage) ListStreams(_ context.Context, exclusiveStartStreamName 
 		limit = 100
 	}
 
-	// Collect and sort stream names.
 	names := make([]string, 0, len(s.Streams))
 	for name := range s.Streams {
 		names = append(names, name)
@@ -381,7 +378,6 @@ func (s *MemoryStorage) ListStreams(_ context.Context, exclusiveStartStreamName 
 
 	sort.Strings(names)
 
-	// Apply pagination.
 	startIndex := 0
 
 	if exclusiveStartStreamName != "" {
@@ -425,7 +421,6 @@ func (s *MemoryStorage) ListShards(_ context.Context, streamName, _ string, maxR
 		maxResults = 100
 	}
 
-	// Collect and sort shards.
 	shards := make([]*Shard, 0, len(sd.Shards))
 	for _, shardData := range sd.Shards {
 		shards = append(shards, shardData.Shard)
@@ -456,7 +451,6 @@ func (s *MemoryStorage) PutRecord(_ context.Context, streamName string, data []b
 		return "", "", &ServiceError{Code: errInvalidArgument, Message: "Invalid PartitionKey"}
 	}
 
-	// Determine shard based on hash key.
 	hashKey := explicitHashKey
 	if hashKey == "" {
 		hashKey = computeHashKey(partitionKey)
@@ -631,7 +625,6 @@ func (s *MemoryStorage) GetRecords(_ context.Context, shardIterator string, limi
 	records := make([]*Record, endPos-startPos)
 	copy(records, shardData.Records[startPos:endPos])
 
-	// Create next iterator.
 	delete(s.shardIterators, shardIterator)
 
 	nextIteratorID := fmt.Sprintf("%s:%s:%d:%d", iterData.streamName, iterData.shardID, endPos, time.Now().UnixNano())

--- a/internal/service/kms/handlers.go
+++ b/internal/service/kms/handlers.go
@@ -590,7 +590,6 @@ func (s *Service) ListKeyPolicies(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify the key exists.
 	if _, err := s.storage.GetKey(r.Context(), req.KeyID); err != nil {
 		handleKMSError(w, err)
 

--- a/internal/service/kms/storage.go
+++ b/internal/service/kms/storage.go
@@ -300,7 +300,6 @@ func (s *MemoryStorage) GetKey(_ context.Context, keyID string) (*Key, error) {
 
 // getKeyLocked retrieves a key without locking (caller must hold lock).
 func (s *MemoryStorage) getKeyLocked(keyID string) (*Key, error) {
-	// Check if it's an alias.
 	if len(keyID) > 6 && keyID[:6] == "alias/" {
 		alias, ok := s.Aliases[keyID]
 		if !ok {
@@ -310,9 +309,7 @@ func (s *MemoryStorage) getKeyLocked(keyID string) (*Key, error) {
 		keyID = alias.TargetKeyID
 	}
 
-	// Check if it's an ARN.
 	if len(keyID) > 8 && keyID[:8] == "arn:aws:" {
-		// Extract key ID from ARN.
 		for _, key := range s.Keys {
 			if key.Arn == keyID {
 				return key, nil
@@ -322,7 +319,6 @@ func (s *MemoryStorage) getKeyLocked(keyID string) (*Key, error) {
 		return nil, &ServiceError{Code: errNotFound, Message: "Key " + keyID + " is not found."}
 	}
 
-	// Look up by key ID.
 	key, ok := s.Keys[keyID]
 	if !ok {
 		return nil, &ServiceError{Code: errNotFound, Message: "Key " + keyID + " is not found."}
@@ -575,7 +571,6 @@ func (s *MemoryStorage) GenerateDataKey(_ context.Context, keyID, keySpec string
 
 	keySize := determineKeySize(keySpec, numberOfBytes)
 
-	// Generate plaintext data key.
 	plaintext := make([]byte, keySize)
 	if _, err := io.ReadFull(rand.Reader, plaintext); err != nil {
 		return nil, nil, &ServiceError{Code: errDependencyTimeout, Message: "Failed to generate data key"}
@@ -696,17 +691,14 @@ func (s *MemoryStorage) CreateAlias(_ context.Context, aliasName, targetKeyID st
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Validate alias name.
 	if len(aliasName) < 7 || aliasName[:6] != "alias/" {
 		return &ServiceError{Code: errInvalidAlias, Message: "Alias must begin with 'alias/'"}
 	}
 
-	// Check if alias already exists.
 	if _, ok := s.Aliases[aliasName]; ok {
 		return &ServiceError{Code: errAlreadyExists, Message: "Alias " + aliasName + " already exists."}
 	}
 
-	// Verify target key exists.
 	key, err := s.getKeyLocked(targetKeyID)
 	if err != nil {
 		return err

--- a/internal/service/lambda/handlers.go
+++ b/internal/service/lambda/handlers.go
@@ -656,7 +656,6 @@ func (s *Service) DeleteEventSourceMapping(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Return the mapping with state set to Deleting
 	mapping.State = "Deleting"
 	writeJSONResponse(w, http.StatusOK, mapping)
 }

--- a/internal/service/lambda/storage.go
+++ b/internal/service/lambda/storage.go
@@ -451,7 +451,6 @@ func (s *MemoryStorage) AddPermission(_ context.Context, functionName string, st
 		}
 	}
 
-	// Check for duplicate statement ID.
 	for _, existing := range fn.Policy.Statements {
 		if existing.Sid == stmt.Sid {
 			return &FunctionError{
@@ -663,7 +662,6 @@ func (s *MemoryStorage) CreateEventSourceMapping(_ context.Context, req *CreateE
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Validate function exists
 	fn, exists := s.Functions[req.FunctionName]
 	if !exists {
 		return nil, &FunctionError{
@@ -672,7 +670,6 @@ func (s *MemoryStorage) CreateEventSourceMapping(_ context.Context, req *CreateE
 		}
 	}
 
-	// Generate UUID
 	mappingUUID := generateUUID()
 
 	// Set defaults
@@ -739,7 +736,6 @@ func (s *MemoryStorage) DeleteEventSourceMapping(_ context.Context, uuid string)
 		}
 	}
 
-	// Mark as deleting state before removing
 	mapping.State = "Deleting"
 
 	delete(s.EventSourceMappings, uuid)
@@ -762,12 +758,10 @@ func (s *MemoryStorage) ListEventSourceMappings(_ context.Context, functionName,
 	var mappings []*EventSourceMapping
 
 	for _, m := range s.EventSourceMappings {
-		// Filter by function name if specified
 		if functionName != "" && !matchesFunctionName(m.FunctionArn, functionName) {
 			continue
 		}
 
-		// Filter by event source ARN if specified
 		if eventSourceArn != "" && m.EventSourceArn != eventSourceArn {
 			continue
 		}
@@ -816,7 +810,6 @@ func (s *MemoryStorage) UpdateEventSourceMapping(_ context.Context, uuid string,
 		}
 	}
 
-	// Update function ARN if function name is specified
 	if req.FunctionName != "" {
 		fn, fnExists := s.Functions[req.FunctionName]
 		if !fnExists {
@@ -876,7 +869,6 @@ func matchesFunctionName(functionArn, functionName string) bool {
 		return true
 	}
 
-	// Extract function name from ARN
 	// ARN format: arn:aws:lambda:region:account:function:name
 	parts := splitARN(functionArn)
 	if len(parts) >= 7 && parts[6] == functionName {

--- a/internal/service/mq/storage.go
+++ b/internal/service/mq/storage.go
@@ -144,7 +144,6 @@ func (s *MemoryStorage) CreateBroker(_ context.Context, req *CreateBrokerRequest
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check for duplicate broker name
 	for _, b := range s.Brokers {
 		if b.BrokerName == req.BrokerName {
 			return nil, &Error{
@@ -234,18 +233,15 @@ func (s *MemoryStorage) ListBrokers(_ context.Context, maxResults int, nextToken
 		maxResults = 100
 	}
 
-	// Collect all brokers
 	brokers := make([]*Broker, 0, len(s.Brokers))
 	for _, b := range s.Brokers {
 		brokers = append(brokers, b)
 	}
 
-	// Sort by broker name for consistent pagination
 	sort.Slice(brokers, func(i, j int) bool {
 		return brokers[i].BrokerName < brokers[j].BrokerName
 	})
 
-	// Handle pagination
 	start := 0
 
 	if nextToken != "" {
@@ -309,7 +305,6 @@ func (s *MemoryStorage) CreateConfiguration(_ context.Context, req *CreateConfig
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check for duplicate configuration name
 	for _, c := range s.Configurations {
 		if c.Name == req.Name {
 			return nil, &Error{

--- a/internal/service/organizations/storage.go
+++ b/internal/service/organizations/storage.go
@@ -227,7 +227,6 @@ func (m *MemoryStorage) Close() error {
 }
 
 func (m *MemoryStorage) initializeDefaultPolicy() {
-	// Create a default full access SCP.
 	defaultSCPID := "p-FullAWSAccess"
 	m.Policies[defaultSCPID] = &Policy{
 		Content: `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`,
@@ -273,7 +272,6 @@ func (m *MemoryStorage) CreateOrganization(_ context.Context, featureSet string)
 		}
 	}
 
-	// Create the root.
 	m.Root = &Root{
 		ARN:  fmt.Sprintf("arn:aws:organizations::%s:root/%s/%s", m.accountID, orgID, rootID),
 		ID:   rootID,
@@ -286,7 +284,6 @@ func (m *MemoryStorage) CreateOrganization(_ context.Context, featureSet string)
 		}
 	}
 
-	// Add the management account.
 	m.Accounts[m.accountID] = &Account{
 		ARN:             m.Organization.MasterAccountARN,
 		Email:           m.Organization.MasterAccountEmail,
@@ -298,7 +295,6 @@ func (m *MemoryStorage) CreateOrganization(_ context.Context, featureSet string)
 		Status:          accountStatusActive,
 	}
 
-	// Attach the default SCP to the root.
 	m.PolicyAttachments[rootID] = map[string]bool{
 		"p-FullAWSAccess": true,
 	}
@@ -322,12 +318,10 @@ func (m *MemoryStorage) DeleteOrganization(_ context.Context) error {
 		return &Error{Code: errOrganizationNotEmptyException, Message: "Organization still has member accounts"}
 	}
 
-	// Check if there are any OUs.
 	if len(m.OrganizationalUnits) > 0 {
 		return &Error{Code: errOrganizationNotEmptyException, Message: "Organization still has organizational units"}
 	}
 
-	// Delete the organization.
 	m.Organization = nil
 	m.Root = nil
 	m.Accounts = make(map[string]*Account)
@@ -363,12 +357,10 @@ func (m *MemoryStorage) CreateAccount(_ context.Context, req *CreateAccountInput
 		return nil, &Error{Code: errInvalidInputException, Message: "AccountName and Email are required"}
 	}
 
-	// Generate a new account ID.
 	accountID := generateAccountID()
 	requestID := uuid.New().String()
 	now := time.Now()
 
-	// Create the account.
 	account := &Account{
 		ARN:             fmt.Sprintf("arn:aws:organizations::%s:account/%s/%s", m.accountID, m.Organization.ID, accountID),
 		Email:           req.Email,
@@ -382,14 +374,12 @@ func (m *MemoryStorage) CreateAccount(_ context.Context, req *CreateAccountInput
 
 	m.Accounts[accountID] = account
 
-	// Attach the default SCP to the new account.
 	m.PolicyAttachments[accountID] = map[string]bool{
 		"p-FullAWSAccess": true,
 	}
 
 	m.saveLocked()
 
-	// Create the status.
 	status := &CreateAccountStatus{
 		AccountID:          accountID,
 		AccountName:        req.AccountName,
@@ -451,19 +441,16 @@ func (m *MemoryStorage) CreateOrganizationalUnit(_ context.Context, name, parent
 		return nil, &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
-	// Validate parent ID.
 	if !m.isValidParentID(parentID) {
 		return nil, &Error{Code: errParentNotFoundException, Message: "Parent not found: " + parentID}
 	}
 
-	// Check for duplicate OU name under the same parent.
 	for ouID, ou := range m.OrganizationalUnits {
 		if m.OuParents[ouID] == parentID && ou.Name == name {
 			return nil, &Error{Code: errDuplicateOrganizationalUnitException, Message: "OU with this name already exists under the parent"}
 		}
 	}
 
-	// Generate OU ID.
 	ouID := fmt.Sprintf("ou-%s-%s", generateShortID()[:4], generateShortID()[:8])
 
 	ou := &OrganizationalUnit{
@@ -475,7 +462,6 @@ func (m *MemoryStorage) CreateOrganizationalUnit(_ context.Context, name, parent
 	m.OrganizationalUnits[ouID] = ou
 	m.OuParents[ouID] = parentID
 
-	// Attach the default SCP to the new OU.
 	m.PolicyAttachments[ouID] = map[string]bool{
 		"p-FullAWSAccess": true,
 	}
@@ -494,7 +480,6 @@ func (m *MemoryStorage) ListOrganizationalUnitsForParent(_ context.Context, pare
 		return nil, "", &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
-	// Validate parent ID.
 	if !m.isValidParentID(parentID) {
 		return nil, "", &Error{Code: errParentNotFoundException, Message: "Parent not found: " + parentID}
 	}
@@ -524,24 +509,20 @@ func (m *MemoryStorage) AttachPolicy(_ context.Context, policyID, targetID strin
 		return &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
-	// Validate policy ID.
 	if _, exists := m.Policies[policyID]; !exists {
 		return &Error{Code: errPolicyNotFoundException, Message: "Policy not found: " + policyID}
 	}
 
-	// Validate target ID.
 	if !m.isValidTargetID(targetID) {
 		return &Error{Code: errInvalidInputException, Message: "Invalid target ID: " + targetID}
 	}
 
-	// Check if already attached.
 	if attachments, exists := m.PolicyAttachments[targetID]; exists {
 		if attachments[policyID] {
 			return &Error{Code: errDuplicatePolicyAttachmentException, Message: "Policy is already attached to the target"}
 		}
 	}
 
-	// Attach the policy.
 	if m.PolicyAttachments[targetID] == nil {
 		m.PolicyAttachments[targetID] = make(map[string]bool)
 	}
@@ -562,23 +543,19 @@ func (m *MemoryStorage) DetachPolicy(_ context.Context, policyID, targetID strin
 		return &Error{Code: errAWSOrganizationsNotInUseException, Message: "Your account is not a member of an organization"}
 	}
 
-	// Validate policy ID.
 	if _, exists := m.Policies[policyID]; !exists {
 		return &Error{Code: errPolicyNotFoundException, Message: "Policy not found: " + policyID}
 	}
 
-	// Validate target ID.
 	if !m.isValidTargetID(targetID) {
 		return &Error{Code: errInvalidInputException, Message: "Invalid target ID: " + targetID}
 	}
 
-	// Check if attached.
 	attachments, exists := m.PolicyAttachments[targetID]
 	if !exists || !attachments[policyID] {
 		return &Error{Code: errPolicyNotAttachedException, Message: "Policy is not attached to the target"}
 	}
 
-	// Detach the policy.
 	delete(m.PolicyAttachments[targetID], policyID)
 
 	m.saveLocked()
@@ -604,12 +581,10 @@ func (m *MemoryStorage) ListRoots(_ context.Context, _ int32, _ string) ([]*Root
 
 // isValidParentID checks if a parent ID is valid (root or OU).
 func (m *MemoryStorage) isValidParentID(parentID string) bool {
-	// Check if it's the root.
 	if m.Root != nil && m.Root.ID == parentID {
 		return true
 	}
 
-	// Check if it's an OU.
 	_, exists := m.OrganizationalUnits[parentID]
 
 	return exists
@@ -617,17 +592,14 @@ func (m *MemoryStorage) isValidParentID(parentID string) bool {
 
 // isValidTargetID checks if a target ID is valid (root, OU, or account).
 func (m *MemoryStorage) isValidTargetID(targetID string) bool {
-	// Check if it's the root.
 	if m.Root != nil && m.Root.ID == targetID {
 		return true
 	}
 
-	// Check if it's an OU.
 	if _, exists := m.OrganizationalUnits[targetID]; exists {
 		return true
 	}
 
-	// Check if it's an account.
 	_, exists := m.Accounts[targetID]
 
 	return exists
@@ -640,7 +612,6 @@ func generateShortID() string {
 }
 
 func generateAccountID() string {
-	// Generate a 12-digit account ID.
 	id := uint64(uuid.New().ID())
 
 	return fmt.Sprintf("%012d", id%1000000000000)

--- a/internal/service/pipes/handlers.go
+++ b/internal/service/pipes/handlers.go
@@ -13,7 +13,6 @@ import (
 func (s *Service) CreatePipe(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Get pipe name from URL path.
 	name := extractPipeName(r.URL.Path)
 	if name == "" {
 		writeError(w, errValidationException, "Pipe name is required", http.StatusBadRequest)
@@ -53,7 +52,6 @@ func (s *Service) CreatePipe(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DescribePipe(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Get pipe name from URL path.
 	name := extractPipeName(r.URL.Path)
 	if name == "" {
 		writeError(w, errValidationException, "Pipe name is required", http.StatusBadRequest)
@@ -96,7 +94,6 @@ func (s *Service) DescribePipe(w http.ResponseWriter, r *http.Request) {
 func (s *Service) UpdatePipe(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Get pipe name from URL path.
 	name := extractPipeName(r.URL.Path)
 	if name == "" {
 		writeError(w, errValidationException, "Pipe name is required", http.StatusBadRequest)
@@ -136,7 +133,6 @@ func (s *Service) UpdatePipe(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeletePipe(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Get pipe name from URL path.
 	name := extractPipeName(r.URL.Path)
 	if name == "" {
 		writeError(w, errValidationException, "Pipe name is required", http.StatusBadRequest)
@@ -167,7 +163,6 @@ func (s *Service) DeletePipe(w http.ResponseWriter, r *http.Request) {
 func (s *Service) ListPipes(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Parse query parameters.
 	query := r.URL.Query()
 	req := &ListPipesInput{
 		CurrentState: query.Get("CurrentState"),
@@ -178,7 +173,6 @@ func (s *Service) ListPipes(w http.ResponseWriter, r *http.Request) {
 		TargetPrefix: query.Get("TargetPrefix"),
 	}
 
-	// Parse limit if provided.
 	if limitStr := query.Get("Limit"); limitStr != "" {
 		var limit int32
 
@@ -267,7 +261,6 @@ func (s *Service) StopPipe(w http.ResponseWriter, r *http.Request) {
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Get resource ARN from URL path.
 	arn := extractResourceArn(r.URL.Path)
 	if arn == "" {
 		writeError(w, errValidationException, "Resource ARN is required", http.StatusBadRequest)
@@ -275,7 +268,6 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// URL decode the ARN.
 	decodedArn, err := url.PathUnescape(arn)
 	if err != nil {
 		writeError(w, errValidationException, "Invalid resource ARN", http.StatusBadRequest)
@@ -303,7 +295,6 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Get resource ARN from URL path.
 	arn := extractResourceArn(r.URL.Path)
 	if arn == "" {
 		writeError(w, errValidationException, "Resource ARN is required", http.StatusBadRequest)
@@ -311,7 +302,6 @@ func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// URL decode the ARN.
 	decodedArn, err := url.PathUnescape(arn)
 	if err != nil {
 		writeError(w, errValidationException, "Invalid resource ARN", http.StatusBadRequest)
@@ -319,7 +309,6 @@ func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get tag keys from query parameters.
 	tagKeys := r.URL.Query()["tagKeys"]
 
 	if err := s.storage.UntagResource(ctx, decodedArn, tagKeys); err != nil {
@@ -335,7 +324,6 @@ func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Get resource ARN from URL path.
 	arn := extractResourceArn(r.URL.Path)
 	if arn == "" {
 		writeError(w, errValidationException, "Resource ARN is required", http.StatusBadRequest)
@@ -343,7 +331,6 @@ func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// URL decode the ARN.
 	decodedArn, err := url.PathUnescape(arn)
 	if err != nil {
 		writeError(w, errValidationException, "Invalid resource ARN", http.StatusBadRequest)
@@ -369,7 +356,6 @@ func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 
 // extractPipeName extracts the pipe name from a URL path like /v1/pipes/{Name}.
 func extractPipeName(path string) string {
-	// Remove prefix and extract name.
 	const prefix = "/v1/pipes/"
 
 	if !strings.HasPrefix(path, prefix) {
@@ -387,7 +373,6 @@ func extractPipeName(path string) string {
 
 // extractPipeNameFromAction extracts the pipe name from a URL path like /v1/pipes/{Name}/{action}.
 func extractPipeNameFromAction(path, action string) string {
-	// Remove prefix and extract name.
 	const prefix = "/v1/pipes/"
 
 	if !strings.HasPrefix(path, prefix) {
@@ -407,7 +392,6 @@ func extractPipeNameFromAction(path, action string) string {
 
 // extractResourceArn extracts the resource ARN from a URL path like /tags/{arn}.
 func extractResourceArn(path string) string {
-	// Remove prefix and extract ARN.
 	const prefix = "/tags/"
 
 	if !strings.HasPrefix(path, prefix) {

--- a/internal/service/pipes/service.go
+++ b/internal/service/pipes/service.go
@@ -45,7 +45,6 @@ func (s *Service) RegisterRoutes(r service.Router) {
 	r.Handle("PUT", "/v1/pipes/{name}", s.UpdatePipe)
 	r.Handle("DELETE", "/v1/pipes/{name}", s.DeletePipe)
 
-	// List pipes.
 	r.Handle("GET", "/v1/pipes", s.ListPipes)
 
 	// Pipe control operations.

--- a/internal/service/pipes/storage.go
+++ b/internal/service/pipes/storage.go
@@ -165,7 +165,6 @@ func (m *MemoryStorage) CreatePipe(_ context.Context, req *CreatePipeInput) (*Pi
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Check if pipe already exists.
 	if _, exists := m.Pipes[req.Name]; exists {
 		return nil, &Error{
 			Code:    errConflictException,
@@ -255,7 +254,6 @@ func (m *MemoryStorage) UpdatePipe(_ context.Context, req *UpdatePipeInput) (*Pi
 		}
 	}
 
-	// Validate required field.
 	if req.RoleArn == "" {
 		return nil, &Error{
 			Code:    errValidationException,
@@ -325,7 +323,6 @@ func (m *MemoryStorage) DeletePipe(_ context.Context, name string) (*Pipe, error
 		}
 	}
 
-	// Update state to deleting.
 	pipe.CurrentState = CurrentStateDeleting
 	pipe.DesiredState = DesiredStateStopped
 	pipe.LastModifiedTime = AWSTimestamp{Time: time.Now()}
@@ -419,7 +416,6 @@ func (m *MemoryStorage) StartPipe(_ context.Context, name string) (*Pipe, error)
 		}
 	}
 
-	// Check if pipe can be started.
 	if pipe.CurrentState != CurrentStateStopped {
 		return nil, &Error{
 			Code:    errConflictException,
@@ -449,7 +445,6 @@ func (m *MemoryStorage) StopPipe(_ context.Context, name string) (*Pipe, error) 
 		}
 	}
 
-	// Check if pipe can be stopped.
 	if pipe.CurrentState != CurrentStateRunning {
 		return nil, &Error{
 			Code:    errConflictException,
@@ -471,7 +466,6 @@ func (m *MemoryStorage) TagResource(_ context.Context, arn string, tags map[stri
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Find pipe by ARN.
 	var pipe *Pipe
 
 	for _, p := range m.Pipes {
@@ -505,7 +499,6 @@ func (m *MemoryStorage) UntagResource(_ context.Context, arn string, tagKeys []s
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Find pipe by ARN.
 	var pipe *Pipe
 
 	for _, p := range m.Pipes {
@@ -541,7 +534,6 @@ func (m *MemoryStorage) ListTagsForResource(_ context.Context, arn string) (map[
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	// Find pipe by ARN.
 	var pipe *Pipe
 
 	for _, p := range m.Pipes {
@@ -559,7 +551,6 @@ func (m *MemoryStorage) ListTagsForResource(_ context.Context, arn string) (map[
 		}
 	}
 
-	// Return a copy of the tags.
 	tags := make(map[string]string)
 	maps.Copy(tags, pipe.Tags)
 

--- a/internal/service/rekognition/storage.go
+++ b/internal/service/rekognition/storage.go
@@ -276,7 +276,6 @@ func (s *MemoryStorage) IndexFaces(_ context.Context, req *IndexFacesRequest) (*
 		}
 	}
 
-	// Generate mock face data
 	faceID := uuid.New().String()
 	imageID := uuid.New().String()
 
@@ -385,7 +384,6 @@ func (s *MemoryStorage) SearchFaces(_ context.Context, req *SearchFacesRequest) 
 		}
 	}
 
-	// Return mock matches (excluding the searched face)
 	matches := make([]FaceMatch, 0)
 
 	for faceID, face := range collection.Faces {
@@ -445,7 +443,6 @@ func (s *MemoryStorage) DeleteFaces(_ context.Context, req *DeleteFacesRequest) 
 
 // DetectFaces detects faces in an image.
 func (s *MemoryStorage) DetectFaces(_ context.Context, _ *DetectFacesRequest) (*DetectFacesResponse, error) {
-	// Return mock face detection results
 	return &DetectFacesResponse{
 		FaceDetails: []FaceDetail{
 			{
@@ -480,7 +477,6 @@ func (s *MemoryStorage) DetectFaces(_ context.Context, _ *DetectFacesRequest) (*
 
 // DetectLabels detects labels in an image.
 func (s *MemoryStorage) DetectLabels(_ context.Context, _ *DetectLabelsRequest) (*DetectLabelsResponse, error) {
-	// Return mock label detection results
 	return &DetectLabelsResponse{
 		LabelModelVersion: defaultLabelModelVersion,
 		Labels: []Label{
@@ -526,7 +522,6 @@ func (s *MemoryStorage) DetectLabels(_ context.Context, _ *DetectLabelsRequest) 
 
 // DetectText detects text in an image.
 func (s *MemoryStorage) DetectText(_ context.Context, _ *DetectTextRequest) (*DetectTextResponse, error) {
-	// Return mock text detection results
 	parentID := 0
 
 	return &DetectTextResponse{
@@ -585,7 +580,6 @@ func (s *MemoryStorage) DetectText(_ context.Context, _ *DetectTextRequest) (*De
 
 // RecognizeCelebrities recognizes celebrities in an image.
 func (s *MemoryStorage) RecognizeCelebrities(_ context.Context, _ *RecognizeCelebritiesRequest) (*RecognizeCelebritiesResponse, error) {
-	// Return mock celebrity recognition results (no celebrities found for mock)
 	return &RecognizeCelebritiesResponse{
 		CelebrityFaces:    []Celebrity{},
 		UnrecognizedFaces: []FaceDetail{},
@@ -594,7 +588,6 @@ func (s *MemoryStorage) RecognizeCelebrities(_ context.Context, _ *RecognizeCele
 
 // DetectModerationLabels detects moderation labels in an image.
 func (s *MemoryStorage) DetectModerationLabels(_ context.Context, _ *DetectModerationLabelsRequest) (*DetectModerationLabelsResponse, error) {
-	// Return mock moderation results (safe content)
 	return &DetectModerationLabelsResponse{
 		ModerationModelVersion: defaultModerationModelVersion,
 		ModerationLabels:       []ModerationLabel{},

--- a/internal/service/resiliencehub/storage.go
+++ b/internal/service/resiliencehub/storage.go
@@ -164,7 +164,6 @@ func (s *MemoryStorage) CreateApp(req *CreateAppRequest) (*App, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check for duplicate name
 	for _, app := range s.Apps {
 		if app.Name == req.Name {
 			return nil, &Error{
@@ -290,7 +289,6 @@ func (s *MemoryStorage) ListApps(req *ListAppsRequest) ([]*AppSummary, string, e
 	summaries := make([]*AppSummary, 0, len(s.Apps))
 
 	for _, app := range s.Apps {
-		// Apply filters
 		if req.Name != "" && app.Name != req.Name {
 			continue
 		}
@@ -324,7 +322,6 @@ func (s *MemoryStorage) CreateResiliencyPolicy(req *CreateResiliencyPolicyReques
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check for duplicate name
 	for _, policy := range s.Policies {
 		if policy.PolicyName == req.PolicyName {
 			return nil, &Error{
@@ -442,7 +439,6 @@ func (s *MemoryStorage) ListResiliencyPolicies(req *ListResiliencyPoliciesReques
 	policies := make([]*ResiliencyPolicy, 0, len(s.Policies))
 
 	for _, policy := range s.Policies {
-		// Apply filters
 		if req.PolicyName != "" && policy.PolicyName != req.PolicyName {
 			continue
 		}
@@ -555,7 +551,6 @@ func (s *MemoryStorage) ListAppAssessments(req *ListAppAssessmentsRequest) ([]*A
 	summaries := make([]*AppAssessmentSummary, 0, len(s.Assessments))
 
 	for _, assessment := range s.Assessments {
-		// Apply filters
 		if req.AppARN != "" && assessment.AppARN != req.AppARN {
 			continue
 		}
@@ -608,7 +603,6 @@ func (s *MemoryStorage) TagResource(resourceARN string, tags map[string]string) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check if resource exists
 	_, appOK := s.Apps[resourceARN]
 	_, policyOK := s.Policies[resourceARN]
 	_, assessmentOK := s.Assessments[resourceARN]
@@ -636,7 +630,6 @@ func (s *MemoryStorage) UntagResource(resourceARN string, tagKeys []string) erro
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check if resource exists
 	_, appOK := s.Apps[resourceARN]
 	_, policyOK := s.Policies[resourceARN]
 	_, assessmentOK := s.Assessments[resourceARN]
@@ -664,7 +657,6 @@ func (s *MemoryStorage) ListTagsForResource(resourceARN string) (map[string]stri
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Check if resource exists
 	_, appOK := s.Apps[resourceARN]
 	_, policyOK := s.Policies[resourceARN]
 	_, assessmentOK := s.Assessments[resourceARN]

--- a/internal/service/route53/handlers.go
+++ b/internal/service/route53/handlers.go
@@ -113,7 +113,6 @@ func (s *Service) CreateHostedZone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Ensure name ends with a dot
 	name := req.Name
 	if !strings.HasSuffix(name, ".") {
 		name += "."
@@ -203,12 +202,10 @@ func (s *Service) ListHostedZones(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Sort zones by ID for consistent pagination.
 	sort.Slice(zones, func(i, j int) bool {
 		return zones[i].ID < zones[j].ID
 	})
 
-	// Find starting position based on marker.
 	startIdx := 0
 
 	if marker != "" {

--- a/internal/service/route53/storage.go
+++ b/internal/service/route53/storage.go
@@ -207,7 +207,6 @@ func (s *MemoryStorage) DeleteHostedZone(id string) error {
 		return ErrHostedZoneNotFound
 	}
 
-	// Check if hosted zone has record sets (other than NS and SOA)
 	if records, ok := s.RecordSets[id]; ok {
 		for i := range records {
 			if records[i].Type != "NS" && records[i].Type != "SOA" {
@@ -219,7 +218,6 @@ func (s *MemoryStorage) DeleteHostedZone(id string) error {
 	delete(s.HostedZones, id)
 	delete(s.RecordSets, id)
 
-	// Clean up tags associated with the hosted zone.
 	bareID := strings.TrimPrefix(id, "/hostedzone/")
 	delete(s.Tags, "hostedzone/"+bareID)
 
@@ -285,7 +283,6 @@ func (s *MemoryStorage) ChangeRecordSets(hostedZoneID string, changes []Change) 
 
 	s.RecordSets[hostedZoneID] = records
 
-	// Update record count
 	if zone, exists := s.HostedZones[hostedZoneID]; exists {
 		zone.ResourceRecordSetCount = int64(len(records))
 	}
@@ -344,7 +341,6 @@ func (s *MemoryStorage) ListTagsForResource(resourceType, resourceID string) ([]
 		return []Tag{}, nil
 	}
 
-	// Return a copy.
 	out := make([]Tag, len(tags))
 	copy(out, tags)
 
@@ -360,7 +356,6 @@ func (s *MemoryStorage) ChangeTagsForResource(resourceType, resourceID string, a
 
 	tags := s.Tags[key]
 
-	// Remove tags by key.
 	for _, rk := range removeKeys {
 		for i := range tags {
 			if tags[i].Key == rk {
@@ -371,7 +366,6 @@ func (s *MemoryStorage) ChangeTagsForResource(resourceType, resourceID string, a
 		}
 	}
 
-	// Add/update tags.
 	for _, at := range addTags {
 		found := false
 

--- a/internal/service/route53resolver/storage.go
+++ b/internal/service/route53resolver/storage.go
@@ -353,7 +353,6 @@ func (s *MemoryStorage) DeleteResolverRule(_ context.Context, id string) (*Resol
 		}
 	}
 
-	// Check if rule is associated with any VPC
 	for _, assoc := range s.Associations {
 		if assoc.ResolverRuleID == id {
 			return nil, &ResolverError{
@@ -397,7 +396,6 @@ func (s *MemoryStorage) AssociateResolverRule(_ context.Context, req *AssociateR
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check if rule exists
 	if _, exists := s.Rules[req.ResolverRuleID]; !exists {
 		return nil, &ResolverError{
 			Code:    errResourceNotFound,
@@ -405,7 +403,6 @@ func (s *MemoryStorage) AssociateResolverRule(_ context.Context, req *AssociateR
 		}
 	}
 
-	// Check if association already exists
 	for _, assoc := range s.Associations {
 		if assoc.ResolverRuleID == req.ResolverRuleID && assoc.VPCID == req.VPCID {
 			return nil, &ResolverError{

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -758,7 +758,6 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Store tags from x-amz-tagging header (URL-encoded query string format).
 	if header := r.Header.Get("X-Amz-Tagging"); header != "" {
 		tags, err := parseTaggingHeader(header)
 		if err == nil && len(tags) > 0 {
@@ -774,13 +773,10 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 
-	// Emit EventBridge notification if enabled.
 	go s.emitObjectCreatedEvent(context.Background(), bucket, key, obj.Size, obj.ETag)
 
-	// Deliver S3 event notification to configured SQS queues.
 	go s.emitSQSNotifications(context.Background(), bucket, key, "s3:ObjectCreated:Put", obj.Size, obj.ETag)
 
-	// Invoke configured Lambda functions.
 	go s.emitLambdaNotifications(context.Background(), bucket, key, "s3:ObjectCreated:Put", obj.Size, obj.ETag)
 }
 
@@ -1257,7 +1253,6 @@ func (s *Service) DeleteObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return version info in headers if applicable
 	if deleteMarker != nil {
 		if deleteMarker.VersionID != "" {
 			w.Header().Set("x-amz-version-id", deleteMarker.VersionID)
@@ -1386,7 +1381,6 @@ func (s *Service) HeadObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(timeFormatHTTP))
 	w.Header().Set("Accept-Ranges", "bytes")
 
-	// Set metadata headers
 	for k, v := range obj.Metadata {
 		if k != contentTypeHeader {
 			w.Header().Set("x-amz-meta-"+k, v)
@@ -2019,13 +2013,11 @@ func checkPresignedURL(w http.ResponseWriter, r *http.Request) bool {
 // validatePresignedURL validates the presigned URL expiration.
 // Returns nil if the URL is valid, or an error if expired.
 func validatePresignedURL(r *http.Request) error {
-	// Get the date when the URL was signed
 	amzDate := r.URL.Query().Get("X-Amz-Date")
 	if amzDate == "" {
 		return &PresignedURLError{Code: "AuthorizationQueryParametersError", Message: "X-Amz-Date must be in the ISO8601 Long Format"}
 	}
 
-	// Get the expiration in seconds
 	expiresStr := r.URL.Query().Get("X-Amz-Expires")
 	if expiresStr == "" {
 		return &PresignedURLError{Code: "AuthorizationQueryParametersError", Message: "X-Amz-Expires must be provided"}
@@ -2042,13 +2034,11 @@ func validatePresignedURL(r *http.Request) error {
 		return &PresignedURLError{Code: "AuthorizationQueryParametersError", Message: "X-Amz-Expires must be less than 604800 seconds"}
 	}
 
-	// Parse the signing date (format: 20060102T150405Z)
 	signTime, err := time.Parse("20060102T150405Z", amzDate)
 	if err != nil {
 		return &PresignedURLError{Code: "AuthorizationQueryParametersError", Message: "Invalid X-Amz-Date format"}
 	}
 
-	// Check if the URL has expired
 	expirationTime := signTime.Add(time.Duration(expires) * time.Second)
 	if time.Now().After(expirationTime) {
 		return &PresignedURLError{Code: "AccessDenied", Message: "Request has expired"}
@@ -2272,7 +2262,6 @@ func (s *Service) CompleteMultipartUpload(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Parse the XML request body
 	var req CompleteMultipartUploadRequest
 	if err := xml.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeS3Error(w, r, "MalformedXML", "The XML you provided was not well-formed", http.StatusBadRequest)
@@ -2301,13 +2290,10 @@ func (s *Service) CompleteMultipartUpload(w http.ResponseWriter, r *http.Request
 
 	writeXMLResponse(w, result)
 
-	// Emit EventBridge notification if enabled.
 	go s.emitObjectCreatedEvent(context.Background(), bucket, key, obj.Size, obj.ETag)
 
-	// Deliver S3 event notification to configured SQS queues.
 	go s.emitSQSNotifications(context.Background(), bucket, key, "s3:ObjectCreated:CompleteMultipartUpload", obj.Size, obj.ETag)
 
-	// Invoke configured Lambda functions.
 	go s.emitLambdaNotifications(context.Background(), bucket, key, "s3:ObjectCreated:CompleteMultipartUpload", obj.Size, obj.ETag)
 }
 

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -238,7 +238,6 @@ func matchesEventFilter(filters []string, eventName string) bool {
 			return true
 		}
 
-		// Handle wildcard: "s3:ObjectCreated:*" matches "s3:ObjectCreated:Put"
 		if strings.HasSuffix(f, "*") {
 			prefix := strings.TrimSuffix(f, "*")
 			if strings.HasPrefix(eventName, prefix) {

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -422,7 +422,6 @@ func (s *MemoryStorage) ListBuckets(_ context.Context) ([]Bucket, error) {
 		})
 	}
 
-	// Sort by name for consistent ordering
 	sort.Slice(buckets, func(i, j int) bool {
 		return buckets[i].Name < buckets[j].Name
 	})
@@ -481,7 +480,6 @@ func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io
 
 	putObjectVersion(b, key, obj)
 
-	// Always update current object
 	b.Objects[key] = obj
 
 	s.saveLocked()
@@ -493,7 +491,6 @@ func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io
 func putObjectVersion(b *MemoryBucket, key string, obj *Object) {
 	switch b.VersioningStatus {
 	case VersioningEnabled:
-		// Generate version ID
 		b.VersionIDCounter++
 		obj.VersionID = fmt.Sprintf("v%d", b.VersionIDCounter)
 
@@ -503,7 +500,6 @@ func putObjectVersion(b *MemoryBucket, key string, obj *Object) {
 		// For suspended versioning, use "null" version ID
 		obj.VersionID = VersionIDNull
 
-		// Remove any existing "null" version
 		versions := b.Versions[key]
 		newVersions := make([]*Object, 0, len(versions))
 
@@ -541,7 +537,6 @@ func (s *MemoryStorage) GetObject(_ context.Context, bucket, key string) (*Objec
 		return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
 	}
 
-	// Check if current version is a delete marker
 	if obj.IsDeleteMarker {
 		return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
 	}
@@ -629,7 +624,6 @@ func (s *MemoryStorage) DeleteObject(_ context.Context, bucket, key string) (*Ob
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
 	}
 
-	// Handle versioning - create delete marker for enabled buckets
 	if b.VersioningStatus == VersioningEnabled {
 		b.VersionIDCounter++
 		deleteMarker := &Object{
@@ -639,7 +633,6 @@ func (s *MemoryStorage) DeleteObject(_ context.Context, bucket, key string) (*Ob
 			LastModified:   time.Now(),
 		}
 
-		// Prepend delete marker to versions
 		b.Versions[key] = append([]*Object{deleteMarker}, b.Versions[key]...)
 		b.Objects[key] = deleteMarker
 
@@ -739,7 +732,6 @@ func (s *MemoryStorage) HeadObject(_ context.Context, bucket, key string) (*Obje
 		return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
 	}
 
-	// Return metadata only (no body)
 	return &Object{
 		Key:                  obj.Key,
 		ContentType:          obj.ContentType,
@@ -770,7 +762,6 @@ func (s *MemoryStorage) ListObjects(_ context.Context, bucket, prefix, delimiter
 	objects := make([]Object, 0)
 	commonPrefixes := make(map[string]bool)
 
-	// Collect all matching keys.
 	keys := make([]string, 0, len(b.Objects))
 
 	for key := range b.Objects {
@@ -779,7 +770,6 @@ func (s *MemoryStorage) ListObjects(_ context.Context, bucket, prefix, delimiter
 		}
 	}
 
-	// Sort keys for consistent ordering
 	sort.Strings(keys)
 
 	for _, key := range keys {
@@ -787,10 +777,8 @@ func (s *MemoryStorage) ListObjects(_ context.Context, bucket, prefix, delimiter
 
 		// Handle delimiter
 		if delimiter != "" {
-			// Find the part after prefix
 			remainder := strings.TrimPrefix(key, prefix)
 			if idx := strings.Index(remainder, delimiter); idx >= 0 {
-				// This is a common prefix
 				commonPrefix := prefix + remainder[:idx+len(delimiter)]
 				commonPrefixes[commonPrefix] = true
 
@@ -810,7 +798,6 @@ func (s *MemoryStorage) ListObjects(_ context.Context, bucket, prefix, delimiter
 		}
 	}
 
-	// Convert common prefixes to sorted slice
 	prefixList := make([]string, 0, len(commonPrefixes))
 	for p := range commonPrefixes {
 		prefixList = append(prefixList, p)
@@ -913,7 +900,6 @@ func processVersionKeys(b *MemoryBucket, keys []string, prefix, delimiter string
 			break
 		}
 
-		// Handle delimiter for common prefixes
 		if delimiter != "" {
 			if cp := extractCommonPrefix(key, prefix, delimiter); cp != "" {
 				commonPrefixes[cp] = true
@@ -922,7 +908,6 @@ func processVersionKeys(b *MemoryBucket, keys []string, prefix, delimiter string
 			}
 		}
 
-		// Add versions for this key
 		added := addKeyVersions(b, key, &objects, maxKeys-count)
 		count += added
 	}
@@ -944,7 +929,6 @@ func extractCommonPrefix(key, prefix, delimiter string) string {
 func addKeyVersions(b *MemoryBucket, key string, objects *[]Object, limit int) int {
 	versions := b.Versions[key]
 	if len(versions) == 0 {
-		// No versioning history, include current object if exists
 		if obj, exists := b.Objects[key]; exists {
 			*objects = append(*objects, objectToVersionInfo(obj))
 
@@ -1198,7 +1182,6 @@ func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, 
 		return nil, err
 	}
 
-	// Calculate final ETag (MD5 of MD5s + "-" + number of parts)
 	etag := calculateMultipartETag(parts, upload.Parts)
 
 	obj := &Object{
@@ -1246,7 +1229,6 @@ func assembleMultipartBody(upload *MultipartUpload, parts []PartRequest, uploadI
 			return nil, &MultipartError{Code: "InvalidPart", Message: "One or more of the specified parts could not be found", UploadID: uploadID}
 		}
 
-		// Verify ETag matches
 		if part.ETag != pr.ETag && part.ETag != fmt.Sprintf("%q", strings.Trim(pr.ETag, "\"")) {
 			return nil, &MultipartError{Code: "InvalidPart", Message: "One or more of the specified parts could not be found", UploadID: uploadID}
 		}
@@ -1329,7 +1311,6 @@ func (s *MemoryStorage) ListMultipartUploads(_ context.Context, bucket, prefix s
 		}
 	}
 
-	// Sort by key and then by upload ID for consistent ordering
 	sort.Slice(uploads, func(i, j int) bool {
 		if uploads[i].Key != uploads[j].Key {
 			return uploads[i].Key < uploads[j].Key
@@ -1369,12 +1350,10 @@ func (s *MemoryStorage) ListParts(_ context.Context, bucket, key, uploadID strin
 		parts = append(parts, part)
 	}
 
-	// Sort by part number
 	sort.Slice(parts, func(i, j int) bool {
 		return parts[i].PartNumber < parts[j].PartNumber
 	})
 
-	// Limit to maxParts
 	if len(parts) > maxParts {
 		parts = parts[:maxParts]
 	}
@@ -1384,7 +1363,6 @@ func (s *MemoryStorage) ListParts(_ context.Context, bucket, key, uploadID strin
 
 // generateUploadID generates a unique upload ID.
 func generateUploadID() string {
-	// Generate a UUID-based upload ID similar to AWS format
 	return strings.ReplaceAll(fmt.Sprintf("%s%s", randomHex(8), randomHex(8)), "-", "")
 }
 
@@ -1404,19 +1382,16 @@ func randomHex(n int) string {
 func calculateMultipartETag(partRequests []PartRequest, parts map[int]*Part) string {
 	const md5Size = 16 // MD5 produces 16 bytes
 
-	// Concatenate all part ETags (raw MD5 values)
 	md5Concat := make([]byte, 0, len(partRequests)*md5Size)
 
 	for _, pr := range partRequests {
 		part := parts[pr.PartNumber]
-		// Extract raw MD5 from ETag (remove quotes)
 		etag := strings.Trim(part.ETag, "\"")
 
 		md5Bytes, _ := hex.DecodeString(etag)
 		md5Concat = append(md5Concat, md5Bytes...)
 	}
 
-	// Calculate MD5 of concatenated MD5s
 	finalHash := md5.Sum(md5Concat) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
 
 	return fmt.Sprintf("%q", fmt.Sprintf("%s-%d", hex.EncodeToString(finalHash[:]), len(partRequests)))

--- a/internal/service/s3control/storage.go
+++ b/internal/service/s3control/storage.go
@@ -192,7 +192,6 @@ func (s *MemoryStorage) CreateAccessPoint(_ context.Context, accountID string, a
 		}
 	}
 
-	// Generate ARN and alias
 	ap.AccountID = accountID
 	ap.AccessPointArn = fmt.Sprintf("arn:aws:s3:%s:%s:accesspoint/%s", s.region, accountID, ap.Name)
 	ap.Alias = fmt.Sprintf("%s-%s-s3alias", ap.Name, accountID[:12])

--- a/internal/service/s3tables/storage.go
+++ b/internal/service/s3tables/storage.go
@@ -153,7 +153,6 @@ func (s *MemoryStorage) CreateTableBucket(_ context.Context, name string) (*Tabl
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check if bucket with same name already exists
 	for _, bucket := range s.TableBuckets {
 		if bucket.Name == name {
 			return nil, &Error{
@@ -195,7 +194,6 @@ func (s *MemoryStorage) DeleteTableBucket(_ context.Context, arn string) error {
 		}
 	}
 
-	// Check if bucket has namespaces
 	if namespaces, exists := s.Namespaces[arn]; exists && len(namespaces) > 0 {
 		return &Error{
 			Code:    errConflict,
@@ -254,10 +252,8 @@ func (s *MemoryStorage) ListTableBuckets(_ context.Context, prefix, continuation
 		})
 	}
 
-	// Sort by name for consistent ordering
 	sortTableBucketSummaries(allBuckets)
 
-	// Apply continuation token (skip buckets until we find the marker)
 	startIdx := 0
 
 	if continuationToken != "" {
@@ -270,7 +266,6 @@ func (s *MemoryStorage) ListTableBuckets(_ context.Context, prefix, continuation
 		}
 	}
 
-	// Apply pagination
 	if startIdx >= len(allBuckets) {
 		return []TableBucketSummary{}, "", nil
 	}
@@ -282,7 +277,6 @@ func (s *MemoryStorage) ListTableBuckets(_ context.Context, prefix, continuation
 
 	result := allBuckets[startIdx:endIdx]
 
-	// Set next continuation token if there are more results
 	var nextToken string
 
 	if endIdx < len(allBuckets) {
@@ -351,7 +345,6 @@ func (s *MemoryStorage) DeleteNamespace(_ context.Context, tableBucketArn, names
 		}
 	}
 
-	// Check if namespace has tables
 	tableKey := tableBucketArn + "/" + namespace
 	if tables, exists := s.Tables[tableKey]; exists && len(tables) > 0 {
 		return &Error{
@@ -460,7 +453,6 @@ func (s *MemoryStorage) CreateTable(_ context.Context, tableBucketArn, namespace
 		}
 	}
 
-	// Extract bucket name from ARN for table ARN
 	bucketName := extractBucketNameFromArn(tableBucketArn)
 	tableArn := fmt.Sprintf("arn:aws:s3tables:%s:%s:bucket/%s/table/%s/%s",
 		defaultRegion, defaultAccountID, bucketName, namespace, name)

--- a/internal/service/sagemaker/storage.go
+++ b/internal/service/sagemaker/storage.go
@@ -215,17 +215,14 @@ func (m *MemoryStorage) CreateNotebookInstance(_ context.Context, req *CreateNot
 		LastModifiedTime:       now,
 	}
 
-	// Set default volume size if not specified.
 	if instance.VolumeSizeInGB == 0 {
 		instance.VolumeSizeInGB = 5
 	}
 
-	// Set default direct internet access.
 	if instance.DirectInternetAccess == "" {
 		instance.DirectInternetAccess = "Enabled"
 	}
 
-	// Set default root access.
 	if instance.RootAccess == "" {
 		instance.RootAccess = "Enabled"
 	}

--- a/internal/service/scheduler/storage.go
+++ b/internal/service/scheduler/storage.go
@@ -90,7 +90,6 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 		_ = storage.Load(ms.dataDir, "scheduler", ms)
 	}
 
-	// Create default schedule group.
 	ms.ScheduleGroups[defaultGroupName] = &ScheduleGroup{
 		Name:         defaultGroupName,
 		ARN:          generateScheduleGroupARN(ms.region, defaultAccountID, defaultGroupName),
@@ -174,7 +173,6 @@ func (m *MemoryStorage) CreateSchedule(_ context.Context, name string, req *Crea
 		return nil, &Error{Code: errConflictException, Message: "Schedule already exists: " + name}
 	}
 
-	// Check if group exists.
 	if _, exists := m.ScheduleGroups[groupName]; !exists {
 		return nil, &Error{Code: errResourceNotFound, Message: "ScheduleGroup not found: " + groupName}
 	}
@@ -248,7 +246,6 @@ func (m *MemoryStorage) UpdateSchedule(_ context.Context, name string, req *Upda
 		return nil, &Error{Code: errResourceNotFound, Message: "Schedule not found: " + name}
 	}
 
-	// Update fields.
 	schedule.Description = req.Description
 	schedule.ScheduleExpression = req.ScheduleExpression
 	schedule.ScheduleExpressionTimezone = defaultString(req.ScheduleExpressionTimezone, defaultTimezone)
@@ -375,7 +372,6 @@ func (m *MemoryStorage) DeleteScheduleGroup(_ context.Context, name string) erro
 		return &Error{Code: errResourceNotFound, Message: "ScheduleGroup not found: " + name}
 	}
 
-	// Check if any schedules use this group.
 	for _, schedule := range m.Schedules {
 		if schedule.GroupName == name {
 			return &Error{Code: errConflictException, Message: "ScheduleGroup has schedules: " + name}

--- a/internal/service/secretsmanager/handlers.go
+++ b/internal/service/secretsmanager/handlers.go
@@ -672,7 +672,6 @@ func buildCharset(req *GetRandomPasswordRequest) string {
 		charset += " "
 	}
 
-	// Remove excluded characters.
 	if req.ExcludeCharacters != "" {
 		var filtered []byte
 

--- a/internal/service/secretsmanager/storage.go
+++ b/internal/service/secretsmanager/storage.go
@@ -171,7 +171,6 @@ func (m *MemoryStorage) CreateSecret(_ context.Context, req *CreateSecretRequest
 		VersionIDs:      make(map[string]*SecretVersion),
 	}
 
-	// Create initial version if secret value is provided.
 	if req.SecretString != "" || len(req.SecretBinary) > 0 {
 		version := &SecretVersion{
 			VersionID:     versionID,
@@ -211,7 +210,6 @@ func (m *MemoryStorage) GetSecretValue(_ context.Context, secretID, versionID, v
 		}
 	}
 
-	// Default to AWSCURRENT if no version specified.
 	if versionStage == "" && versionID == "" {
 		versionStage = stageCurrent
 	}
@@ -221,7 +219,6 @@ func (m *MemoryStorage) GetSecretValue(_ context.Context, secretID, versionID, v
 	if versionID != "" {
 		version = secret.VersionIDs[versionID]
 	} else {
-		// Find version by stage.
 		for _, v := range secret.VersionIDs {
 			if slices.Contains(v.VersionStages, versionStage) {
 				version = v
@@ -238,7 +235,6 @@ func (m *MemoryStorage) GetSecretValue(_ context.Context, secretID, versionID, v
 		}
 	}
 
-	// Update last accessed date.
 	now := time.Now()
 	secret.LastAccessedDate = &now
 
@@ -272,12 +268,10 @@ func (m *MemoryStorage) PutSecretValue(_ context.Context, secretID, clientToken,
 		versionID = uuid.New().String()
 	}
 
-	// Default stages.
 	if len(versionStages) == 0 {
 		versionStages = []string{stageCurrent}
 	}
 
-	// Remove AWSCURRENT stage from previous version.
 	m.rotateVersionStages(secret)
 
 	version := &SecretVersion{
@@ -316,7 +310,6 @@ func (m *MemoryStorage) DeleteSecret(_ context.Context, secretID string, recover
 	now := time.Now()
 
 	if forceDelete {
-		// Immediately delete.
 		delete(m.Secrets, secret.Name)
 		delete(m.Policies, secret.Name)
 		secret.DeletedDate = &now
@@ -349,11 +342,9 @@ func (m *MemoryStorage) ListSecrets(_ context.Context, maxResults int, nextToken
 		maxResults = 100
 	}
 
-	// Collect all secrets.
 	allSecrets := make([]*Secret, 0, len(m.Secrets))
 
 	for _, secret := range m.Secrets {
-		// Skip deleted secrets unless requested.
 		if secret.DeletedDate != nil && !includePlannedDeletion {
 			continue
 		}
@@ -361,12 +352,10 @@ func (m *MemoryStorage) ListSecrets(_ context.Context, maxResults int, nextToken
 		allSecrets = append(allSecrets, secret)
 	}
 
-	// Sort by name for consistent ordering.
 	sort.Slice(allSecrets, func(i, j int) bool {
 		return allSecrets[i].Name < allSecrets[j].Name
 	})
 
-	// Handle pagination.
 	startIdx := 0
 
 	if nextToken != "" {
@@ -493,12 +482,10 @@ func (m *MemoryStorage) rotateVersionStages(secret *Secret) {
 
 // findSecret finds a secret by name or ARN.
 func (m *MemoryStorage) findSecret(secretID string) *Secret {
-	// Try by name first.
 	if secret, exists := m.Secrets[secretID]; exists {
 		return secret
 	}
 
-	// Try by ARN (exact match).
 	for _, secret := range m.Secrets {
 		if secret.ARN == secretID {
 			return secret

--- a/internal/service/securitylake/storage.go
+++ b/internal/service/securitylake/storage.go
@@ -186,7 +186,6 @@ func (s *MemoryStorage) CreateDataLake(_ context.Context, req *CreateDataLakeReq
 			region = s.region
 		}
 
-		// Check if data lake already exists for this region
 		if _, exists := s.DataLakes[region]; exists {
 			return nil, &Error{
 				Code:    errConflict,
@@ -312,7 +311,6 @@ func (s *MemoryStorage) CreateSubscriber(_ context.Context, req *CreateSubscribe
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Check for duplicate subscriber name
 	for _, sub := range s.Subscribers {
 		if sub.SubscriberName == req.SubscriberName {
 			return nil, &Error{
@@ -511,12 +509,10 @@ func (s *MemoryStorage) ListLogSources(_ context.Context, req *ListLogSourcesReq
 	sources := make([]*LogSource, 0, len(s.LogSources))
 
 	for _, source := range s.LogSources {
-		// Filter by regions if specified
 		if len(req.Regions) > 0 && !slices.Contains(req.Regions, source.Region) {
 			continue
 		}
 
-		// Filter by accounts if specified
 		if len(req.Accounts) > 0 && !slices.Contains(req.Accounts, source.Account) {
 			continue
 		}

--- a/internal/service/servicequotas/storage.go
+++ b/internal/service/servicequotas/storage.go
@@ -394,19 +394,16 @@ func (m *MemoryStorage) RequestServiceQuotaIncrease(_ context.Context, serviceCo
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Check if the service exists
 	serviceQuotas, exists := m.Quotas[serviceCode]
 	if !exists {
 		return nil, &Error{Code: errNoSuchResourceException, Message: "Service not found: " + serviceCode}
 	}
 
-	// Check if the quota exists
 	quota, exists := serviceQuotas[quotaCode]
 	if !exists {
 		return nil, &Error{Code: errNoSuchResourceException, Message: "Quota not found: " + quotaCode}
 	}
 
-	// Check if the quota is adjustable
 	if !quota.Adjustable {
 		return nil, &Error{Code: errIllegalArgumentException, Message: "Quota is not adjustable: " + quotaCode}
 	}

--- a/internal/service/ses/handlers.go
+++ b/internal/service/ses/handlers.go
@@ -104,19 +104,15 @@ func (s *Service) SendRawEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Decode base64-encoded raw message data.
 	rawBytes, err := base64.StdEncoding.DecodeString(req.RawMessageData)
 	if err != nil {
-		// Try the raw data as-is if base64 decoding fails.
 		rawBytes = []byte(req.RawMessageData)
 	}
 
 	rawData := string(rawBytes)
 
-	// Parse the raw email to extract subject and body.
 	subject, body, htmlBody := extractRawEmailContent(rawBytes)
 
-	// Use destinations from the request or extract from headers.
 	destinations := req.Destinations
 	if len(destinations) == 0 {
 		destinations = extractRawEmailRecipients(rawBytes)

--- a/internal/service/sesv2/handlers.go
+++ b/internal/service/sesv2/handlers.go
@@ -505,7 +505,6 @@ func extractPathParam(path, prefix string) string {
 		return ""
 	}
 
-	// Remove any trailing path segments.
 	if idx := strings.Index(param, "/"); idx != -1 {
 		param = param[:idx]
 	}

--- a/internal/service/sesv2/storage.go
+++ b/internal/service/sesv2/storage.go
@@ -47,10 +47,8 @@ type Storage interface {
 	DeleteEmailTemplate(ctx context.Context, name string) error
 	ListEmailTemplates(ctx context.Context, nextToken string, pageSize int32) ([]*EmailTemplate, string, error)
 
-	// Send Email.
 	SendEmail(ctx context.Context, req *SendEmailRequest) (string, error)
 
-	// Send Bulk Email.
 	SendBulkEmail(ctx context.Context, req *SendBulkEmailRequest) (*SendBulkEmailResponse, error)
 
 	// Get sent emails (for testing purposes).
@@ -296,7 +294,6 @@ func (s *MemoryStorage) CreateConfigurationSet(_ context.Context, req *CreateCon
 		Tags:              req.Tags,
 	}
 
-	// Set defaults if not provided.
 	if configSet.SendingOptions == nil {
 		configSet.SendingOptions = &SendingOptions{SendingEnabled: true}
 	}
@@ -503,7 +500,6 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 		}
 	}
 
-	// Basic validation.
 	// Destination is not required when Content.Raw is set,
 	// because recipients can be extracted from MIME headers.
 	hasDestination := req.Destination != nil &&
@@ -518,7 +514,6 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 		}
 	}
 
-	// Generate message ID.
 	messageID := uuid.New().String()
 
 	// Extract content based on email type.
@@ -540,7 +535,6 @@ func (s *MemoryStorage) SendEmail(_ context.Context, req *SendEmailRequest) (str
 		subject, body, htmlBody = extractSimpleEmailContent(req.Content.Simple)
 	}
 
-	// Store the sent email.
 	sentEmail := &SentEmail{
 		MessageID:            messageID,
 		FromEmailAddress:     req.FromEmailAddress,

--- a/internal/service/sns/storage.go
+++ b/internal/service/sns/storage.go
@@ -175,7 +175,6 @@ func (m *MemoryStorage) CreateTopic(_ context.Context, name string, attributes m
 
 	arn := m.buildTopicARN(name)
 
-	// Return existing topic if it exists.
 	if topic, exists := m.Topics[arn]; exists {
 		return topic, nil
 	}
@@ -263,7 +262,6 @@ func (m *MemoryStorage) DeleteTopic(_ context.Context, topicARN string) error {
 		}
 	}
 
-	// Delete all subscriptions for this topic.
 	for subARN := range topic.Subscriptions {
 		delete(m.Subscriptions, subARN)
 	}
@@ -364,18 +362,15 @@ func (m *MemoryStorage) ListTopics(_ context.Context, nextToken string) ([]*Topi
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	// Collect all topics.
 	allTopics := make([]*Topic, 0, len(m.Topics))
 	for _, topic := range m.Topics {
 		allTopics = append(allTopics, topic)
 	}
 
-	// Sort by ARN for consistent ordering.
 	sort.Slice(allTopics, func(i, j int) bool {
 		return allTopics[i].ARN < allTopics[j].ARN
 	})
 
-	// Handle pagination.
 	startIdx := 0
 	maxResults := 100
 
@@ -413,7 +408,6 @@ func (m *MemoryStorage) Subscribe(_ context.Context, topicARN, protocol, endpoin
 		}
 	}
 
-	// Validate protocol.
 	validProtocols := map[string]bool{
 		"http": true, "https": true, "email": true, "email-json": true,
 		"sms": true, "sqs": true, "application": true, "lambda": true,
@@ -504,7 +498,6 @@ func (m *MemoryStorage) Unsubscribe(_ context.Context, subscriptionARN string) e
 		}
 	}
 
-	// Remove from topic's subscriptions.
 	if topic, exists := m.Topics[subscription.TopicARN]; exists {
 		delete(topic.Subscriptions, subscriptionARN)
 	}
@@ -573,7 +566,6 @@ func matchesFilterPolicy(filterPolicyJSON string, attributes map[string]MessageA
 		return true
 	}
 
-	// Parse the filter policy.
 	var policy map[string][]json.RawMessage
 	if err := json.Unmarshal([]byte(filterPolicyJSON), &policy); err != nil {
 		// Malformed policy -- deliver to be safe (same as AWS fallback).
@@ -725,7 +717,6 @@ func matchAnythingBut(obj map[string]json.RawMessage, value string, exists bool)
 
 // deliverMessage delivers a message to a subscription.
 func (m *MemoryStorage) deliverMessage(ctx context.Context, sub *Subscription, message, subject, messageID, messageGroupID, messageDeduplicationID string, attributes map[string]MessageAttribute) error {
-	// Check FilterPolicy before delivering.
 	if sub.SubscriptionAttributes != nil {
 		if fp, ok := sub.SubscriptionAttributes["FilterPolicy"]; ok {
 			if !matchesFilterPolicy(fp, attributes) {
@@ -757,7 +748,6 @@ func (m *MemoryStorage) deliverToSQS(ctx context.Context, sub *Subscription, mes
 
 	raw := isRawMessageDelivery(sub)
 
-	// Build the message body based on RawMessageDelivery setting.
 	body := message
 	if !raw {
 		body = buildSNSNotificationEnvelope(sub.TopicARN, message, subject, messageID, attributes)
@@ -861,18 +851,15 @@ func (m *MemoryStorage) ListSubscriptions(_ context.Context, nextToken string) (
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	// Collect all subscriptions.
 	allSubs := make([]*Subscription, 0, len(m.Subscriptions))
 	for _, sub := range m.Subscriptions {
 		allSubs = append(allSubs, sub)
 	}
 
-	// Sort by ARN for consistent ordering.
 	sort.Slice(allSubs, func(i, j int) bool {
 		return allSubs[i].ARN < allSubs[j].ARN
 	})
 
-	// Handle pagination.
 	startIdx := 0
 	maxResults := 100
 
@@ -910,18 +897,15 @@ func (m *MemoryStorage) ListSubscriptionsByTopic(_ context.Context, topicARN, ne
 		}
 	}
 
-	// Collect subscriptions for this topic.
 	allSubs := make([]*Subscription, 0, len(topic.Subscriptions))
 	for _, sub := range topic.Subscriptions {
 		allSubs = append(allSubs, sub)
 	}
 
-	// Sort by ARN for consistent ordering.
 	sort.Slice(allSubs, func(i, j int) bool {
 		return allSubs[i].ARN < allSubs[j].ARN
 	})
 
-	// Handle pagination.
 	startIdx := 0
 	maxResults := 100
 
@@ -957,7 +941,6 @@ func (m *MemoryStorage) buildTopicARN(name string) string {
 
 // buildSubscriptionARN builds an ARN for a subscription.
 func (m *MemoryStorage) buildSubscriptionARN(topicARN string) string {
-	// Extract topic name from ARN.
 	parts := strings.Split(topicARN, ":")
 	topicName := parts[len(parts)-1]
 

--- a/internal/service/sqs/handlers.go
+++ b/internal/service/sqs/handlers.go
@@ -294,7 +294,6 @@ func (s *Service) SendMessageBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check for duplicate IDs.
 	seen := make(map[string]struct{}, len(req.Entries))
 	for _, entry := range req.Entries {
 		if _, exists := seen[entry.ID]; exists {
@@ -491,7 +490,6 @@ func (s *Service) DeleteMessageBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check for duplicate IDs.
 	seen := make(map[string]struct{}, len(req.Entries))
 	for _, entry := range req.Entries {
 		if _, exists := seen[entry.ID]; exists {

--- a/internal/service/sqs/storage.go
+++ b/internal/service/sqs/storage.go
@@ -241,7 +241,6 @@ func (s *MemoryStorage) CreateQueue(_ context.Context, name string, attributes, 
 		return qd.Queue, nil
 	}
 
-	// Check FIFO queue requirements.
 	isFifo := strings.HasSuffix(name, ".fifo")
 	if attributes["FifoQueue"] == attrValueTrue && !isFifo {
 		return nil, &QueueError{
@@ -267,7 +266,6 @@ func (s *MemoryStorage) CreateQueue(_ context.Context, name string, attributes, 
 		ContentBasedDeduplication: attributes["ContentBasedDeduplication"] == attrValueTrue,
 	}
 
-	// Apply attributes.
 	applyQueueAttributes(queue, attributes)
 
 	qd := &QueueData{
@@ -438,7 +436,6 @@ func (qd *QueueData) validateFIFO(body, messageGroupID, messageDeduplicationID s
 		}
 	}
 
-	// Clean up expired deduplication entries.
 	for id, entry := range qd.DeduplicationCache {
 		if now.After(entry.ExpiresAt) {
 			delete(qd.DeduplicationCache, id)
@@ -454,10 +451,8 @@ func (qd *QueueData) validateFIFO(body, messageGroupID, messageDeduplicationID s
 		}
 	}
 
-	// Generate sequence number.
 	qd.SequenceCounter++
 
-	// Add to deduplication cache (5-minute TTL).
 	qd.DeduplicationCache[dedupID] = DeduplicationEntry{
 		MessageID: "",
 		ExpiresAt: now.Add(5 * time.Minute),
@@ -535,7 +530,6 @@ func (s *MemoryStorage) SendMessage(_ context.Context, queueURL, body string, de
 
 	qd.Messages = append(qd.Messages, msg)
 
-	// Notify long-polling receivers.
 	select {
 	case qd.notify <- struct{}{}:
 	default:
@@ -622,13 +616,11 @@ func (s *MemoryStorage) receiveMessagesLocked(queueURL string, maxMessages, visi
 
 	now := time.Now()
 
-	// Re-enqueue inflight messages whose visibility timeout has expired.
 	s.requeueExpiredMessages(qd, now)
 
 	result := make([]*Message, 0, maxMessages)
 	remaining := make([]*Message, 0, len(qd.Messages))
 
-	// For FIFO queues, track which message groups are locked (have in-flight messages).
 	lockedGroups := qd.lockedMessageGroups()
 
 	for _, msg := range qd.Messages {
@@ -644,7 +636,6 @@ func (s *MemoryStorage) receiveMessagesLocked(queueURL string, maxMessages, visi
 			continue
 		}
 
-		// FIFO: skip messages from groups that are locked (have in-flight messages).
 		if lockedGroups != nil && msg.MessageGroupID != "" {
 			if _, locked := lockedGroups[msg.MessageGroupID]; locked {
 				remaining = append(remaining, msg)
@@ -653,7 +644,6 @@ func (s *MemoryStorage) receiveMessagesLocked(queueURL string, maxMessages, visi
 			}
 		}
 
-		// Deliver the message: make invisible and add to inflight.
 		if s.deliverMessage(qd, msg, now, visibilityTimeout) {
 			result = append(result, msg)
 		}
@@ -784,7 +774,6 @@ func (s *MemoryStorage) GetQueueAttributes(_ context.Context, queueURL string, a
 		allAttrs["RedrivePolicy"] = q.RedrivePolicy
 	}
 
-	// Check if "All" is requested.
 	if slices.Contains(attributeNames, "All") {
 		return allAttrs, nil
 	}
@@ -879,10 +868,8 @@ func (s *MemoryStorage) moveToDeadLetterQueue(dlqArn string, msg *Message) {
 		return
 	}
 
-	// Find the DLQ by ARN.
 	for _, qd := range s.Queues {
 		if qd.Queue.ARN == dlqArn {
-			// Reset message for DLQ.
 			dlqMsg := &Message{
 				MessageID:         msg.MessageID,
 				Body:              msg.Body,
@@ -896,7 +883,6 @@ func (s *MemoryStorage) moveToDeadLetterQueue(dlqArn string, msg *Message) {
 
 			qd.Messages = append(qd.Messages, dlqMsg)
 
-			// Notify long-polling receivers on the DLQ.
 			select {
 			case qd.notify <- struct{}{}:
 			default:

--- a/internal/service/ssm/storage.go
+++ b/internal/service/ssm/storage.go
@@ -148,7 +148,6 @@ func (s *MemoryStorage) PutParameter(_ context.Context, req *PutParameterRequest
 
 	existing, exists := s.Parameters[req.Name]
 
-	// Check if parameter exists and overwrite is not set
 	if exists && !req.Overwrite {
 		return nil, &ParameterError{
 			Type:    ErrParameterAlreadyExists,
@@ -156,7 +155,6 @@ func (s *MemoryStorage) PutParameter(_ context.Context, req *PutParameterRequest
 		}
 	}
 
-	// Set defaults
 	paramType := req.Type
 	if paramType == "" {
 		if exists {
@@ -246,7 +244,6 @@ func (s *MemoryStorage) GetParametersByPath(_ context.Context, path string, recu
 		maxResults = 10
 	}
 
-	// Normalize path
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
@@ -255,7 +252,6 @@ func (s *MemoryStorage) GetParametersByPath(_ context.Context, path string, recu
 		path += "/"
 	}
 
-	// Collect matching parameters
 	var matches []*Parameter
 
 	for name, param := range s.Parameters {
@@ -264,12 +260,10 @@ func (s *MemoryStorage) GetParametersByPath(_ context.Context, path string, recu
 		}
 	}
 
-	// Sort by name for consistent pagination
 	sort.Slice(matches, func(i, j int) bool {
 		return matches[i].Name < matches[j].Name
 	})
 
-	// Handle pagination
 	start := 0
 
 	if nextToken != "" {
@@ -371,7 +365,6 @@ func (s *MemoryStorage) DescribeParameters(_ context.Context, filters []Paramete
 		maxResults = 50
 	}
 
-	// Collect all parameters, applying filters.
 	params := make([]*Parameter, 0, len(s.Parameters))
 
 	for _, p := range s.Parameters {
@@ -380,12 +373,10 @@ func (s *MemoryStorage) DescribeParameters(_ context.Context, filters []Paramete
 		}
 	}
 
-	// Sort by name for consistent pagination
 	sort.Slice(params, func(i, j int) bool {
 		return params[i].Name < params[j].Name
 	})
 
-	// Handle pagination
 	start := 0
 
 	if nextToken != "" {

--- a/internal/service/xray/storage.go
+++ b/internal/service/xray/storage.go
@@ -199,7 +199,6 @@ func (s *MemoryStorage) PutTraceSegments(_ context.Context, documents []string) 
 
 		s.Segments[segDoc.ID] = segment
 
-		// Create or update trace.
 		trace, exists := s.Traces[segDoc.TraceID]
 		if !exists {
 			trace = &Trace{
@@ -211,7 +210,6 @@ func (s *MemoryStorage) PutTraceSegments(_ context.Context, documents []string) 
 
 		trace.Segments = append(trace.Segments, segment)
 
-		// Calculate duration.
 		if segDoc.EndTime > 0 && segDoc.StartTime > 0 {
 			duration := segDoc.EndTime - segDoc.StartTime
 			if duration > trace.Duration {
@@ -238,7 +236,6 @@ func (s *MemoryStorage) GetTraceSummaries(_ context.Context, _, _ time.Time) ([]
 			Duration: trace.Duration,
 		}
 
-		// Parse first segment to get additional info.
 		if len(trace.Segments) > 0 {
 			var segDoc SegmentDocument
 			if err := json.Unmarshal([]byte(trace.Segments[0].Document), &segDoc); err == nil {
@@ -286,7 +283,6 @@ func (s *MemoryStorage) GetServiceGraph(_ context.Context, _, _ time.Time, _ str
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Build service graph from traces.
 	serviceMap := make(map[string]*ServiceNode)
 
 	for _, trace := range s.Traces {
@@ -373,7 +369,6 @@ func (s *MemoryStorage) DeleteGroup(_ context.Context, groupName, groupARN strin
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Find group by name or ARN.
 	var targetName string
 
 	if groupName != "" {

--- a/internal/streams/store.go
+++ b/internal/streams/store.go
@@ -150,7 +150,6 @@ func (s *Store) PutRecord(record *StreamRecord) {
 	record.EventVersion = "1.1"
 	record.EventSource = "aws:dynamodb"
 
-	// Append to the last (active) shard.
 	activeShard := sd.shards[len(sd.shards)-1]
 	activeShard.records = append(activeShard.records, record)
 }


### PR DESCRIPTION
## Summary
Removes 555 comment lines that merely restate the next line of code (`// Parse form data.`, `// Apply pagination.`, ...) across ~70 service packages, server, storage, and cli. Also trims two history-narration leftovers (ec2, appsync). Comments that carry a why, an AWS behavior note, or a non-obvious constraint are untouched, as are the revive-mandated exported doc comments. sfn and cloudcontrol are excluded; a follow-up PR compresses their long prose separately.

Deletion-only diff: the single inserted line is the rewritten ec2 rationale sentence.

## Test plan
- [x] `make lint` 0 issues, `go test -race -shuffle=on ./...` green