### PR TITLE
refactor(test): consolidate duplicated test helpers

### DIFF
--- a/internal/service/apigateway/storage_stage_variables_test.go
+++ b/internal/service/apigateway/storage_stage_variables_test.go
@@ -1,6 +1,9 @@
 package apigateway
 
-import "testing"
+import (
+	"maps"
+	"testing"
+)
 
 func TestMemoryStorage_CreateStage_Variables(t *testing.T) {
 	t.Parallel()
@@ -38,7 +41,7 @@ func TestMemoryStorage_CreateStage_Variables(t *testing.T) {
 				t.Fatalf("CreateStage() error = %v", err)
 			}
 
-			if !mapsEqualV1(created.Variables, tt.variables) {
+			if !maps.Equal(created.Variables, tt.variables) {
 				t.Errorf("CreateStage() Variables = %v, want %v", created.Variables, tt.variables)
 			}
 
@@ -47,28 +50,14 @@ func TestMemoryStorage_CreateStage_Variables(t *testing.T) {
 				t.Fatalf("GetStage() error = %v", err)
 			}
 
-			if !mapsEqualV1(got.Variables, tt.variables) {
+			if !maps.Equal(got.Variables, tt.variables) {
 				t.Errorf("GetStage() Variables = %v, want %v", got.Variables, tt.variables)
 			}
 
 			resp := toStageResponse(got)
-			if !mapsEqualV1(resp.Variables, tt.variables) {
+			if !maps.Equal(resp.Variables, tt.variables) {
 				t.Errorf("toStageResponse() Variables = %v, want %v", resp.Variables, tt.variables)
 			}
 		})
 	}
-}
-
-func mapsEqualV1(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for k, v := range a {
-		if b[k] != v {
-			return false
-		}
-	}
-
-	return true
 }

--- a/internal/service/apigatewayv2/executeapi_jwt_test.go
+++ b/internal/service/apigatewayv2/executeapi_jwt_test.go
@@ -228,12 +228,6 @@ func TestHandleExecuteAPI_JWTAuthorizer_Valid(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
 	}
 
-	checkCapturedJWTClaims(t, captured, future)
-}
-
-func checkCapturedJWTClaims(t *testing.T, captured jwtEventCapture, wantExpUnix int64) {
-	t.Helper()
-
 	claims := captured.RequestContext.Authorizer.JWT.Claims
 	if claims["sub"] != "user-1" {
 		t.Errorf("claims[sub] = %q, want %q", claims["sub"], "user-1")
@@ -243,7 +237,7 @@ func checkCapturedJWTClaims(t *testing.T, captured jwtEventCapture, wantExpUnix 
 		t.Errorf("claims[iss] = %q, want %q", claims["iss"], testJWTIssuer)
 	}
 
-	wantExp := strconv.FormatInt(wantExpUnix, 10)
+	wantExp := strconv.FormatInt(future, 10)
 	if claims["exp"] != wantExp {
 		t.Errorf("claims[exp] = %q, want %q (stringified number)", claims["exp"], wantExp)
 	}

--- a/internal/service/apigatewayv2/executeapi_stage_variables_test.go
+++ b/internal/service/apigatewayv2/executeapi_stage_variables_test.go
@@ -1,6 +1,7 @@
 package apigatewayv2
 
 import (
+	"maps"
 	"net/http/httptest"
 	"testing"
 )
@@ -74,7 +75,7 @@ func checkResolveStageReturnsVariables(t *testing.T, stageName, invokePath, want
 		t.Fatal("resolveStage() stageObj is nil, want a resolved *Stage")
 	}
 
-	if !mapsEqualV2(stageObj.StageVariables, wantVars) {
+	if !maps.Equal(stageObj.StageVariables, wantVars) {
 		t.Errorf("resolveStage() stageObj.StageVariables = %v, want %v", stageObj.StageVariables, wantVars)
 	}
 }
@@ -97,18 +98,4 @@ func TestResolveStage_UnknownStage(t *testing.T) {
 	if stage != "" || stageObj != nil || routePath != "" {
 		t.Errorf("resolveStage() = (%q, %v, %q), want (\"\", nil, \"\")", stage, stageObj, routePath)
 	}
-}
-
-func mapsEqualV2(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for k, v := range a {
-		if b[k] != v {
-			return false
-		}
-	}
-
-	return true
 }

--- a/internal/service/execapi/event_test.go
+++ b/internal/service/execapi/event_test.go
@@ -2,6 +2,7 @@ package execapi
 
 import (
 	"encoding/json"
+	"maps"
 	"net/http/httptest"
 	"testing"
 )
@@ -29,41 +30,36 @@ func TestBuildEventV1_StageVariables(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			checkBuildEventV1StageVariables(t, tt.stageVariables, tt.wantVars)
+
+			r := httptest.NewRequestWithContext(t.Context(), "GET", "/dev/items", nil)
+			req := &Request{
+				APIID:          "api1",
+				Stage:          "dev",
+				ResourcePath:   "/items",
+				StageVariables: tt.stageVariables,
+			}
+
+			data, err := buildEventV1(r, req, nil)
+			if err != nil {
+				t.Fatalf("buildEventV1() error = %v", err)
+			}
+
+			var decoded struct {
+				StageVariables map[string]string `json:"stageVariables"`
+			}
+
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unmarshal event: %v", err)
+			}
+
+			if !maps.Equal(decoded.StageVariables, tt.wantVars) {
+				t.Errorf("stageVariables = %v, want %v", decoded.StageVariables, tt.wantVars)
+			}
+
+			if tt.stageVariables == nil && !hasNullField(data, "stageVariables") {
+				t.Error("expected stageVariables to be present as null in the v1 event")
+			}
 		})
