### PR TITLE
refactor(service): add decode and required-field helpers in the densest packages

### DIFF
--- a/internal/service/cloudwatch/handlers.go
+++ b/internal/service/cloudwatch/handlers.go
@@ -25,21 +25,15 @@ const (
 // PutMetricData handles the PutMetricData action.
 func (s *Service) PutMetricData(w http.ResponseWriter, r *http.Request) {
 	var req PutMetricDataRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
-	if req.Namespace == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter Namespace is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.Namespace != "", "Namespace") {
 		return
 	}
 
-	if len(req.MetricData) == 0 {
-		writeCloudWatchError(w, errMissingParameter, "The parameter MetricData is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, len(req.MetricData) != 0, "MetricData") {
 		return
 	}
 
@@ -55,15 +49,11 @@ func (s *Service) PutMetricData(w http.ResponseWriter, r *http.Request) {
 // GetMetricData handles the GetMetricData action.
 func (s *Service) GetMetricData(w http.ResponseWriter, r *http.Request) {
 	var req GetMetricDataRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
-	if len(req.MetricDataQueries) == 0 {
-		writeCloudWatchError(w, errMissingParameter, "The parameter MetricDataQueries is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, len(req.MetricDataQueries) != 0, "MetricDataQueries") {
 		return
 	}
 
@@ -83,21 +73,15 @@ func (s *Service) GetMetricData(w http.ResponseWriter, r *http.Request) {
 // GetMetricStatistics handles the GetMetricStatistics action.
 func (s *Service) GetMetricStatistics(w http.ResponseWriter, r *http.Request) {
 	var req GetMetricStatisticsRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
-	if req.Namespace == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter Namespace is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.Namespace != "", "Namespace") {
 		return
 	}
 
-	if req.MetricName == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter MetricName is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.MetricName != "", "MetricName") {
 		return
 	}
 
@@ -117,9 +101,7 @@ func (s *Service) GetMetricStatistics(w http.ResponseWriter, r *http.Request) {
 // ListMetrics handles the ListMetrics action.
 func (s *Service) ListMetrics(w http.ResponseWriter, r *http.Request) {
 	var req ListMetricsRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
@@ -140,33 +122,23 @@ func (s *Service) ListMetrics(w http.ResponseWriter, r *http.Request) {
 // PutMetricAlarm handles the PutMetricAlarm action.
 func (s *Service) PutMetricAlarm(w http.ResponseWriter, r *http.Request) {
 	var req PutMetricAlarmRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
-	if req.AlarmName == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter AlarmName is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.AlarmName != "", "AlarmName") {
 		return
 	}
 
-	if req.MetricName == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter MetricName is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.MetricName != "", "MetricName") {
 		return
 	}
 
-	if req.Namespace == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter Namespace is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.Namespace != "", "Namespace") {
 		return
 	}
 
-	if req.ComparisonOperator == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter ComparisonOperator is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.ComparisonOperator != "", "ComparisonOperator") {
 		return
 	}
 
@@ -187,15 +159,11 @@ func (s *Service) PutMetricAlarm(w http.ResponseWriter, r *http.Request) {
 // DeleteAlarms handles the DeleteAlarms action.
 func (s *Service) DeleteAlarms(w http.ResponseWriter, r *http.Request) {
 	var req DeleteAlarmsRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
-	if len(req.AlarmNames) == 0 {
-		writeCloudWatchError(w, errMissingParameter, "The parameter AlarmNames is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, len(req.AlarmNames) != 0, "AlarmNames") {
 		return
 	}
 
@@ -216,9 +184,7 @@ func (s *Service) DeleteAlarms(w http.ResponseWriter, r *http.Request) {
 // DescribeAlarms handles the DescribeAlarms action.
 func (s *Service) DescribeAlarms(w http.ResponseWriter, r *http.Request) {
 	var req DescribeAlarmsRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
@@ -243,15 +209,11 @@ func (s *Service) DescribeAlarms(w http.ResponseWriter, r *http.Request) {
 // SetAlarmState handles the SetAlarmState action via JSON protocol.
 func (s *Service) SetAlarmState(w http.ResponseWriter, r *http.Request) {
 	var req SetAlarmStateRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
-	if req.AlarmName == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter AlarmName is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.AlarmName != "", "AlarmName") {
 		return
 	}
 
@@ -267,15 +229,11 @@ func (s *Service) SetAlarmState(w http.ResponseWriter, r *http.Request) {
 // ListTagsForResource returns the tags attached to a CloudWatch resource.
 func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 	var req ListTagsForResourceRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
-	if req.ResourceARN == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter ResourceARN is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.ResourceARN != "", "ResourceARN") {
 		return
 	}
 
@@ -303,15 +261,11 @@ func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 // TagResource attaches tags to a CloudWatch resource.
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
-	if req.ResourceARN == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter ResourceARN is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.ResourceARN != "", "ResourceARN") {
 		return
 	}
 
@@ -330,15 +284,11 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 // UntagResource removes tags from a CloudWatch resource.
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchRequest(w, r, &req) {
 		return
 	}
 
-	if req.ResourceARN == "" {
-		writeCloudWatchError(w, errMissingParameter, "The parameter ResourceARN is required", http.StatusBadRequest)
-
+	if !requireCloudWatchParameter(w, req.ResourceARN != "", "ResourceARN") {
 		return
 	}
 
@@ -414,26 +364,44 @@ func writeCloudWatchError(w http.ResponseWriter, code, message string, status in
 	service.WriteJSONError(w, service.ContentTypeAmzJSON10, code, message, status)
 }
 
+// decodeCloudWatchRequest decodes the JSON request body into req, writing the
+// standard CloudWatch decode-failure error and returning false on failure.
+func decodeCloudWatchRequest(w http.ResponseWriter, r *http.Request, req any) bool {
+	if err := service.ReadJSONRequest(r, req); err != nil {
+		writeCloudWatchError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
+// requireCloudWatchParameter writes the standard CloudWatch MissingParameter
+// error and returns false if present is false.
+func requireCloudWatchParameter(w http.ResponseWriter, present bool, name string) bool {
+	if !present {
+		writeCloudWatchError(w, errMissingParameter, "The parameter "+name+" is required", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
 // CBOR Protocol Handlers for RPC v2 CBOR
 
 // PutMetricDataCBOR handles the PutMetricData action with CBOR protocol.
 func (s *Service) PutMetricDataCBOR(w http.ResponseWriter, r *http.Request) {
 	var req PutMetricDataRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
-	if req.Namespace == "" {
-		server.WriteCBORError(w, errMissingParameter, "The parameter Namespace is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, req.Namespace != "", "Namespace") {
 		return
 	}
 
-	if len(req.MetricData) == 0 {
-		server.WriteCBORError(w, errMissingParameter, "The parameter MetricData is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, len(req.MetricData) != 0, "MetricData") {
 		return
 	}
 
@@ -450,15 +418,11 @@ func (s *Service) PutMetricDataCBOR(w http.ResponseWriter, r *http.Request) {
 // GetMetricDataCBOR handles the GetMetricData action with CBOR protocol.
 func (s *Service) GetMetricDataCBOR(w http.ResponseWriter, r *http.Request) {
 	var req GetMetricDataCBORRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
-	if len(req.MetricDataQueries) == 0 {
-		server.WriteCBORError(w, errMissingParameter, "The parameter MetricDataQueries is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, len(req.MetricDataQueries) != 0, "MetricDataQueries") {
 		return
 	}
 
@@ -506,21 +470,15 @@ func (s *Service) GetMetricDataCBOR(w http.ResponseWriter, r *http.Request) {
 // GetMetricStatisticsCBOR handles the GetMetricStatistics action with CBOR protocol.
 func (s *Service) GetMetricStatisticsCBOR(w http.ResponseWriter, r *http.Request) {
 	var req GetMetricStatisticsCBORRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
-	if req.Namespace == "" {
-		server.WriteCBORError(w, errMissingParameter, "The parameter Namespace is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, req.Namespace != "", "Namespace") {
 		return
 	}
 
-	if req.MetricName == "" {
-		server.WriteCBORError(w, errMissingParameter, "The parameter MetricName is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, req.MetricName != "", "MetricName") {
 		return
 	}
 
@@ -567,9 +525,7 @@ func (s *Service) GetMetricStatisticsCBOR(w http.ResponseWriter, r *http.Request
 // ListMetricsCBOR handles the ListMetrics action with CBOR protocol.
 func (s *Service) ListMetricsCBOR(w http.ResponseWriter, r *http.Request) {
 	var req ListMetricsRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
@@ -590,33 +546,23 @@ func (s *Service) ListMetricsCBOR(w http.ResponseWriter, r *http.Request) {
 // PutMetricAlarmCBOR handles the PutMetricAlarm action with CBOR protocol.
 func (s *Service) PutMetricAlarmCBOR(w http.ResponseWriter, r *http.Request) {
 	var req PutMetricAlarmRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
-	if req.AlarmName == "" {
-		server.WriteCBORError(w, errMissingParameter, "The parameter AlarmName is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, req.AlarmName != "", "AlarmName") {
 		return
 	}
 
-	if req.MetricName == "" {
-		server.WriteCBORError(w, errMissingParameter, "The parameter MetricName is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, req.MetricName != "", "MetricName") {
 		return
 	}
 
-	if req.Namespace == "" {
-		server.WriteCBORError(w, errMissingParameter, "The parameter Namespace is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, req.Namespace != "", "Namespace") {
 		return
 	}
 
-	if req.ComparisonOperator == "" {
-		server.WriteCBORError(w, errMissingParameter, "The parameter ComparisonOperator is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, req.ComparisonOperator != "", "ComparisonOperator") {
 		return
 	}
 
@@ -632,15 +578,11 @@ func (s *Service) PutMetricAlarmCBOR(w http.ResponseWriter, r *http.Request) {
 // DeleteAlarmsCBOR handles the DeleteAlarms action with CBOR protocol.
 func (s *Service) DeleteAlarmsCBOR(w http.ResponseWriter, r *http.Request) {
 	var req DeleteAlarmsRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
-	if len(req.AlarmNames) == 0 {
-		server.WriteCBORError(w, errMissingParameter, "The parameter AlarmNames is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, len(req.AlarmNames) != 0, "AlarmNames") {
 		return
 	}
 
@@ -656,9 +598,7 @@ func (s *Service) DeleteAlarmsCBOR(w http.ResponseWriter, r *http.Request) {
 // DescribeAlarmsCBOR handles the DescribeAlarms action with CBOR protocol.
 func (s *Service) DescribeAlarmsCBOR(w http.ResponseWriter, r *http.Request) {
 	var req DescribeAlarmsRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
@@ -706,9 +646,7 @@ func (s *Service) DescribeAlarmsCBOR(w http.ResponseWriter, r *http.Request) {
 // SetAlarmStateCBOR handles the SetAlarmState action via CBOR protocol.
 func (s *Service) SetAlarmStateCBOR(w http.ResponseWriter, r *http.Request) {
 	var req SetAlarmStateCBORRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
@@ -730,15 +668,11 @@ func (s *Service) SetAlarmStateCBOR(w http.ResponseWriter, r *http.Request) {
 // ListTagsForResourceCBOR handles the ListTagsForResource action with CBOR protocol.
 func (s *Service) ListTagsForResourceCBOR(w http.ResponseWriter, r *http.Request) {
 	var req ListTagsForResourceRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
-	if req.ResourceARN == "" {
-		server.WriteCBORError(w, errMissingParameter, "The parameter ResourceARN is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, req.ResourceARN != "", "ResourceARN") {
 		return
 	}
 
@@ -757,15 +691,11 @@ func (s *Service) ListTagsForResourceCBOR(w http.ResponseWriter, r *http.Request
 // TagResourceCBOR handles the TagResource action with CBOR protocol.
 func (s *Service) TagResourceCBOR(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
-	if req.ResourceARN == "" {
-		server.WriteCBORError(w, errMissingParameter, "The parameter ResourceARN is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, req.ResourceARN != "", "ResourceARN") {
 		return
 	}
 
@@ -781,15 +711,11 @@ func (s *Service) TagResourceCBOR(w http.ResponseWriter, r *http.Request) {
 // UntagResourceCBOR handles the UntagResource action with CBOR protocol.
 func (s *Service) UntagResourceCBOR(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceRequest
-	if err := server.DecodeCBORRequest(r, &req); err != nil {
-		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeCloudWatchCBORRequest(w, r, &req) {
 		return
 	}
 
-	if req.ResourceARN == "" {
-		server.WriteCBORError(w, errMissingParameter, "The parameter ResourceARN is required", http.StatusBadRequest)
-
+	if !requireCloudWatchCBORParameter(w, req.ResourceARN != "", "ResourceARN") {
 		return
 	}
 
@@ -817,6 +743,30 @@ func handleCloudWatchCBORError(w http.ResponseWriter, err error) {
 	}
 
 	server.WriteCBORError(w, errInternalServiceError, "Internal server error", http.StatusInternalServerError)
+}
+
+// decodeCloudWatchCBORRequest decodes the CBOR request body into req, writing
+// the standard CloudWatch decode-failure error and returning false on failure.
+func decodeCloudWatchCBORRequest(w http.ResponseWriter, r *http.Request, req any) bool {
+	if err := server.DecodeCBORRequest(r, req); err != nil {
+		server.WriteCBORError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
+// requireCloudWatchCBORParameter writes the standard CloudWatch
+// MissingParameter error and returns false if present is false.
+func requireCloudWatchCBORParameter(w http.ResponseWriter, present bool, name string) bool {
+	if !present {
+		server.WriteCBORError(w, errMissingParameter, "The parameter "+name+" is required", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
 }
 
 // parseTimestamp parses a timestamp string in various formats.

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -15,21 +15,15 @@ import (
 // CreateTable handles the CreateTable action.
 func (s *Service) CreateTable(w http.ResponseWriter, r *http.Request) {
 	var req CreateTableRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
-	if len(req.KeySchema) == 0 {
-		writeDynamoDBError(w, "ValidationException", "KeySchema is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, len(req.KeySchema) == 0, "KeySchema is required") {
 		return
 	}
 
@@ -55,15 +49,11 @@ func (s *Service) CreateTable(w http.ResponseWriter, r *http.Request) {
 // DeleteTable handles the DeleteTable action.
 func (s *Service) DeleteTable(w http.ResponseWriter, r *http.Request) {
 	var req DeleteTableRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
@@ -89,9 +79,7 @@ func (s *Service) DeleteTable(w http.ResponseWriter, r *http.Request) {
 // ListTables handles the ListTables action.
 func (s *Service) ListTables(w http.ResponseWriter, r *http.Request) {
 	var req ListTablesRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
@@ -111,15 +99,11 @@ func (s *Service) ListTables(w http.ResponseWriter, r *http.Request) {
 // DescribeTable handles the DescribeTable action.
 func (s *Service) DescribeTable(w http.ResponseWriter, r *http.Request) {
 	var req DescribeTableRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
@@ -145,21 +129,15 @@ func (s *Service) DescribeTable(w http.ResponseWriter, r *http.Request) {
 // PutItem handles the PutItem action.
 func (s *Service) PutItem(w http.ResponseWriter, r *http.Request) {
 	var req PutItemRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
-	if len(req.Item) == 0 {
-		writeDynamoDBError(w, "ValidationException", "Item is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, len(req.Item) == 0, "Item is required") {
 		return
 	}
 
@@ -195,21 +173,15 @@ func (s *Service) PutItem(w http.ResponseWriter, r *http.Request) {
 // GetItem handles the GetItem action.
 func (s *Service) GetItem(w http.ResponseWriter, r *http.Request) {
 	var req GetItemRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
-	if len(req.Key) == 0 {
-		writeDynamoDBError(w, "ValidationException", "Key is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, len(req.Key) == 0, "Key is required") {
 		return
 	}
 
@@ -237,21 +209,15 @@ func (s *Service) GetItem(w http.ResponseWriter, r *http.Request) {
 // DeleteItem handles the DeleteItem action.
 func (s *Service) DeleteItem(w http.ResponseWriter, r *http.Request) {
 	var req DeleteItemRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
-	if len(req.Key) == 0 {
-		writeDynamoDBError(w, "ValidationException", "Key is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, len(req.Key) == 0, "Key is required") {
 		return
 	}
 
@@ -287,21 +253,15 @@ func (s *Service) DeleteItem(w http.ResponseWriter, r *http.Request) {
 // UpdateItem handles the UpdateItem action.
 func (s *Service) UpdateItem(w http.ResponseWriter, r *http.Request) {
 	var req UpdateItemRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
-	if len(req.Key) == 0 {
-		writeDynamoDBError(w, "ValidationException", "Key is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, len(req.Key) == 0, "Key is required") {
 		return
 	}
 
@@ -348,15 +308,11 @@ func (s *Service) UpdateItem(w http.ResponseWriter, r *http.Request) {
 // Query handles the Query action.
 func (s *Service) Query(w http.ResponseWriter, r *http.Request) {
 	var req QueryRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
@@ -405,15 +361,11 @@ func (s *Service) Query(w http.ResponseWriter, r *http.Request) {
 // Scan handles the Scan action.
 func (s *Service) Scan(w http.ResponseWriter, r *http.Request) {
 	var req ScanRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
@@ -542,18 +494,38 @@ func writeDynamoDBError(w http.ResponseWriter, code, message string, status int)
 	service.WriteJSONError(w, service.ContentTypeAmzJSON10, code, message, status)
 }
 
+// decodeDynamoDBRequest decodes the JSON request body into req, writing the
+// standard DynamoDB decode-failure error and returning false on failure.
+func decodeDynamoDBRequest(w http.ResponseWriter, r *http.Request, req any) bool {
+	if err := service.ReadJSONRequest(r, req); err != nil {
+		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
+// requireDynamoDBField writes the standard DynamoDB ValidationException error
+// and returns false if missing is true.
+func requireDynamoDBField(w http.ResponseWriter, missing bool, message string) bool {
+	if missing {
+		writeDynamoDBError(w, "ValidationException", message, http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
 // UpdateTimeToLive handles the UpdateTimeToLive action.
 func (s *Service) UpdateTimeToLive(w http.ResponseWriter, r *http.Request) {
 	var req UpdateTimeToLiveRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
@@ -578,15 +550,11 @@ func (s *Service) UpdateTimeToLive(w http.ResponseWriter, r *http.Request) {
 // DescribeTimeToLive handles the DescribeTimeToLive action.
 func (s *Service) DescribeTimeToLive(w http.ResponseWriter, r *http.Request) {
 	var req DescribeTimeToLiveRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if req.TableName == "" {
-		writeDynamoDBError(w, "ValidationException", "TableName is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, req.TableName == "", "TableName is required") {
 		return
 	}
 
@@ -620,15 +588,11 @@ func (s *Service) DescribeTimeToLive(w http.ResponseWriter, r *http.Request) {
 // TransactWriteItems handles the TransactWriteItems action.
 func (s *Service) TransactWriteItems(w http.ResponseWriter, r *http.Request) {
 	var req TransactWriteItemsRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if len(req.TransactItems) == 0 {
-		writeDynamoDBError(w, "ValidationException", "TransactItems is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, len(req.TransactItems) == 0, "TransactItems is required") {
 		return
 	}
 
@@ -670,15 +634,11 @@ func (s *Service) TransactWriteItems(w http.ResponseWriter, r *http.Request) {
 // TransactGetItems handles the TransactGetItems action.
 func (s *Service) TransactGetItems(w http.ResponseWriter, r *http.Request) {
 	var req TransactGetItemsRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if len(req.TransactItems) == 0 {
-		writeDynamoDBError(w, "ValidationException", "TransactItems is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, len(req.TransactItems) == 0, "TransactItems is required") {
 		return
 	}
 
@@ -749,15 +709,11 @@ func (s *Service) actionHandlers() map[string]func(http.ResponseWriter, *http.Re
 // BatchWriteItem handles the BatchWriteItem action.
 func (s *Service) BatchWriteItem(w http.ResponseWriter, r *http.Request) {
 	var req BatchWriteItemRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if len(req.RequestItems) == 0 {
-		writeDynamoDBError(w, "ValidationException", "RequestItems is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, len(req.RequestItems) == 0, "RequestItems is required") {
 		return
 	}
 
@@ -792,15 +748,11 @@ func (s *Service) BatchWriteItem(w http.ResponseWriter, r *http.Request) {
 // BatchGetItem handles the BatchGetItem action.
 func (s *Service) BatchGetItem(w http.ResponseWriter, r *http.Request) {
 	var req BatchGetItemRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
-	if len(req.RequestItems) == 0 {
-		writeDynamoDBError(w, "ValidationException", "RequestItems is required", http.StatusBadRequest)
-
+	if !requireDynamoDBField(w, len(req.RequestItems) == 0, "RequestItems is required") {
 		return
 	}
 
@@ -942,9 +894,7 @@ func (s *Service) UpdateTable(w http.ResponseWriter, r *http.Request) {
 // ListTagsOfResource returns the tags for a DynamoDB resource.
 func (s *Service) ListTagsOfResource(w http.ResponseWriter, r *http.Request) {
 	var req ListTagsOfResourceRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
@@ -961,9 +911,7 @@ func (s *Service) ListTagsOfResource(w http.ResponseWriter, r *http.Request) {
 // TagResource adds tags to a DynamoDB resource.
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 
@@ -979,9 +927,7 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 // UntagResource removes tags from a DynamoDB resource.
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeDynamoDBError(w, "SerializationException", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeDynamoDBRequest(w, r, &req) {
 		return
 	}
 

--- a/internal/service/ec2/handlers.go
+++ b/internal/service/ec2/handlers.go
@@ -27,15 +27,11 @@ const (
 // RunInstances handles the RunInstances action.
 func (s *Service) RunInstances(w http.ResponseWriter, r *http.Request) {
 	var req RunInstancesRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.ImageID == "" {
-		writeError(w, errInvalidParameter, "ImageId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.ImageID == "", "ImageId") {
 		return
 	}
 
@@ -63,15 +59,11 @@ func (s *Service) RunInstances(w http.ResponseWriter, r *http.Request) {
 // TerminateInstances handles the TerminateInstances action.
 func (s *Service) TerminateInstances(w http.ResponseWriter, r *http.Request) {
 	var req TerminateInstancesRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if len(req.InstanceIDs) == 0 {
-		writeError(w, errInvalidParameter, "InstanceIds is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, len(req.InstanceIDs) == 0, "InstanceIds") {
 		return
 	}
 
@@ -92,9 +84,7 @@ func (s *Service) TerminateInstances(w http.ResponseWriter, r *http.Request) {
 // DescribeInstances handles the DescribeInstances action.
 func (s *Service) DescribeInstances(w http.ResponseWriter, r *http.Request) {
 	var req DescribeInstancesRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
@@ -130,15 +120,11 @@ func (s *Service) DescribeInstances(w http.ResponseWriter, r *http.Request) {
 // StartInstances handles the StartInstances action.
 func (s *Service) StartInstances(w http.ResponseWriter, r *http.Request) {
 	var req StartInstancesRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if len(req.InstanceIDs) == 0 {
-		writeError(w, errInvalidParameter, "InstanceIds is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, len(req.InstanceIDs) == 0, "InstanceIds") {
 		return
 	}
 
@@ -159,15 +145,11 @@ func (s *Service) StartInstances(w http.ResponseWriter, r *http.Request) {
 // StopInstances handles the StopInstances action.
 func (s *Service) StopInstances(w http.ResponseWriter, r *http.Request) {
 	var req StopInstancesRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if len(req.InstanceIDs) == 0 {
-		writeError(w, errInvalidParameter, "InstanceIds is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, len(req.InstanceIDs) == 0, "InstanceIds") {
 		return
 	}
 
@@ -188,21 +170,15 @@ func (s *Service) StopInstances(w http.ResponseWriter, r *http.Request) {
 // CreateSecurityGroup handles the CreateSecurityGroup action.
 func (s *Service) CreateSecurityGroup(w http.ResponseWriter, r *http.Request) {
 	var req CreateSecurityGroupRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.GroupName == "" {
-		writeError(w, errInvalidParameter, "GroupName is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.GroupName == "", "GroupName") {
 		return
 	}
 
-	if req.GroupDescription == "" {
-		writeError(w, errInvalidParameter, "GroupDescription is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.GroupDescription == "", "GroupDescription") {
 		return
 	}
 
@@ -226,15 +202,11 @@ func (s *Service) CreateSecurityGroup(w http.ResponseWriter, r *http.Request) {
 // DeleteSecurityGroup handles the DeleteSecurityGroup action.
 func (s *Service) DeleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
 	var req DeleteSecurityGroupRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.GroupID == "" && req.GroupName == "" {
-		writeError(w, errInvalidParameter, "GroupId or GroupName is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.GroupID == "" && req.GroupName == "", "GroupId or GroupName") {
 		return
 	}
 
@@ -255,15 +227,11 @@ func (s *Service) DeleteSecurityGroup(w http.ResponseWriter, r *http.Request) {
 // AuthorizeSecurityGroupIngress handles the AuthorizeSecurityGroupIngress action.
 func (s *Service) AuthorizeSecurityGroupIngress(w http.ResponseWriter, r *http.Request) {
 	var req AuthorizeSecurityGroupIngressRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.GroupID == "" && req.GroupName == "" {
-		writeError(w, errInvalidParameter, "GroupId or GroupName is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.GroupID == "" && req.GroupName == "", "GroupId or GroupName") {
 		return
 	}
 
@@ -296,15 +264,11 @@ func (s *Service) AuthorizeSecurityGroupIngress(w http.ResponseWriter, r *http.R
 // AuthorizeSecurityGroupEgress handles the AuthorizeSecurityGroupEgress action.
 func (s *Service) AuthorizeSecurityGroupEgress(w http.ResponseWriter, r *http.Request) {
 	var req AuthorizeSecurityGroupEgressRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.GroupID == "" {
-		writeError(w, errInvalidParameter, "GroupId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.GroupID == "", "GroupId") {
 		return
 	}
 
@@ -333,15 +297,11 @@ func (s *Service) AuthorizeSecurityGroupEgress(w http.ResponseWriter, r *http.Re
 // CreateKeyPair handles the CreateKeyPair action.
 func (s *Service) CreateKeyPair(w http.ResponseWriter, r *http.Request) {
 	var req CreateKeyPairRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.KeyName == "" {
-		writeError(w, errInvalidParameter, "KeyName is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.KeyName == "", "KeyName") {
 		return
 	}
 
@@ -365,15 +325,11 @@ func (s *Service) CreateKeyPair(w http.ResponseWriter, r *http.Request) {
 // DeleteKeyPair handles the DeleteKeyPair action.
 func (s *Service) DeleteKeyPair(w http.ResponseWriter, r *http.Request) {
 	var req DeleteKeyPairRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.KeyName == "" && req.KeyPairID == "" {
-		writeError(w, errInvalidParameter, "KeyName or KeyPairId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.KeyName == "" && req.KeyPairID == "", "KeyName or KeyPairId") {
 		return
 	}
 
@@ -394,9 +350,7 @@ func (s *Service) DeleteKeyPair(w http.ResponseWriter, r *http.Request) {
 // DescribeKeyPairs handles the DescribeKeyPairs action.
 func (s *Service) DescribeKeyPairs(w http.ResponseWriter, r *http.Request) {
 	var req DescribeKeyPairsRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
@@ -426,15 +380,11 @@ func (s *Service) DescribeKeyPairs(w http.ResponseWriter, r *http.Request) {
 // CreateVpc handles the CreateVpc action.
 func (s *Service) CreateVpc(w http.ResponseWriter, r *http.Request) {
 	var req CreateVpcRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.CidrBlock == "" {
-		writeError(w, errInvalidParameter, "CidrBlock is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.CidrBlock == "", "CidrBlock") {
 		return
 	}
 
@@ -477,15 +427,11 @@ func applyTagsOnCreate(r *http.Request, storage Storage, resourceID, resourceTyp
 // DeleteVpc handles the DeleteVpc action.
 func (s *Service) DeleteVpc(w http.ResponseWriter, r *http.Request) {
 	var req DeleteVpcRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.VpcID == "" {
-		writeError(w, errInvalidParameter, "VpcId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.VpcID == "", "VpcId") {
 		return
 	}
 
@@ -505,9 +451,7 @@ func (s *Service) DeleteVpc(w http.ResponseWriter, r *http.Request) {
 // DescribeVpcs handles the DescribeVpcs action.
 func (s *Service) DescribeVpcs(w http.ResponseWriter, r *http.Request) {
 	var req DescribeVpcsRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
@@ -533,21 +477,15 @@ func (s *Service) DescribeVpcs(w http.ResponseWriter, r *http.Request) {
 // CreateSubnet handles the CreateSubnet action.
 func (s *Service) CreateSubnet(w http.ResponseWriter, r *http.Request) {
 	var req CreateSubnetRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.VpcID == "" {
-		writeError(w, errInvalidParameter, "VpcId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.VpcID == "", "VpcId") {
 		return
 	}
 
-	if req.CidrBlock == "" {
-		writeError(w, errInvalidParameter, "CidrBlock is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.CidrBlock == "", "CidrBlock") {
 		return
 	}
 
@@ -570,15 +508,11 @@ func (s *Service) CreateSubnet(w http.ResponseWriter, r *http.Request) {
 // DeleteSubnet handles the DeleteSubnet action.
 func (s *Service) DeleteSubnet(w http.ResponseWriter, r *http.Request) {
 	var req DeleteSubnetRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.SubnetID == "" {
-		writeError(w, errInvalidParameter, "SubnetId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.SubnetID == "", "SubnetId") {
 		return
 	}
 
@@ -598,9 +532,7 @@ func (s *Service) DeleteSubnet(w http.ResponseWriter, r *http.Request) {
 // DescribeSubnets handles the DescribeSubnets action.
 func (s *Service) DescribeSubnets(w http.ResponseWriter, r *http.Request) {
 	var req DescribeSubnetsRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
@@ -626,9 +558,7 @@ func (s *Service) DescribeSubnets(w http.ResponseWriter, r *http.Request) {
 // CreateInternetGateway handles the CreateInternetGateway action.
 func (s *Service) CreateInternetGateway(w http.ResponseWriter, r *http.Request) {
 	var req CreateInternetGatewayRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
@@ -651,21 +581,15 @@ func (s *Service) CreateInternetGateway(w http.ResponseWriter, r *http.Request) 
 // AttachInternetGateway handles the AttachInternetGateway action.
 func (s *Service) AttachInternetGateway(w http.ResponseWriter, r *http.Request) {
 	var req AttachInternetGatewayRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.InternetGatewayID == "" {
-		writeError(w, errInvalidParameter, "InternetGatewayId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.InternetGatewayID == "", "InternetGatewayId") {
 		return
 	}
 
-	if req.VpcID == "" {
-		writeError(w, errInvalidParameter, "VpcId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.VpcID == "", "VpcId") {
 		return
 	}
 
@@ -685,9 +609,7 @@ func (s *Service) AttachInternetGateway(w http.ResponseWriter, r *http.Request) 
 // DescribeInternetGateways handles the DescribeInternetGateways action.
 func (s *Service) DescribeInternetGateways(w http.ResponseWriter, r *http.Request) {
 	var req DescribeInternetGatewaysRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
@@ -713,15 +635,11 @@ func (s *Service) DescribeInternetGateways(w http.ResponseWriter, r *http.Reques
 // CreateRouteTable handles the CreateRouteTable action.
 func (s *Service) CreateRouteTable(w http.ResponseWriter, r *http.Request) {
 	var req CreateRouteTableRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.VpcID == "" {
-		writeError(w, errInvalidParameter, "VpcId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.VpcID == "", "VpcId") {
 		return
 	}
 
@@ -744,21 +662,15 @@ func (s *Service) CreateRouteTable(w http.ResponseWriter, r *http.Request) {
 // CreateRoute handles the CreateRoute action.
 func (s *Service) CreateRoute(w http.ResponseWriter, r *http.Request) {
 	var req CreateRouteRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.RouteTableID == "" {
-		writeError(w, errInvalidParameter, "RouteTableId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.RouteTableID == "", "RouteTableId") {
 		return
 	}
 
-	if req.DestinationCidrBlock == "" {
-		writeError(w, errInvalidParameter, "DestinationCidrBlock is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.DestinationCidrBlock == "", "DestinationCidrBlock") {
 		return
 	}
 
@@ -778,21 +690,15 @@ func (s *Service) CreateRoute(w http.ResponseWriter, r *http.Request) {
 // AssociateRouteTable handles the AssociateRouteTable action.
 func (s *Service) AssociateRouteTable(w http.ResponseWriter, r *http.Request) {
 	var req AssociateRouteTableRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.RouteTableID == "" {
-		writeError(w, errInvalidParameter, "RouteTableId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.RouteTableID == "", "RouteTableId") {
 		return
 	}
 
-	if req.SubnetID == "" {
-		writeError(w, errInvalidParameter, "SubnetId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.SubnetID == "", "SubnetId") {
 		return
 	}
 
@@ -813,9 +719,7 @@ func (s *Service) AssociateRouteTable(w http.ResponseWriter, r *http.Request) {
 // DescribeRouteTables handles the DescribeRouteTables action.
 func (s *Service) DescribeRouteTables(w http.ResponseWriter, r *http.Request) {
 	var req DescribeRouteTablesRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
@@ -841,15 +745,11 @@ func (s *Service) DescribeRouteTables(w http.ResponseWriter, r *http.Request) {
 // CreateNatGateway handles the CreateNatGateway action.
 func (s *Service) CreateNatGateway(w http.ResponseWriter, r *http.Request) {
 	var req CreateNatGatewayRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.SubnetID == "" {
-		writeError(w, errInvalidParameter, "SubnetId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.SubnetID == "", "SubnetId") {
 		return
 	}
 
@@ -870,9 +770,7 @@ func (s *Service) CreateNatGateway(w http.ResponseWriter, r *http.Request) {
 // DescribeNatGateways handles the DescribeNatGateways action.
 func (s *Service) DescribeNatGateways(w http.ResponseWriter, r *http.Request) {
 	var req DescribeNatGatewaysRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
@@ -904,15 +802,11 @@ func (s *Service) CreateTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(resources) == 0 {
-		writeError(w, errInvalidParameter, "ResourceId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, len(resources) == 0, "ResourceId") {
 		return
 	}
 
-	if len(tags) == 0 {
-		writeError(w, errInvalidParameter, "Tag is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, len(tags) == 0, "Tag") {
 		return
 	}
 
@@ -938,9 +832,7 @@ func (s *Service) DeleteTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(resources) == 0 {
-		writeError(w, errInvalidParameter, "ResourceId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, len(resources) == 0, "ResourceId") {
 		return
 	}
 
@@ -959,9 +851,7 @@ func (s *Service) DeleteTags(w http.ResponseWriter, r *http.Request) {
 
 // DescribeTags handles the DescribeTags action.
 func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
-
+	if !decodeEC2Form(w, r) {
 		return
 	}
 
@@ -989,16 +879,12 @@ func (s *Service) DescribeTags(w http.ResponseWriter, r *http.Request) {
 // ModifyVpcAttribute handles the ModifyVpcAttribute action. AWS modifies one
 // attribute per call; the handler updates only the fields the request supplies.
 func (s *Service) ModifyVpcAttribute(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
-
+	if !decodeEC2Form(w, r) {
 		return
 	}
 
 	vpcID := r.Form.Get("VpcId")
-	if vpcID == "" {
-		writeError(w, errInvalidParameter, "VpcId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, vpcID == "", "VpcId") {
 		return
 	}
 
@@ -1020,9 +906,7 @@ func (s *Service) ModifyVpcAttribute(w http.ResponseWriter, r *http.Request) {
 // EnableNetworkAddressUsageMetrics. The attribute name in the request uses
 // the AWS lowercase-camel form (e.g. "enableDnsHostnames").
 func (s *Service) DescribeVpcAttribute(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
-
+	if !decodeEC2Form(w, r) {
 		return
 	}
 
@@ -1083,16 +967,12 @@ type xmlBoolValue struct {
 
 // ModifySubnetAttribute handles the ModifySubnetAttribute action.
 func (s *Service) ModifySubnetAttribute(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
-
+	if !decodeEC2Form(w, r) {
 		return
 	}
 
 	subnetID := r.Form.Get("SubnetId")
-	if subnetID == "" {
-		writeError(w, errInvalidParameter, "SubnetId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, subnetID == "", "SubnetId") {
 		return
 	}
 
@@ -1524,6 +1404,42 @@ func readEC2JSONRequest(r *http.Request, v any) error {
 	return nil
 }
 
+// decodeEC2Request decodes the JSON request body into req, writing the
+// standard EC2 decode-failure error and returning false on failure.
+func decodeEC2Request(w http.ResponseWriter, r *http.Request, req any) bool {
+	if err := readEC2JSONRequest(r, req); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
+// decodeEC2Form parses the request's form data, writing the standard EC2
+// form-parse-failure error and returning false on failure.
+func decodeEC2Form(w http.ResponseWriter, r *http.Request) bool {
+	if err := r.ParseForm(); err != nil {
+		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
+// requireEC2Parameter writes the standard EC2 InvalidParameterValue error
+// and returns false if missing is true.
+func requireEC2Parameter(w http.ResponseWriter, missing bool, name string) bool {
+	if missing {
+		writeError(w, errInvalidParameter, name+" is required", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
 // extractAction extracts the action name from the request.
 // It tries X-Amz-Target header first (set by QueryProtocolDispatcher),
 // then falls back to URL query parameter.
@@ -1670,15 +1586,11 @@ func convertToXMLRouteTable(rt *RouteTable) XMLRouteTable {
 // form so IpPermissions.N.* lands in the request.
 func (s *Service) RevokeSecurityGroupIngress(w http.ResponseWriter, r *http.Request) {
 	var req AuthorizeSecurityGroupIngressRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.GroupID == "" && req.GroupName == "" {
-		writeError(w, errInvalidParameter, "GroupId or GroupName is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.GroupID == "" && req.GroupName == "", "GroupId or GroupName") {
 		return
 	}
 
@@ -1707,15 +1619,11 @@ func (s *Service) RevokeSecurityGroupIngress(w http.ResponseWriter, r *http.Requ
 // the existing Authorize handler.
 func (s *Service) RevokeSecurityGroupEgress(w http.ResponseWriter, r *http.Request) {
 	var req AuthorizeSecurityGroupEgressRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.GroupID == "" {
-		writeError(w, errInvalidParameter, "GroupId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.GroupID == "", "GroupId") {
 		return
 	}
 
@@ -1743,9 +1651,7 @@ func (s *Service) RevokeSecurityGroupEgress(w http.ResponseWriter, r *http.Reque
 // Filters honoured: GroupId.N, GroupName.N. Without either, every SG
 // in storage is returned.
 func (s *Service) DescribeSecurityGroups(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse form data", http.StatusBadRequest)
-
+	if !decodeEC2Form(w, r) {
 		return
 	}
 

--- a/internal/service/ec2/igw_destroy.go
+++ b/internal/service/ec2/igw_destroy.go
@@ -13,21 +13,15 @@ import (
 // destroy fails with InvalidAction and the IGW leaks in kumo.
 func (s *Service) DetachInternetGateway(w http.ResponseWriter, r *http.Request) {
 	var req AttachInternetGatewayRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.InternetGatewayID == "" {
-		writeError(w, errInvalidParameter, "InternetGatewayId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.InternetGatewayID == "", "InternetGatewayId") {
 		return
 	}
 
-	if req.VpcID == "" {
-		writeError(w, errInvalidParameter, "VpcId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.VpcID == "", "VpcId") {
 		return
 	}
 
@@ -47,15 +41,11 @@ func (s *Service) DetachInternetGateway(w http.ResponseWriter, r *http.Request) 
 // DeleteInternetGateway handles the DeleteInternetGateway action.
 func (s *Service) DeleteInternetGateway(w http.ResponseWriter, r *http.Request) {
 	var req DeleteInternetGatewayRequest
-	if err := readEC2JSONRequest(r, &req); err != nil {
-		writeError(w, errInvalidParameter, "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeEC2Request(w, r, &req) {
 		return
 	}
 
-	if req.InternetGatewayID == "" {
-		writeError(w, errInvalidParameter, "InternetGatewayId is required", http.StatusBadRequest)
-
+	if !requireEC2Parameter(w, req.InternetGatewayID == "", "InternetGatewayId") {
 		return
 	}
 

--- a/internal/service/sqs/handlers.go
+++ b/internal/service/sqs/handlers.go
@@ -12,15 +12,11 @@ import (
 // CreateQueue handles the CreateQueue action.
 func (s *Service) CreateQueue(w http.ResponseWriter, r *http.Request) {
 	var req CreateQueueRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueName == "" {
-		writeSQSError(w, "MissingParameter", "QueueName is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueName, "QueueName") {
 		return
 	}
 
@@ -46,15 +42,11 @@ func (s *Service) CreateQueue(w http.ResponseWriter, r *http.Request) {
 // ListQueueTags handles the ListQueueTags action.
 func (s *Service) ListQueueTags(w http.ResponseWriter, r *http.Request) {
 	var req ListQueueTagsRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -80,15 +72,11 @@ func (s *Service) ListQueueTags(w http.ResponseWriter, r *http.Request) {
 // TagQueue handles the TagQueue action.
 func (s *Service) TagQueue(w http.ResponseWriter, r *http.Request) {
 	var req TagQueueRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -111,15 +99,11 @@ func (s *Service) TagQueue(w http.ResponseWriter, r *http.Request) {
 // UntagQueue handles the UntagQueue action.
 func (s *Service) UntagQueue(w http.ResponseWriter, r *http.Request) {
 	var req UntagQueueRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -142,15 +126,11 @@ func (s *Service) UntagQueue(w http.ResponseWriter, r *http.Request) {
 // DeleteQueue handles the DeleteQueue action.
 func (s *Service) DeleteQueue(w http.ResponseWriter, r *http.Request) {
 	var req DeleteQueueRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -173,9 +153,7 @@ func (s *Service) DeleteQueue(w http.ResponseWriter, r *http.Request) {
 // ListQueues handles the ListQueues action.
 func (s *Service) ListQueues(w http.ResponseWriter, r *http.Request) {
 	var req ListQueuesRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
@@ -194,15 +172,11 @@ func (s *Service) ListQueues(w http.ResponseWriter, r *http.Request) {
 // GetQueueURL handles the GetQueueURL action.
 func (s *Service) GetQueueURL(w http.ResponseWriter, r *http.Request) {
 	var req GetQueueURLRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueName == "" {
-		writeSQSError(w, "MissingParameter", "QueueName is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueName, "QueueName") {
 		return
 	}
 
@@ -228,21 +202,15 @@ func (s *Service) GetQueueURL(w http.ResponseWriter, r *http.Request) {
 // SendMessage handles the SendMessage action.
 func (s *Service) SendMessage(w http.ResponseWriter, r *http.Request) {
 	var req SendMessageRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
-	if req.MessageBody == "" {
-		writeSQSError(w, "MissingParameter", "MessageBody is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.MessageBody, "MessageBody") {
 		return
 	}
 
@@ -270,15 +238,11 @@ func (s *Service) SendMessage(w http.ResponseWriter, r *http.Request) {
 // SendMessageBatch handles the SendMessageBatch action.
 func (s *Service) SendMessageBatch(w http.ResponseWriter, r *http.Request) {
 	var req SendMessageBatchRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -367,15 +331,11 @@ func (s *Service) batchEntryError(id string, err error) BatchResultErrorEntry {
 // ReceiveMessage handles the ReceiveMessage action.
 func (s *Service) ReceiveMessage(w http.ResponseWriter, r *http.Request) {
 	var req ReceiveMessageRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -429,21 +389,15 @@ func convertMessagesToResponse(messages []*Message) []MessageResponse {
 // DeleteMessage handles the DeleteMessage action.
 func (s *Service) DeleteMessage(w http.ResponseWriter, r *http.Request) {
 	var req DeleteMessageRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
-	if req.ReceiptHandle == "" {
-		writeSQSError(w, "MissingParameter", "ReceiptHandle is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.ReceiptHandle, "ReceiptHandle") {
 		return
 	}
 
@@ -466,15 +420,11 @@ func (s *Service) DeleteMessage(w http.ResponseWriter, r *http.Request) {
 // DeleteMessageBatch handles the DeleteMessageBatch action.
 func (s *Service) DeleteMessageBatch(w http.ResponseWriter, r *http.Request) {
 	var req DeleteMessageBatchRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -539,21 +489,15 @@ func (s *Service) processDeleteBatchEntries(ctx context.Context, queueURL string
 // ChangeMessageVisibility handles the ChangeMessageVisibility action.
 func (s *Service) ChangeMessageVisibility(w http.ResponseWriter, r *http.Request) {
 	var req ChangeMessageVisibilityRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
-	if req.ReceiptHandle == "" {
-		writeSQSError(w, "MissingParameter", "ReceiptHandle is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.ReceiptHandle, "ReceiptHandle") {
 		return
 	}
 
@@ -576,15 +520,11 @@ func (s *Service) ChangeMessageVisibility(w http.ResponseWriter, r *http.Request
 // ChangeMessageVisibilityBatch handles the ChangeMessageVisibilityBatch action.
 func (s *Service) ChangeMessageVisibilityBatch(w http.ResponseWriter, r *http.Request) {
 	var req ChangeMessageVisibilityBatchRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -614,15 +554,11 @@ func (s *Service) ChangeMessageVisibilityBatch(w http.ResponseWriter, r *http.Re
 // PurgeQueue handles the PurgeQueue action.
 func (s *Service) PurgeQueue(w http.ResponseWriter, r *http.Request) {
 	var req PurgeQueueRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -645,15 +581,11 @@ func (s *Service) PurgeQueue(w http.ResponseWriter, r *http.Request) {
 // GetQueueAttributes handles the GetQueueAttributes action.
 func (s *Service) GetQueueAttributes(w http.ResponseWriter, r *http.Request) {
 	var req GetQueueAttributesRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -679,15 +611,11 @@ func (s *Service) GetQueueAttributes(w http.ResponseWriter, r *http.Request) {
 // SetQueueAttributes handles the SetQueueAttributes action.
 func (s *Service) SetQueueAttributes(w http.ResponseWriter, r *http.Request) {
 	var req SetQueueAttributesRequest
-	if err := service.ReadJSONRequest(r, &req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
-
+	if !decodeSQSRequest(w, r, &req) {
 		return
 	}
 
-	if req.QueueURL == "" {
-		writeSQSError(w, "MissingParameter", "QueueUrl is required", http.StatusBadRequest)
-
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
 		return
 	}
 
@@ -715,6 +643,30 @@ func writeJSONResponse(w http.ResponseWriter, v any) {
 // writeSQSError writes an SQS error response in JSON format.
 func writeSQSError(w http.ResponseWriter, code, message string, status int) {
 	service.WriteJSONError(w, service.ContentTypeAmzJSON10, code, message, status)
+}
+
+// decodeSQSRequest decodes the JSON request body into req, writing the
+// standard SQS decode-failure error and returning false on failure.
+func decodeSQSRequest(w http.ResponseWriter, r *http.Request, req any) bool {
+	if err := service.ReadJSONRequest(r, req); err != nil {
+		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
+// requireSQSParameter writes the standard SQS MissingParameter error and
+// returns false if value is empty.
+func requireSQSParameter(w http.ResponseWriter, value, name string) bool {
+	if value == "" {
+		writeSQSError(w, "MissingParameter", name+" is required", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
 }
 
 // sqsActions maps an X-Amz-Target action name to its handler method.


### PR DESCRIPTION
## Summary
sqs, dynamodb, cloudwatch, and ec2 repeated the same decode-failure and required-field blocks dozens of times each. Each package gets small helpers matching its own protocol idiom (cloudwatch gets JSON and CBOR variants, ec2 gets JSON-body and form variants), and ~195 call sites are converted: net -256 lines. Helpers lift the literal code/message/status from the existing sites, and call sites with bespoke wording are deliberately left alone, so wire responses are byte-identical.

## Test plan
- [x] `make lint` 0 issues, `go test -race -shuffle=on ./...` green
- [ ] CI integration suite validates the wire format (local port was held by a concurrent golden task)