### PR TITLE
refactor(service): normalize writeError signatures to (w, code, message, status)

### DIFF
--- a/internal/service/backup/handlers.go
+++ b/internal/service/backup/handlers.go
@@ -11,7 +11,7 @@ import (
 func (s *Service) CreateBackupVault(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("backupVaultName")
 	if name == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "backup vault name is required")
+		writeError(w, "InvalidParameterValueException", "backup vault name is required", http.StatusBadRequest)
 
 		return
 	}
@@ -19,7 +19,7 @@ func (s *Service) CreateBackupVault(w http.ResponseWriter, r *http.Request) {
 	var input CreateBackupVaultInput
 	if r.Body != nil && r.ContentLength > 0 {
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			writeError(w, http.StatusBadRequest, "InvalidRequestException", "invalid request body")
+			writeError(w, "InvalidRequestException", "invalid request body", http.StatusBadRequest)
 
 			return
 		}
@@ -28,12 +28,12 @@ func (s *Service) CreateBackupVault(w http.ResponseWriter, r *http.Request) {
 	vault, err := s.storage.CreateVault(name, &input)
 	if err != nil {
 		if strings.Contains(err.Error(), "AlreadyExistsException") {
-			writeError(w, http.StatusConflict, "AlreadyExistsException", err.Error())
+			writeError(w, "AlreadyExistsException", err.Error(), http.StatusConflict)
 
 			return
 		}
 
-		writeError(w, http.StatusInternalServerError, "ServiceUnavailableException", err.Error())
+		writeError(w, "ServiceUnavailableException", err.Error(), http.StatusInternalServerError)
 
 		return
 	}
@@ -49,14 +49,14 @@ func (s *Service) CreateBackupVault(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DescribeBackupVault(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("backupVaultName")
 	if name == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "backup vault name is required")
+		writeError(w, "InvalidParameterValueException", "backup vault name is required", http.StatusBadRequest)
 
 		return
 	}
 
 	vault, err := s.storage.DescribeVault(name)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -76,13 +76,13 @@ func (s *Service) ListBackupVaults(w http.ResponseWriter, _ *http.Request) {
 func (s *Service) DeleteBackupVault(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("backupVaultName")
 	if name == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "backup vault name is required")
+		writeError(w, "InvalidParameterValueException", "backup vault name is required", http.StatusBadRequest)
 
 		return
 	}
 
 	if err := s.storage.DeleteVault(name); err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -94,20 +94,20 @@ func (s *Service) DeleteBackupVault(w http.ResponseWriter, r *http.Request) {
 func (s *Service) CreateBackupPlan(w http.ResponseWriter, r *http.Request) {
 	var input CreateBackupPlanInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "InvalidRequestException", "invalid request body")
+		writeError(w, "InvalidRequestException", "invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if input.BackupPlan == nil || input.BackupPlan.BackupPlanName == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "backup plan name is required")
+		writeError(w, "InvalidParameterValueException", "backup plan name is required", http.StatusBadRequest)
 
 		return
 	}
 
 	plan, err := s.storage.CreatePlan(&input)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "ServiceUnavailableException", err.Error())
+		writeError(w, "ServiceUnavailableException", err.Error(), http.StatusInternalServerError)
 
 		return
 	}
@@ -124,14 +124,14 @@ func (s *Service) CreateBackupPlan(w http.ResponseWriter, r *http.Request) {
 func (s *Service) GetBackupPlan(w http.ResponseWriter, r *http.Request) {
 	planID := r.PathValue("backupPlanId")
 	if planID == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "backup plan ID is required")
+		writeError(w, "InvalidParameterValueException", "backup plan ID is required", http.StatusBadRequest)
 
 		return
 	}
 
 	plan, err := s.storage.GetPlan(planID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -157,13 +157,13 @@ func (s *Service) ListBackupPlans(w http.ResponseWriter, _ *http.Request) {
 func (s *Service) DeleteBackupPlan(w http.ResponseWriter, r *http.Request) {
 	planID := r.PathValue("backupPlanId")
 	if planID == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "backup plan ID is required")
+		writeError(w, "InvalidParameterValueException", "backup plan ID is required", http.StatusBadRequest)
 
 		return
 	}
 
 	if err := s.storage.DeletePlan(planID); err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -175,20 +175,20 @@ func (s *Service) DeleteBackupPlan(w http.ResponseWriter, r *http.Request) {
 func (s *Service) CreateBackupSelection(w http.ResponseWriter, r *http.Request) {
 	planID := r.PathValue("backupPlanId")
 	if planID == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "backup plan ID is required")
+		writeError(w, "InvalidParameterValueException", "backup plan ID is required", http.StatusBadRequest)
 
 		return
 	}
 
 	var input CreateBackupSelectionInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "InvalidRequestException", "invalid request body")
+		writeError(w, "InvalidRequestException", "invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if input.BackupSelection == nil || input.BackupSelection.SelectionName == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "selection name is required")
+		writeError(w, "InvalidParameterValueException", "selection name is required", http.StatusBadRequest)
 
 		return
 	}
@@ -196,12 +196,12 @@ func (s *Service) CreateBackupSelection(w http.ResponseWriter, r *http.Request) 
 	selection, err := s.storage.CreateSelection(planID, &input)
 	if err != nil {
 		if strings.Contains(err.Error(), "ResourceNotFoundException") {
-			writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+			writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 			return
 		}
 
-		writeError(w, http.StatusInternalServerError, "ServiceUnavailableException", err.Error())
+		writeError(w, "ServiceUnavailableException", err.Error(), http.StatusInternalServerError)
 
 		return
 	}
@@ -219,14 +219,14 @@ func (s *Service) GetBackupSelection(w http.ResponseWriter, r *http.Request) {
 	selectionID := r.PathValue("selectionId")
 
 	if planID == "" || selectionID == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "plan ID and selection ID are required")
+		writeError(w, "InvalidParameterValueException", "plan ID and selection ID are required", http.StatusBadRequest)
 
 		return
 	}
 
 	selection, err := s.storage.GetSelection(planID, selectionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -243,7 +243,7 @@ func (s *Service) GetBackupSelection(w http.ResponseWriter, r *http.Request) {
 func (s *Service) ListBackupSelections(w http.ResponseWriter, r *http.Request) {
 	planID := r.PathValue("backupPlanId")
 	if planID == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "backup plan ID is required")
+		writeError(w, "InvalidParameterValueException", "backup plan ID is required", http.StatusBadRequest)
 
 		return
 	}
@@ -260,13 +260,13 @@ func (s *Service) DeleteBackupSelection(w http.ResponseWriter, r *http.Request) 
 	selectionID := r.PathValue("selectionId")
 
 	if planID == "" || selectionID == "" {
-		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", "plan ID and selection ID are required")
+		writeError(w, "InvalidParameterValueException", "plan ID and selection ID are required", http.StatusBadRequest)
 
 		return
 	}
 
 	if err := s.storage.DeleteSelection(planID, selectionID); err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -280,7 +280,7 @@ func writeJSON(w http.ResponseWriter, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-func writeError(w http.ResponseWriter, status int, code, message string) {
+func writeError(w http.ResponseWriter, code, message string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("x-amzn-ErrorType", code)
 	w.WriteHeader(status)

--- a/internal/service/codegurureviewer/handlers.go
+++ b/internal/service/codegurureviewer/handlers.go
@@ -11,7 +11,7 @@ func writeJSON(w http.ResponseWriter, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-func writeError(w http.ResponseWriter, status int, errType, message string) {
+func writeError(w http.ResponseWriter, errType, message string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("x-amzn-ErrorType", errType)
 	w.WriteHeader(status)
@@ -25,7 +25,7 @@ func writeError(w http.ResponseWriter, status int, errType, message string) {
 func (s *Service) AssociateRepository(w http.ResponseWriter, r *http.Request) {
 	var input AssociateRepositoryInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "ValidationException", "invalid request body")
+		writeError(w, "ValidationException", "invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -44,7 +44,7 @@ func (s *Service) DescribeRepositoryAssociation(w http.ResponseWriter, r *http.R
 
 	assoc, err := s.storage.DescribeRepositoryAssociation(arn)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NotFoundException", err.Error())
+		writeError(w, "NotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -61,7 +61,7 @@ func (s *Service) DisassociateRepository(w http.ResponseWriter, r *http.Request)
 
 	assoc, err := s.storage.DisassociateRepository(arn)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NotFoundException", err.Error())
+		writeError(w, "NotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -85,14 +85,14 @@ func (s *Service) ListRepositoryAssociations(w http.ResponseWriter, _ *http.Requ
 func (s *Service) CreateCodeReview(w http.ResponseWriter, r *http.Request) {
 	var input CreateCodeReviewInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "ValidationException", "invalid request body")
+		writeError(w, "ValidationException", "invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	review, err := s.storage.CreateCodeReview(&input)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NotFoundException", err.Error())
+		writeError(w, "NotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -108,7 +108,7 @@ func (s *Service) DescribeCodeReview(w http.ResponseWriter, r *http.Request) {
 
 	review, err := s.storage.DescribeCodeReview(arn)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -141,13 +141,13 @@ func (s *Service) ListRecommendations(w http.ResponseWriter, r *http.Request) {
 func (s *Service) PutRecommendationFeedback(w http.ResponseWriter, r *http.Request) {
 	var input PutRecommendationFeedbackInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "ValidationException", "invalid request body")
+		writeError(w, "ValidationException", "invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if err := s.storage.PutRecommendationFeedback(&input); err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -162,7 +162,7 @@ func (s *Service) DescribeRecommendationFeedback(w http.ResponseWriter, r *http.
 
 	fb, err := s.storage.DescribeRecommendationFeedback(arn, recommendationID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}

--- a/internal/service/dataexchange/handlers.go
+++ b/internal/service/dataexchange/handlers.go
@@ -11,13 +11,13 @@ import (
 func (s *Service) CreateDataSet(w http.ResponseWriter, r *http.Request) {
 	var input CreateDataSetInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "ValidationException", "invalid request body")
+		writeError(w, "ValidationException", "invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if input.Name == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "name is required")
+		writeError(w, "ValidationException", "name is required", http.StatusBadRequest)
 
 		return
 	}
@@ -34,14 +34,14 @@ func (s *Service) CreateDataSet(w http.ResponseWriter, r *http.Request) {
 func (s *Service) GetDataSet(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("dataSetId")
 	if id == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "data set ID is required")
+		writeError(w, "ValidationException", "data set ID is required", http.StatusBadRequest)
 
 		return
 	}
 
 	ds, err := s.storage.GetDataSet(id)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -61,21 +61,21 @@ func (s *Service) ListDataSets(w http.ResponseWriter, _ *http.Request) {
 func (s *Service) UpdateDataSet(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("dataSetId")
 	if id == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "data set ID is required")
+		writeError(w, "ValidationException", "data set ID is required", http.StatusBadRequest)
 
 		return
 	}
 
 	var input UpdateDataSetInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "ValidationException", "invalid request body")
+		writeError(w, "ValidationException", "invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	ds, err := s.storage.UpdateDataSet(id, &input)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -87,13 +87,13 @@ func (s *Service) UpdateDataSet(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteDataSet(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("dataSetId")
 	if id == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "data set ID is required")
+		writeError(w, "ValidationException", "data set ID is required", http.StatusBadRequest)
 
 		return
 	}
 
 	if err := s.storage.DeleteDataSet(id); err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -105,7 +105,7 @@ func (s *Service) DeleteDataSet(w http.ResponseWriter, r *http.Request) {
 func (s *Service) CreateRevision(w http.ResponseWriter, r *http.Request) {
 	dataSetID := r.PathValue("dataSetId")
 	if dataSetID == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "data set ID is required")
+		writeError(w, "ValidationException", "data set ID is required", http.StatusBadRequest)
 
 		return
 	}
@@ -113,7 +113,7 @@ func (s *Service) CreateRevision(w http.ResponseWriter, r *http.Request) {
 	var input CreateRevisionInput
 	if r.Body != nil && r.ContentLength > 0 {
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			writeError(w, http.StatusBadRequest, "ValidationException", "invalid request body")
+			writeError(w, "ValidationException", "invalid request body", http.StatusBadRequest)
 
 			return
 		}
@@ -122,12 +122,12 @@ func (s *Service) CreateRevision(w http.ResponseWriter, r *http.Request) {
 	rev, err := s.storage.CreateRevision(dataSetID, &input)
 	if err != nil {
 		if strings.Contains(err.Error(), "ResourceNotFoundException") {
-			writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+			writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 			return
 		}
 
-		writeError(w, http.StatusInternalServerError, "InternalServerException", err.Error())
+		writeError(w, "InternalServerException", err.Error(), http.StatusInternalServerError)
 
 		return
 	}
@@ -141,14 +141,14 @@ func (s *Service) GetRevision(w http.ResponseWriter, r *http.Request) {
 	revisionID := r.PathValue("revisionId")
 
 	if dataSetID == "" || revisionID == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "data set ID and revision ID are required")
+		writeError(w, "ValidationException", "data set ID and revision ID are required", http.StatusBadRequest)
 
 		return
 	}
 
 	rev, err := s.storage.GetRevision(dataSetID, revisionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -160,14 +160,14 @@ func (s *Service) GetRevision(w http.ResponseWriter, r *http.Request) {
 func (s *Service) ListRevisions(w http.ResponseWriter, r *http.Request) {
 	dataSetID := r.PathValue("dataSetId")
 	if dataSetID == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "data set ID is required")
+		writeError(w, "ValidationException", "data set ID is required", http.StatusBadRequest)
 
 		return
 	}
 
 	revisions, err := s.storage.ListRevisions(dataSetID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -183,21 +183,21 @@ func (s *Service) UpdateRevision(w http.ResponseWriter, r *http.Request) {
 	revisionID := r.PathValue("revisionId")
 
 	if dataSetID == "" || revisionID == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "data set ID and revision ID are required")
+		writeError(w, "ValidationException", "data set ID and revision ID are required", http.StatusBadRequest)
 
 		return
 	}
 
 	var input UpdateRevisionInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "ValidationException", "invalid request body")
+		writeError(w, "ValidationException", "invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	rev, err := s.storage.UpdateRevision(dataSetID, revisionID, &input)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -211,13 +211,13 @@ func (s *Service) DeleteRevision(w http.ResponseWriter, r *http.Request) {
 	revisionID := r.PathValue("revisionId")
 
 	if dataSetID == "" || revisionID == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "data set ID and revision ID are required")
+		writeError(w, "ValidationException", "data set ID and revision ID are required", http.StatusBadRequest)
 
 		return
 	}
 
 	if err := s.storage.DeleteRevision(dataSetID, revisionID); err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -229,13 +229,13 @@ func (s *Service) DeleteRevision(w http.ResponseWriter, r *http.Request) {
 func (s *Service) CreateJob(w http.ResponseWriter, r *http.Request) {
 	var input CreateJobInput
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "ValidationException", "invalid request body")
+		writeError(w, "ValidationException", "invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if input.Type == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "type is required")
+		writeError(w, "ValidationException", "type is required", http.StatusBadRequest)
 
 		return
 	}
@@ -248,14 +248,14 @@ func (s *Service) CreateJob(w http.ResponseWriter, r *http.Request) {
 func (s *Service) GetJob(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("jobId")
 	if id == "" {
-		writeError(w, http.StatusBadRequest, "ValidationException", "job ID is required")
+		writeError(w, "ValidationException", "job ID is required", http.StatusBadRequest)
 
 		return
 	}
 
 	job, err := s.storage.GetJob(id)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+		writeError(w, "ResourceNotFoundException", err.Error(), http.StatusNotFound)
 
 		return
 	}
@@ -277,7 +277,7 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-func writeError(w http.ResponseWriter, status int, errType, message string) {
+func writeError(w http.ResponseWriter, errType, message string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("x-amzn-ErrorType", errType)
 	w.WriteHeader(status)

--- a/internal/service/eks/handlers.go
+++ b/internal/service/eks/handlers.go
@@ -27,19 +27,19 @@ const (
 func (s *Service) CreateCluster(w http.ResponseWriter, r *http.Request) {
 	var req CreateClusterRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Invalid request body")
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.Name == "" {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Cluster name is required")
+		writeError(w, errInvalidParameter, "Cluster name is required", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.RoleArn == "" {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Role ARN is required")
+		writeError(w, errInvalidParameter, "Role ARN is required", http.StatusBadRequest)
 
 		return
 	}
@@ -58,7 +58,7 @@ func (s *Service) CreateCluster(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteCluster(w http.ResponseWriter, r *http.Request) {
 	name := extractClusterName(r.URL.Path)
 	if name == "" {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Cluster name is required")
+		writeError(w, errInvalidParameter, "Cluster name is required", http.StatusBadRequest)
 
 		return
 	}
@@ -77,7 +77,7 @@ func (s *Service) DeleteCluster(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DescribeCluster(w http.ResponseWriter, r *http.Request) {
 	name := extractClusterName(r.URL.Path)
 	if name == "" {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Cluster name is required")
+		writeError(w, errInvalidParameter, "Cluster name is required", http.StatusBadRequest)
 
 		return
 	}
@@ -112,7 +112,7 @@ func (s *Service) ListClusters(w http.ResponseWriter, r *http.Request) {
 
 	clusters, next, err := s.storage.ListClusters(r.Context(), maxResults, nextToken)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, errInternalServerError, err.Error())
+		writeError(w, errInternalServerError, err.Error(), http.StatusInternalServerError)
 
 		return
 	}
@@ -131,14 +131,14 @@ func (s *Service) ListClusters(w http.ResponseWriter, r *http.Request) {
 func (s *Service) CreateNodegroup(w http.ResponseWriter, r *http.Request) {
 	clusterName := extractClusterName(r.URL.Path)
 	if clusterName == "" {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Cluster name is required")
+		writeError(w, errInvalidParameter, "Cluster name is required", http.StatusBadRequest)
 
 		return
 	}
 
 	var req CreateNodegroupRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Invalid request body")
+		writeError(w, errInvalidParameter, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -146,19 +146,19 @@ func (s *Service) CreateNodegroup(w http.ResponseWriter, r *http.Request) {
 	req.ClusterName = clusterName
 
 	if req.NodegroupName == "" {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Nodegroup name is required")
+		writeError(w, errInvalidParameter, "Nodegroup name is required", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.NodeRole == "" {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Node role is required")
+		writeError(w, errInvalidParameter, "Node role is required", http.StatusBadRequest)
 
 		return
 	}
 
 	if len(req.Subnets) == 0 {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Subnets are required")
+		writeError(w, errInvalidParameter, "Subnets are required", http.StatusBadRequest)
 
 		return
 	}
@@ -177,7 +177,7 @@ func (s *Service) CreateNodegroup(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteNodegroup(w http.ResponseWriter, r *http.Request) {
 	clusterName, nodegroupName := extractClusterAndNodegroupName(r.URL.Path)
 	if clusterName == "" || nodegroupName == "" {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Cluster name and nodegroup name are required")
+		writeError(w, errInvalidParameter, "Cluster name and nodegroup name are required", http.StatusBadRequest)
 
 		return
 	}
@@ -196,7 +196,7 @@ func (s *Service) DeleteNodegroup(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DescribeNodegroup(w http.ResponseWriter, r *http.Request) {
 	clusterName, nodegroupName := extractClusterAndNodegroupName(r.URL.Path)
 	if clusterName == "" || nodegroupName == "" {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Cluster name and nodegroup name are required")
+		writeError(w, errInvalidParameter, "Cluster name and nodegroup name are required", http.StatusBadRequest)
 
 		return
 	}
@@ -215,7 +215,7 @@ func (s *Service) DescribeNodegroup(w http.ResponseWriter, r *http.Request) {
 func (s *Service) ListNodegroups(w http.ResponseWriter, r *http.Request) {
 	clusterName := extractClusterName(r.URL.Path)
 	if clusterName == "" {
-		writeError(w, http.StatusBadRequest, errInvalidParameter, "Cluster name is required")
+		writeError(w, errInvalidParameter, "Cluster name is required", http.StatusBadRequest)
 
 		return
 	}
@@ -292,7 +292,7 @@ func writeJSON(w http.ResponseWriter, v any) {
 }
 
 // writeError writes an error response.
-func writeError(w http.ResponseWriter, status int, code, message string) {
+func writeError(w http.ResponseWriter, code, message string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 
@@ -320,10 +320,10 @@ func handleError(w http.ResponseWriter, err error) {
 			status = http.StatusConflict
 		}
 
-		writeError(w, status, eksErr.Code, eksErr.Message)
+		writeError(w, eksErr.Code, eksErr.Message, status)
 
 		return
 	}
 
-	writeError(w, http.StatusInternalServerError, errInternalServerError, "Internal server error")
+	writeError(w, errInternalServerError, "Internal server error", http.StatusInternalServerError)
 }

--- a/internal/service/entityresolution/handlers.go
+++ b/internal/service/entityresolution/handlers.go
@@ -12,19 +12,19 @@ import (
 func (s *Service) CreateSchemaMapping(w http.ResponseWriter, r *http.Request) {
 	var req CreateSchemaMappingRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.SchemaName == "" {
-		writeError(w, http.StatusBadRequest, errValidation, "schemaName is required")
+		writeError(w, errValidation, "schemaName is required", http.StatusBadRequest)
 
 		return
 	}
 
 	if len(req.MappedInputFields) == 0 {
-		writeError(w, http.StatusBadRequest, errValidation, "mappedInputFields is required")
+		writeError(w, errValidation, "mappedInputFields is required", http.StatusBadRequest)
 
 		return
 	}
@@ -43,7 +43,7 @@ func (s *Service) CreateSchemaMapping(w http.ResponseWriter, r *http.Request) {
 func (s *Service) GetSchemaMapping(w http.ResponseWriter, r *http.Request) {
 	schemaName := r.PathValue("schemaName")
 	if schemaName == "" {
-		writeError(w, http.StatusBadRequest, errValidation, "schemaName is required")
+		writeError(w, errValidation, "schemaName is required", http.StatusBadRequest)
 
 		return
 	}
@@ -62,7 +62,7 @@ func (s *Service) GetSchemaMapping(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteSchemaMapping(w http.ResponseWriter, r *http.Request) {
 	schemaName := r.PathValue("schemaName")
 	if schemaName == "" {
-		writeError(w, http.StatusBadRequest, errValidation, "schemaName is required")
+		writeError(w, errValidation, "schemaName is required", http.StatusBadRequest)
 
 		return
 	}
@@ -96,13 +96,13 @@ func (s *Service) ListSchemaMappings(w http.ResponseWriter, r *http.Request) {
 func (s *Service) CreateMatchingWorkflow(w http.ResponseWriter, r *http.Request) {
 	var req CreateMatchingWorkflowRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.WorkflowName == "" {
-		writeError(w, http.StatusBadRequest, errValidation, "workflowName is required")
+		writeError(w, errValidation, "workflowName is required", http.StatusBadRequest)
 
 		return
 	}
@@ -121,7 +121,7 @@ func (s *Service) CreateMatchingWorkflow(w http.ResponseWriter, r *http.Request)
 func (s *Service) GetMatchingWorkflow(w http.ResponseWriter, r *http.Request) {
 	workflowName := r.PathValue("workflowName")
 	if workflowName == "" {
-		writeError(w, http.StatusBadRequest, errValidation, "workflowName is required")
+		writeError(w, errValidation, "workflowName is required", http.StatusBadRequest)
 
 		return
 	}
@@ -140,7 +140,7 @@ func (s *Service) GetMatchingWorkflow(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteMatchingWorkflow(w http.ResponseWriter, r *http.Request) {
 	workflowName := r.PathValue("workflowName")
 	if workflowName == "" {
-		writeError(w, http.StatusBadRequest, errValidation, "workflowName is required")
+		writeError(w, errValidation, "workflowName is required", http.StatusBadRequest)
 
 		return
 	}
@@ -174,13 +174,13 @@ func (s *Service) ListMatchingWorkflows(w http.ResponseWriter, r *http.Request) 
 func (s *Service) CreateIDMappingWorkflow(w http.ResponseWriter, r *http.Request) {
 	var req CreateIDMappingWorkflowRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.WorkflowName == "" {
-		writeError(w, http.StatusBadRequest, errValidation, "workflowName is required")
+		writeError(w, errValidation, "workflowName is required", http.StatusBadRequest)
 
 		return
 	}
@@ -199,7 +199,7 @@ func (s *Service) CreateIDMappingWorkflow(w http.ResponseWriter, r *http.Request
 func (s *Service) GetIDMappingWorkflow(w http.ResponseWriter, r *http.Request) {
 	workflowName := r.PathValue("workflowName")
 	if workflowName == "" {
-		writeError(w, http.StatusBadRequest, errValidation, "workflowName is required")
+		writeError(w, errValidation, "workflowName is required", http.StatusBadRequest)
 
 		return
 	}
@@ -218,7 +218,7 @@ func (s *Service) GetIDMappingWorkflow(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteIDMappingWorkflow(w http.ResponseWriter, r *http.Request) {
 	workflowName := r.PathValue("workflowName")
 	if workflowName == "" {
-		writeError(w, http.StatusBadRequest, errValidation, "workflowName is required")
+		writeError(w, errValidation, "workflowName is required", http.StatusBadRequest)
 
 		return
 	}
@@ -273,7 +273,7 @@ func writeJSON(w http.ResponseWriter, v any) {
 	}
 }
 
-func writeError(w http.ResponseWriter, status int, code, message string) {
+func writeError(w http.ResponseWriter, code, message string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 
@@ -295,10 +295,10 @@ func handleError(w http.ResponseWriter, err error) {
 			status = http.StatusConflict
 		}
 
-		writeError(w, status, erErr.Code, erErr.Message)
+		writeError(w, erErr.Code, erErr.Message, status)
 
 		return
 	}
 
-	writeError(w, http.StatusInternalServerError, errInternalError, "Internal server error")
+	writeError(w, errInternalError, "Internal server error", http.StatusInternalServerError)
 }

--- a/internal/service/finspace/handlers.go
+++ b/internal/service/finspace/handlers.go
@@ -11,7 +11,7 @@ import (
 func (s *Service) CreateKxEnvironment(w http.ResponseWriter, r *http.Request) {
 	var req CreateKxEnvironmentRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -62,7 +62,7 @@ func (s *Service) ListKxEnvironments(w http.ResponseWriter, r *http.Request) {
 
 		maxResults, err = strconv.Atoi(maxResultsStr)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, errValidation, "Invalid maxResults")
+			writeError(w, errValidation, "Invalid maxResults", http.StatusBadRequest)
 
 			return
 		}
@@ -86,7 +86,7 @@ func (s *Service) UpdateKxEnvironment(w http.ResponseWriter, r *http.Request) {
 
 	var req UpdateKxEnvironmentRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -109,7 +109,7 @@ func (s *Service) CreateKxDatabase(w http.ResponseWriter, r *http.Request) {
 
 	var req CreateKxDatabaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -165,7 +165,7 @@ func (s *Service) ListKxDatabases(w http.ResponseWriter, r *http.Request) {
 
 		maxResults, err = strconv.Atoi(maxResultsStr)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, errValidation, "Invalid maxResults")
+			writeError(w, errValidation, "Invalid maxResults", http.StatusBadRequest)
 
 			return
 		}
@@ -190,7 +190,7 @@ func (s *Service) UpdateKxDatabase(w http.ResponseWriter, r *http.Request) {
 
 	var req UpdateKxDatabaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -214,7 +214,7 @@ func (s *Service) CreateKxUser(w http.ResponseWriter, r *http.Request) {
 
 	var req CreateKxUserRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -270,7 +270,7 @@ func (s *Service) ListKxUsers(w http.ResponseWriter, r *http.Request) {
 
 		maxResults, err = strconv.Atoi(maxResultsStr)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, errValidation, "Invalid maxResults")
+			writeError(w, errValidation, "Invalid maxResults", http.StatusBadRequest)
 
 			return
 		}
@@ -295,7 +295,7 @@ func (s *Service) UpdateKxUser(w http.ResponseWriter, r *http.Request) {
 
 	var req UpdateKxUserRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -319,7 +319,7 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 
 	var req TagResourceRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -370,7 +370,7 @@ func writeJSON(w http.ResponseWriter, data any) {
 	}
 }
 
-func writeError(w http.ResponseWriter, statusCode int, code, message string) {
+func writeError(w http.ResponseWriter, code, message string, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 
@@ -397,10 +397,10 @@ func handleStorageError(w http.ResponseWriter, err error) {
 			statusCode = http.StatusConflict
 		}
 
-		writeError(w, statusCode, fsErr.Code, fsErr.Message)
+		writeError(w, fsErr.Code, fsErr.Message, statusCode)
 
 		return
 	}
 
-	writeError(w, http.StatusInternalServerError, "InternalException", err.Error())
+	writeError(w, "InternalException", err.Error(), http.StatusInternalServerError)
 }

--- a/internal/service/kafka/handlers.go
+++ b/internal/service/kafka/handlers.go
@@ -13,19 +13,19 @@ import (
 func (s *Service) CreateCluster(w http.ResponseWriter, r *http.Request) {
 	var req CreateClusterRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Invalid request body")
+		writeError(w, errBadRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.ClusterName == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Cluster name is required")
+		writeError(w, errBadRequest, "Cluster name is required", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.BrokerNodeGroupInfo == nil {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Broker node group info is required")
+		writeError(w, errBadRequest, "Broker node group info is required", http.StatusBadRequest)
 
 		return
 	}
@@ -56,7 +56,7 @@ func (s *Service) ListClusters(w http.ResponseWriter, r *http.Request) {
 
 	clusters, next, err := s.storage.ListClusters(r.Context(), maxResults, nextToken)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, errInternalError, err.Error())
+		writeError(w, errInternalError, err.Error(), http.StatusInternalServerError)
 
 		return
 	}
@@ -75,7 +75,7 @@ func (s *Service) ListClusters(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DescribeCluster(w http.ResponseWriter, r *http.Request) {
 	clusterArn := extractClusterArn(r.URL.Path)
 	if clusterArn == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Cluster ARN is required")
+		writeError(w, errBadRequest, "Cluster ARN is required", http.StatusBadRequest)
 
 		return
 	}
@@ -94,7 +94,7 @@ func (s *Service) DescribeCluster(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteCluster(w http.ResponseWriter, r *http.Request) {
 	clusterArn := extractClusterArn(r.URL.Path)
 	if clusterArn == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Cluster ARN is required")
+		writeError(w, errBadRequest, "Cluster ARN is required", http.StatusBadRequest)
 
 		return
 	}
@@ -113,7 +113,7 @@ func (s *Service) DeleteCluster(w http.ResponseWriter, r *http.Request) {
 func (s *Service) GetBootstrapBrokers(w http.ResponseWriter, r *http.Request) {
 	clusterArn := extractClusterArn(r.URL.Path)
 	if clusterArn == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Cluster ARN is required")
+		writeError(w, errBadRequest, "Cluster ARN is required", http.StatusBadRequest)
 
 		return
 	}
@@ -132,14 +132,14 @@ func (s *Service) GetBootstrapBrokers(w http.ResponseWriter, r *http.Request) {
 func (s *Service) UpdateClusterConfiguration(w http.ResponseWriter, r *http.Request) {
 	clusterArn := extractClusterArn(r.URL.Path)
 	if clusterArn == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Cluster ARN is required")
+		writeError(w, errBadRequest, "Cluster ARN is required", http.StatusBadRequest)
 
 		return
 	}
 
 	var req UpdateClusterConfigurationRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Invalid request body")
+		writeError(w, errBadRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -189,7 +189,7 @@ func writeJSON(w http.ResponseWriter, v any) {
 }
 
 // writeError writes an error response.
-func writeError(w http.ResponseWriter, status int, code, message string) {
+func writeError(w http.ResponseWriter, code, message string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 
@@ -217,10 +217,10 @@ func handleError(w http.ResponseWriter, err error) {
 			status = http.StatusConflict
 		}
 
-		writeError(w, status, mskErr.Code, mskErr.Message)
+		writeError(w, mskErr.Code, mskErr.Message, status)
 
 		return
 	}
 
-	writeError(w, http.StatusInternalServerError, errInternalError, "Internal server error")
+	writeError(w, errInternalError, "Internal server error", http.StatusInternalServerError)
 }

--- a/internal/service/s3tables/handlers.go
+++ b/internal/service/s3tables/handlers.go
@@ -20,13 +20,13 @@ const (
 func (s *Service) CreateTableBucket(w http.ResponseWriter, r *http.Request) {
 	var req CreateTableBucketRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Invalid request body")
+		writeError(w, errBadRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.Name == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket name is required")
+		writeError(w, errBadRequest, "Table bucket name is required", http.StatusBadRequest)
 
 		return
 	}
@@ -45,7 +45,7 @@ func (s *Service) CreateTableBucket(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteTableBucket(w http.ResponseWriter, r *http.Request) {
 	arn := extractTableBucketARN(getURLPath(r))
 	if arn == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket ARN is required")
+		writeError(w, errBadRequest, "Table bucket ARN is required", http.StatusBadRequest)
 
 		return
 	}
@@ -63,7 +63,7 @@ func (s *Service) DeleteTableBucket(w http.ResponseWriter, r *http.Request) {
 func (s *Service) GetTableBucket(w http.ResponseWriter, r *http.Request) {
 	arn := extractTableBucketARN(getURLPath(r))
 	if arn == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket ARN is required")
+		writeError(w, errBadRequest, "Table bucket ARN is required", http.StatusBadRequest)
 
 		return
 	}
@@ -113,20 +113,20 @@ func (s *Service) ListTableBuckets(w http.ResponseWriter, r *http.Request) {
 func (s *Service) CreateNamespace(w http.ResponseWriter, r *http.Request) {
 	tableBucketArn := extractTableBucketARNFromNamespacePath(getURLPath(r))
 	if tableBucketArn == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket ARN is required")
+		writeError(w, errBadRequest, "Table bucket ARN is required", http.StatusBadRequest)
 
 		return
 	}
 
 	var req CreateNamespaceRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Invalid request body")
+		writeError(w, errBadRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if len(req.Namespace) == 0 {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Namespace is required")
+		writeError(w, errBadRequest, "Namespace is required", http.StatusBadRequest)
 
 		return
 	}
@@ -148,7 +148,7 @@ func (s *Service) CreateNamespace(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteNamespace(w http.ResponseWriter, r *http.Request) {
 	tableBucketArn, namespace := extractNamespaceParams(getURLPath(r))
 	if tableBucketArn == "" || namespace == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket ARN and namespace are required")
+		writeError(w, errBadRequest, "Table bucket ARN and namespace are required", http.StatusBadRequest)
 
 		return
 	}
@@ -166,7 +166,7 @@ func (s *Service) DeleteNamespace(w http.ResponseWriter, r *http.Request) {
 func (s *Service) GetNamespace(w http.ResponseWriter, r *http.Request) {
 	tableBucketArn, namespace := extractNamespaceParams(getURLPath(r))
 	if tableBucketArn == "" || namespace == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket ARN and namespace are required")
+		writeError(w, errBadRequest, "Table bucket ARN and namespace are required", http.StatusBadRequest)
 
 		return
 	}
@@ -191,7 +191,7 @@ func (s *Service) GetNamespace(w http.ResponseWriter, r *http.Request) {
 func (s *Service) ListNamespaces(w http.ResponseWriter, r *http.Request) {
 	tableBucketArn := extractTableBucketARNFromNamespacePath(getURLPath(r))
 	if tableBucketArn == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket ARN is required")
+		writeError(w, errBadRequest, "Table bucket ARN is required", http.StatusBadRequest)
 
 		return
 	}
@@ -222,26 +222,26 @@ func (s *Service) ListNamespaces(w http.ResponseWriter, r *http.Request) {
 func (s *Service) CreateTable(w http.ResponseWriter, r *http.Request) {
 	tableBucketArn, namespace := extractTablePathParams(getURLPath(r))
 	if tableBucketArn == "" || namespace == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket ARN and namespace are required")
+		writeError(w, errBadRequest, "Table bucket ARN and namespace are required", http.StatusBadRequest)
 
 		return
 	}
 
 	var req CreateTableRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Invalid request body")
+		writeError(w, errBadRequest, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.Name == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table name is required")
+		writeError(w, errBadRequest, "Table name is required", http.StatusBadRequest)
 
 		return
 	}
 
 	if req.Format == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table format is required")
+		writeError(w, errBadRequest, "Table format is required", http.StatusBadRequest)
 
 		return
 	}
@@ -263,7 +263,7 @@ func (s *Service) CreateTable(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteTable(w http.ResponseWriter, r *http.Request) {
 	tableBucketArn, namespace, tableName := extractFullTableParams(getURLPath(r))
 	if tableBucketArn == "" || namespace == "" || tableName == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket ARN, namespace, and table name are required")
+		writeError(w, errBadRequest, "Table bucket ARN, namespace, and table name are required", http.StatusBadRequest)
 
 		return
 	}
@@ -285,7 +285,7 @@ func (s *Service) GetTable(w http.ResponseWriter, r *http.Request) {
 	tableName := r.URL.Query().Get("name")
 
 	if tableBucketArn == "" || namespace == "" || tableName == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket ARN, namespace, and table name are required")
+		writeError(w, errBadRequest, "Table bucket ARN, namespace, and table name are required", http.StatusBadRequest)
 
 		return
 	}
@@ -319,7 +319,7 @@ func (s *Service) GetTable(w http.ResponseWriter, r *http.Request) {
 func (s *Service) ListTables(w http.ResponseWriter, r *http.Request) {
 	tableBucketArn, namespace := extractTablePathParams(getURLPath(r))
 	if tableBucketArn == "" {
-		writeError(w, http.StatusBadRequest, errBadRequest, "Table bucket ARN is required")
+		writeError(w, errBadRequest, "Table bucket ARN is required", http.StatusBadRequest)
 
 		return
 	}
@@ -481,7 +481,7 @@ func writeJSON(w http.ResponseWriter, v any) {
 }
 
 // writeError writes an error response.
-func writeError(w http.ResponseWriter, status int, code, message string) {
+func writeError(w http.ResponseWriter, code, message string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 
@@ -511,10 +511,10 @@ func handleError(w http.ResponseWriter, err error) {
 			status = http.StatusInternalServerError
 		}
 
-		writeError(w, status, s3tablesErr.Code, s3tablesErr.Message)
+		writeError(w, s3tablesErr.Code, s3tablesErr.Message, status)
 
 		return
 	}
 
-	writeError(w, http.StatusInternalServerError, errInternalError, "Internal server error")
+	writeError(w, errInternalError, "Internal server error", http.StatusInternalServerError)
 }

--- a/internal/service/securitylake/handlers.go
+++ b/internal/service/securitylake/handlers.go
@@ -11,7 +11,7 @@ import (
 func (s *Service) CreateDataLake(w http.ResponseWriter, r *http.Request) {
 	var req CreateDataLakeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -30,7 +30,7 @@ func (s *Service) CreateDataLake(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteDataLake(w http.ResponseWriter, r *http.Request) {
 	var req DeleteDataLakeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -62,7 +62,7 @@ func (s *Service) ListDataLakes(w http.ResponseWriter, r *http.Request) {
 func (s *Service) UpdateDataLake(w http.ResponseWriter, r *http.Request) {
 	var req UpdateDataLakeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -81,7 +81,7 @@ func (s *Service) UpdateDataLake(w http.ResponseWriter, r *http.Request) {
 func (s *Service) CreateSubscriber(w http.ResponseWriter, r *http.Request) {
 	var req CreateSubscriberRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -129,7 +129,7 @@ func (s *Service) UpdateSubscriber(w http.ResponseWriter, r *http.Request) {
 
 	var req UpdateSubscriberRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -155,7 +155,7 @@ func (s *Service) ListSubscribers(w http.ResponseWriter, r *http.Request) {
 
 		maxResults, err = strconv.Atoi(maxResultsStr)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, errValidation, "Invalid maxResults")
+			writeError(w, errValidation, "Invalid maxResults", http.StatusBadRequest)
 
 			return
 		}
@@ -180,7 +180,7 @@ func (s *Service) ListSubscribers(w http.ResponseWriter, r *http.Request) {
 func (s *Service) CreateAwsLogSource(w http.ResponseWriter, r *http.Request) {
 	var req CreateAwsLogSourceRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -199,7 +199,7 @@ func (s *Service) CreateAwsLogSource(w http.ResponseWriter, r *http.Request) {
 func (s *Service) DeleteAwsLogSource(w http.ResponseWriter, r *http.Request) {
 	var req DeleteAwsLogSourceRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -218,7 +218,7 @@ func (s *Service) DeleteAwsLogSource(w http.ResponseWriter, r *http.Request) {
 func (s *Service) ListLogSources(w http.ResponseWriter, r *http.Request) {
 	var req ListLogSourcesRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -242,7 +242,7 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 
 	var req TagResourceRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errValidation, "Invalid request body")
+		writeError(w, errValidation, "Invalid request body", http.StatusBadRequest)
 
 		return
 	}
@@ -293,7 +293,7 @@ func writeJSON(w http.ResponseWriter, data any) {
 	}
 }
 
-func writeError(w http.ResponseWriter, statusCode int, code, message string) {
+func writeError(w http.ResponseWriter, code, message string, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 
@@ -320,10 +320,10 @@ func handleStorageError(w http.ResponseWriter, err error) {
 			statusCode = http.StatusConflict
 		}
 
-		writeError(w, statusCode, slErr.Code, slErr.Message)
+		writeError(w, slErr.Code, slErr.Message, statusCode)
 
 		return
 	}
 
-	writeError(w, http.StatusInternalServerError, "InternalException", err.Error())
+	writeError(w, "InternalException", err.Error(), http.StatusInternalServerError)
 }


### PR DESCRIPTION
## Summary
9 packages (backup, codegurureviewer, dataexchange, eks, entityresolution, finspace, kafka, s3tables, securitylake) defined writeError with the status argument first, opposite to the canonical order used by the other ~50 packages. Since code and message are both strings, a silent swap at any call site would compile fine, so this reorders the 161 call sites mechanically (script-driven, not regex) and verifies per call site that code/message/status each map to the same value as before. Structurally different helpers (typed-error variants, different arity) are left alone.

## Test plan
- [x] Per-call-site diff verification: no code/message swaps across all 161 sites
- [x] Error-path integration tests for all 9 services pass against a live kumo
- [x] `make lint` 0 issues, `go test -race -shuffle=on ./...` green