-	}
-}
-
-func checkBuildEventV1StageVariables(t *testing.T, stageVariables, wantVars map[string]string) {
-	t.Helper()
-
-	r := httptest.NewRequestWithContext(t.Context(), "GET", "/dev/items", nil)
-	req := &Request{
-		APIID:          "api1",
-		Stage:          "dev",
-		ResourcePath:   "/items",
-		StageVariables: stageVariables,
-	}
-
-	data, err := buildEventV1(r, req, nil)
-	if err != nil {
-		t.Fatalf("buildEventV1() error = %v", err)
-	}
-
-	var decoded struct {
-		StageVariables map[string]string `json:"stageVariables"`
-	}
-
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatalf("unmarshal event: %v", err)
-	}
-
-	if !mapsEqual(decoded.StageVariables, wantVars) {
-		t.Errorf("stageVariables = %v, want %v", decoded.StageVariables, wantVars)
-	}
-
-	if stageVariables == nil && !hasNullField(data, "stageVariables") {
-		t.Error("expected stageVariables to be present as null in the v1 event")
 	}
 }
 
@@ -137,7 +133,7 @@ func checkBuildEventV2StageVariables(t *testing.T, stageVariables, wantVars map[
 		t.Fatalf("unmarshal event: %v", err)
 	}
 
-	if !mapsEqual(typed.StageVariables, wantVars) {
+	if !maps.Equal(typed.StageVariables, wantVars) {
 		t.Errorf("stageVariables = %v, want %v", typed.StageVariables, wantVars)
 	}
 }
@@ -269,20 +265,6 @@ func TestBuildEventV1_StagePath(t *testing.T) {
 			}
 		})
 	}
-}
-
-func mapsEqual(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for k, v := range a {
-		if b[k] != v {
-			return false
-		}
-	}
-
-	return true
 }
 
 // hasNullField reports whether the given top-level JSON field is present and

--- a/internal/service/sfn/iodata_test.go
+++ b/internal/service/sfn/iodata_test.go
@@ -1,7 +1,6 @@
 package sfn
 
 import (
-	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -254,7 +253,9 @@ func TestApplyResultPath(t *testing.T) {
 				t.Fatalf("applyResultPath: %v", err)
 			}
 
-			assertJSONEqual(t, got, tt.want)
+			if !jsonDeepEqual(got, tt.want) {
+				t.Fatalf("JSON mismatch: got %s, want %s", got, tt.want)
+			}
 		})
 	}
 }
