### PR TITLE
refactor: compress verbose comments in sfn and cloudcontrol

### DIFF
--- a/internal/service/cloudcontrol/aws_ec2_subnet.go
+++ b/internal/service/cloudcontrol/aws_ec2_subnet.go
@@ -134,10 +134,9 @@ func (h *awsEC2Subnet) List(ctx context.Context) ([]ResourceDescription, error) 
 	return out, nil
 }
 
-// subnetStateJSON serialises a Subnet for read responses. The full
-// CloudFormation schema is emitted (with null / empty defaults for what
-// kumo doesn't model) because terraform-provider-awscc requires every
-// Computed property to be resolved after apply.
+// subnetStateJSON emits the full CloudFormation schema (null / empty
+// defaults for what kumo doesn't model) because terraform-provider-awscc
+// requires every Computed property to be resolved after apply.
 func subnetStateJSON(s *ec2.Subnet) ([]byte, error) {
 	state := map[string]any{
 		"SubnetId":                      s.SubnetID,

--- a/internal/service/cloudcontrol/aws_ec2_vpc.go
+++ b/internal/service/cloudcontrol/aws_ec2_vpc.go
@@ -9,22 +9,16 @@ import (
 	"github.com/sivchari/kumo/internal/service/ec2"
 )
 
-// awsEC2VPC adapts the AWS::EC2::VPC Cloud Control type to kumo's EC2
-// storage. Properties model the CloudFormation surface, but only the
-// fields kumo's storage actually persists are honoured today —
-// additional CFN properties (Ipv6CidrBlock, EnableDnsHostnames, …) can
-// be wired through ModifyVpcAttribute calls in a follow-up without
-// changing the wire shape.
+// awsEC2VPC adapts AWS::EC2::VPC to kumo's EC2 storage. Only the fields
+// kumo's storage actually persists are honoured; other CFN properties can
+// be wired through ModifyVpcAttribute later without changing the wire shape.
 type awsEC2VPC struct{}
 
 func init() {
 	registerDefaultHandler(&awsEC2VPC{})
 }
 
-// vpcProperties is the JSON shape AWS::EC2::VPC uses on the wire. JSON
-// tags are PascalCase to match AWS CloudFormation; the Go field names
-// stay idiomatic (DNS upper-cased) even though the JSON spelling uses
-// "Dns".
+// vpcProperties is the JSON shape AWS::EC2::VPC uses on the wire.
 type vpcProperties struct {
 	VpcID              string `json:"VpcId,omitempty"`
 	CidrBlock          string `json:"CidrBlock,omitempty"`
@@ -88,10 +82,9 @@ func (h *awsEC2VPC) Read(ctx context.Context, identifier string) ([]byte, error)
 	return vpcStateJSON(vpcs[0])
 }
 
-// Update is currently read-back-only. The mutable VPC attributes
-// (EnableDnsHostnames, EnableDnsSupport) ride a separate AWS API
-// (ModifyVpcAttribute); wiring those through Cloud Control's PatchDocument
-// flow is a follow-up.
+// Update is read-back-only: the mutable VPC attributes (EnableDnsHostnames,
+// EnableDnsSupport) ride a separate AWS API (ModifyVpcAttribute), not yet
+// wired through Cloud Control's PatchDocument flow.
 func (h *awsEC2VPC) Update(ctx context.Context, identifier string, _ []byte) ([]byte, error) {
 	return h.Read(ctx, identifier)
 }
@@ -139,11 +132,9 @@ func (h *awsEC2VPC) List(ctx context.Context) ([]ResourceDescription, error) {
 	return out, nil
 }
 
-// vpcStateJSON is the shared serialiser for read paths so Create / Read /
-// List all produce the same wire shape. The full CloudFormation schema
-// is emitted (with null / empty defaults for what kumo doesn't model)
-// because terraform-provider-awscc treats every Computed property as
-// "must be known after apply".
+// vpcStateJSON emits the full CloudFormation schema (null / empty defaults
+// for what kumo doesn't model) because terraform-provider-awscc treats
+// every Computed property as "must be known after apply".
 func vpcStateJSON(v *ec2.Vpc) ([]byte, error) {
 	state := map[string]any{
 		"VpcId":                 v.VpcID,

--- a/internal/service/cloudcontrol/aws_iam_role.go
+++ b/internal/service/cloudcontrol/aws_iam_role.go
@@ -9,11 +9,10 @@ import (
 	"github.com/sivchari/kumo/internal/service/iam"
 )
 
-// awsIAMRole adapts AWS::IAM::Role to kumo's IAM storage. The
-// CloudFormation surface accepts AssumeRolePolicyDocument as either a
-// JSON string or a structured object; AWS clients send the structured
-// form, but the IAM storage stores it as a string, so we re-marshal on
-// the way in and just echo the stored string on the way out.
+// awsIAMRole adapts AWS::IAM::Role to kumo's IAM storage.
+// AssumeRolePolicyDocument arrives as either a JSON string or a structured
+// object, but the IAM storage stores it as a string, so we re-marshal it
+// on the way in and echo the stored string on the way out.
 type awsIAMRole struct{}
 
 func init() {
@@ -142,11 +141,9 @@ func (h *awsIAMRole) List(ctx context.Context) ([]ResourceDescription, error) {
 	return out, nil
 }
 
-// roleStateJSON serialises a Role for read responses. The full
-// CloudFormation schema is emitted (with null / empty defaults for what
-// kumo doesn't model — managed policies, permissions boundary, inline
-// policies, tags) because terraform-provider-awscc treats every Computed
-// property as "must be known after apply".
+// roleStateJSON emits the full CloudFormation schema (null / empty
+// defaults for what kumo doesn't model) because terraform-provider-awscc
+// treats every Computed property as "must be known after apply".
 func roleStateJSON(r *iam.Role) ([]byte, error) {
 	var policy any
 	if r.AssumeRolePolicyDocument != "" {

--- a/internal/service/cloudcontrol/aws_s3_bucket.go
+++ b/internal/service/cloudcontrol/aws_s3_bucket.go
@@ -9,11 +9,9 @@ import (
 	"github.com/sivchari/kumo/internal/service/s3"
 )
 
-// awsS3Bucket adapts the AWS::S3::Bucket Cloud Control resource type to
-// kumo's existing S3 storage. The Properties payload is full-schema:
-// every CloudFormation-modelled property is emitted (with null / empty
-// defaults when kumo doesn't model it yet) so terraform-provider-awscc's
-// "unknown after apply" plan resolves cleanly.
+// awsS3Bucket adapts AWS::S3::Bucket to kumo's S3 storage. The Properties
+// payload is full-schema (null / empty defaults for what kumo doesn't
+// model) so terraform-provider-awscc's "unknown after apply" plan resolves.
 type awsS3Bucket struct{}
 
 func init() {
@@ -111,11 +109,10 @@ func (h *awsS3Bucket) List(ctx context.Context) ([]ResourceDescription, error) {
 	return out, nil
 }
 
-// s3BucketStateJSON emits the full AWS::S3::Bucket CloudFormation schema
-// for the named bucket. Sub-resources kumo doesn't model (encryption,
-// lifecycle, replication, …) come back as JSON null so the awscc
-// provider's "(known after apply)" plan resolves without a placeholder
-// being left behind.
+// s3BucketStateJSON emits the full AWS::S3::Bucket CloudFormation schema.
+// Sub-resources kumo doesn't model (encryption, lifecycle, replication, …)
+// come back as JSON null so the awscc provider's "(known after apply)"
+// plan resolves.
 func s3BucketStateJSON(name string) []byte {
 	state := map[string]any{
 		"BucketName":                       name,

--- a/internal/service/cloudcontrol/handlers.go
+++ b/internal/service/cloudcontrol/handlers.go
@@ -7,10 +7,9 @@ import (
 )
 
 // CreateResource provisions a resource of the given type from a
-// DesiredState JSON document. kumo runs the underlying storage call
-// synchronously, so the returned ProgressEvent always reports SUCCESS
-// with the read-back ResourceModel attached — pollers calling
-// GetResourceRequestStatus afterwards just see the same SUCCESS.
+// DesiredState JSON document. kumo runs the storage call synchronously,
+// so the returned ProgressEvent always reports SUCCESS with the read-back
+// ResourceModel attached.
 func (s *Service) CreateResource(w http.ResponseWriter, r *http.Request) {
 	var input CreateResourceInput
 	if err := readJSON(r, &input); err != nil {
@@ -128,9 +127,8 @@ func (s *Service) UpdateResource(w http.ResponseWriter, r *http.Request) {
 }
 
 // DeleteResource removes the resource. NotFound is reported as
-// ResourceNotFoundException, matching real Cloud Control which surfaces
-// "you tried to delete a resource that wasn't there" rather than silently
-// succeeding.
+// ResourceNotFoundException, matching real Cloud Control rather than
+// silently succeeding.
 func (s *Service) DeleteResource(w http.ResponseWriter, r *http.Request) {
 	var input DeleteResourceInput
 	if err := readJSON(r, &input); err != nil {
@@ -209,12 +207,10 @@ func (s *Service) ListResources(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetResourceRequestStatus is invoked by clients polling an asynchronous
-// operation. kumo executes everything synchronously, so by the time a
-// caller asks, the operation is already done — we look up the original
-// CreateResource / UpdateResource / DeleteResource ProgressEvent and
-// re-emit it. Without echoing back the original Identifier + TypeName
-// the awscc terraform provider can't follow the create with a
-// GetResource and "unknown after apply" never resolves.
+// operation. kumo executes everything synchronously, so we look up and
+// re-emit the original ProgressEvent; echoing back its Identifier +
+// TypeName is required for the awscc terraform provider's "unknown after
+// apply" to resolve.
 func (s *Service) GetResourceRequestStatus(w http.ResponseWriter, r *http.Request) {
 	var input GetResourceRequestStatusInput
 	if err := readJSON(r, &input); err != nil {

--- a/internal/service/cloudcontrol/progress.go
+++ b/internal/service/cloudcontrol/progress.go
@@ -2,33 +2,21 @@ package cloudcontrol
 
 import "sync"
 
-// maxTrackedEvents bounds the progressTracker map. Without a cap, every
-// Create / Update / Delete leaks one ProgressEvent into the map for the
-// process lifetime, which adds up under sustained load. Real Cloud
-// Control surfaces a recent window (the API doc says ~7 days);
-// remembering the most-recent maxTrackedEvents keeps memory bounded
-// while preserving the SDK polling contract for fresh requests.
+// maxTrackedEvents bounds the progressTracker map so unbounded
+// Create/Update/Delete traffic doesn't leak ProgressEvents for the
+// process lifetime; real Cloud Control only retains a recent window too.
 const maxTrackedEvents = 1024
 
 // progressTracker keeps the per-RequestToken outcome of every Cloud
-// Control operation kumo serves. Real Cloud Control is asynchronous, so
-// SDK clients call GetResourceRequestStatus until they get SUCCESS plus
-// the Identifier of the resource. kumo runs everything synchronously,
-// but the SDK still polls — so we have to remember what each token
-// resolved to so the polling loop completes with the correct Identifier
-// + TypeName.
+// Control operation. kumo runs everything synchronously but SDK clients
+// still poll GetResourceRequestStatus expecting SUCCESS plus the original
+// Identifier + TypeName, so we remember what each token resolved to.
 type progressTracker struct {
-	// RWMutex because lookup is the dominant operation: terraform-awscc
-	// polls GetResourceRequestStatus far more often than it fires
-	// Create / Update / Delete, so concurrent readers shouldn't be
-	// serialised by a plain Mutex.
+	// RWMutex: lookup (status polling) is far more frequent than record.
 	mu     sync.RWMutex
 	events map[string]ProgressEvent
-	// order mirrors insertion order so we can evict the oldest entry
-	// when the map hits maxTrackedEvents. A real LRU would track touch
-	// time; for kumo the polling loop only revisits a token a handful
-	// of times immediately after the operation, so insertion-order FIFO
-	// is enough.
+	// order mirrors insertion so the oldest entry can be evicted FIFO
+	// when the map hits maxTrackedEvents.
 	order []string
 }
 
@@ -39,12 +27,9 @@ func newProgressTracker() *progressTracker {
 	}
 }
 
-// record stores the event keyed by its RequestToken. Pointer-passed to
-// avoid the 100+ byte struct copy the linter flags. The token is
-// generated client-side (or by us when the client sent none) and is
-// echoed back through every subsequent status poll. When the map is
-// full, the oldest entry is evicted FIFO so memory stays bounded under
-// long-running load.
+// record stores the event keyed by its RequestToken, evicting the oldest
+// entry FIFO once the map is full. Pointer-passed to avoid the 100+ byte
+// struct copy the linter flags.
 func (p *progressTracker) record(ev *ProgressEvent) {
 	if ev == nil || ev.RequestToken == "" {
 		return
@@ -67,9 +52,8 @@ func (p *progressTracker) record(ev *ProgressEvent) {
 }
 
 // lookup returns the previously-recorded event for the token, if any.
-// Read-locked because every CC poll path lands here; with the prior
-// Mutex contention serialised the polling loop and capped throughput
-// at ~5K req/s on a 32-way concurrent client.
+// Read-locked: a plain Mutex here previously serialised the polling loop
+// and capped throughput at ~5K req/s on a 32-way concurrent client.
 func (p *progressTracker) lookup(requestToken string) (ProgressEvent, bool) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()

--- a/internal/service/cloudcontrol/registry.go
+++ b/internal/service/cloudcontrol/registry.go
@@ -7,18 +7,16 @@ import (
 
 // Handler implements Cloud Control CRUD for one CloudFormation-style
 // resource type (e.g. "AWS::S3::Bucket"). Each method takes and returns
-// the JSON-serialised resource state — Cloud Control's wire format is
-// "DesiredState as a JSON string", so handlers operate on string-typed
-// JSON to avoid double encode/decode.
+// JSON-serialised resource state, matching Cloud Control's wire format,
+// to avoid double encode/decode.
 type Handler interface {
 	// TypeName returns the resource type the handler serves, e.g.
 	// "AWS::S3::Bucket".
 	TypeName() string
 
 	// Create provisions a new resource from the supplied desired-state
-	// JSON. Returns the primary identifier (the value Cloud Control uses
-	// to address the resource on subsequent calls) and the read-back
-	// state, which may differ from desired (server-assigned fields, etc.).
+	// JSON. Returns the primary identifier and the read-back state, which
+	// may differ from desired (server-assigned fields, etc.).
 	Create(ctx context.Context, desiredState []byte) (identifier string, state []byte, err error)
 
 	// Read returns the current state of the resource addressed by
@@ -35,9 +33,7 @@ type Handler interface {
 	Delete(ctx context.Context, identifier string) error
 
 	// List returns identifiers + state for every resource of this type.
-	// kumo doesn't paginate Cloud Control responses today; pagination can
-	// be added later through a separate List(ctx, after) signature without
-	// breaking existing handlers.
+	// kumo doesn't paginate Cloud Control responses today.
 	List(ctx context.Context) ([]ResourceDescription, error)
 }
 
@@ -86,13 +82,8 @@ func (r *Registry) Get(typeName string) (Handler, bool) {
 // every imported handler shows up in defaultRegistry().
 var defaultHandlers []Handler
 
-// registerDefaultHandler appends a handler to the package-level list. It
-// is the entry point per-resource init() functions use, e.g.:
-//
-//	func init() { registerDefaultHandler(&S3Bucket{}) }
-//
-// The handler will be present in every Service constructed via
-// defaultRegistry() / init().
+// registerDefaultHandler is the entry point per-resource init() functions
+// use, e.g. `func init() { registerDefaultHandler(&S3Bucket{}) }`.
 func registerDefaultHandler(h Handler) {
 	defaultHandlers = append(defaultHandlers, h)
 }

--- a/internal/service/cloudcontrol/service.go
+++ b/internal/service/cloudcontrol/service.go
@@ -1,10 +1,6 @@
-// Package cloudcontrol provides AWS Cloud Control API emulation. Cloud
-// Control is AWS's unified CRUD interface that exposes any
-// CloudFormation-modeled resource type through the same six operations
-// (Create / Read / Update / Delete / List / status polling). Implementing
-// it lets clients that target Cloud Control — most notably the
-// terraform-provider-awscc — drive a kumo-modeled resource without
-// per-service handler implementations on the kumo side.
+// Package cloudcontrol provides AWS Cloud Control API emulation, letting
+// clients that target Cloud Control — most notably terraform-provider-awscc
+// — drive any kumo-modeled resource through the same six CRUD operations.
 package cloudcontrol
 
 import (

--- a/internal/service/cloudcontrol/storage_lookup.go
+++ b/internal/service/cloudcontrol/storage_lookup.go
@@ -7,14 +7,9 @@ import (
 )
 
 // lookupStorage finds the registered Service named serviceName and casts
-// it to a type that exposes a Storage() method returning the requested
-// storage type T. Resource handlers use this from their request paths so
-// they share the same in-memory store as the underlying service —
-// without coupling init() ordering between packages.
-//
-// The cast pattern means each underlying service only has to expose a
-// `Storage() <ItsStorageType>` method; cloudcontrol doesn't need to know
-// the concrete struct.
+// it to a type exposing `Storage() T`, letting resource handlers share the
+// same in-memory store as the underlying service without coupling init()
+// ordering between packages or knowing its concrete struct.
 func lookupStorage[T any](serviceName string) (T, error) {
 	var zero T
 

--- a/internal/service/cloudcontrol/types.go
+++ b/internal/service/cloudcontrol/types.go
@@ -67,12 +67,10 @@ type GetResourceRequestStatusInput struct {
 }
 
 // ProgressEvent is the wire shape Cloud Control returns from every
-// asynchronous operation. kumo runs all operations synchronously, so we
-// always return SUCCESS — the field is still populated for SDK
-// compatibility. EventTime is encoded as Unix-epoch seconds (a float)
-// because the AWS JSON 1.0 protocol decodes timestamps as numbers; an
-// RFC3339 string trips the SDK's `expected Timestamp to be a JSON Number`
-// check.
+// asynchronous operation. kumo runs everything synchronously, so
+// OperationStatus is always SUCCESS. EventTime is a float (Unix-epoch
+// seconds) because the AWS JSON 1.0 protocol decodes timestamps as
+// numbers; an RFC3339 string trips the SDK's timestamp check.
 type ProgressEvent struct {
 	TypeName        string  `json:"TypeName,omitempty"`
 	Identifier      string  `json:"Identifier,omitempty"`
@@ -127,10 +125,8 @@ func writeJSON(w http.ResponseWriter, body any) {
 	_ = json.NewEncoder(w).Encode(body)
 }
 
-// writeError writes an AWS JSON error response. code becomes __type and
-// is what AWS SDK clients use to populate the error name. Cloud Control
-// always returns 400 for application errors; transport errors don't
-// flow through here.
+// writeError writes an AWS JSON error response. code becomes __type,
+// which AWS SDK clients use to populate the error name.
 func writeError(w http.ResponseWriter, code, message string) {
 	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
 	w.Header().Set("x-amzn-RequestId", uuid.New().String())

--- a/internal/service/sfn/activity.go
+++ b/internal/service/sfn/activity.go
@@ -27,10 +27,9 @@ func (s *MemoryStorage) activityARN(name string) string {
 	return fmt.Sprintf("arn:aws:states:%s:%s:activity:%s", s.region, s.accountID, name)
 }
 
-// CreateActivity creates an activity. Per AWS documentation, CreateActivity
-// is idempotent on name: a repeated call for a name that already has an
-// activity returns the existing ActivityArn/CreationDate unchanged, and any
-// different Tags on the repeat request are ignored rather than applied.
+// CreateActivity creates an activity. It is idempotent on name: a repeat
+// call returns the existing ActivityArn/CreationDate unchanged and ignores
+// any different Tags.
 func (s *MemoryStorage) CreateActivity(_ context.Context, name string, tags []Tag) (*Activity, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/service/sfn/activity_queue.go
+++ b/internal/service/sfn/activity_queue.go
@@ -15,27 +15,18 @@ type activityTask struct {
 }
 
 // activityQueueWaiter is a single GetActivityTask long poll blocked waiting
-// for a task. claimed and ch are both guarded by the owning activityQueue's
-// mutex, so enqueue and poll never race over which of them delivers (or
-// fails to deliver) a given task; see activityQueue's own doc comment.
+// for a task. claimed and ch are guarded by activityQueue's mutex so
+// enqueue and poll never race over delivery.
 type activityQueueWaiter struct {
 	ch      chan *activityTask
 	claimed bool
 }
 
-// activityQueue implements one activity's task hand-off: a Task state
-// enqueues a scheduled task, and GetActivityTask pollers dequeue one --
-// each task delivered to exactly one poller, per AWS's GetActivityTask
-// documentation. When a poller is already waiting, enqueue hands the task
-// to it directly; otherwise the task sits in pending until a poller
-// arrives.
-//
-// A poller that times out or whose context is done must still check
-// whether it was claimed after all: enqueue may have already committed to
-// delivering it a task (under waiters's lock) in the same instant the
-// poller decided to give up. Coordinating this through the same mutex
-// enqueue uses to pick a waiter is what makes delivery exactly-once even
-// under that race, without ever silently dropping a scheduled task.
+// activityQueue hands off one activity's scheduled tasks to GetActivityTask
+// pollers, each task delivered to exactly one poller (per AWS's
+// GetActivityTask docs). A poller that gives up on timeout must recheck
+// under the same mutex whether enqueue already claimed it in that instant,
+// so delivery stays exactly-once without ever dropping a task.
 type activityQueue struct {
 	mu      sync.Mutex
 	pending []*activityTask
@@ -101,11 +92,9 @@ func (q *activityQueue) poll(ctx context.Context, timeout time.Duration) *activi
 	return q.giveUpOrClaimed(w)
 }
 
-// giveUpOrClaimed resolves the race between a poller's own timeout/context
-// cancellation and enqueue claiming the same waiter: if enqueue had already
-// claimed w by the time this runs (under the same lock enqueue used), w.ch
-// is guaranteed to have a task ready to read; otherwise w is removed from
-// the queue so no later enqueue can claim it.
+// giveUpOrClaimed resolves the race between a poller giving up and enqueue
+// claiming the same waiter: if already claimed, w.ch is guaranteed to have
+// a task ready; otherwise w is removed so no later enqueue can claim it.
 func (q *activityQueue) giveUpOrClaimed(w *activityQueueWaiter) *activityTask {
 	q.mu.Lock()
 

--- a/internal/service/sfn/activity_task.go
+++ b/internal/service/sfn/activity_task.go
@@ -9,10 +9,9 @@ import (
 	"time"
 )
 
-// isActivityResource reports whether resource is an activity ARN created
-// via CreateActivity (arn:aws:states:{region}:{account}:activity:{name}),
-// as opposed to the arn:aws:states:::service:action shape optimized
-// integrations use, which always leaves the region/account segments empty.
+// isActivityResource reports whether resource is an activity ARN
+// (arn:aws:states:{region}:{account}:activity:{name}), as opposed to the
+// arn:aws:states:::service:action shape optimized integrations use.
 func isActivityResource(resource string) bool {
 	return strings.HasPrefix(resource, "arn:aws:states:") && strings.Contains(resource, ":activity:")
 }
@@ -44,15 +43,10 @@ func (r *activityQueueRegistry) get(arn string) *activityQueue {
 	return q
 }
 
-// executeActivityTask executes a Task state whose Resource references an
-// activity created via CreateActivity: it resolves the task's input
-// (resolved Parameters if set, else the effective input verbatim -- the
-// same fallback executeLambdaFunctionTask in executor.go uses for the
-// directly-specified-function integration), enqueues it for a
-// GetActivityTask poller, and then waits for SendTaskSuccess/SendTaskFailure
-// exactly like a callback Task state (see awaitTaskToken in
-// callback_task.go), honoring the same TimeoutSeconds/HeartbeatSeconds
-// semantics.
+// executeActivityTask executes a Task state whose Resource is an activity
+// ARN: enqueues the resolved input for a GetActivityTask poller, then waits
+// for SendTaskSuccess/SendTaskFailure like a callback Task state, honoring
+// the same TimeoutSeconds/HeartbeatSeconds semantics.
 func (e *executionEngine) executeActivityTask(ctx context.Context, name string, state *stateDefinition, resource, input string) (string, error) {
 	taskInput := input
 
@@ -82,9 +76,8 @@ func (e *executionEngine) executeActivityTask(ctx context.Context, name string, 
 const activityPollTimeout = 60 * time.Second
 
 // GetActivityTask long-polls for a task scheduled against activityArn,
-// returning an empty taskToken if none arrives within the poll window --
-// per AWS's documented behavior of responding with "a taskToken with a
-// null string" once the 60-second poll elapses.
+// returning an empty taskToken if none arrives within the poll window,
+// matching AWS's documented null-string response on timeout.
 func (s *MemoryStorage) GetActivityTask(ctx context.Context, activityArn, _ string) (string, string, error) {
 	s.mu.RLock()
 	_, exists := s.Activities[activityArn]
@@ -121,10 +114,9 @@ func (s *MemoryStorage) SendTaskHeartbeat(_ context.Context, taskToken string) e
 	return tokenServiceError(s.engine.tokens.heartbeatToken(taskToken))
 }
 
-// tokenServiceError turns a tokenRegistry result code (tokenErrDoesNotExist,
-// tokenErrTimedOut, or "" for success) into the ServiceError handlers.go
-// expects, matching AWS's documented SendTaskSuccess/SendTaskFailure/
-// SendTaskHeartbeat error messages.
+// tokenServiceError turns a tokenRegistry result code into the
+// ServiceError handlers.go expects, matching AWS's documented error
+// messages for these APIs.
 func tokenServiceError(code string) error {
 	switch code {
 	case "":

--- a/internal/service/sfn/callback.go
+++ b/internal/service/sfn/callback.go
@@ -6,58 +6,44 @@ import (
 	"github.com/google/uuid"
 )
 
-// Task token error codes, matching AWS's documented SendTaskSuccess/
-// SendTaskFailure/SendTaskHeartbeat errors: TaskDoesNotExist ("the activity
-// does not exist") is a token kumo has never seen; TaskTimedOut ("the task
-// token has either expired or the task associated with the token has
-// already been closed") is a token that was valid but has since resolved
-// (success, failure, or its own timeout) or already been reported on.
+// Task token error codes: TaskDoesNotExist is a token kumo has never seen;
+// TaskTimedOut is one that was valid but has since resolved or already
+// been reported on.
 const (
 	tokenErrDoesNotExist = "TaskDoesNotExist"
 	tokenErrTimedOut     = "TaskTimedOut"
 )
 
-// callbackResult carries the outcome delivered by SendTaskSuccess or
-// SendTaskFailure for a single waiting task token. err is nil for a
-// success; for a failure it is a failStateError carrying the reported
-// Error/Cause, so it flows through Retry/Catch exactly like any other named
-// error.
+// callbackResult carries the outcome of SendTaskSuccess/SendTaskFailure
+// for a waiting task token. err is nil on success; on failure it is a
+// failStateError so it flows through Retry/Catch like any named error.
 type callbackResult struct {
 	output string
 	err    error
 }
 
 // pendingCallback is a single task token's wait state, shared between the
-// executor goroutine blocked on it (see awaitTaskToken in callback_task.go
-// and executeActivityTask in activity_task.go) and the SendTaskSuccess/
-// SendTaskFailure/SendTaskHeartbeat handlers that resolve it. done and
-// heartbeat are both buffered so a resolving call never blocks on a waiter
-// that has already stopped listening (e.g. TimeoutSeconds expired first).
+// blocked executor goroutine and the SendTaskSuccess/Failure/Heartbeat
+// handlers that resolve it. done and heartbeat are buffered so a resolving
+// call never blocks on a waiter that already stopped listening.
 type pendingCallback struct {
 	done      chan callbackResult
 	heartbeat chan struct{}
 }
 
-// tokenRegistry tracks every task token currently awaited by a callback
-// Task state (.waitForTaskToken) or an activity Task state, and the
-// executor goroutines waiting on them. It is entirely in-memory: waiting
-// tokens do not need to survive a kumo restart, since the execution
-// goroutine SendTaskSuccess/Failure ultimately resumes does not survive one
+// tokenRegistry tracks every task token currently awaited by a callback or
+// activity Task state. It is in-memory only: waiting tokens need not
+// survive a restart since the execution goroutine they resume doesn't
 // either.
 //
-// The registry's own mutex is intentionally separate from
-// MemoryStorage.mu: an executor goroutine blocks on pendingCallback.done
-// without holding any lock (see awaitTaskToken), and every registry method
-// below only ever holds this mutex for the duration of a single map
-// operation, so SendTaskSuccess/Failure/Heartbeat requests are never
-// blocked behind a long-running execution.
+// Its mutex is intentionally separate from MemoryStorage.mu and is only
+// ever held for a single map operation, so SendTaskSuccess/Failure/
+// Heartbeat requests are never blocked behind a long-running execution.
 type tokenRegistry struct {
 	mu     sync.Mutex
 	active map[string]*pendingCallback
 	// closed records every token that has ever left active, so a late
-	// SendTaskSuccess/Failure/Heartbeat for it reports TaskTimedOut instead
-	// of TaskDoesNotExist, which AWS reserves for a token that never
-	// existed.
+	// request for it reports TaskTimedOut instead of TaskDoesNotExist.
 	closed map[string]bool
 }
 
@@ -86,11 +72,9 @@ func (r *tokenRegistry) register() (string, *pendingCallback) {
 	return token, pending
 }
 
-// release removes token from the active set without resolving it, moving it
-// to closed. Callers use this when they abandon a token before any
-// SendTaskSuccess/Failure resolves it (a callback integration call that
-// itself failed, or the wait timing out), so a late SendTaskSuccess/Failure
-// for that token correctly reports TaskTimedOut rather than succeeding.
+// release moves token from active to closed without resolving it, for
+// when a token is abandoned before SendTaskSuccess/Failure (integration
+// call failed, or the wait timed out) so a late call reports TaskTimedOut.
 func (r *tokenRegistry) release(token string) {
 	r.mu.Lock()
 	delete(r.active, token)

--- a/internal/service/sfn/callback_task.go
+++ b/internal/service/sfn/callback_task.go
@@ -12,11 +12,9 @@ import (
 // https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html.
 const callbackResourceSuffix = ".waitForTaskToken"
 
-// callbackIntegrations are the optimized service integrations kumo supports
-// with .waitForTaskToken appended. AWS documents Lambda and SQS (among
-// others) as supporting the "Wait for a Callback with Task Token" pattern;
-// kumo implements the two integrations it already supports without the
-// suffix (see executeTaskState in executor.go).
+// callbackIntegrations are the optimized service integrations kumo
+// supports with .waitForTaskToken appended (AWS supports more; kumo only
+// implements the two integrations it already has without the suffix).
 var callbackIntegrations = map[string]bool{
 	"arn:aws:states:::lambda:invoke":   true,
 	"arn:aws:states:::sqs:sendMessage": true,
@@ -38,15 +36,10 @@ func isCallbackResource(resource string) (baseResource string, ok bool) {
 	return resource[:suffixStart], true
 }
 
-// executeCallbackTask executes a Task state whose Resource uses the "Wait
-// for a Callback with Task Token" pattern: it generates a task token,
-// injects it into the resolved Parameters via the Context object
-// ($$.Task.Token), fires the underlying integration once, and then blocks
-// until SendTaskSuccess/SendTaskFailure resolves the token or the wait
-// times out. TimeoutSeconds bounds the whole wait; HeartbeatSeconds, if
-// set, must see a SendTaskHeartbeat within every interval or the wait times
-// out early -- both report States.Timeout, per AWS's documentation for this
-// pattern.
+// executeCallbackTask executes a .waitForTaskToken Task state: injects a
+// task token into Parameters via $$.Task.Token, fires the integration
+// once, then blocks until SendTaskSuccess/SendTaskFailure or a
+// TimeoutSeconds/HeartbeatSeconds timeout (both report States.Timeout).
 func (e *executionEngine) executeCallbackTask(ctx context.Context, name string, state *stateDefinition, baseResource, input string) (string, error) {
 	if !callbackIntegrations[baseResource] {
 		return "", fmt.Errorf("unsupported %s resource %q", callbackResourceSuffix, baseResource)
@@ -70,21 +63,18 @@ func (e *executionEngine) executeCallbackTask(ctx context.Context, name string, 
 	return e.awaitTaskToken(ctx, name, token, state, pending)
 }
 
-// taskTokenContext builds the Context object subset ($$.Task.Token) a
-// callback/activity Task state's Parameters may reference via
-// resolveParametersWithContext. kumo does not model the rest of the
-// Context object ($$.Execution, $$.State, ...); see mapItemContext in
-// itemselector.go for the only other place the Context object is built.
+// taskTokenContext builds the $$.Task.Token Context object subset a
+// callback/activity Task state's Parameters may reference. kumo does not
+// model the rest of the Context object ($$.Execution, $$.State, ...).
 func taskTokenContext(token string) map[string]any {
 	return map[string]any{
 		"Task": map[string]any{"Token": token},
 	}
 }
 
-// fireCallbackIntegration performs the "fire" half of a callback task: the
-// underlying integration call itself, discarding its response, since a
-// callback task's real output comes from SendTaskSuccess, not the
-// integration's own response.
+// fireCallbackIntegration performs the "fire" half of a callback task,
+// discarding the integration's response since the real output comes from
+// SendTaskSuccess, not this call.
 func (e *executionEngine) fireCallbackIntegration(ctx context.Context, baseResource string, params map[string]any) error {
 	switch baseResource {
 	case "arn:aws:states:::sqs:sendMessage":
@@ -100,14 +90,10 @@ func (e *executionEngine) fireCallbackIntegration(ctx context.Context, baseResou
 	}
 }
 
-// awaitTaskToken blocks until token is resolved by SendTaskSuccess/
-// SendTaskFailure, a HeartbeatSeconds interval elapses with no
-// SendTaskHeartbeat, or ctx is done (TimeoutSeconds, or an outer
-// execution-level deadline). All three timeout paths report the same
-// taskTimeoutError (see timeout.go), which executionErrorCode surfaces as
-// States.Timeout; on any of them, token is released so a
-// SendTaskSuccess/Failure that arrives afterward correctly reports
-// TaskTimedOut instead of resolving a state that has already failed.
+// awaitTaskToken blocks until token is resolved, a HeartbeatSeconds
+// interval elapses with no heartbeat, or ctx is done. All timeout paths
+// release token, so a late SendTaskSuccess/Failure correctly reports
+// TaskTimedOut instead of resolving an already-failed state.
 func (e *executionEngine) awaitTaskToken(ctx context.Context, name, token string, state *stateDefinition, pending *pendingCallback) (string, error) {
 	heartbeat := heartbeatInterval(state)
 
@@ -152,9 +138,7 @@ func (e *executionEngine) timeoutOrLateResult(name, token string, pending *pendi
 }
 
 // heartbeatInterval resolves a Task state's HeartbeatSeconds, returning
-// zero if unset. HeartbeatSecondsPath is decoded (see stateDefinition in
-// retry.go) but not implemented -- it is a dynamic reference-path form AWS
-// documents far less prominently than the static field.
+// zero if unset. HeartbeatSecondsPath is decoded but not implemented.
 func heartbeatInterval(state *stateDefinition) time.Duration {
 	if state.HeartbeatSeconds == nil {
 		return 0

--- a/internal/service/sfn/choice.go
+++ b/internal/service/sfn/choice.go
@@ -6,21 +6,14 @@ import (
 	"time"
 )
 
-// choiceRule is a single rule within a Choice state's Choices array. Per the
-// Amazon States Language spec it is either a Data-test Expression (a
-// "Variable" JSONPath plus exactly one comparison operator) or a Boolean
-// Expression (And/Or/Not combining nested rules).
+// choiceRule is a single rule within a Choice state's Choices array: either
+// a Data-test Expression (Variable path + one comparison operator) or a
+// Boolean Expression (And/Or/Not combining nested rules). Every comparator
+// has a "*Path" variant resolving its operand from a Path instead of a
+// literal.
 //
-// Every comparison operator also has a "*Path" variant (e.g.
-// "StringEqualsPath"), whose value is a Path resolved against the state's
-// effective input to yield the comparison operand, instead of a static
-// literal -- see resolveStringOperand/resolveNumericOperand/
-// resolveBooleanOperand.
-//
-// JSON tags are lowerCamelCase rather than the Amazon States Language's own
-// PascalCase (e.g. "Variable", "StringEquals"); encoding/json matches object
-// keys to struct fields case-insensitively when there is no exact match, so
-// definitions using the spec's PascalCase field names still decode correctly.
+// JSON tags are lowerCamelCase; encoding/json matches ASL's PascalCase
+// field names case-insensitively, so definitions still decode correctly.
 type choiceRule struct {
 	Variable string `json:"variable"`
 	Next     string `json:"next"`
@@ -219,12 +212,9 @@ func evaluateStringMatches(value any, pattern string) (matched, handled bool, er
 	return stringMatchesGlob(s, segments), true, nil
 }
 
-// parseStringMatchesPattern splits a StringMatches pattern into the literal
-// segments between its unescaped "*" wildcards, per
-// https://states-language.net/spec.html's StringMatches rules: "*" matches
-// zero or more characters; "\*" is a literal "*"; "\\" is a literal "\";
-// any other use of "\" (including a trailing, unescaped one) is a runtime
-// error.
+// parseStringMatchesPattern splits pattern into literal segments between
+// unescaped "*" wildcards. "\*" is a literal "*", "\\" a literal "\"; any
+// other backslash use (including a trailing one) is a runtime error.
 func parseStringMatchesPattern(pattern string) ([]string, error) {
 	var (
 		segments []string
@@ -261,11 +251,9 @@ func parseStringMatchesPattern(pattern string) ([]string, error) {
 	return segments, nil
 }
 
-// stringMatchesGlob reports whether value matches a StringMatches pattern
-// already split into segments by parseStringMatchesPattern: segments[0]
-// must prefix value and segments[len-1] must suffix it (the sole segment
-// must equal value exactly when there was no wildcard at all), with every
-// segment in between required to appear, in order, somewhere between them.
+// stringMatchesGlob reports whether value matches segments produced by
+// parseStringMatchesPattern: segments[0] must prefix value, segments[-1]
+// must suffix it, and every segment between must appear in order.
 func stringMatchesGlob(value string, segments []string) bool {
 	if len(segments) == 1 {
 		return value == segments[0]
@@ -289,11 +277,9 @@ func stringMatchesGlob(value string, segments []string) bool {
 	return strings.HasSuffix(value, segments[len(segments)-1])
 }
 
-// evaluateTypeCheck evaluates IsNumeric/IsString/IsBoolean/IsTimestamp: each
-// takes a boolean operand and matches when value's type (JSON number/
-// string/boolean, or -- for IsTimestamp -- an RFC3339 string) equals it,
-// mirroring how IsNull compares (value == nil) against its own boolean
-// operand. handled is false if rule sets none of them.
+// evaluateTypeCheck evaluates IsNumeric/IsString/IsBoolean/IsTimestamp:
+// each matches when value's type equals the boolean operand. handled is
+// false if rule sets none of them.
 func evaluateTypeCheck(rule *choiceRule, value any) (matched, handled bool) {
 	switch {
 	case rule.IsNumeric != nil:
@@ -346,11 +332,9 @@ func compareStringWith(value any, static, path *string, input map[string]any, ma
 	return ok && matches(cmp), true, nil
 }
 
-// resolveStringOperand resolves a String*/Timestamp* comparator's operand:
-// the static value if set, else the "*Path" variant's Path resolved
-// against input. ok is false if path resolves to a non-string value, per
-// the spec's "if the values are not both of the appropriate type... the
-// comparison will return false".
+// resolveStringOperand resolves a String*/Timestamp* comparator's operand
+// (static value, or the "*Path" variant resolved against input). ok is
+// false if path resolves to a non-string value.
 func resolveStringOperand(static, path *string, input map[string]any) (want string, ok bool, err error) {
 	if static != nil {
 		return *static, true, nil
@@ -480,10 +464,9 @@ func evaluateTimestampComparison(rule *choiceRule, value any, input map[string]a
 	}
 }
 
-// compareTimestampWith resolves a Timestamp* comparator's operand -- from a
-// static value or, for the "*Path" variant, by resolving path against
-// input -- and reports whether value satisfies it per matches. The operand
-// is a string in both cases, so this reuses resolveStringOperand.
+// compareTimestampWith resolves a Timestamp* comparator's operand and
+// reports whether value satisfies it per matches; reuses
+// resolveStringOperand since the operand is a string in both cases.
 func compareTimestampWith(value any, static, path *string, input map[string]any, matches func(cmp int) bool) (matched, handled bool, err error) {
 	want, ok, err := resolveStringOperand(static, path, input)
 	if err != nil {

--- a/internal/service/sfn/executor.go
+++ b/internal/service/sfn/executor.go
@@ -21,18 +21,14 @@ type stateMachineDefinition struct {
 	StartAt string                     `json:"StartAt"`
 	States  map[string]stateDefinition `json:"States"`
 
-	// ProcessorConfig selects a Map state's ItemProcessor processing mode
-	// (see mapstate.go). It is decoded on every stateMachineDefinition,
-	// since Parallel Branches reuse this same struct, but it is only
-	// meaningful when this stateMachineDefinition is itself a Map state's
-	// ItemProcessor.
+	// ProcessorConfig selects a Map state's ItemProcessor processing mode.
+	// Decoded on every stateMachineDefinition (Parallel Branches reuse this
+	// struct) but only meaningful when it is itself a Map's ItemProcessor.
 	ProcessorConfig *processorConfig `json:"ProcessorConfig"`
 
-	// TimeoutSeconds bounds the whole execution's wall-clock time. It is only
-	// meaningful on the top-level definition; MemoryStorage.runExecution is
-	// the sole reader of this field, since sub-state-machines (Parallel
-	// Branches / Map ItemProcessor) reuse this same struct but must not
-	// inherit an outer execution's timeout as their own.
+	// TimeoutSeconds bounds the whole execution's wall-clock time. Only
+	// meaningful on the top-level definition -- sub-state-machines (Parallel
+	// Branches / Map ItemProcessor) reuse this struct but must not inherit it.
 	TimeoutSeconds *int `json:"TimeoutSeconds"`
 }
 
@@ -48,16 +44,10 @@ type stateDefinition struct {
 	Result     any            `json:"Result"`
 	Comment    string         `json:"Comment"`
 
-	// ResultSelector, ResultPath, InputPath, and OutputPath are the
-	// remaining fields of the standard data-flow pipeline (see iodata.go).
-	// ResultPath, InputPath, and OutputPath are left as raw JSON so an
-	// explicit "null" (which, per the ASL spec, discards data) can be told
-	// apart from the field being absent (which defaults to "$", no
-	// filtering/replacement); both would otherwise unmarshal to the same
-	// value through a plain *string. Per the spec's per-state field table,
-	// not every state type honors every field -- see resolveEffectiveInput,
-	// runRetryCatchResultPipeline in retry.go, and validateStateFields in
-	// validate.go for which types actually apply which fields.
+	// ResultPath, InputPath, and OutputPath are raw JSON so an explicit "null"
+	// (discards data, per ASL) can be told apart from the field being absent
+	// (defaults to "$"); both would otherwise unmarshal identically through a
+	// plain *string. Not every state type honors every field.
 	ResultSelector map[string]any  `json:"ResultSelector"`
 	ResultPath     json.RawMessage `json:"ResultPath"`
 	InputPath      json.RawMessage `json:"InputPath"`
@@ -84,20 +74,11 @@ type stateDefinition struct {
 	// Parallel state fields.
 	Branches []stateMachineDefinition `json:"Branches"`
 
-	// Map state fields. ItemProcessor is the current field name; Iterator is
-	// the legacy alias for the same sub-state-machine. If both are present,
-	// ItemProcessor takes precedence. See mapstate.go, itemselector.go,
-	// itemreader.go, itembatcher.go, and resultwriter.go for how
-	// ItemSelector/ItemReader/ItemBatcher/ResultWriter are implemented, and
-	// requireDistributedModeForFields in mapstate.go for which of these
-	// fields require ItemProcessor.ProcessorConfig.Mode "DISTRIBUTED".
-	// MaxItemsPerBatchPath/MaxInputBytesPerBatchPath/MaxConcurrencyPath/
-	// ToleratedFailurePercentagePath/ToleratedFailureCountPath (the dynamic,
-	// reference-path forms of these fields) are resolved against the Map
-	// state's effective input, preferring the Path form when both it and
-	// the static field are set -- see resolveMaxConcurrency in mapstate.go,
-	// resolveMapTolerance in maptolerance.go, and buildProcessorUnits in
-	// itembatcher.go.
+	// Map state fields. ItemProcessor is the current name; Iterator is the
+	// legacy alias for the same sub-state-machine (ItemProcessor takes
+	// precedence if both are present). Several fields require Distributed
+	// mode; their "*Path" variants are resolved against the effective input,
+	// preferring the Path form when both it and the static field are set.
 	ItemsPath                  string                  `json:"ItemsPath"`
 	ItemProcessor              *stateMachineDefinition `json:"ItemProcessor"`
 	Iterator                   *stateMachineDefinition `json:"Iterator"`
@@ -116,33 +97,23 @@ type stateDefinition struct {
 	ToleratedFailureCountPath      string `json:"ToleratedFailureCountPath"`
 
 	// Task state timeout fields. TimeoutSeconds/TimeoutSecondsPath bound a
-	// single execution attempt of the task (see timeout.go); per the ASL
-	// spec's default of 99999999 seconds (~3.17 years) when absent, kumo
-	// treats "unset" as no timeout at all rather than wrapping every task in
-	// a multi-year context.
+	// single execution attempt. kumo treats "unset" as no timeout at all
+	// rather than the spec's ~3.17-year default.
 	TimeoutSeconds     *int   `json:"TimeoutSeconds"`
 	TimeoutSecondsPath string `json:"TimeoutSecondsPath"`
 
-	// HeartbeatSeconds is enforced only for callback (.waitForTaskToken) and
-	// activity Task states (see heartbeatInterval and awaitTaskToken in
-	// callback_task.go, and executeActivityTask in activity_task.go): those
-	// are the only Task states that can ever receive a SendTaskHeartbeat.
-	// For every other (ordinary HTTP) Task state it is decoded but not
-	// enforced, since such a task can never send a heartbeat -- enforcing it
-	// there would fail every task that sets it, for a reason kumo can never
-	// satisfy. HeartbeatSecondsPath is decoded but not implemented at all
-	// (see heartbeatInterval).
+	// HeartbeatSeconds is enforced only for callback/activity Task states --
+	// the only ones that can ever receive a SendTaskHeartbeat. Ordinary Task
+	// states decode but never enforce it, since they can never send one.
+	// HeartbeatSecondsPath is decoded but not implemented.
 	HeartbeatSeconds     *int   `json:"HeartbeatSeconds"`
 	HeartbeatSecondsPath string `json:"HeartbeatSecondsPath"`
 }
 
-// Execution error codes surfaced via DescribeExecution. States.TaskFailed is
-// reserved for failures of a Task state's work itself; States.NoChoiceMatched
-// is reserved for a Choice state with no matching rule and no Default;
-// States.Timeout is reported when a Task or the whole execution exceeds its
-// TimeoutSeconds; States.ALL is the Retry/Catch wildcard that matches any
-// other Error Name; every other engine-level failure (unsupported state, bad
-// definition wiring) is States.Runtime.
+// Execution error codes surfaced via DescribeExecution: States.TaskFailed
+// for Task work failures, States.NoChoiceMatched for an unmatched Choice
+// with no Default, States.Timeout for a Task/execution deadline, States.ALL
+// is the Retry/Catch wildcard, everything else is States.Runtime.
 const (
 	errorStatesRuntime         = "States.Runtime"
 	errorStatesTaskFailed      = "States.TaskFailed"
@@ -249,20 +220,15 @@ type executionEngine struct {
 	// override this directly to keep runtime bounded.
 	activityPollTimeout time.Duration
 
-	// starter services the states:startExecution Task integration (see
-	// nestedexec.go). It is wired to the same MemoryStorage that owns this
-	// engine (see NewMemoryStorage in storage.go) rather than an HTTP round
-	// trip back to kumo's own server, since it recurses into kumo's own SFN
-	// engine -- see nestedexec.go's executionStarter doc for why. It is nil
-	// for engines built directly via newExecutionEngine in tests that never
-	// exercise states:startExecution.
+	// starter services the states:startExecution Task integration. Wired
+	// directly to MemoryStorage rather than an HTTP round trip, since it
+	// recurses into kumo's own SFN engine. Nil for engines built via
+	// newExecutionEngine in tests that never exercise it.
 	starter executionStarter
 
-	// mapRuns records distributed-mode Map Runs (see maprun.go), wired the
-	// same way as starter and for the same reason: it is storage
-	// bookkeeping, not a real AWS service call. It is nil for engines built
-	// directly via newExecutionEngine in tests that never exercise a
-	// Distributed Map.
+	// mapRuns records distributed-mode Map Runs, wired the same way as
+	// starter since it is storage bookkeeping, not a real AWS call. Nil for
+	// engines built via newExecutionEngine in tests that never exercise it.
 	mapRuns mapRunTracker
 }
 
@@ -318,10 +284,9 @@ func (e *executionEngine) execute(ctx context.Context, def *stateMachineDefiniti
 			return output, nil
 		}
 
-		// nextOverride is set by states that pick their own successor
-		// dynamically: Choice, and any Task/Parallel/Map whose Catch routed
-		// to a fallback state. It always takes priority over End/Next, since
-		// a Catch must be able to redirect even a state marked End: true.
+		// nextOverride is set by states with a dynamic successor (Choice, or
+		// a Catch-routed fallback) and always takes priority over End/Next,
+		// so a Catch can redirect even a state marked End: true.
 		if nextOverride != "" {
 			currentInput = output
 			currentState = nextOverride
@@ -342,10 +307,9 @@ func (e *executionEngine) execute(ctx context.Context, def *stateMachineDefiniti
 	}
 }
 
-// executeState executes a single state and returns its output and, for
-// states that determine the next state dynamically (Choice), the name of
-// that next state. nextOverride is empty for states that use the state's own
-// Next/End fields.
+// executeState executes a single state, returning its output and, for
+// Choice (which picks its next state dynamically), that state's name.
+// nextOverride is empty when the state uses its own Next/End fields.
 func (e *executionEngine) executeState(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
 	switch state.Type {
 	case "Pass":
@@ -375,14 +339,11 @@ func (e *executionEngine) executeState(ctx context.Context, name string, state *
 	}
 }
 
-// executeTaskStateWithPolicy executes a Task state's full standard field
-// pipeline: InputPath narrows the raw input to the effective input, Retry
-// and Catch govern the work itself (each attempt individually bounded by
-// TimeoutSeconds/TimeoutSecondsPath; see executeTaskStateWithTimeout in
-// timeout.go), and on success ResultSelector/ResultPath/OutputPath shape
-// the effective output. Parameters is resolved inside executeTaskState,
-// against the effective input, since its resolved value doubles as the
-// resource invocation's request payload rather than a generic JSON blob.
+// executeTaskStateWithPolicy executes a Task state's standard field
+// pipeline: InputPath narrows input, Retry/Catch govern the work (each
+// attempt bounded by TimeoutSeconds), then ResultSelector/ResultPath/
+// OutputPath shape the output. Parameters is resolved inside
+// executeTaskState since its value doubles as the request payload.
 func (e *executionEngine) executeTaskStateWithPolicy(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
 	effectiveInput, err := applyInputPath(state.InputPath, input)
 	if err != nil {
@@ -394,11 +355,9 @@ func (e *executionEngine) executeTaskStateWithPolicy(ctx context.Context, name s
 	})
 }
 
-// executePassState executes a Pass state's full standard field pipeline:
-// InputPath and Parameters build the effective input, Result (if present)
-// -- else the effective input itself -- is the state's result, and
-// ResultPath/OutputPath shape the effective output. Pass has no
-// ResultSelector; see the spec's per-state field table.
+// executePassState executes a Pass state: InputPath/Parameters build the
+// effective input, Result (or the input itself) is the result, and
+// ResultPath/OutputPath shape the output. Pass has no ResultSelector.
 func (e *executionEngine) executePassState(name string, state *stateDefinition, input string) (string, error) {
 	effectiveInput, err := resolveEffectiveInput(state.InputPath, state.Parameters, input)
 	if err != nil {
@@ -429,13 +388,10 @@ func (e *executionEngine) executePassState(name string, state *stateDefinition, 
 	return output, nil
 }
 
-// executeChoiceState executes a Choice state: InputPath narrows the raw
-// input to the effective input, which the Choice Rules -- including the
-// "*Path" comparators (see choice.go) -- are evaluated against; the first
-// matching rule's Next is chosen, falling back to Default. Choice has no
-// Parameters/ResultSelector/ResultPath (it produces no result of its own),
-// so the state output is simply the effective input, narrowed by
-// OutputPath.
+// executeChoiceState executes a Choice state: the Choice Rules are
+// evaluated against the effective input, choosing the first match's Next
+// (falling back to Default). Choice has no result of its own, so output
+// is just the effective input narrowed by OutputPath.
 func (e *executionEngine) executeChoiceState(name string, state *stateDefinition, input string) (string, string, error) {
 	effectiveInput, err := applyInputPath(state.InputPath, input)
 	if err != nil {
@@ -511,12 +467,10 @@ func (e *executionEngine) executeFailState(state *stateDefinition) error {
 }
 
 // executeTaskState executes a Task state by calling the appropriate
-// service. Callback (.waitForTaskToken) and activity resources are
-// dispatched before the ordinary integrations below, since both pause the
-// state on a task token rather than completing from the integration call's
-// own response; wrapCallbackTaskResult -- not wrapTaskResult -- wraps their
-// result, so a taskTimeoutError from a HeartbeatSeconds/TimeoutSeconds
-// expiry reaches executionErrorCode unwrapped (see wrapCallbackTaskResult).
+// service. Callback and activity resources are dispatched first since
+// they pause on a task token rather than the integration's own response;
+// wrapCallbackTaskResult (not wrapTaskResult) wraps their result so a
+// timeout reaches executionErrorCode unwrapped.
 func (e *executionEngine) executeTaskState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
 	resource := state.Resource
 	if resource == "" {
@@ -562,12 +516,9 @@ func wrapTaskResult(output string, err error) (string, error) {
 }
 
 // wrapCallbackTaskResult is wrapTaskResult's counterpart for callback and
-// activity Task states: a taskTimeoutError (HeartbeatSeconds/TimeoutSeconds
-// expiry, or a SendTaskFailure's own reported error via failStateError) must
-// reach executionErrorCode unwrapped, since executionErrorCode checks for
-// *taskFailedError before *taskTimeoutError/*failStateError -- wrapping
-// either in *taskFailedError here would misreport a real States.Timeout or
-// SendTaskFailure error as States.TaskFailed instead.
+// activity Task states: taskTimeoutError/failStateError must reach
+// executionErrorCode unwrapped, since it checks *taskFailedError first --
+// wrapping either here would misreport them as States.TaskFailed.
 func wrapCallbackTaskResult(output string, err error) (string, error) {
 	if err == nil {
 		return output, nil
@@ -594,17 +545,15 @@ func resolveParameters(params map[string]any, input string) (map[string]any, err
 
 // resolveParametersWithContext extends resolveParameters with an optional
 // Context object ($$.) lookup: contextData is nil everywhere except
-// ItemSelector (see itemselector.go), which is the only place the Amazon
-// States Language allows "$$." references.
+// ItemSelector, the only place ASL allows "$$." references.
 func resolveParametersWithContext(params map[string]any, input string, contextData map[string]any) (map[string]any, error) {
 	if params == nil {
 		return map[string]any{}, nil
 	}
 
-	// inputData is parsed lazily on the first JSONPath reference and reused.
-	// It is typed any, not map[string]any, since a Payload Template's input
-	// is not always a JSON object -- ResultSelector, in particular, resolves
-	// against a Parallel/Map state's result, which is a JSON array.
+	// inputData is parsed lazily on first JSONPath reference and reused. It
+	// is typed any, not map[string]any, since ResultSelector resolves
+	// against a Parallel/Map result, which is a JSON array.
 	var inputData any
 
 	resolved := make(map[string]any, len(params))
@@ -634,12 +583,10 @@ func resolveParametersWithContext(params map[string]any, input string, contextDa
 	return resolved, nil
 }
 
-// resolveJSONPathRef resolves a "key.$" JSONPath reference against the
-// input, or, for a "$$."-prefixed path, against contextData. inputData is
-// the lazily-parsed input (nil until first use); the possibly newly parsed
-// value is returned so the caller can reuse it for later references,
-// keeping the input JSON unmarshaled at most once per resolveParameters
-// call.
+// resolveJSONPathRef resolves a "key.$" reference against input, or
+// against contextData for a "$$."-prefixed path. inputData is returned
+// (possibly newly parsed) so callers reuse it and unmarshal input at
+// most once per resolveParameters call.
 func resolveJSONPathRef(key string, value any, input string, inputData any, contextData map[string]any) (any, any, error) {
 	pathStr, ok := value.(string)
 	if !ok {
@@ -806,13 +753,11 @@ func (e *executionEngine) executeLambdaInvoke(ctx context.Context, params map[st
 	return string(result), nil
 }
 
-// executeLambdaFunctionTask invokes a Lambda function specified directly by
-// ARN in a Task state's Resource field (the "directly specified function
-// resource" integration, as opposed to the optimized
-// arn:aws:states:::lambda:invoke integration). With this integration the
-// state input becomes the invocation payload verbatim, or resolved
-// Parameters if given, and the task output is the function's response
-// payload directly with no ExecutedVersion/Payload/StatusCode wrapping.
+// executeLambdaFunctionTask invokes a Lambda function specified directly
+// by ARN (the "directly specified function resource" integration, as
+// opposed to arn:aws:states:::lambda:invoke): input (or resolved
+// Parameters) becomes the payload verbatim, and output is the response
+// payload with no wrapping.
 func (e *executionEngine) executeLambdaFunctionTask(ctx context.Context, name, resourceARN string, params map[string]any, input string) (string, error) {
 	functionName := extractLambdaFunctionName(resourceARN)
 

--- a/internal/service/sfn/handlers.go
+++ b/internal/service/sfn/handlers.go
@@ -630,10 +630,9 @@ func (s *Service) DeleteActivity(w http.ResponseWriter, r *http.Request) {
 	writeResponse(w, &DeleteActivityResponse{})
 }
 
-// GetActivityTask handles the GetActivityTask API: a worker's long poll for
-// a scheduled task. It blocks for up to activityPollTimeout inside
-// s.storage.GetActivityTask, so the HTTP response itself is only written
-// once a task arrives or the poll window elapses.
+// GetActivityTask handles the GetActivityTask API: a worker's long poll.
+// It blocks inside s.storage.GetActivityTask, so the HTTP response is
+// only written once a task arrives or the poll window elapses.
 func (s *Service) GetActivityTask(w http.ResponseWriter, r *http.Request) {
 	var req GetActivityTaskRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -655,13 +654,10 @@ func (s *Service) GetActivityTask(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// ValidateStateMachineDefinition runs kumo's structural checks against the
-// supplied definition and reports diagnostics in AWS's documented shape.
-//
-// terraform-provider-aws calls ValidateStateMachineDefinition during the
-// plan phase of every aws_sfn_state_machine, before issuing CreateStateMachine.
-// Without it, `tofu plan` fails with InvalidAction and the resource never
-// reaches the create path.
+// ValidateStateMachineDefinition runs kumo's structural checks and reports
+// diagnostics in AWS's documented shape. terraform-provider-aws calls this
+// during every plan phase before CreateStateMachine; without it, `tofu
+// plan` fails with InvalidAction.
 func (s *Service) ValidateStateMachineDefinition(w http.ResponseWriter, r *http.Request) {
 	var req ValidateStateMachineDefinitionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -737,11 +733,9 @@ func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	writeResponse(w, &UntagResourceResponse{})
 }
 
-// ListStateMachineVersions lists versions for a state machine.
-//
-// Versions are not modeled in storage. terraform-provider-aws calls this
-// on every refresh; the StateMachineVersions field must be present even
-// when empty.
+// ListStateMachineVersions lists versions for a state machine. Versions
+// are not modeled in storage; terraform-provider-aws calls this on every
+// refresh and requires the field present even when empty.
 func (s *Service) ListStateMachineVersions(w http.ResponseWriter, r *http.Request) {
 	var req ListStateMachineVersionsRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/internal/service/sfn/iodata.go
+++ b/internal/service/sfn/iodata.go
@@ -8,33 +8,18 @@ import (
 
 // This file implements the Amazon States Language's standard data-flow
 // field pipeline (InputPath, Parameters, ResultSelector, ResultPath,
-// OutputPath), shared by every state type per
-// https://states-language.net/spec.html#filters:
+// OutputPath), shared by every state type: raw input -> effective input
+// (via InputPath/Parameters) -> result (the state's own work) -> effective
+// result (via ResultSelector) -> effective output (result merged into
+// effective input per ResultPath, then narrowed by OutputPath).
 //
-//   - "raw input" is the JSON text a state receives.
-//   - "effective input" is the raw input after InputPath (and, on the state
-//     types that support it, Parameters).
-//   - "result" is whatever the state's own work produces (a Task response,
-//     a Parallel/Map branch-output array, a Pass state's Result-or-input).
-//   - "effective result" is the result after ResultSelector.
-//   - "effective output" is the effective result merged into the effective
-//     input per ResultPath, then narrowed by OutputPath.
-//
-// A state that fails to apply one of these fields (a ResultPath that
-// cannot address its base, an OutputPath that matches nothing, malformed
-// JSON) reports a plain error, which executionErrorCode surfaces as
-// States.Runtime: per AWS's own documentation, States.Runtime is "often
-// caused by errors at runtime, such as attempting to apply InputPath or
-// OutputPath on a null JSON payload," is not retriable, and is never
-// matched by Retry/Catch (including the States.ALL wildcard) -- see
-// errorNameMatches in retry.go.
+// A state that fails to apply one of these fields reports a plain error,
+// which executionErrorCode surfaces as States.Runtime: not retriable, and
+// never matched by Retry/Catch (including the States.ALL wildcard).
 
-// parsePathField interprets a JSONPath-valued field (InputPath, OutputPath,
-// ResultPath, or a Catcher's ResultPath) decoded as raw JSON so that an
-// explicit "null" -- which per the spec discards the raw input/result --
-// can be told apart from the field being absent from the definition, which
-// defaults to "$" (no filtering or replacement); both would otherwise
-// unmarshal to the same value through a plain *string.
+// parsePathField interprets a JSONPath-valued field decoded as raw JSON so
+// an explicit "null" (discards data) can be told apart from the field
+// being absent (defaults to "$"); both unmarshal identically via *string.
 func parsePathField(raw json.RawMessage) (path string, isNull bool, err error) {
 	if len(raw) == 0 {
 		return "$", false, nil
@@ -116,12 +101,10 @@ func applyPathField(raw json.RawMessage, data string) (string, error) {
 	return string(out), nil
 }
 
-// resolveEffectiveInput computes a state's effective input: InputPath
-// applied to the raw input, then -- on the state types where Parameters
-// means "the Payload Template that becomes the effective input" (Task,
-// Parallel, Pass; Map's "Parameters" is instead the deprecated alias for
-// ItemSelector, so callers for Map must not use this helper) -- Parameters
-// resolved against that filtered input.
+// resolveEffectiveInput computes a state's effective input: InputPath then
+// Parameters resolved against it. Only for Task/Parallel/Pass -- Map's
+// "Parameters" is the deprecated ItemSelector alias, so Map must not use
+// this helper.
 func resolveEffectiveInput(inputPath json.RawMessage, parameters map[string]any, rawInput string) (string, error) {
 	filtered, err := applyInputPath(inputPath, rawInput)
 	if err != nil {
@@ -145,11 +128,9 @@ func resolveEffectiveInput(inputPath json.RawMessage, parameters map[string]any,
 	return string(out), nil
 }
 
-// applyResultSelector transforms a state's result per ResultSelector, a
-// Payload Template resolved the same way as Parameters -- static values, or
-// "$."-prefixed JSONPath references, except resolved against the result
-// itself rather than the state's input. A nil ResultSelector leaves the
-// result unchanged, per its spec default of "no effect".
+// applyResultSelector transforms result per ResultSelector, resolved like
+// Parameters but against the result itself, not the state's input. A nil
+// ResultSelector leaves the result unchanged.
 func applyResultSelector(selector map[string]any, result string) (string, error) {
 	if selector == nil {
 		return result, nil
@@ -168,12 +149,10 @@ func applyResultSelector(selector map[string]any, result string) (string, error)
 	return string(out), nil
 }
 
-// applyResultPath merges a state's effective result into its effective
-// input per ResultPath (default "$", meaning the result replaces the input
-// entirely). An explicit null ResultPath discards the result, passing the
-// effective input through unchanged. Any other Reference Path injects the
-// result at that location, relative to the effective input, creating
-// intermediate objects as needed.
+// applyResultPath merges result into effectiveInput per ResultPath:
+// default "$" replaces input with result; null discards result; any other
+// Reference Path injects result at that location, creating intermediate
+// objects as needed.
 func applyResultPath(raw json.RawMessage, effectiveInput, result string) (string, error) {
 	path, isNull, err := parsePathField(raw)
 	if err != nil {
@@ -196,11 +175,9 @@ func applyResultPath(raw json.RawMessage, effectiveInput, result string) (string
 	return out, nil
 }
 
-// injectResultPath injects a JSON-encoded result into base at an
-// arbitrary-depth "$.a.b.c" Reference Path, creating intermediate objects
-// as needed and overwriting whatever was already at that location -- see
-// the spec's "Input and Output Processing" section's worked example of
-// "$.master.result.sum" building a chain of new fields.
+// injectResultPath injects result into base at an arbitrary-depth
+// "$.a.b.c" Reference Path, creating intermediate objects as needed and
+// overwriting whatever was already there.
 func injectResultPath(path, base, result string) (string, error) {
 	field, ok := strings.CutPrefix(path, "$.")
 	if !ok || field == "" {

--- a/internal/service/sfn/itembatcher.go
+++ b/internal/service/sfn/itembatcher.go
@@ -6,14 +6,8 @@ import (
 )
 
 // itemBatcherDef is the decoded ItemBatcher field. JSON tags are
-// lowerCamelCase rather than the Amazon States Language's own PascalCase;
-// see retrier in retry.go for why this still decodes AWS's PascalCase field
-// names correctly.
-//
-// MaxItemsPerBatchPath and MaxInputBytesPerBatchPath (the dynamic,
-// reference-path forms of MaxItemsPerBatch/MaxInputBytesPerBatch) are
-// resolved against the Map state's input in buildProcessorUnits, preferring
-// the Path form over its static counterpart when both are set.
+// lowerCamelCase but still decode AWS's PascalCase field names (see retry.go).
+// The *Path fields take precedence over their static counterparts when both are set.
 type itemBatcherDef struct {
 	MaxItemsPerBatch          *int           `json:"maxItemsPerBatch"`
 	MaxInputBytesPerBatch     *int           `json:"maxInputBytesPerBatch"`
@@ -22,20 +16,17 @@ type itemBatcherDef struct {
 	BatchInput                map[string]any `json:"batchInput"`
 }
 
-// mapUnit is a single processor invocation: either one dataset item (no
-// ItemBatcher) or a batch envelope (with ItemBatcher). itemCount is how
-// many original dataset items this unit represents, which is what
-// ToleratedFailurePercentage/ToleratedFailureCount count against (see
-// mapTolerance in mapstate.go).
+// mapUnit is a single processor invocation: one item, or a batch envelope
+// when ItemBatcher is set. itemCount is how many original items it
+// represents, which tolerance thresholds count against.
 type mapUnit struct {
 	input     string
 	itemCount int
 }
 
 // buildProcessorUnits groups items into one mapUnit per item, or, when
-// ItemBatcher is set, into batch envelopes shaped exactly as AWS documents
-// for the processor's input: {"BatchInput": {...}, "Items": [...]} (see
-// https://docs.aws.amazon.com/step-functions/latest/dg/input-output-itembatcher.html).
+// ItemBatcher is set, into batch envelopes shaped as AWS documents:
+// {"BatchInput": {...}, "Items": [...]}.
 func buildProcessorUnits(raw json.RawMessage, items []json.RawMessage, mapInput string) ([]mapUnit, error) {
 	if len(raw) == 0 {
 		return itemUnits(items), nil
@@ -110,10 +101,8 @@ func resolveBatchInput(batchInput map[string]any, mapInput string) (map[string]a
 }
 
 // groupIntoBatches splits items into batches bounded by maxItems and/or
-// maxBytes (either may be nil, but buildProcessorUnits requires at least
-// one to be set). A batch always contains at least one item, even if that
-// item alone exceeds maxBytes, so a single oversized item cannot stall
-// batching entirely.
+// maxBytes. A batch always contains at least one item, even if that item
+// alone exceeds maxBytes, so a single oversized item cannot stall batching.
 func groupIntoBatches(items []json.RawMessage, maxItems, maxBytes *int) [][]json.RawMessage {
 	var (
 		batches      [][]json.RawMessage
@@ -155,9 +144,8 @@ func newBatch(maxItems *int, totalItems int) []json.RawMessage {
 }
 
 // marshalBatchEnvelope builds one child processor invocation's input JSON.
-// A plain map (rather than a struct) is used so the wire keys "BatchInput"
-// and "Items" -- which must match AWS's documented envelope exactly -- do
-// not require a struct-tag casing exception.
+// Uses a plain map so the wire keys "BatchInput"/"Items" (must match AWS's
+// envelope exactly) don't require a struct-tag casing exception.
 func marshalBatchEnvelope(batchInput map[string]any, items []json.RawMessage) (string, error) {
 	envelope := map[string]any{
 		"BatchInput": batchInput,

--- a/internal/service/sfn/itemreader.go
+++ b/internal/service/sfn/itemreader.go
@@ -34,10 +34,8 @@ const (
 )
 
 // itemReaderTransformationLoadAndFlatten is ReaderConfig.Transformation's
-// only non-default value, meaningful only for s3:listObjectsV2: it reads
-// and parses the actual object contents (per InputType) referenced by each
-// listing entry, instead of returning the S3 object metadata itself. kumo
-// does not implement it -- see readItemsFromS3ListObjectsV2 -- since it is
+// only non-default value (s3:listObjectsV2 only): reads and parses each
+// listed object's contents instead of returning metadata. Not implemented --
 // effectively a second, nested ItemReader pass per listed object.
 const itemReaderTransformationLoadAndFlatten = "LOAD_AND_FLATTEN"
 
@@ -50,9 +48,8 @@ type itemReaderDef struct {
 }
 
 // itemReaderConfig is ItemReader.ReaderConfig. ItemsPointer and
-// CSVDelimiter are not implemented. MaxItemsPath is resolved against the
-// Map state's input in readItemsFromS3, preferring it over the static
-// MaxItems when both are set.
+// CSVDelimiter are not implemented. MaxItemsPath takes precedence over
+// the static MaxItems when both are set.
 type itemReaderConfig struct {
 	InputType         string   `json:"inputType"`
 	CSVHeaderLocation string   `json:"csvHeaderLocation"`
@@ -121,9 +118,8 @@ func readItemsFromS3GetObject(ctx context.Context, e *executionEngine, params ma
 }
 
 // readItemsFromS3ListObjectsV2 implements the s3:listObjectsV2 ItemReader
-// Resource: items are the object summaries AWS's own ListObjectsV2 API
-// action returns (Etag, Key, LastModified, Size, StorageClass -- see
-// marshalS3ObjectSummaries), not the objects' own contents.
+// Resource: items are object summaries (Etag, Key, LastModified, Size,
+// StorageClass), not the objects' own contents.
 func readItemsFromS3ListObjectsV2(ctx context.Context, e *executionEngine, params map[string]any, cfg *itemReaderConfig) ([]json.RawMessage, error) {
 	if strings.EqualFold(cfg.Transformation, itemReaderTransformationLoadAndFlatten) {
 		return nil, fmt.Errorf(
@@ -181,12 +177,9 @@ func (e *executionEngine) getS3Object(ctx context.Context, bucket, key string) (
 // XML format (see timeFormatISO in internal/service/s3/handlers.go).
 const s3ListObjectsV2TimeFormat = "2006-01-02T15:04:05.000Z"
 
-// s3ListBucketResult mirrors just the fields of kumo's own S3
-// ListObjectsV2 XML response (see ListBucketResult in
-// internal/service/s3/types.go) that the ItemReader s3:listObjectsV2
-// integration needs. It is redefined here rather than imported since kumo
-// services only ever talk to each other over HTTP (see
-// getS3Object/putS3Object), never via direct package imports.
+// s3ListBucketResult mirrors the fields of kumo's own S3 ListObjectsV2 XML
+// response this integration needs. Redefined here (not imported) since kumo
+// services only talk to each other over HTTP, never via package imports.
 type s3ListBucketResult struct {
 	XMLName               xml.Name          `xml:"ListBucketResult"`
 	IsTruncated           bool              `xml:"IsTruncated"`
@@ -273,8 +266,7 @@ func (e *executionEngine) getS3ListObjectsV2Page(ctx context.Context, bucket, pr
 
 // marshalS3ObjectSummaries converts S3 object metadata into the item shape
 // AWS documents for s3:listObjectsV2 (without LOAD_AND_FLATTEN): Etag, Key,
-// LastModified (Unix seconds), Size, StorageClass -- see
-// https://docs.aws.amazon.com/step-functions/latest/dg/input-output-itemreader.html.
+// LastModified (Unix seconds), Size, StorageClass.
 func marshalS3ObjectSummaries(objects []s3ObjectSummary) ([]json.RawMessage, error) {
 	items := make([]json.RawMessage, len(objects))
 

--- a/internal/service/sfn/itemselector.go
+++ b/internal/service/sfn/itemselector.go
@@ -6,13 +6,8 @@ import (
 )
 
 // applyItemSelector transforms every item per the Map state's ItemSelector
-// field, which works identically in Inline and Distributed mode (see
-// https://docs.aws.amazon.com/step-functions/latest/dg/input-output-itemselector.html).
-// ItemSelector's key-value pairs may be static values, "$."-prefixed
-// JSONPath references against the Map state's own input (mapInput), or
-// "$$."-prefixed Context object references: $$.Map.Item.Value (the
-// current item) and $$.Map.Item.Index (its 0-based index). An unset
-// ItemSelector leaves items unchanged.
+// field. Values may be static, "$."-prefixed paths against mapInput, or
+// "$$."-prefixed Context refs. An unset ItemSelector leaves items unchanged.
 func applyItemSelector(raw json.RawMessage, items []json.RawMessage, mapInput string) ([]json.RawMessage, error) {
 	if len(raw) == 0 {
 		return items, nil
@@ -49,8 +44,7 @@ func applyItemSelector(raw json.RawMessage, items []json.RawMessage, mapInput st
 
 // mapItemContext builds the "$$." Context object exposed to ItemSelector
 // for one item: {"Map": {"Item": {"Index": index, "Value": <item>}}}.
-// Map.Item.Source (which real AWS sets for S3 ListObjectsV2 datasets) is
-// not modeled; kumo's ItemReader always yields STATE_DATA-equivalent items.
+// Map.Item.Source (AWS sets it for S3 ListObjectsV2 datasets) is not modeled.
 func mapItemContext(index int, item json.RawMessage) (map[string]any, error) {
 	var value any
 	if err := json.Unmarshal(item, &value); err != nil {

--- a/internal/service/sfn/jsonpath.go
+++ b/internal/service/sfn/jsonpath.go
@@ -6,11 +6,8 @@ import (
 )
 
 // resolveAnyJSONPath resolves "$" or "$.field[.field...]" against an
-// already-decoded JSON value of any shape. Only single-level field access
-// is supported per path segment (e.g., "$.message"), plus "$" for the
-// whole input. It does not require the root value to be a JSON object, so
-// e.g. Map state's ItemsPath can select the entire input when the input
-// itself is a JSON array.
+// already-decoded JSON value of any shape. Unlike other JSONPath resolvers,
+// the root need not be an object, so Map's ItemsPath can select an array.
 func resolveAnyJSONPath(path string, data any) (any, error) {
 	if path == "$" {
 		return data, nil

--- a/internal/service/sfn/mapconcurrency.go
+++ b/internal/service/sfn/mapconcurrency.go
@@ -29,18 +29,9 @@ type mapUnitRunner struct {
 }
 
 // runMapUnits executes the processor once per unit, honoring MaxConcurrency
-// (0 or negative means unlimited).
-//
-// When tolerant is false (the default: no ToleratedFailurePercentage/
-// ToleratedFailureCount configured), the first unit to fail cancels the
-// remaining units via cancel and its error is returned immediately --
-// matching real AWS Inline-mode Map, where any iteration failure fails the
-// whole state.
-//
-// When tolerant is true, every unit runs to completion regardless of
-// individual failures, cancel is never called, and runMapUnits always
-// returns a nil error; the caller (executeMapState) decides whether the
-// aggregate failure count exceeds the configured threshold.
+// (0/negative = unlimited). Non-tolerant: the first failure cancels the rest
+// and returns immediately (matches AWS Inline-mode Map). Tolerant: every
+// unit runs to completion; the caller checks the aggregate failure count.
 func runMapUnits(ctx context.Context, e *executionEngine, processor *stateMachineDefinition, units []mapUnit, maxConcurrency int, tolerant bool, cancel context.CancelFunc) ([]mapUnitResult, error) {
 	r := &mapUnitRunner{
 		e:         e,

--- a/internal/service/sfn/maprun.go
+++ b/internal/service/sfn/maprun.go
@@ -17,10 +17,8 @@ const (
 )
 
 // executionArnContextKey is the context.Context key carrying the current
-// (top-level or nested) execution's ARN through its own synchronous call
-// graph, the same way nestedExecutionDepthKey carries nesting depth (see
-// nestedexec.go) -- set once in MemoryStorage.runExecution and read back by
-// executionEngine.startMapRunIfDistributed, which needs it to attribute a
+// execution's ARN through its synchronous call graph, set once in
+// MemoryStorage.runExecution so startMapRunIfDistributed can attribute a
 // new Map Run to the execution that started it.
 type executionArnContextKey struct{}
 
@@ -40,25 +38,18 @@ func executionArnFromContext(ctx context.Context) string {
 }
 
 // mapRunTracker is the subset of Storage a Distributed Map state uses to
-// record its Map Run (see startMapRunIfDistributed/finishMapRunIfDistributed
-// below). Like executionStarter (nestedexec.go), executionEngine calls back
-// into the same MemoryStorage that constructed it rather than an HTTP round
-// trip: recording a Map Run is storage bookkeeping local to this process,
-// not a call to another emulated AWS service.
+// record its Map Run. executionEngine calls back into the same
+// MemoryStorage that constructed it rather than an HTTP round trip: this is
+// local storage bookkeeping, not a call to another emulated AWS service.
 type mapRunTracker interface {
 	startMapRun(ctx context.Context, executionArn, mapStateName string, maxConcurrency int, tolerance mapTolerance) (mapRunArn string, err error)
 	finishMapRun(mapRunArn, status string, itemCounts, executionCounts *MapRunCounts)
 }
 
 // startMapRunIfDistributed records a new Map Run for a Distributed-mode Map
-// state (isDistributedMode(processor)), returning "" for an Inline-mode Map
-// (Map Runs are a Distributed-mode-only AWS concept -- see
-// https://docs.aws.amazon.com/step-functions/latest/dg/concepts-state-machine-executions.html#concepts-map-run)
-// or when e.mapRuns/the current execution ARN is unavailable (an engine
-// built directly via newExecutionEngine in tests, bypassing
-// MemoryStorage.runExecution). Bookkeeping failures are logged and
-// otherwise ignored -- see finishMapRunIfDistributed -- so the Map state
-// itself still completes normally even if Map Run tracking could not.
+// state, returning "" for Inline mode (Map Runs are a Distributed-mode-only
+// concept) or when e.mapRuns/the execution ARN is unavailable. Bookkeeping
+// failures are logged and ignored so the Map state itself still completes.
 func (e *executionEngine) startMapRunIfDistributed(ctx context.Context, name string, processor *stateMachineDefinition, maxConcurrency int, tolerance mapTolerance) string {
 	if e.mapRuns == nil || !isDistributedMode(processor) {
 		return ""
@@ -80,10 +71,8 @@ func (e *executionEngine) startMapRunIfDistributed(ctx context.Context, name str
 }
 
 // finishMapRunIfDistributed finalizes the Map Run started by
-// startMapRunIfDistributed, computing its item/execution counts from the
-// processed units. results is nil when runMapUnits itself returned an error
-// (the non-tolerant fast-fail path, which cancels and discards the
-// remaining units' outcomes -- see mapRunCountsFromResults).
+// startMapRunIfDistributed. results is nil when runMapUnits returned an
+// error (the non-tolerant fast-fail path discards the remaining outcomes).
 func (e *executionEngine) finishMapRunIfDistributed(mapRunArn, status string, units []mapUnit, results []mapUnitResult, totalItems int) {
 	if e.mapRuns == nil || mapRunArn == "" {
 		return
@@ -93,25 +82,18 @@ func (e *executionEngine) finishMapRunIfDistributed(mapRunArn, status string, un
 	e.mapRuns.finishMapRun(mapRunArn, status, &itemCounts, &executionCounts)
 }
 
-// mapRunCountsFromResults derives a finished Map Run's itemCounts (dataset
-// items, weighted by each unit's itemCount -- see mapUnit in itembatcher.go
-// for why a unit can represent more than one item under ItemBatcher) and
-// executionCounts (processor invocations, one per unit) from its units'
-// outcomes. kumo runs every unit in-process rather than as a real child
-// *execution* (see mapstate.go), so Pending/Running/Aborted/TimedOut/
-// ResultsWritten/FailuresNotRedrivable/PendingRedrive are always reported as
-// 0 rather than fabricated -- kumo's Map processing has no notion of any of
-// those states.
+// mapRunCountsFromResults derives itemCounts (weighted by itemCount, since
+// ItemBatcher can group items per unit) and executionCounts (one per unit).
+// Pending/Running/Aborted/TimedOut/ResultsWritten/FailuresNotRedrivable/
+// PendingRedrive are always 0: kumo has no notion of those states.
 func mapRunCountsFromResults(units []mapUnit, results []mapUnitResult, totalItems int) (itemCounts, executionCounts MapRunCounts) {
 	executionCounts.Total = int64(len(units))
 	itemCounts.Total = int64(totalItems)
 
 	if results == nil {
-		// The non-tolerant fast-fail path (see runMapUnits in
-		// mapconcurrency.go) cancels and discards the remaining units'
-		// results once the first failure occurs, so kumo cannot attribute
-		// success/failure per unit here; report the whole run as failed,
-		// matching the Map state's own outcome.
+		// The non-tolerant fast-fail path discards remaining units' results
+		// on first failure, so kumo cannot attribute success/failure per
+		// unit here; report the whole run as failed.
 		executionCounts.Failed = executionCounts.Total
 		itemCounts.Failed = itemCounts.Total
 
@@ -170,10 +152,9 @@ func (s *MemoryStorage) startMapRun(_ context.Context, executionArn, mapStateNam
 	return mapRunArn, nil
 }
 
-// finishMapRun implements mapRunTracker: it records status and the final
-// item/execution counts on an existing Map Run. A mapRunArn kumo does not
-// recognize is silently ignored -- startMapRunIfDistributed already logs
-// the failure that would cause this.
+// finishMapRun implements mapRunTracker: records status and final counts
+// on an existing Map Run. An unrecognized mapRunArn is silently ignored --
+// startMapRunIfDistributed already logs the failure that would cause this.
 func (s *MemoryStorage) finishMapRun(mapRunArn, status string, itemCounts, executionCounts *MapRunCounts) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -193,14 +174,9 @@ func (s *MemoryStorage) finishMapRun(mapRunArn, status string, itemCounts, execu
 }
 
 // buildMapRunArn builds a Map Run ARN in AWS's documented format
-// arn:aws:states:{region}:{account}:mapRun:{stateMachineName}/{label}:{uuid}
-// (see
-// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-distributed.html#state-map-distributed-nested-workflow).
-// AWS's {label} segment is either a user-supplied Map state "Label" field or
-// an auto-generated one; kumo does not model the "Label" field, so it uses
-// the Map state's own name instead -- more useful for debugging than a
-// random value, and, unlike AWS's auto-generated label, deterministic given
-// the same definition.
+// arn:aws:states:{region}:{account}:mapRun:{stateMachineName}/{label}:{uuid}.
+// kumo does not model the Label field, so it uses the Map state's own name
+// instead -- deterministic, unlike AWS's auto-generated label.
 func buildMapRunArn(region, accountID, stateMachineName, mapStateName string) string {
 	return fmt.Sprintf("arn:aws:states:%s:%s:mapRun:%s/%s:%s", region, accountID, stateMachineName, mapStateName, uuid.New().String())
 }

--- a/internal/service/sfn/mapstate.go
+++ b/internal/service/sfn/mapstate.go
@@ -22,13 +22,9 @@ const (
 )
 
 // executeMapStateWithPolicy executes a Map state's full standard field
-// pipeline: InputPath builds the effective input that ItemsPath resolves
-// the Items Array against (Map's own "Parameters" field, when present, is
-// the deprecated alias for ItemSelector rather than the standard
-// effective-input Payload Template, so it is deliberately not folded in
-// here -- see resolveEffectiveInput), Retry and Catch govern item
-// processing as a whole, and on success ResultSelector/ResultPath/
-// OutputPath shape the effective output.
+// pipeline. Map's "Parameters" field is the deprecated alias for
+// ItemSelector, not the standard effective-input Payload Template, so it
+// is deliberately not folded into InputPath here (see resolveEffectiveInput).
 func (e *executionEngine) executeMapStateWithPolicy(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
 	effectiveInput, err := applyInputPath(state.InputPath, input)
 	if err != nil {
@@ -40,16 +36,11 @@ func (e *executionEngine) executeMapStateWithPolicy(ctx context.Context, name st
 	})
 }
 
-// executeMapState resolves a Map state's item list (from ItemsPath or, in
-// Distributed mode, ItemReader), applies ItemSelector, groups items into
-// processor units (individually, or via ItemBatcher), and runs every unit
-// through the state's ItemProcessor (or its legacy alias, Iterator),
-// bounding concurrency at MaxConcurrency when it is positive.
-//
-// Both Inline and Distributed mode run each unit in-process in kumo, rather
-// than as a real child *execution* (see maprun.go's mapRunCountsFromResults
-// doc for the consequences of that simplification); a Distributed-mode run
-// is still recorded as a queryable Map Run (see runMapProcessorUnits).
+// executeMapState resolves a Map state's item list, applies ItemSelector,
+// groups items into processor units, and runs every unit through
+// ItemProcessor (or its legacy alias Iterator). Both Inline and Distributed
+// mode run each unit in-process rather than as a real child execution; a
+// Distributed-mode run is still recorded as a queryable Map Run.
 func (e *executionEngine) executeMapState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
 	processor, err := itemProcessorDefinition(state)
 	if err != nil {
@@ -79,12 +70,9 @@ func (e *executionEngine) executeMapState(ctx context.Context, name string, stat
 }
 
 // runMapProcessorUnits runs every processor unit and shapes the Map
-// state's output: the ExceedToleratedFailureThreshold check, the plain
-// item-output array, or -- when ResultWriter is set -- the
-// ResultWriterDetails{Bucket, Key} shape (see resultwriter.go). For a
-// Distributed-mode processor it also records the run as a Map Run (see
-// maprun.go), whose ARN (when recorded) is included in the ResultWriter
-// output.
+// state's output: item-output array, or -- when ResultWriter is set --
+// ResultWriterDetails{Bucket, Key}. Also records a Map Run for a
+// Distributed-mode processor, whose ARN is included in ResultWriter output.
 func (e *executionEngine) runMapProcessorUnits(ctx context.Context, name string, state *stateDefinition, processor *stateMachineDefinition, units []mapUnit, totalItems int, input string) (string, error) {
 	tolerance, err := resolveMapTolerance(state, input)
 	if err != nil {
@@ -142,9 +130,7 @@ func (e *executionEngine) runMapProcessorUnits(ctx context.Context, name string,
 }
 
 // resolveMaxConcurrency resolves a Map state's MaxConcurrency, preferring
-// MaxConcurrencyPath when set (the same precedence every other *Path field
-// in this package gives its static counterpart -- see taskTimeout in
-// timeout.go).
+// MaxConcurrencyPath over the static value when both are set.
 func resolveMaxConcurrency(state *stateDefinition, input string) (int, error) {
 	if state.MaxConcurrencyPath == "" {
 		return state.MaxConcurrency, nil
@@ -159,12 +145,10 @@ func resolveMaxConcurrency(state *stateDefinition, input string) (int, error) {
 }
 
 // collectMapResults turns per-unit results into the Map state's output
-// array and the total count of dataset items that failed. A failed unit
-// contributes a JSON null for every item it represented, rather than being
-// omitted, so the output array's length always matches the unit count --
-// an emulator simplification, since AWS does not document the exact
-// per-item output shape for a partially-failed Map Run that isn't exported
-// via ResultWriter.
+// array and the total count of failed dataset items. A failed unit
+// contributes a JSON null (not omitted), so the output array length always
+// matches the unit count -- an emulator simplification since AWS does not
+// document this shape for a partially-failed Map Run.
 func collectMapResults(units []mapUnit, results []mapUnitResult) (outputs []json.RawMessage, failedItems int) {
 	outputs = make([]json.RawMessage, len(results))
 
@@ -183,9 +167,8 @@ func collectMapResults(units []mapUnit, results []mapUnitResult) (outputs []json
 }
 
 // itemProcessorDefinition returns the Map state's sub-state-machine.
-// ItemProcessor is the current field name; Iterator is the legacy alias for
-// the same sub-state-machine. If both are present, ItemProcessor takes
-// precedence.
+// Iterator is the legacy alias for ItemProcessor; if both are present,
+// ItemProcessor takes precedence.
 func itemProcessorDefinition(state *stateDefinition) (*stateMachineDefinition, error) {
 	switch {
 	case state.ItemProcessor != nil:
@@ -206,12 +189,9 @@ func isDistributedMode(processor *stateMachineDefinition) bool {
 
 // requireDistributedModeForFields enforces AWS's rule that ItemReader,
 // ItemBatcher, ResultWriter, ToleratedFailurePercentage, and
-// ToleratedFailureCount are Distributed-mode-only Map state fields (see
-// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-inline.html,
-// whose field list omits all five, versus
-// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-distributed.html,
-// which documents them). validateMapDistributedFields in validate.go
-// reports the same rule as a definition-time diagnostic.
+// ToleratedFailureCount are Distributed-mode-only Map state fields.
+// validateMapDistributedFields (validate.go) reports the same rule at
+// definition time.
 func requireDistributedModeForFields(state *stateDefinition, processor *stateMachineDefinition) error {
 	if isDistributedMode(processor) {
 		return nil

--- a/internal/service/sfn/maptolerance.go
+++ b/internal/service/sfn/maptolerance.go
@@ -3,20 +3,16 @@ package sfn
 import "fmt"
 
 // mapTolerance is a Map state's resolved ToleratedFailurePercentage/
-// ToleratedFailureCount (see
-// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-distributed.html#state-map-fields-failure-tolerance).
+// ToleratedFailureCount.
 type mapTolerance struct {
 	percentage *float64
 	count      *int
 }
 
-// resolveMapTolerance reads a Map state's tolerance fields, resolving
-// ToleratedFailurePercentagePath/ToleratedFailureCountPath against input
-// (the Map state's effective input) when set, preferring the Path form over
-// its static counterpart -- see resolveOptionalFloatPath/
-// resolveOptionalIntPath in wait.go. Only requireDistributedModeForFields
-// lets these fields take effect at all (they are Distributed-mode-only), so
-// resolveMapTolerance itself does not need to check mode.
+// resolveMapTolerance reads a Map state's tolerance fields, preferring the
+// *Path form over its static counterpart when both are set. It does not
+// check Distributed mode itself -- requireDistributedModeForFields already
+// gates whether these fields take effect at all.
 func resolveMapTolerance(state *stateDefinition, input string) (mapTolerance, error) {
 	percentage, err := resolveOptionalFloatPath(state.ToleratedFailurePercentage, state.ToleratedFailurePercentagePath, input)
 	if err != nil {
@@ -32,10 +28,9 @@ func resolveMapTolerance(state *stateDefinition, input string) (mapTolerance, er
 }
 
 // enabled reports whether either threshold was configured. When neither is
-// set, AWS's documented default (a 0% tolerated failure percentage) means
-// any single item failure fails the Map Run; runMapProcessorUnits achieves
-// that identical result more cheaply via the non-tolerant fast-fail path in
-// runMapUnits, without needing every unit to run to completion first.
+// set, AWS's default (0% tolerance) means any single failure fails the Map
+// Run; runMapProcessorUnits achieves that more cheaply via the non-tolerant
+// fast-fail path, without running every unit to completion first.
 func (t mapTolerance) enabled() bool {
 	return t.percentage != nil || t.count != nil
 }

--- a/internal/service/sfn/nestedexec.go
+++ b/internal/service/sfn/nestedexec.go
@@ -7,13 +7,11 @@ import (
 	"time"
 )
 
-// resourceStartExecutionBase is the Task Resource for the "AWS Step
-// Functions integrates with its own API" service integration
-// (https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html):
-// starting a nested execution of another (or the same) state machine.
+// resourceStartExecutionBase is the Task Resource for starting a nested
+// execution of another (or the same) state machine.
 // startExecutionSyncSuffix/startExecutionSyncV2Suffix are its "Run a Job"
-// (.sync) variants; unlike most other optimized integrations, startExecution
-// does NOT support .waitForTaskToken -- see classifyStartExecutionResource.
+// (.sync) variants; unlike most optimized integrations, startExecution does
+// NOT support .waitForTaskToken (see classifyStartExecutionResource).
 const (
 	resourceStartExecutionBase  = "arn:aws:states:::states:startExecution"
 	startExecutionSyncSuffix    = ".sync"
@@ -23,11 +21,9 @@ const (
 )
 
 // nestedExecutionMaxDepth caps how many states:startExecution calls may
-// nest before kumo reports a States.Runtime error. This guards against a
-// state machine starting itself (directly, or via a cycle of state
-// machines) and running forever; real AWS instead bounds this indirectly
-// via account-level running-execution quotas, which kumo does not model, so
-// this fixed depth cap is a documented emulator-only bound.
+// nest, guarding against a state machine recursively starting itself. Real
+// AWS bounds this indirectly via running-execution quotas kumo doesn't
+// model; this fixed depth is an emulator-only substitute.
 const nestedExecutionMaxDepth = 5
 
 // nestedExecutionPollInterval is how often a .sync/.sync:2 Task polls the
@@ -57,12 +53,8 @@ const (
 // classifyStartExecutionResource identifies which
 // arn:aws:states:::states:startExecution* variant resource selects. ok is
 // false for any other suffix (including .waitForTaskToken, which AWS does
-// not document as supported for this integration -- see
-// https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html's
-// "Optimized integrations in Step Functions" table, which lists AWS Step
-// Functions as supporting only Request Response and Run a Job), so callers
-// reject it with a clear "unsupported task resource" error instead of
-// silently treating it as fire-and-forget.
+// not support for this integration), so callers reject it explicitly
+// instead of silently treating it as fire-and-forget.
 func classifyStartExecutionResource(resource string) (variant startExecutionVariant, ok bool) {
 	switch resource {
 	case resourceStartExecutionBase:
@@ -77,14 +69,11 @@ func classifyStartExecutionResource(resource string) (variant startExecutionVari
 }
 
 // nestedExecutionDepthKey is the context.Context key carrying the current
-// nesting depth through one execution's own synchronous call graph (see
-// withNestedExecutionDepth). It does not, and cannot, cross the boundary
-// into a child execution's own background goroutine -- MemoryStorage.
-// StartExecution intentionally ignores its caller's context, since an
-// execution must outlive the request that started it -- so the depth for a
-// child execution is instead passed explicitly to
-// MemoryStorage.startExecutionAtDepth/runExecution (see storage.go) and
-// re-installed into that child's own context there.
+// nesting depth through one execution's synchronous call graph. It cannot
+// cross into a child execution's background goroutine (StartExecution
+// intentionally ignores its caller's context, since an execution must
+// outlive the request that started it), so depth is instead passed
+// explicitly to MemoryStorage.startExecutionAtDepth/runExecution.
 type nestedExecutionDepthKey struct{}
 
 // withNestedExecutionDepth returns a context carrying depth as the current
@@ -103,36 +92,22 @@ func nestedExecutionDepthFromContext(ctx context.Context) int {
 
 // executionStarter is the subset of Storage the states:startExecution
 // integration needs. executionEngine calls back into the same MemoryStorage
-// that constructed it (see the storage field wiring in NewMemoryStorage,
-// storage.go) rather than looping an HTTP request back to kumo's own
-// server, the way the SQS/Lambda/S3 integrations address those (separate)
-// services: this integration recurses into kumo's own SFN engine, and the
-// recursion-depth guard above needs to travel with the Go call stack via
-// context.Context. A real HTTP round trip could still carry that via a
-// custom header, but real AWS's StartExecution API has no such field, and
-// kumo already has a direct reference to the very storage object that would
-// answer that HTTP call -- looping back out over HTTP to reach code in the
-// same process is unnecessary indirection with its own failure modes (e.g.
-// exhausting the shared http.Client's connections under deep nesting).
+// that constructed it, rather than looping an HTTP request the way
+// SQS/Lambda/S3 integrations do: this recurses into kumo's own SFN engine,
+// and the recursion-depth guard needs to travel via context.Context, which
+// an HTTP round trip would complicate for no benefit.
 type executionStarter interface {
 	// startNestedExecution is StartExecution's counterpart for a nested
-	// (states:startExecution-originated) call: depth is the nesting depth
-	// the new execution runs at, threaded explicitly since context values
-	// do not survive StartExecution's intentional context detachment (see
-	// nestedExecutionDepthKey).
+	// call: depth is threaded explicitly since context values do not
+	// survive StartExecution's intentional context detachment.
 	startNestedExecution(ctx context.Context, stateMachineArn, name, input string, depth int) (*Execution, error)
 	DescribeExecution(ctx context.Context, executionArn string) (*Execution, error)
 }
 
 // executeStartExecutionTask executes a Task state whose Resource is
-// arn:aws:states:::states:startExecution (optionally suffixed .sync or
-// .sync:2): it starts a child execution of Parameters.StateMachineArn with
-// Parameters.Input (default "{}") and Parameters.Name, then -- for the
-// .sync/.sync:2 variants -- waits for it to finish and reports a child
-// failure as this Task's own failure (wrapTaskResult then reports
-// States.TaskFailed, matching every other Task integration's failure
-// mapping; see AWS's own documented behavior for nested workflow
-// executions).
+// arn:aws:states:::states:startExecution (optionally .sync/.sync:2): starts
+// a child execution, then for .sync/.sync:2 waits for it and reports a
+// child failure as this Task's own States.TaskFailed.
 func (e *executionEngine) executeStartExecutionTask(ctx context.Context, resource string, params map[string]any) (string, error) {
 	variant, ok := classifyStartExecutionResource(resource)
 	if !ok {
@@ -202,9 +177,8 @@ func startExecutionSuffixFor(variant startExecutionVariant) string {
 }
 
 // awaitChildExecution polls DescribeExecution until executionArn leaves
-// RUNNING, or ctx is done (the Task's own TimeoutSeconds, Retry/Catch
-// context, or the outer execution's own deadline all apply here exactly as
-// they would to any other Task invocation).
+// RUNNING, or ctx is done -- the Task's TimeoutSeconds/Retry/Catch context
+// applies here like any other Task invocation.
 func (e *executionEngine) awaitChildExecution(ctx context.Context, executionArn string) (*Execution, error) {
 	ticker := time.NewTicker(nestedExecutionPollInterval)
 	defer ticker.Stop()
@@ -227,10 +201,9 @@ func (e *executionEngine) awaitChildExecution(ctx context.Context, executionArn 
 	}
 }
 
-// marshalStartExecutionInput builds a child execution's input JSON from a
-// startExecution Task's resolved Parameters.Input: absent input defaults to
-// "{}", matching AWS's own StartExecution requirement that input always be
-// at least an empty JSON object.
+// marshalStartExecutionInput builds a child execution's input JSON from
+// Parameters.Input; absent input defaults to "{}", matching AWS's
+// StartExecution requirement that input always be at least an empty object.
 func marshalStartExecutionInput(v any) (string, error) {
 	if v == nil {
 		return "{}", nil
@@ -246,8 +219,7 @@ func marshalStartExecutionInput(v any) (string, error) {
 
 // marshalStartExecutionAsyncOutput builds the plain (fire-and-forget)
 // startExecution Task's output: {executionArn, startDate}, matching AWS's
-// documented StartExecution API response shape exactly (see
-// https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html).
+// StartExecution API response shape.
 func marshalStartExecutionAsyncOutput(exec *Execution) (string, error) {
 	encoded, err := json.Marshal(map[string]any{
 		"executionArn": exec.ExecutionArn,
@@ -262,9 +234,8 @@ func marshalStartExecutionAsyncOutput(exec *Execution) (string, error) {
 
 // describeExecutionEnvelope builds the DescribeExecution-shaped fields
 // shared by both .sync and .sync:2 output (everything except "output",
-// which differs -- see marshalSyncExecutionOutput/marshalSyncV2ExecutionOutput),
-// using AWS's documented DescribeExecution response field names (see
-// https://docs.aws.amazon.com/step-functions/latest/apireference/API_DescribeExecution.html).
+// which differs between the two -- see marshalSyncExecutionOutput/
+// marshalSyncV2ExecutionOutput).
 func describeExecutionEnvelope(exec *Execution) map[string]any {
 	env := map[string]any{
 		"executionArn":    exec.ExecutionArn,
@@ -284,9 +255,7 @@ func describeExecutionEnvelope(exec *Execution) map[string]any {
 
 // marshalSyncExecutionOutput builds the .sync Task's output: the
 // DescribeExecution-style envelope with "output" left as a JSON string,
-// exactly as the child execution itself reports it -- see AWS's documented
-// "Nested state machines return the following" table at
-// https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html.
+// exactly as the child execution itself reports it.
 func marshalSyncExecutionOutput(exec *Execution) (string, error) {
 	env := describeExecutionEnvelope(exec)
 	env["output"] = exec.Output

--- a/internal/service/sfn/parallel.go
+++ b/internal/service/sfn/parallel.go
@@ -7,11 +7,9 @@ import (
 	"sync"
 )
 
-// executeParallelStateWithPolicy executes a Parallel state's full standard
-// field pipeline: InputPath and Parameters build the effective input fed to
-// every Branch's StartAt state, Retry and Catch govern the branches as a
-// whole, and on success ResultSelector/ResultPath/OutputPath shape the
-// effective output.
+// executeParallelStateWithPolicy builds the effective input from
+// InputPath/Parameters, then runs it through the Retry/Catch/
+// ResultSelector/ResultPath/OutputPath pipeline.
 func (e *executionEngine) executeParallelStateWithPolicy(ctx context.Context, name string, state *stateDefinition, input string) (string, string, error) {
 	effectiveInput, err := resolveEffectiveInput(state.InputPath, state.Parameters, input)
 	if err != nil {
@@ -23,11 +21,9 @@ func (e *executionEngine) executeParallelStateWithPolicy(ctx context.Context, na
 	})
 }
 
-// executeParallelState runs every Branch concurrently against the same
-// state input and collects their outputs, in branch order, as a JSON array.
-// The first branch to fail cancels the remaining branches and the Parallel
-// state fails with States.BranchFailed, carrying the branch's own failure
-// as the cause, matching real Step Functions.
+// executeParallelState runs each Branch concurrently and collects outputs in
+// branch order as a JSON array. The first branch to fail cancels the rest
+// and fails the state with States.BranchFailed, matching real Step Functions.
 func (e *executionEngine) executeParallelState(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
 	if len(state.Branches) == 0 {
 		return "", fmt.Errorf("parallel state %q: Branches is required", name)

--- a/internal/service/sfn/resultwriter.go
+++ b/internal/service/sfn/resultwriter.go
@@ -47,20 +47,11 @@ type resultWriterConfig struct {
 	Transformation string `json:"transformation"`
 }
 
-// writeMapResultToS3 uploads outputs -- the Map state's would-be plain-array
-// result, reshaped per WriterConfig.Transformation and serialized per
-// WriterConfig.OutputType -- as a single file to kumo's S3 under
-// Parameters.Prefix, and returns the Map state's output in AWS's documented
-// {MapRunArn, ResultWriterDetails: {Bucket, Key}} shape (see
-// https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultwriter.html#export-s3).
-// mapRunArn is "" when the Map Run could not be recorded (see
-// startMapRunIfDistributed in maprun.go), in which case the field is
-// omitted entirely rather than sent empty.
-//
-// This is a deliberate emulator simplification of AWS's real behavior: AWS
-// partitions results into a manifest.json plus per-status
-// SUCCEEDED_n.json/FAILED_n.json files; kumo writes one combined result
-// file instead.
+// writeMapResultToS3 uploads outputs as a single combined file (a
+// deliberate emulator simplification of AWS's manifest.json + per-status
+// SUCCEEDED_n.json/FAILED_n.json layout), returning the documented
+// {MapRunArn, ResultWriterDetails: {Bucket, Key}} shape. mapRunArn is
+// omitted when "" (Map Run could not be recorded).
 func writeMapResultToS3(ctx context.Context, e *executionEngine, raw json.RawMessage, outputs []json.RawMessage, mapInput, mapRunArn string) (string, error) {
 	var def resultWriterDef
 	if err := json.Unmarshal(raw, &def); err != nil {
@@ -109,20 +100,12 @@ func writeMapResultToS3(ctx context.Context, e *executionEngine, raw json.RawMes
 	return marshalResultWriterOutput(bucket, key, mapRunArn)
 }
 
-// applyResultWriterTransformation reshapes outputs (one entry per processor
-// unit) per WriterConfig.Transformation:
-//
-//   - "" or COMPACT (kumo's default, matching AWS's own documented default
-//     "when ResultWriter is not specified"): outputs unchanged, each entry
-//     keeping whatever shape its own unit produced.
-//   - FLATTEN: any entry that is itself a JSON array has its elements
-//     spliced into the result in place of the array; other entries pass
-//     through unchanged.
-//   - NONE: rejected. AWS's NONE wraps each entry in a DescribeExecution-
-//     style envelope (ExecutionArn, Status, StartDate, ...) describing the
-//     real child *execution* that produced it; kumo runs every Map unit
-//     in-process rather than as one (see mapstate.go), so it has none of
-//     that data to report and would have to fabricate it.
+// applyResultWriterTransformation reshapes outputs per
+// WriterConfig.Transformation: "" or COMPACT (the default) passes outputs
+// through unchanged; FLATTEN splices any array-valued entry's elements into
+// the result. NONE is rejected -- it requires per-item child-execution
+// metadata (ExecutionArn, Status, ...) kumo doesn't track since Map units
+// run in-process rather than as real child executions.
 func applyResultWriterTransformation(outputs []json.RawMessage, transformation string) ([]json.RawMessage, error) {
 	switch strings.ToUpper(transformation) {
 	case "", resultWriterTransformationCompact:
@@ -139,11 +122,9 @@ func applyResultWriterTransformation(outputs []json.RawMessage, transformation s
 	}
 }
 
-// flattenResultWriterOutputs implements Transformation FLATTEN: an entry
-// that unmarshals as a JSON array contributes its own elements instead of
-// itself (dropping a JSON null this way too, matching a failed unit
-// contributing nothing to the flattened success list); every other entry
-// passes through unchanged.
+// flattenResultWriterOutputs splices array-valued entries' elements into the
+// result; other entries pass through unchanged. A JSON null entry is
+// dropped this way too, matching a failed unit contributing nothing.
 func flattenResultWriterOutputs(outputs []json.RawMessage) []json.RawMessage {
 	flattened := make([]json.RawMessage, 0, len(outputs))
 
@@ -196,10 +177,9 @@ func resultWriterKey(prefix string) string {
 	return strings.TrimSuffix(prefix, "/") + "/" + resultWriterFileName
 }
 
-// marshalResultWriterOutput builds the Map state's output when ResultWriter
-// exported to S3: {"MapRunArn": ..., "ResultWriterDetails": {"Bucket": ...,
-// "Key": ...}}. A plain map is used so the wire keys need not be exempted
-// from tagliatelle.
+// marshalResultWriterOutput builds the Map state's
+// {MapRunArn, ResultWriterDetails: {Bucket, Key}} output. Uses a plain map
+// so the wire keys need not be exempted from tagliatelle.
 func marshalResultWriterOutput(bucket, key, mapRunArn string) (string, error) {
 	result := map[string]any{
 		"ResultWriterDetails": map[string]any{

--- a/internal/service/sfn/retry.go
+++ b/internal/service/sfn/retry.go
@@ -10,11 +10,8 @@ import (
 
 // retrier is a single entry in a Task/Parallel/Map state's Retry field.
 //
-// JSON tags are lowerCamelCase rather than the Amazon States Language's own
-// PascalCase (e.g. "ErrorEquals", "IntervalSeconds"); encoding/json matches
-// object keys to struct fields case-insensitively when there is no exact
-// match, so definitions using the spec's PascalCase field names still decode
-// correctly.
+// JSON tags are lowerCamelCase, not ASL's PascalCase; encoding/json matches
+// keys case-insensitively so PascalCase definitions still decode correctly.
 type retrier struct {
 	ErrorEquals     []string `json:"errorEquals"`
 	IntervalSeconds *int     `json:"intervalSeconds"`
@@ -22,9 +19,8 @@ type retrier struct {
 	BackoffRate     *float64 `json:"backoffRate"`
 	MaxDelaySeconds *int     `json:"maxDelaySeconds"`
 
-	// JitterStrategy is accepted but not implemented: kumo is a
-	// deterministic emulator, and randomizing retry delays would make retry
-	// timing (and therefore test timing) non-reproducible.
+	// JitterStrategy is accepted but not implemented: kumo is a deterministic
+	// emulator, and randomized delays would make retry timing non-reproducible.
 	JitterStrategy string `json:"jitterStrategy"`
 }
 
@@ -44,31 +40,12 @@ const (
 	defaultRetryBackoffRate     = 2.0
 )
 
-// runRetryCatchResultPipeline executes work (a state's own work for one
-// execution, already given whatever effective input the caller computed
-// for it -- see executeTaskStateWithPolicy, executeParallelStateWithPolicy,
-// and executeMapStateWithPolicy in executor.go/parallel.go/mapstate.go,
-// which each fold InputPath/Parameters differently), applying that state's
-// Retry and Catch policy: retries are attempted first, using the matching
-// Retrier's backoff schedule; if retries do not resolve the error, or no
-// Retrier matches, the first matching Catcher routes to its Next state
-// with the Catcher's Error Output merged into the state's raw
-// (un-filtered) input via the Catcher's own ResultPath.
-//
-// On success, the result passes through ResultSelector, ResultPath, and
-// OutputPath to produce the effective output (see applyResultPipeline). On
-// a Catch match, only OutputPath applies to the Catcher's output --
-// ResultSelector/ResultPath are skipped, since the Catcher already shaped
-// its own output via its own ResultPath -- because OutputPath is a
-// state-level field that applies to the state's output regardless of
-// which path produced it (see applyCatchResult). An unmatched error
-// propagates unchanged: per AWS, a data-flow failure itself (e.g. an
-// unresolvable ResultPath) reports as States.Runtime, which is never
-// caught (see errorNameMatches), so such failures never reach Retry/Catch
-// in the first place.
-//
-// The return shape mirrors executeState: nextOverride is non-empty only
-// when a Catcher matched.
+// runRetryCatchResultPipeline applies work's Retry policy, then Catch on
+// failure or the Result pipeline on success. On a Catch match, only
+// OutputPath applies to the Catcher's output -- ResultSelector/ResultPath
+// are skipped since the Catcher already shaped its own output via its own
+// ResultPath. nextOverride (second return) is non-empty only when a
+// Catcher matched.
 func (e *executionEngine) runRetryCatchResultPipeline(
 	ctx context.Context, name string, state *stateDefinition, rawInput, effectiveInput string,
 	work func(context.Context) (string, error),
@@ -102,10 +79,8 @@ func (e *executionEngine) applyCatchResult(name string, state *stateDefinition, 
 	return out, catchNext, nil
 }
 
-// applyResultPipeline turns a state's own successful result into its
-// effective output: ResultSelector produces the effective result,
-// ResultPath merges it into effectiveInput, and OutputPath narrows the
-// merged output.
+// applyResultPipeline turns a successful result into the state's effective
+// output via ResultSelector -> ResultPath -> OutputPath, in that order.
 func (e *executionEngine) applyResultPipeline(name string, state *stateDefinition, effectiveInput, result string) (string, string, error) {
 	effectiveResult, err := applyResultSelector(state.ResultSelector, result)
 	if err != nil {
@@ -125,12 +100,10 @@ func (e *executionEngine) applyResultPipeline(name string, state *stateDefinitio
 	return out, "", nil
 }
 
-// runWithRetry executes fn, applying the state's Retry policy. Per the
-// spec, the interpreter scans the Retriers in order and uses the first one
-// whose ErrorEquals matches the reported error; each Retrier's attempt
-// budget (MaxAttempts) is independent of the others, and the budgets reset
-// whenever the state is entered anew, which holds naturally here since
-// runWithRetry is scoped to a single state execution.
+// runWithRetry executes fn under the state's Retry policy: the first
+// Retrier whose ErrorEquals matches wins, and each Retrier's MaxAttempts
+// budget is independent and resets on every state execution (this function
+// is scoped to one).
 func (e *executionEngine) runWithRetry(ctx context.Context, state *stateDefinition, fn func(context.Context) (string, error)) (string, error) {
 	attemptsUsed := make([]int, len(state.Retry))
 
@@ -170,11 +143,9 @@ func matchingRetrierIndex(retriers []retrier, errName string) int {
 	return -1
 }
 
-// errorNameMatches reports whether errName is matched by an ErrorEquals
-// list from a Retrier or Catcher. States.Runtime is a special case: per AWS
-// documentation it "isn't retriable, and will always cause the execution to
-// fail" -- it is never matched, even by an explicit "States.Runtime" entry
-// or by the States.ALL wildcard.
+// errorNameMatches reports whether errName matches an ErrorEquals list.
+// States.Runtime is never matched, even by an explicit entry or States.ALL
+// -- per AWS it "isn't retriable, and will always cause the execution to fail".
 func errorNameMatches(errorEquals []string, errName string) bool {
 	if errName == errorStatesRuntime {
 		return false
@@ -266,12 +237,9 @@ func applyCatch(state *stateDefinition, input string, err error) (output, next s
 	return "", "", false, nil
 }
 
-// buildCatchOutput builds a Catcher's output: the Error Output object
-// {"Error": errName, "Cause": cause}, merged into the state's original
-// (raw) input per the Catcher's own ResultPath -- "works exactly like a
-// state's top-level ResultPath" per the spec's JSONPath Catchers section,
-// so it reuses applyResultPath, supporting the same "$", null, and
-// arbitrary-depth "$.a.b.c" semantics.
+// buildCatchOutput builds the Error Output object {"Error", "Cause"} and
+// merges it into the state's raw input via the Catcher's own ResultPath,
+// which "works exactly like a state's top-level ResultPath" per the spec.
 func buildCatchOutput(rawResultPath json.RawMessage, input, errName, cause string) (string, error) {
 	errorOutput := map[string]string{"Error": errName, "Cause": cause}
 

--- a/internal/service/sfn/storage.go
+++ b/internal/service/sfn/storage.go
@@ -143,10 +143,8 @@ func NewMemoryStorage(opts ...Option) *MemoryStorage {
 	}
 
 	s.engine = newExecutionEngine(s.baseURL)
-	// Wire the engine's states:startExecution and Map Run bookkeeping back
-	// to this same storage -- see executionStarter in nestedexec.go and
-	// mapRunTracker in maprun.go for why this is a direct reference rather
-	// than an HTTP round trip.
+	// Wire the engine's states:startExecution and Map Run bookkeeping back to
+	// this storage as a direct reference rather than an HTTP round trip.
 	s.engine.starter = s
 	s.engine.mapRuns = s
 
@@ -332,11 +330,9 @@ func (s *MemoryStorage) StartExecution(ctx context.Context, stateMachineArn, nam
 	return s.startExecutionAtDepth(ctx, stateMachineArn, name, input, traceHeader, 0)
 }
 
-// startNestedExecution implements executionStarter (see nestedexec.go) for
-// a states:startExecution Task: identical to StartExecution except it
-// carries the caller's nesting depth through to the child's own runExecution
-// goroutine, since StartExecution's own ctx parameter cannot (see
-// nestedExecutionDepthKey's doc in nestedexec.go).
+// startNestedExecution implements executionStarter for a
+// states:startExecution Task: like StartExecution, but carries the caller's
+// nesting depth through since StartExecution's ctx parameter cannot.
 func (s *MemoryStorage) startNestedExecution(ctx context.Context, stateMachineArn, name, input string, depth int) (*Execution, error) {
 	return s.startExecutionAtDepth(ctx, stateMachineArn, name, input, "", depth)
 }
@@ -389,18 +385,16 @@ func (s *MemoryStorage) startExecutionAtDepth(_ context.Context, stateMachineArn
 	return copyExecution(exec), nil
 }
 
-// executionTimeoutCap is kumo's own safety valve on how long a background
-// execution goroutine may run, independent of whether the definition sets
-// its own TimeoutSeconds. Standard state machine executions have no default
-// timeout in real AWS; this cap exists purely to bound the emulator's own
-// resource usage, so it must never be reported as a real States.Timeout --
-// see executionTimeoutDiagnosis.
+// executionTimeoutCap bounds how long a background execution goroutine may
+// run, independent of the definition's own TimeoutSeconds (real AWS has no
+// default execution timeout). This is purely an emulator resource cap and
+// must never be reported as a real States.Timeout -- see
+// executionTimeoutDiagnosis.
 const executionTimeoutCap = 5 * time.Minute
 
 // runExecution executes the state machine in a background goroutine, bounded
-// by min(definition TimeoutSeconds, executionTimeoutCap). depth is this
-// execution's states:startExecution nesting depth (0 for a top-level
-// execution reached via StartExecution; see startNestedExecution).
+// by min(definition TimeoutSeconds, executionTimeoutCap). depth is the
+// states:startExecution nesting depth (0 for a top-level execution).
 func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string, lastEventID int64, depth int) {
 	def, err := parseDefinition(definition)
 	if err != nil {
@@ -432,12 +426,10 @@ func (s *MemoryStorage) runExecution(ed *ExecutionData, definition, input string
 	s.succeedExecution(ed, lastEventID, output)
 }
 
-// executionContext builds the context a top-level execution runs under. The
-// deadline is min(definition TimeoutSeconds, executionTimeoutCap): kumo
-// always enforces its own cap so a runaway execution cannot leak a goroutine
-// forever, even when the definition sets no timeout or one longer than the
-// cap. definitionTimeoutApplies reports whether the definition's own
-// TimeoutSeconds is the tighter (and therefore effective) bound.
+// executionContext builds the execution's context with deadline
+// min(definition TimeoutSeconds, executionTimeoutCap), so a runaway
+// execution can never leak a goroutine. definitionTimeoutApplies reports
+// whether the definition's own TimeoutSeconds was the tighter bound.
 func executionContext(def *stateMachineDefinition) (ctx context.Context, cancel context.CancelFunc, definitionTimeoutApplies bool) {
 	effective := executionTimeoutCap
 
@@ -454,12 +446,10 @@ func executionContext(def *stateMachineDefinition) (ctx context.Context, cancel 
 	return ctx, cancel, definitionTimeoutApplies
 }
 
-// executionTimeoutDiagnosis reports the error code and cause for an
-// execution that hit its context deadline. A definition-set TimeoutSeconds
-// that was reached is a real States.Timeout; kumo's own executionTimeoutCap
-// firing on its own is an emulator implementation detail with no AWS
-// equivalent, so it is reported as States.Runtime with a cause that says so,
-// keeping the two causes distinguishable.
+// executionTimeoutDiagnosis reports the timeout error code/cause: a reached
+// definition TimeoutSeconds is a real States.Timeout, while kumo's own
+// executionTimeoutCap firing is an emulator-only detail reported as
+// States.Runtime instead, keeping the two distinguishable.
 func executionTimeoutDiagnosis(def *stateMachineDefinition, definitionTimeoutApplies bool) (code, cause string) {
 	if definitionTimeoutApplies {
 		return errorStatesTimeout, fmt.Sprintf("State machine execution exceeded its TimeoutSeconds (%d)", *def.TimeoutSeconds)

--- a/internal/service/sfn/timeout.go
+++ b/internal/service/sfn/timeout.go
@@ -7,10 +7,9 @@ import (
 	"time"
 )
 
-// taskTimeoutError marks a Task state whose invocation attempt exceeded its
-// TimeoutSeconds/TimeoutSecondsPath. Per the Amazon States Language spec
-// this reports as States.Timeout which, unlike States.Runtime, is an
-// ordinary named error: Retry/Catch can match it like any other Error Name.
+// taskTimeoutError marks a Task invocation that exceeded its
+// TimeoutSeconds/TimeoutSecondsPath. Unlike States.Runtime, it reports as
+// States.Timeout, an ordinary named error Retry/Catch can match.
 type taskTimeoutError struct {
 	state string
 }
@@ -19,11 +18,9 @@ func (e *taskTimeoutError) Error() string {
 	return fmt.Sprintf("state %q: task execution exceeded TimeoutSeconds", e.state)
 }
 
-// executeTaskStateWithTimeout wraps a single Task state invocation attempt
-// in a context bounded by TimeoutSeconds/TimeoutSecondsPath. It is called
-// once per Retry attempt (see executeTaskStateWithPolicy), so each attempt
-// gets its own fresh timeout window: TimeoutSeconds bounds one execution
-// attempt of the task, not the state's total retry budget.
+// executeTaskStateWithTimeout wraps one Task invocation attempt in a context
+// bounded by TimeoutSeconds/TimeoutSecondsPath. Called once per Retry
+// attempt, so the timeout bounds a single attempt, not the retry budget.
 func (e *executionEngine) executeTaskStateWithTimeout(ctx context.Context, name string, state *stateDefinition, input string) (string, error) {
 	timeout, err := taskTimeout(state, input)
 	if err != nil {
@@ -45,11 +42,9 @@ func (e *executionEngine) executeTaskStateWithTimeout(ctx context.Context, name 
 	return output, err
 }
 
-// taskTimeout resolves a Task state's timeout duration from TimeoutSeconds
-// or TimeoutSecondsPath, preferring the path form when both are set. It
-// returns zero -- meaning "do not wrap the call in a timeout context at all"
-// -- when neither field is set, since the spec's default of 99999999
-// seconds (~3.17 years) is effectively unbounded.
+// taskTimeout resolves the timeout from TimeoutSeconds/TimeoutSecondsPath
+// (path preferred). Returns zero (no timeout context) when neither is set,
+// since the spec's default of 99999999 seconds is effectively unbounded.
 func taskTimeout(state *stateDefinition, input string) (time.Duration, error) {
 	switch {
 	case state.TimeoutSecondsPath != "":

--- a/internal/service/sfn/types.go
+++ b/internal/service/sfn/types.go
@@ -138,9 +138,10 @@ type MapRun struct {
 // and .../API_MapRunItemCounts.html), reused directly as both MapRun's own
 // storage field type and (embedded in DescribeMapRunResponse) the wire type,
 // the same way Tag and LoggingConfiguration double as both elsewhere in this
-// file. Every field except FailuresNotRedrivable/PendingRedrive is
-// documented "Required: Yes", so none but those two get "omitempty" -- a
-// legitimate 0 count must still be sent, not omitted.
+// file.
+//
+// Every field except FailuresNotRedrivable/PendingRedrive is "Required: Yes"
+// per AWS, so only those two get omitempty.
 type MapRunCounts struct {
 	Total                 int64 `json:"total"`
 	Succeeded             int64 `json:"succeeded"`

--- a/internal/service/sfn/validate.go
+++ b/internal/service/sfn/validate.go
@@ -21,10 +21,8 @@ const (
 	defaultValidateMaxResults = 100
 )
 
-// Diagnostic codes. The first block reuses AWS's own documented codes where
-// kumo's check matches their meaning exactly. The second block is best
-// effort: AWS does not document a code for these two checks, so kumo names
-// them descriptively rather than guessing at an undocumented AWS string.
+// Diagnostic codes. First block reuses AWS's documented codes; second block
+// is best-effort naming for checks AWS does not document a code for.
 const (
 	codeInvalidJSONDescription  = "INVALID_JSON_DESCRIPTION"
 	codeSchemaValidationFailed  = "SCHEMA_VALIDATION_FAILED"
@@ -46,17 +44,11 @@ var terminalStateTypes = map[string]bool{
 }
 
 // pathFieldTypes, resultFieldTypes, resultSelectorTypes, and
-// retryCatchTypes are the sets of state Types the ASL spec's "Table of
-// State Types and Fields (JSONPath)"
+// retryCatchTypes are the state Types the ASL spec's state-type/field table
 // (https://states-language.net/spec.html#statetypetable) allows each
-// data-flow field group on:
-//
-//   - InputPath/OutputPath: every state type except Fail.
-//   - ResultPath/Parameters: Task, Parallel, Map, Pass (the states that can
-//     generate a result, plus Pass, which uses Parameters/ResultPath to
-//     shape its Result-or-input).
-//   - ResultSelector: Task, Parallel, Map only (not Pass).
-//   - Retry/Catch: Task, Parallel, Map only.
+// data-flow field group on: InputPath/OutputPath on all but Fail;
+// ResultPath/Parameters on Task/Parallel/Map/Pass; ResultSelector on
+// Task/Parallel/Map; Retry/Catch on Task/Parallel/Map.
 var (
 	pathFieldTypes = map[string]bool{
 		"Task": true, "Parallel": true, "Map": true, "Pass": true,
@@ -87,10 +79,7 @@ type stateFieldRule struct {
 
 // mapDistributedOnlyFields are Map state fields AWS documents only under
 // Distributed mode (see requireDistributedModeForFields in mapstate.go):
-// they are absent from the Inline Map state field list at
-// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-inline.html
-// but present at
-// https://docs.aws.amazon.com/step-functions/latest/dg/state-map-distributed.html.
+// absent from AWS's Inline Map field list, present only in Distributed Map's.
 var mapDistributedOnlyFields = []struct {
 	name  string
 	isSet func(*stateDefinition) bool
@@ -103,11 +92,10 @@ var mapDistributedOnlyFields = []struct {
 }
 
 // validateStateMachineDefinition runs kumo's best-effort structural checks
-// against a Step Functions definition and returns diagnostics in AWS's
-// documented ValidateStateMachineDefinition shape. Definitions that
+// and returns diagnostics in AWS's documented shape. Definitions
 // CreateStateMachine already accepts must keep validating with no ERROR
-// diagnostics; only genuinely broken or kumo-unsupported constructs are
-// flagged, so this never rejects anything the engine can actually run.
+// diagnostics -- only genuinely broken or kumo-unsupported constructs are
+// flagged.
 func validateStateMachineDefinition(definition string) []validateDiagnostic {
 	var def stateMachineDefinition
 	if err := json.Unmarshal([]byte(definition), &def); err != nil {
@@ -149,10 +137,9 @@ func (v *definitionValidator) addWarning(code, location, message string) {
 	})
 }
 
-// validateStateMachine validates one state machine's worth of States --
-// the top-level definition, or a Parallel Branch / Map ItemProcessor
-// sub-definition -- prefixing every diagnostic's location with
-// locationPrefix so nested diagnostics point at the right JSON path.
+// validateStateMachine validates one state machine's worth of States (the
+// top-level definition, or a nested Branch/ItemProcessor), prefixing each
+// diagnostic's location with locationPrefix.
 func (v *definitionValidator) validateStateMachine(def *stateMachineDefinition, locationPrefix string) {
 	if def.StartAt == "" {
 		v.addError(codeSchemaValidationFailed, locationPrefix+"/StartAt", "state machine is missing required field \"StartAt\"")
@@ -229,12 +216,9 @@ func (v *definitionValidator) validateState(name string, state *stateDefinition,
 	}
 }
 
-// validateStateFields flags any data-flow field (InputPath, OutputPath,
-// ResultPath, Parameters, ResultSelector, Retry, Catch) set on a state Type
-// the spec's field table does not allow it on -- for example, a ResultPath
-// on a Wait state -- so a definition that structurally validates does not
-// still surprise the caller when it runs (the pipeline in iodata.go and
-// retry.go simply never reads a field its state type does not support).
+// validateStateFields flags a data-flow field set on a state Type the
+// spec's field table disallows (e.g. ResultPath on a Wait state), so a
+// definition that validates doesn't still surprise the caller at runtime.
 func (v *definitionValidator) validateStateFields(name string, state *stateDefinition, location string) {
 	for _, rule := range stateDataFlowFieldSet {
 		if !rule.isSet(state) || rule.allowed[state.Type] {
@@ -268,12 +252,10 @@ func (v *definitionValidator) validateCatchers(name string, state *stateDefiniti
 	}
 }
 
-// validateTaskState checks a Task state's required Resource field, and, for
-// the .waitForTaskToken integration pattern, that Parameters actually
-// references the task token ($$.Task.Token) -- otherwise the integration
-// fires but no caller can ever resolve the token, so the state can only
-// ever fail with States.Timeout. AWS rejects this at CreateStateMachine
-// time.
+// validateTaskState checks Resource is set, and for .waitForTaskToken
+// tasks, that Parameters references $$.Task.Token -- otherwise no caller
+// can ever resolve it and the state can only fail with States.Timeout. AWS
+// rejects this at CreateStateMachine time.
 func (v *definitionValidator) validateTaskState(name string, state *stateDefinition, location string) {
 	if state.Resource == "" {
 		v.addError(codeInvalidResource, location+"/Resource", fmt.Sprintf("Task state %q is missing required field \"Resource\"", name))
@@ -371,10 +353,9 @@ func (v *definitionValidator) validateMapState(name string, state *stateDefiniti
 }
 
 // validateMapDistributedFields checks the Distributed-mode rules
-// requireDistributedModeForFields enforces at runtime (see mapstate.go),
-// and flags constructs kumo does not implement at all. processor is nil
-// when neither ItemProcessor nor Iterator was set (already reported by
-// validateMapState).
+// requireDistributedModeForFields enforces at runtime, and flags
+// unimplemented constructs. processor is nil when neither ItemProcessor nor
+// Iterator was set (already reported by validateMapState).
 func (v *definitionValidator) validateMapDistributedFields(name string, state *stateDefinition, processor *stateMachineDefinition, location string) {
 	if processor != nil && isDistributedMode(processor) {
 		v.validateDistributedExecutionType(name, processor, location)
@@ -397,12 +378,9 @@ func (v *definitionValidator) validateDistributedExecutionType(name string, proc
 	))
 }
 
-// warnDistributedOnlyFields flags Map fields AWS documents as
-// Distributed-mode-only (see mapDistributedOnlyFields) that are set
-// without ProcessorConfig.Mode "DISTRIBUTED": requireDistributedModeForFields
-// fails these at runtime, so a definition that structurally validates does
-// not still surprise the caller when it runs -- the class of gap reported
-// in issue #861.
+// warnDistributedOnlyFields flags Distributed-mode-only Map fields (see
+// mapDistributedOnlyFields) set without ProcessorConfig.Mode "DISTRIBUTED":
+// requireDistributedModeForFields fails these at runtime (issue #861).
 func (v *definitionValidator) warnDistributedOnlyFields(name string, state *stateDefinition, location string) {
 	for _, field := range mapDistributedOnlyFields {
 		if !field.isSet(state) {
@@ -416,14 +394,9 @@ func (v *definitionValidator) warnDistributedOnlyFields(name string, state *stat
 	}
 }
 
-// warnUnimplementedMapConstructs flags Map/ItemReader/ResultWriter
-// constructs kumo's engine still does not implement at all (see
-// itemreader.go, resultwriter.go), so a definition that structurally
-// validates does not still surprise the caller when it runs. ItemBatcher's
-// MaxItemsPerBatchPath/MaxInputBytesPerBatchPath and the Map state's own
-// ToleratedFailurePercentagePath/ToleratedFailureCountPath are implemented
-// (see buildProcessorUnits in itembatcher.go and resolveMapTolerance in
-// maptolerance.go), so neither warns anymore.
+// warnUnimplementedMapConstructs flags ItemReader/ResultWriter constructs
+// kumo's engine does not implement at all, so a definition that
+// structurally validates doesn't surprise the caller at runtime.
 func (v *definitionValidator) warnUnimplementedMapConstructs(name string, state *stateDefinition, location string) {
 	v.warnUnimplementedItemReaderConstructs(name, state.ItemReader, location)
 	v.warnUnimplementedResultWriterConstructs(name, state.ResultWriter, location)
@@ -452,11 +425,9 @@ func (v *definitionValidator) warnUnimplementedItemReaderConstructs(name string,
 	}
 }
 
-// warnUnimplementedResultWriterConstructs flags the ResultWriter
-// combinations kumo still does not implement: WriterConfig.Transformation
-// "NONE", and WriterConfig used without Resource/Parameters ("preview"
-// mode, which AWS documents as valid but kumo does not implement -- see
-// writeMapResultToS3 in resultwriter.go).
+// warnUnimplementedResultWriterConstructs flags ResultWriter combinations
+// kumo doesn't implement: Transformation "NONE", and WriterConfig without
+// Resource/Parameters ("preview" mode, valid per AWS but unimplemented).
 func (v *definitionValidator) warnUnimplementedResultWriterConstructs(name string, raw json.RawMessage, location string) {
 	var def resultWriterDef
 	if len(raw) == 0 || json.Unmarshal(raw, &def) != nil || len(def.WriterConfig) == 0 {

--- a/internal/service/sfn/wait.go
+++ b/internal/service/sfn/wait.go
@@ -7,17 +7,13 @@ import (
 	"time"
 )
 
-// executeWaitState executes a Wait state by sleeping for the duration
-// determined by Seconds, SecondsPath, Timestamp, or TimestampPath, resolved
-// against the effective input (InputPath applied to the raw input). Wait
-// has no Parameters/Result/ResultPath: its output is always its (possibly
-// filtered) input, narrowed once more by OutputPath.
+// executeWaitState sleeps for the duration from Seconds/SecondsPath/
+// Timestamp/TimestampPath. Wait has no Parameters/Result/ResultPath: its
+// output is always its (possibly filtered) input via OutputPath.
 //
-// The wait is not artificially capped: kumo sleeps for the full requested
-// duration but honors ctx cancellation, and every execution already runs
-// under the timeout context applied in MemoryStorage.runExecution
-// (min(definition TimeoutSeconds, executionTimeoutCap)), which bounds how
-// long any single Wait can actually block.
+// The wait itself is not capped, but honors ctx cancellation and runs under
+// the outer execution timeout (MemoryStorage.runExecution), which bounds
+// how long it can actually block.
 func (e *executionEngine) executeWaitState(ctx context.Context, state *stateDefinition, input string) (string, error) {
 	effectiveInput, err := applyInputPath(state.InputPath, input)
 	if err != nil {
@@ -145,14 +141,10 @@ func resolvePath(path, input string) (any, error) {
 	return value, nil
 }
 
-// resolveOptionalIntPath resolves the dynamic "*Path" variant of an
-// otherwise-static optional integer field, preferring path over static when
-// both are set -- the same precedence taskTimeout gives
-// TimeoutSecondsPath/TimeoutSeconds. It returns static unchanged (possibly
-// nil) when path is empty. Shared by the several Map/ItemReader/ItemBatcher
-// fields with this exact shape: ReaderConfig.MaxItems(Path),
-// ItemBatcher.MaxItemsPerBatch(Path)/MaxInputBytesPerBatch(Path), and
-// ToleratedFailureCount(Path).
+// resolveOptionalIntPath resolves a static-or-"*Path" optional int field,
+// preferring path over static when both are set (same precedence as
+// taskTimeout's TimeoutSecondsPath/TimeoutSeconds). Returns static
+// unchanged when path is empty.
 func resolveOptionalIntPath(static *int, path, input string) (*int, error) {
 	if path == "" {
 		return static, nil


### PR DESCRIPTION
## Summary
sfn and cloudcontrol carried 5-20 line prose comments on nearly every private function (comment density roughly double the repo norm). This compresses each to 1-3 lines keeping only the why: locking invariants, AWS deviations, and interop workarounds stay; algorithm walkthroughs and AWS-spec restatements go. Comment-only diff, verified no code lines changed: sfn 1456 to 1078 comment lines, cloudcontrol 227 to 169.

## Test plan
- [x] `make lint` 0 issues, `go test -race -shuffle=on ./...` green