### PR TITLE
fix(s3): decode the xsi:type grantee attribute in PutObjectAcl

### DIFF
--- a/internal/service/s3/object_acl.go
+++ b/internal/service/s3/object_acl.go
@@ -68,6 +68,29 @@ type AccessControlGrantee struct {
 	DisplayName string `xml:"DisplayName,omitempty"`
 }
 
+// UnmarshalXML decodes a Grantee, resolving the xsi:type attribute by its
+// local name. encoding/xml matches the `xml:"xsi:type,attr"` tag literally
+// on marshal but by resolved namespace URI on unmarshal, so the struct tag
+// alone never populates Type from real client requests.
+func (g *AccessControlGrantee) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type plain AccessControlGrantee
+
+	var p plain
+	if err := d.DecodeElement(&p, &start); err != nil {
+		return fmt.Errorf("decode Grantee: %w", err)
+	}
+
+	*g = AccessControlGrantee(p)
+
+	for _, attr := range start.Attr {
+		if attr.Name.Local == "type" {
+			g.Type = attr.Value
+		}
+	}
+
+	return nil
+}
+
 // PutObjectACL handles PUT /{bucket}/{key}?acl.
 //
 // The grant list comes from one of two sources, mutually exclusive:

--- a/test/integration/testdata/s3_object_ops_test_TestS3_ObjectACL_TestS3_ObjectACL_explicit.golden.go
+++ b/test/integration/testdata/s3_object_ops_test_TestS3_ObjectACL_TestS3_ObjectACL_explicit.golden.go
@@ -2,7 +2,7 @@
   "Grants": [
     {
       "Grantee": {
-        "Type": "",
+        "Type": "CanonicalUser",
         "DisplayName": "Alice",
         "EmailAddress": null,
         "ID": "user-1",
@@ -12,7 +12,7 @@
     },
     {
       "Grantee": {
-        "Type": "",
+        "Type": "Group",
         "DisplayName": null,
         "EmailAddress": null,
         "ID": null,


### PR DESCRIPTION
## Summary
encoding/xml matches the `xml:"xsi:type,attr"` tag literally on marshal but by resolved namespace URI on unmarshal, so PutObjectAcl stored every explicit grantee type as an empty string (found while migrating the ACL tests to golden in #891). A custom UnmarshalXML resolves the attribute by local name; the marshal output is unchanged. The TestS3_ObjectACL_explicit golden now records the correct CanonicalUser / Group values instead of locking in the bug.

## Test plan
- [x] Regenerated golden shows Type CanonicalUser / Group; full TestS3_ suite green against live kumo
- [x] `make lint` 0 issues, `go test -race ./...` green