@@ -284,36 +285,7 @@ func TestResolveEffectiveInput(t *testing.T) {
 		t.Fatalf("resolveEffectiveInput: %v", err)
 	}
 
-	assertJSONEqual(t, got, `{"total":3}`)
-}
-
-// assertJSONEqual fails the test unless got and want decode to
-// deep-equal JSON values, so tests are not sensitive to key ordering
-// (encoding/json's map marshaling order is not guaranteed to match a
-// hand-written literal).
-func assertJSONEqual(t *testing.T, got, want string) {
-	t.Helper()
-
-	var gotVal, wantVal any
-	if err := json.Unmarshal([]byte(got), &gotVal); err != nil {
-		t.Fatalf("unmarshal got %q: %v", got, err)
-	}
-
-	if err := json.Unmarshal([]byte(want), &wantVal); err != nil {
-		t.Fatalf("unmarshal want %q: %v", want, err)
-	}
-
-	gotNorm, err := json.Marshal(gotVal)
-	if err != nil {
-		t.Fatalf("marshal got: %v", err)
-	}
-
-	wantNorm, err := json.Marshal(wantVal)
-	if err != nil {
-		t.Fatalf("marshal want: %v", err)
-	}
-
-	if !bytes.Equal(gotNorm, wantNorm) {
-		t.Fatalf("JSON mismatch: got %s, want %s", got, want)
+	if !jsonDeepEqual(got, `{"total":3}`) {
+		t.Fatalf("JSON mismatch: got %s, want %s", got, `{"total":3}`)
 	}
 }

--- a/internal/service/sfn/itembatcher_test.go
+++ b/internal/service/sfn/itembatcher_test.go
@@ -1,7 +1,6 @@
 package sfn
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -172,20 +171,4 @@ func TestMapStateItemBatcherMaxItemsPerBatchPathTakesPrecedenceOverStatic(t *tes
 	if len(envelopes) != 5 {
 		t.Fatalf("batches: got %d, want 5 (MaxItemsPerBatchPath=1 must win over MaxItemsPerBatch=10)", len(envelopes))
 	}
-}
-
-// jsonDeepEqual compares two already-decoded JSON values by re-encoding
-// them, avoiding a reflect.DeepEqual dependency on map/slice identity.
-func jsonDeepEqual(a, b any) bool {
-	aJSON, err := json.Marshal(a)
-	if err != nil {
-		return false
-	}
-
-	bJSON, err := json.Marshal(b)
-	if err != nil {
-		return false
-	}
-
-	return bytes.Equal(aJSON, bJSON)
 }

--- a/internal/service/sfn/itemselector_test.go
+++ b/internal/service/sfn/itemselector_test.go
@@ -1,7 +1,6 @@
 package sfn
 
 import (
-	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -52,26 +51,8 @@ func TestMapStateItemSelectorStaticAndContextAndInputPaths(t *testing.T) {
 	}
 
 	for i, w := range want {
-		assertMapEqual(t, i, w, outputs[i])
-	}
-}
-
-// assertMapEqual fails the test unless got deep-equals want, field by
-// field, reporting the specific mismatched key when it doesn't.
-func assertMapEqual(t *testing.T, index int, want, got map[string]any) {
-	t.Helper()
-
-	for k, wv := range want {
-		gv, ok := got[k]
-		if !ok {
-			t.Fatalf("item %d: missing key %q in %+v", index, k, got)
-		}
-
-		wantJSON, _ := json.Marshal(wv)
-		gotJSON, _ := json.Marshal(gv)
-
-		if !bytes.Equal(wantJSON, gotJSON) {
-			t.Fatalf("item %d: key %q: got %s, want %s", index, k, gotJSON, wantJSON)
+		if !jsonDeepEqual(outputs[i], w) {
+			t.Fatalf("item %d: got %+v, want %+v", i, outputs[i], w)
 		}
 	}
 }

--- a/internal/service/sfn/jsondeepequal_test.go
+++ b/internal/service/sfn/jsondeepequal_test.go
@@ -1,0 +1,47 @@
+package sfn
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// jsonDeepEqual reports whether a and b represent the same JSON value. Each
+// argument may be an already-decoded Go value (e.g. map[string]any,
+// []any, from unmarshaling a test fixture) or a raw JSON document (a
+// string), so callers are not sensitive to map key ordering or to
+// formatting differences between two JSON documents.
+func jsonDeepEqual(a, b any) bool {
+	aJSON, ok := normalizedJSON(a)
+	if !ok {
+		return false
+	}
+
+	bJSON, ok := normalizedJSON(b)
+	if !ok {
+		return false
+	}
+
+	return bytes.Equal(aJSON, bJSON)
+}
+
+// normalizedJSON returns the canonical JSON encoding of v, and whether
+// encoding succeeded. A string v is first decoded as a JSON document (so
+// two differently formatted documents still compare equal) before being
+// re-encoded; any other v is encoded as-is.
+func normalizedJSON(v any) ([]byte, bool) {
+	if s, ok := v.(string); ok {
+		var decoded any
+		if err := json.Unmarshal([]byte(s), &decoded); err != nil {
+			return nil, false
+		}
+
+		v = decoded
+	}
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, false
+	}
+
+	return b, true
+}

--- a/internal/service/sfn/pipeline_test.go
+++ b/internal/service/sfn/pipeline_test.go
@@ -63,7 +63,10 @@ func TestPassStatePipelineAppliesResultAndResultPath(t *testing.T) {
 
 	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"georefOf":"Home"}`)
 
-	assertJSONEqual(t, exec.Output, `{"georefOf":"Home","coords":{"x-datum":0.381018,"y-datum":622.2269926397355}}`)
+	want := `{"georefOf":"Home","coords":{"x-datum":0.381018,"y-datum":622.2269926397355}}`
+	if !jsonDeepEqual(exec.Output, want) {
+		t.Fatalf("JSON mismatch: got %s, want %s", exec.Output, want)
+	}
 }
 
 // TestPassStatePipelineDefaultsToPassThrough checks that a Pass state with
@@ -115,7 +118,10 @@ func TestParallelStatePipelineAppliesResultSelectorAndResultPath(t *testing.T) {
 
 	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"seed":1}`)
 
