### PR TITLE
fix(test): wait for terminal state before asserting SFN DescribeExecution golden

### DIFF
--- a/test/integration/sfn_test.go
+++ b/test/integration/sfn_test.go
@@ -134,13 +134,9 @@ func TestSFN_StartAndDescribeExecution(t *testing.T) {
 	}
 	golden.New(t, golden.WithIgnoreFields("ExecutionArn", "StartDate", "ResultMetadata")).Assert(t.Name()+"_start", startOutput)
 
-	// Describe execution.
-	describeOutput, err := client.DescribeExecution(ctx, &sfn.DescribeExecutionInput{
-		ExecutionArn: startOutput.ExecutionArn,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Describe execution. Wait for the terminal state first: even a
+	// single-Pass execution can still be RUNNING on a slow runner.
+	describeOutput := waitForSFNExecutionTerminal(t, client, *startOutput.ExecutionArn)
 	golden.New(t, golden.WithIgnoreFields("ExecutionArn", "StateMachineArn", "StartDate", "StopDate", "ResultMetadata")).Assert(t.Name()+"_describe", describeOutput)
 }
 


### PR DESCRIPTION
## Summary
TestSFN_StartAndDescribeExecution called DescribeExecution immediately after StartExecution and asserted Status SUCCEEDED; on a slow CI runner the execution was still RUNNING (observed on the PR #887 integration run). This reuses the existing waitForSFNExecutionTerminal helper so the golden assert runs against the terminal state. Golden file unchanged.

## Test plan
- [x] Compile-checked; CI integration run validates (local port was occupied by a concurrent golden-generation task)