### PR TITLE
refactor(test): move cloudfront public key and key group coverage to golden tests

### DIFF
--- a/internal/service/cloudfront/handlers_signing_test.go
+++ b/internal/service/cloudfront/handlers_signing_test.go
@@ -44,68 +44,6 @@ func createPublicKeyForTest(t *testing.T, svc *Service, callerRef, name string) 
 	return &out
 }
 
-func TestPublicKey_CreateGetListDelete(t *testing.T) {
-	t.Parallel()
-
-	svc := newSigningTestService()
-
-	created := createPublicKeyForTest(t, svc, "ref-1", "key-one")
-
-	if !strings.HasPrefix(created.ID, "K") {
-		t.Fatalf("PublicKey.ID should start with K, got %q", created.ID)
-	}
-
-	// Get
-	getReq := httptest.NewRequest(http.MethodGet, "/2020-05-31/public-key/"+created.ID, http.NoBody)
-	getReq.SetPathValue("id", created.ID)
-
-	getW := httptest.NewRecorder()
-	svc.GetPublicKey(getW, getReq)
-
-	if getW.Code != http.StatusOK {
-		t.Fatalf("GetPublicKey status: %d body=%s", getW.Code, getW.Body.String())
-	}
-
-	// List
-	listW := httptest.NewRecorder()
-	svc.ListPublicKeys(listW, httptest.NewRequest(http.MethodGet, "/2020-05-31/public-key", http.NoBody))
-
-	if listW.Code != http.StatusOK {
-		t.Fatalf("ListPublicKeys status: %d", listW.Code)
-	}
-
-	var list PublicKeyListXML
-	if err := xml.Unmarshal(listW.Body.Bytes(), &list); err != nil {
-		t.Fatalf("unmarshal list: %v body=%s", err, listW.Body.String())
-	}
-
-	if list.Quantity != 1 || len(list.Items) != 1 {
-		t.Fatalf("ListPublicKeys: quantity=%d items=%d, want 1/1", list.Quantity, len(list.Items))
-	}
-
-	// Delete
-	delReq := httptest.NewRequest(http.MethodDelete, "/2020-05-31/public-key/"+created.ID, http.NoBody)
-	delReq.SetPathValue("id", created.ID)
-
-	delW := httptest.NewRecorder()
-	svc.DeletePublicKey(delW, delReq)
-
-	if delW.Code != http.StatusNoContent {
-		t.Fatalf("DeletePublicKey status: %d body=%s", delW.Code, delW.Body.String())
-	}
-
-	// Get-after-delete is 404.
-	getReq2 := httptest.NewRequest(http.MethodGet, "/2020-05-31/public-key/"+created.ID, http.NoBody)
-	getReq2.SetPathValue("id", created.ID)
-
-	getW2 := httptest.NewRecorder()
-	svc.GetPublicKey(getW2, getReq2)
-
-	if getW2.Code != http.StatusNotFound {
-		t.Fatalf("GetPublicKey after delete: status %d, want 404", getW2.Code)
-	}
-}
-
 func TestPublicKey_DuplicateCallerReferenceConflicts(t *testing.T) {
 	t.Parallel()
 
@@ -136,43 +74,6 @@ func TestKeyGroup_CreateRejectsUnknownPublicKey(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status: got %d, want 404 (NoSuchPublicKey)", w.Code)
-	}
-}
-
-func TestKeyGroup_CreateGetListAndPublicKeyInUseBlock(t *testing.T) {
-	t.Parallel()
-
-	svc := newSigningTestService()
-	pk := createPublicKeyForTest(t, svc, "ref-x", "kx")
-
-	body := KeyGroupConfigXML{Name: "g-prod", Items: []string{pk.ID}, Comment: "prod"}
-	raw, _ := xml.Marshal(body)
-
-	w := httptest.NewRecorder()
-	svc.CreateKeyGroup(w, httptest.NewRequest(http.MethodPost, "/2020-05-31/key-group", strings.NewReader(string(raw))))
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateKeyGroup status: %d body=%s", w.Code, w.Body.String())
-	}
-
-	var group KeyGroupResultXML
-	if err := xml.Unmarshal(w.Body.Bytes(), &group); err != nil {
-		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
-	}
-
-	if len(group.KeyGroupConfig.Items) != 1 || group.KeyGroupConfig.Items[0] != pk.ID {
-		t.Fatalf("KeyGroupConfig.Items: got %v, want [%s]", group.KeyGroupConfig.Items, pk.ID)
-	}
-
-	// Deleting the underlying PublicKey should fail with 409 PublicKeyInUse.
-	delReq := httptest.NewRequest(http.MethodDelete, "/2020-05-31/public-key/"+pk.ID, http.NoBody)
-	delReq.SetPathValue("id", pk.ID)
-
-	delW := httptest.NewRecorder()
-	svc.DeletePublicKey(delW, delReq)
-
-	if delW.Code != http.StatusConflict {
-		t.Fatalf("DeletePublicKey while referenced: status %d, want 409", delW.Code)
 	}
 }
 