-	assertJSONEqual(t, exec.Output, `{"seed":1,"parallelResult":{"all":[{"branch":"a"},{"branch":"b"}]}}`)
+	want := `{"seed":1,"parallelResult":{"all":[{"branch":"a"},{"branch":"b"}]}}`
+	if !jsonDeepEqual(exec.Output, want) {
+		t.Fatalf("JSON mismatch: got %s, want %s", exec.Output, want)
+	}
 }
 
 // TestMapStatePipelineAppliesResultSelectorAndResultPath checks the same
@@ -143,10 +149,13 @@ func TestMapStatePipelineAppliesResultSelectorAndResultPath(t *testing.T) {
 
 	exec := startAndAwaitSuccess(t, store, sm.StateMachineArn, `{"items":[1,2,3]}`)
 
-	assertJSONEqual(t, exec.Output, `{
+	want := `{
 		"items": [1, 2, 3],
 		"mapResult": {"outputs": [{"doubled": true}, {"doubled": true}, {"doubled": true}]}
-	}`)
+	}`
+	if !jsonDeepEqual(exec.Output, want) {
+		t.Fatalf("JSON mismatch: got %s, want %s", exec.Output, want)
+	}
 }
 
 // TestWaitStatePipelineAppliesInputPathAndOutputPath checks that a Wait


### PR DESCRIPTION
## Summary
Three byte-identical map-equality helpers (mapsEqual / mapsEqualV1 / mapsEqualV2 across execapi, apigateway, apigatewayv2) are replaced by stdlib `maps.Equal`. sfn's three homegrown JSON-comparison helpers become one `jsonDeepEqual` in a shared test file. check* helpers that existed only to dodge funlen are inlined back where the resulting test stays under the limit (2 inlined, 4 kept with the measured line count documented in the PR).

## Test plan
- [x] `make lint` 0 issues (funlen included), `go test -race ./...` green