### PR TITLE
refactor(service): migrate coded error types to service.CodedError (a-m)

### DIFF
--- a/internal/service/acm/types.go
+++ b/internal/service/acm/types.go
@@ -4,6 +4,8 @@ package acm
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // AWSTimestamp is a time.Time that marshals to Unix timestamp (float64).
@@ -247,12 +249,4 @@ type ErrorResponse struct {
 }
 
 // Error represents an ACM error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError

--- a/internal/service/appsync/types.go
+++ b/internal/service/appsync/types.go
@@ -1,6 +1,8 @@
 // Package appsync provides AWS AppSync service emulation for kumo.
 package appsync
 
+import "github.com/sivchari/kumo/internal/service"
+
 // Authentication types.
 const (
 	AuthTypeAPIKey           = "API_KEY"
@@ -363,12 +365,4 @@ type ErrorResponse struct {
 }
 
 // Error represents an AppSync error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError

--- a/internal/service/batch/types.go
+++ b/internal/service/batch/types.go
@@ -1,7 +1,11 @@
 // Package batch provides AWS Batch service emulation for kumo.
 package batch
 
-import "time"
+import (
+	"time"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // Compute environment states.
 const (
@@ -763,15 +767,7 @@ type ErrorResponse struct {
 }
 
 // Error represents a Batch error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // Timestamp helper for job creation.
 func nowMillis() int64 {

--- a/internal/service/cloudfront/storage.go
+++ b/internal/service/cloudfront/storage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/sivchari/kumo/internal/service"
 	"github.com/sivchari/kumo/internal/storage"
 )
 
@@ -145,14 +146,7 @@ func (s *MemoryStorage) Close() error {
 }
 
 // Error represents a CloudFront error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // CreateDistribution creates a new distribution.
 func (s *MemoryStorage) CreateDistribution(_ context.Context, config *CreateDistributionRequest) (*Distribution, error) {

--- a/internal/service/cloudwatch/types.go
+++ b/internal/service/cloudwatch/types.go
@@ -3,6 +3,8 @@ package cloudwatch
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // CBORTime wraps time.Time for CBOR serialization.
@@ -263,15 +265,7 @@ type ErrorResponse struct {
 }
 
 // Error represents a CloudWatch error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // CBOR Request types for RPC v2 CBOR protocol.
 // These types use time.Time for timestamps which are sent as CBOR Tag (ID: 1).

--- a/internal/service/cloudwatchlogs/types.go
+++ b/internal/service/cloudwatchlogs/types.go
@@ -1,6 +1,8 @@
 // Package cloudwatchlogs provides CloudWatch Logs service emulation for kumo.
 package cloudwatchlogs
 
+import "github.com/sivchari/kumo/internal/service"
+
 // LogGroup represents a log group in CloudWatch Logs.
 type LogGroup struct {
 	LogGroupName      string
@@ -231,12 +233,4 @@ type ErrorResponse struct {
 }
 
 // LogsError represents a CloudWatch Logs error.
-type LogsError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *LogsError) Error() string {
-	return e.Message
-}
+type LogsError = service.CodedError

--- a/internal/service/documentdb/types.go
+++ b/internal/service/documentdb/types.go
@@ -2,6 +2,8 @@ package documentdb
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // DBCluster represents a DocumentDB database cluster.
@@ -113,15 +115,7 @@ type DescribeDBInstancesInput struct {
 // Error types.
 
 // Error represents a DocumentDB error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // ErrorResponse represents a DocumentDB error response.
 type ErrorResponse struct {

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // ReturnValues constants for DynamoDB operations.
@@ -610,15 +612,7 @@ type ErrorResponse struct {
 }
 
 // TableError represents a DynamoDB table error.
-type TableError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *TableError) Error() string {
-	return e.Message
-}
+type TableError = service.CodedError
 
 // Tag represents a key-value tag for a DynamoDB resource.
 type Tag struct {

--- a/internal/service/elasticache/types.go
+++ b/internal/service/elasticache/types.go
@@ -2,6 +2,8 @@ package elasticache
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // CacheCluster represents an ElastiCache cluster.
@@ -230,15 +232,7 @@ type DescribeReplicationGroupsOutput struct {
 // Error types.
 
 // Error represents an ElastiCache error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // Error codes.
 const (

--- a/internal/service/firehose/types.go
+++ b/internal/service/firehose/types.go
@@ -1,7 +1,11 @@
 // Package firehose provides a mock implementation of Amazon Data Firehose.
 package firehose
 
-import "time"
+import (
+	"time"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // DeliveryStreamStatus represents the status of a delivery stream.
 type DeliveryStreamStatus string
@@ -310,15 +314,7 @@ type ErrorResponse struct {
 }
 
 // Error represents a service error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // Error codes.
 const (

--- a/internal/service/glue/types.go
+++ b/internal/service/glue/types.go
@@ -4,6 +4,8 @@ package glue
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // AWSTimestamp is a time.Time that marshals to Unix timestamp (float64).
@@ -367,15 +369,7 @@ type ErrorResponse struct {
 }
 
 // Error represents a Glue error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // GetTagsInput is the request for GetTags.
 type GetTagsInput struct {


### PR DESCRIPTION
## Summary
11 packages (acm, appsync, batch, cloudfront, cloudwatch, cloudwatchlogs, documentdb, dynamodb, elasticache, firehose, glue) defined a private {Code, Message} error struct byte-identical in behavior to `service.CodedError`. Each becomes a type alias, dropping the duplicated Error() methods. Only packages whose Error() output matches byte for byte were migrated; the 24 packages with a different format, extra fields, or client-marshaled JSON tags are deliberately left alone (n-z batch and format-divergent groups are follow-ups).

## Test plan
- [x] `make lint` 0 issues, `go test -race -shuffle=on ./...` green, no golden changes