### PR TITLE
refactor(lambda): delegate writeJSONResponse to the shared implementation

### DIFF
--- a/internal/service/lambda/handlers.go
+++ b/internal/service/lambda/handlers.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 const pathSegmentFunctions = "functions"
@@ -572,10 +574,7 @@ func functionToConfiguration(fn *Function) *FunctionConfiguration {
 
 // writeJSONResponse writes a JSON response.
 func writeJSONResponse(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Amzn-Requestid", uuid.New().String())
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
+	service.WriteJSONResponseWithStatus(w, service.ContentTypeJSON, status, v)
 }
 
 // writeFunctionError writes a Lambda error response.

--- a/internal/service/response.go
+++ b/internal/service/response.go
@@ -18,8 +18,14 @@ const (
 // Content-Type, and a generated x-amzn-RequestId header. This is the shared
 // implementation behind the per-service writeJSONResponse helpers.
 func WriteJSONResponse(w http.ResponseWriter, contentType string, v any) {
+	WriteJSONResponseWithStatus(w, contentType, http.StatusOK, v)
+}
+
+// WriteJSONResponseWithStatus is WriteJSONResponse with an explicit status
+// code, for REST-style services whose success responses are not always 200.
+func WriteJSONResponseWithStatus(w http.ResponseWriter, contentType string, status int, v any) {
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("X-Amzn-Requestid", uuid.New().String())
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
 }


### PR DESCRIPTION
## Summary
lambda was the one package still hand-rolling its JSON response headers instead of delegating to `service.WriteJSONResponse`. Since Lambda's REST API returns 201/202 as well as 200, this adds `service.WriteJSONResponseWithStatus` (the existing `WriteJSONResponse` now delegates to it with 200) and routes lambda's helper through it. Headers and encoding are byte-identical.

## Test plan
- [x] `make lint` 0 issues, `go test -race ./...` green (pre-commit hook re-verified)