### PR TITLE
refactor(service): migrate coded error types to service.CodedError (n-z)

### DIFF
--- a/internal/service/neptune/types.go
+++ b/internal/service/neptune/types.go
@@ -2,6 +2,8 @@ package neptune
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // DBCluster represents a Neptune database cluster.
@@ -97,15 +99,7 @@ type DescribeDBInstancesInput struct {
 // Error types.
 
 // Error represents a Neptune error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // ErrorResponse represents a Neptune error response.
 type ErrorResponse struct {

--- a/internal/service/pinpointsmsvoicev2/types.go
+++ b/internal/service/pinpointsmsvoicev2/types.go
@@ -1,7 +1,11 @@
 //nolint:tagliatelle // AWS Pinpoint SMS Voice v2 API uses PascalCase for JSON tags
 package pinpointsmsvoicev2
 
-import "time"
+import (
+	"time"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // SentTextMessage represents a sent text message for debugging purposes.
 type SentTextMessage struct {
@@ -40,12 +44,4 @@ type ErrorResponse struct {
 }
 
 // Error represents a service error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError

--- a/internal/service/rds/types.go
+++ b/internal/service/rds/types.go
@@ -2,6 +2,8 @@ package rds
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // DBInstance represents an RDS database instance.
@@ -298,15 +300,7 @@ type DeleteDBSnapshotOutput struct {
 // Error types.
 
 // Error represents an RDS error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // ErrorResponse represents an RDS error response.
 type ErrorResponse struct {

--- a/internal/service/redshift/types.go
+++ b/internal/service/redshift/types.go
@@ -2,6 +2,8 @@ package redshift
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // Cluster represents a Redshift cluster.
@@ -97,15 +99,7 @@ type DescribeClusterSnapshotsInput struct {
 // Error types.
 
 // Error represents a Redshift error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // ErrorResponse represents a Redshift error response.
 type ErrorResponse struct {

--- a/internal/service/route53resolver/types.go
+++ b/internal/service/route53resolver/types.go
@@ -1,6 +1,8 @@
 // Package route53resolver provides Route 53 Resolver service emulation for kumo.
 package route53resolver
 
+import "github.com/sivchari/kumo/internal/service"
+
 // ResolverEndpoint represents a Route 53 Resolver endpoint.
 type ResolverEndpoint struct {
 	ID                    string
@@ -284,12 +286,4 @@ type ErrorResponse struct {
 }
 
 // ResolverError represents a Route 53 Resolver error.
-type ResolverError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *ResolverError) Error() string {
-	return e.Message
-}
+type ResolverError = service.CodedError

--- a/internal/service/s3tables/types.go
+++ b/internal/service/s3tables/types.go
@@ -1,7 +1,11 @@
 // Package s3tables provides S3 Tables service emulation for kumo.
 package s3tables
 
-import "time"
+import (
+	"time"
+
+	"github.com/sivchari/kumo/internal/service"
+)
 
 // TableBucket represents an S3 table bucket.
 type TableBucket struct {
@@ -219,15 +223,7 @@ type TableSummary struct {
 }
 
 // Error represents an S3 Tables error.
-type Error struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError
 
 // Error codes.
 const (

--- a/internal/service/secretsmanager/types.go
+++ b/internal/service/secretsmanager/types.go
@@ -3,6 +3,8 @@ package secretsmanager
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // Secret represents a secret in Secrets Manager.
@@ -256,15 +258,7 @@ type ErrorResponse struct {
 }
 
 // SecretError represents a Secrets Manager error.
-type SecretError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *SecretError) Error() string {
-	return e.Message
-}
+type SecretError = service.CodedError
 
 // ExternalSecretRotationMetadataItem represents the metadata for external secret rotation.
 type ExternalSecretRotationMetadataItem struct {

--- a/internal/service/ses/types.go
+++ b/internal/service/ses/types.go
@@ -4,6 +4,8 @@ package ses
 import (
 	"encoding/xml"
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // Identity represents a verified email identity.
@@ -197,12 +199,4 @@ type XMLErrorDetail struct {
 }
 
 // Error represents an SES error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError

--- a/internal/service/sesv2/types.go
+++ b/internal/service/sesv2/types.go
@@ -4,6 +4,8 @@ package sesv2
 import (
 	"strconv"
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // epochSeconds is a time.Time-compatible value that JSON-marshals as a
@@ -347,12 +349,4 @@ type ErrorResponse struct {
 }
 
 // IdentityError represents an SES error.
-type IdentityError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *IdentityError) Error() string {
-	return e.Message
-}
+type IdentityError = service.CodedError

--- a/internal/service/sns/types.go
+++ b/internal/service/sns/types.go
@@ -3,6 +3,8 @@ package sns
 
 import (
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // Topic represents an SNS topic.
@@ -290,15 +292,7 @@ type XMLErrorDetail struct {
 }
 
 // TopicError represents an SNS error.
-type TopicError struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *TopicError) Error() string {
-	return e.Message
-}
+type TopicError = service.CodedError
 
 // XMLSetTopicAttributesResponse is the XML response for SetTopicAttributes.
 type XMLSetTopicAttributesResponse struct {

--- a/internal/service/xray/types.go
+++ b/internal/service/xray/types.go
@@ -4,6 +4,8 @@ package xray
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/sivchari/kumo/internal/service"
 )
 
 // AWSTimestamp is a time.Time that marshals to/from Unix timestamp (float64).
@@ -404,12 +406,4 @@ type ErrorResponse struct {
 }
 
 // Error represents an X-Ray error.
-type Error struct {
-	Code    string
-	Message string
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	return e.Message
-}
+type Error = service.CodedError


### PR DESCRIPTION
## Summary
Batch 2 of the CodedError consolidation: 11 more packages (neptune, pinpointsmsvoicev2, rds, redshift, route53resolver, s3tables, secretsmanager, ses, sesv2, sns, xray) replace their private {Code, Message} error struct with a type alias to `service.CodedError`. Only byte-identical Error() formats were migrated; packages whose error struct is wire-marshaled with its own tags or uses a different format are skipped and documented in the migration notes.

## Test plan
- [x] `make lint` 0 issues, `go test -race -shuffle=on ./...` green, no golden changes