--- a/test/integration/cloudfront_test.go
+++ b/test/integration/cloudfront_test.go
@@ -4,11 +4,13 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	"github.com/aws/smithy-go"
 	"github.com/sivchari/golden"
 )
 
@@ -425,4 +427,201 @@ func TestCloudFront_GetInvalidation(t *testing.T) {
 		"CreateTime",
 		"ResultMetadata",
 	)).Assert(t.Name(), getResult)
+}
+
+func TestCloudFront_PublicKeyCRUD(t *testing.T) {
+	t.Parallel()
+
+	client := newCloudFrontClient(t)
+	ctx := t.Context()
+
+	_, pubPEM := generateTestKeyPair(t)
+
+	createResult, err := client.CreatePublicKey(ctx, &cloudfront.CreatePublicKeyInput{
+		PublicKeyConfig: &types.PublicKeyConfig{
+			CallerReference: aws.String("test-pk-crud"),
+			Name:            aws.String("test-pk-crud-key"),
+			EncodedKey:      aws.String(pubPEM),
+			Comment:         aws.String("CRUD test key"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"Id",
+		"CreatedTime",
+		"ETag",
+		"EncodedKey",
+		"ResultMetadata",
+	)).Assert(t.Name()+"_create", createResult)
+
+	// Get.
+	getResult, err := client.GetPublicKey(ctx, &cloudfront.GetPublicKeyInput{
+		Id: createResult.PublicKey.Id,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"Id",
+		"CreatedTime",
+		"ETag",
+		"EncodedKey",
+		"ResultMetadata",
+	)).Assert(t.Name()+"_get", getResult)
+
+	// List: find our key by ID rather than asserting the whole list,
+	// since other parallel tests create PublicKeys too.
+	listResult, err := client.ListPublicKeys(ctx, &cloudfront.ListPublicKeysInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+
+	if listResult.PublicKeyList != nil {
+		for _, item := range listResult.PublicKeyList.Items {
+			if aws.ToString(item.Id) == aws.ToString(createResult.PublicKey.Id) {
+				found = true
+
+				break
+			}
+		}
+	}
+
+	if !found {
+		t.Error("PublicKey should be in list")
+	}
+
+	// Delete.
+	_, err = client.DeletePublicKey(ctx, &cloudfront.DeletePublicKeyInput{
+		Id:      createResult.PublicKey.Id,
+		IfMatch: createResult.ETag,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get-after-delete is NoSuchPublicKey.
+	_, err = client.GetPublicKey(ctx, &cloudfront.GetPublicKeyInput{
+		Id: createResult.PublicKey.Id,
+	})
+	if err == nil {
+		t.Fatal("expected NoSuchPublicKey error after delete")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "NoSuchPublicKey" {
+		t.Fatalf("expected NoSuchPublicKey, got: %T: %v", err, err)
+	}
+}
+
+func TestCloudFront_KeyGroupCRUD(t *testing.T) {
+	t.Parallel()
+
+	client := newCloudFrontClient(t)
+	ctx := t.Context()
+
+	_, pubPEM := generateTestKeyPair(t)
+
+	pkResult, err := client.CreatePublicKey(ctx, &cloudfront.CreatePublicKeyInput{
+		PublicKeyConfig: &types.PublicKeyConfig{
+			CallerReference: aws.String("test-kg-crud-pk"),
+			Name:            aws.String("test-kg-crud-key"),
+			EncodedKey:      aws.String(pubPEM),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeletePublicKey(context.Background(), &cloudfront.DeletePublicKeyInput{
+			Id:      pkResult.PublicKey.Id,
+			IfMatch: pkResult.ETag,
+		})
+	})
+
+	createResult, err := client.CreateKeyGroup(ctx, &cloudfront.CreateKeyGroupInput{
+		KeyGroupConfig: &types.KeyGroupConfig{
+			Name:    aws.String("test-kg-crud-group"),
+			Items:   []string{*pkResult.PublicKey.Id},
+			Comment: aws.String("CRUD test group"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"Id",
+		"LastModifiedTime",
+		"ETag",
+		"Items",
+		"ResultMetadata",
+	)).Assert(t.Name()+"_create", createResult)
+
+	// Get.
+	getResult, err := client.GetKeyGroup(ctx, &cloudfront.GetKeyGroupInput{
+		Id: createResult.KeyGroup.Id,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"Id",
+		"LastModifiedTime",
+		"ETag",
+		"Items",
+		"ResultMetadata",
+	)).Assert(t.Name()+"_get", getResult)
+
+	// List: find our group by ID rather than asserting the whole list.
+	listResult, err := client.ListKeyGroups(ctx, &cloudfront.ListKeyGroupsInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+
+	if listResult.KeyGroupList != nil {
+		for _, item := range listResult.KeyGroupList.Items {
+			if item.KeyGroup != nil && aws.ToString(item.KeyGroup.Id) == aws.ToString(createResult.KeyGroup.Id) {
+				found = true
+
+				break
+			}
+		}
+	}
+
+	if !found {
+		t.Error("KeyGroup should be in list")
+	}
+
+	// Deleting the referenced PublicKey must fail with PublicKeyInUse.
+	_, err = client.DeletePublicKey(ctx, &cloudfront.DeletePublicKeyInput{
+		Id:      pkResult.PublicKey.Id,
+		IfMatch: pkResult.ETag,
+	})
+	if err == nil {
+		t.Fatal("expected PublicKeyInUse error while KeyGroup references it")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "PublicKeyInUse" {
+		t.Fatalf("expected PublicKeyInUse, got: %T: %v", err, err)
+	}
+
+	// Delete KeyGroup.
+	_, err = client.DeleteKeyGroup(ctx, &cloudfront.DeleteKeyGroupInput{
+		Id:      createResult.KeyGroup.Id,
+		IfMatch: createResult.ETag,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_KeyGroupCRUD_TestCloudFront_KeyGroupCRUD_create.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_KeyGroupCRUD_TestCloudFront_KeyGroupCRUD_create.golden.go
@@ -1,0 +1,16 @@
+{
+  "ETag": "E4d499465-fb02-484d-8e3e-b6eea256",
+  "KeyGroup": {
+    "Id": "0388392039F3875EE121656F45D0DA77DE61",
+    "KeyGroupConfig": {
+      "Items": [
+        "K0843A049A0BD4"
+      ],
+      "Name": "test-kg-crud-group",
+      "Comment": "CRUD test group"
+    },
+    "LastModifiedTime": "2026-08-06T04:52:59Z"
+  },
+  "Location": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_KeyGroupCRUD_TestCloudFront_KeyGroupCRUD_get.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_KeyGroupCRUD_TestCloudFront_KeyGroupCRUD_get.golden.go
@@ -1,0 +1,15 @@
+{
+  "ETag": "E4d499465-fb02-484d-8e3e-b6eea256",
+  "KeyGroup": {
+    "Id": "0388392039F3875EE121656F45D0DA77DE61",
+    "KeyGroupConfig": {
+      "Items": [
+        "K0843A049A0BD4"
+      ],
+      "Name": "test-kg-crud-group",
+      "Comment": "CRUD test group"
+    },
+    "LastModifiedTime": "2026-08-06T04:52:59Z"
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_PublicKeyCRUD_TestCloudFront_PublicKeyCRUD_create.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_PublicKeyCRUD_TestCloudFront_PublicKeyCRUD_create.golden.go
@@ -1,0 +1,15 @@
+{
+  "ETag": "Eb0bd4b3c-7434-4d51-a398-7f18bb85",
+  "Location": null,
+  "PublicKey": {
+    "CreatedTime": "2026-08-06T04:52:59Z",
+    "Id": "K595A788EE6A54",
+    "PublicKeyConfig": {
+      "CallerReference": "test-pk-crud",
+      "EncodedKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvhF44sO4sXzykVryGnoh\naszdr1tZ5qwl54gNmmrACbW+h/lr+ePO4XDSd6G2IZTJfKhotCcIPQ8m87WTHjrS\nPmlUpDa6X+0PyPP6kAS/phvDoADFk9D2u6zLhUc/arwtuPyqP+zts1OHVL6jRz73\nBSKe+CD+YCIrOVLZHFfeG/HwlzzgVOy9ESWVQwr6ERoIk34QRbZP85YxIkfQFUGE\nG5wfuiTHE15IEMKGfYG8xSwAxCIJOoEhLHvXQWUSaO53NIcpLvYVQe6A3RZ1607v\niBYAK1xrfc3GkYVCafMOoNEbfpsgEAh1SkUhtG0LsDVd8I1dtVPCTpMffalOob5D\nKwIDAQAB\n-----END PUBLIC KEY-----\n",
+      "Name": "test-pk-crud-key",
+      "Comment": "CRUD test key"
+    }
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cloudfront_test_TestCloudFront_PublicKeyCRUD_TestCloudFront_PublicKeyCRUD_get.golden.go
+++ b/test/integration/testdata/cloudfront_test_TestCloudFront_PublicKeyCRUD_TestCloudFront_PublicKeyCRUD_get.golden.go
@@ -1,0 +1,14 @@
+{
+  "ETag": "Eb0bd4b3c-7434-4d51-a398-7f18bb85",
+  "PublicKey": {
+    "CreatedTime": "2026-08-06T04:52:59Z",
+    "Id": "K595A788EE6A54",
+    "PublicKeyConfig": {
+      "CallerReference": "test-pk-crud",
+      "EncodedKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvhF44sO4sXzykVryGnoh\naszdr1tZ5qwl54gNmmrACbW+h/lr+ePO4XDSd6G2IZTJfKhotCcIPQ8m87WTHjrS\nPmlUpDa6X+0PyPP6kAS/phvDoADFk9D2u6zLhUc/arwtuPyqP+zts1OHVL6jRz73\nBSKe+CD+YCIrOVLZHFfeG/HwlzzgVOy9ESWVQwr6ERoIk34QRbZP85YxIkfQFUGE\nG5wfuiTHE15IEMKGfYG8xSwAxCIJOoEhLHvXQWUSaO53NIcpLvYVQe6A3RZ1607v\niBYAK1xrfc3GkYVCafMOoNEbfpsgEAh1SkUhtG0LsDVd8I1dtVPCTpMffalOob5D\nKwIDAQAB\n-----END PUBLIC KEY-----\n",
+      "Name": "test-pk-crud-key",
+      "Comment": "CRUD test key"
+    }
+  },
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
Moves the PublicKey and KeyGroup CRUD coverage (including the PublicKeyInUse deletion block) from httptest unit tests to golden integration tests, per the repo testing policy. Edge-case unit tests that golden tests cannot reach (duplicate caller reference, unknown-key rejection, distribution-referenced deletion block, nil-map reads) and all signature-verification tests stay.

## Test plan
- [x] New goldens stable across 3 re-runs; full TestCloudFront_ suite green against live kumo; existing goldens untouched
- [x] `make lint` 0 issues, `go test -race -shuffle=on ./...` green