### PR TITLE
refactor(service): extend decode and required-field helpers to the next tier

### DIFF
--- a/internal/service/cognito/handlers.go
+++ b/internal/service/cognito/handlers.go
@@ -56,9 +56,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateUserPool handles the CreateUserPool API.
 func (s *Service) CreateUserPool(w http.ResponseWriter, r *http.Request) {
 	var req CreateUserPoolRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -88,9 +86,7 @@ func (s *Service) CreateUserPool(w http.ResponseWriter, r *http.Request) {
 // DescribeUserPool handles the DescribeUserPool API.
 func (s *Service) DescribeUserPool(w http.ResponseWriter, r *http.Request) {
 	var req DescribeUserPoolRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -111,9 +107,7 @@ func (s *Service) DescribeUserPool(w http.ResponseWriter, r *http.Request) {
 // ListUserPools handles the ListUserPools API.
 func (s *Service) ListUserPools(w http.ResponseWriter, r *http.Request) {
 	var req ListUserPoolsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -141,9 +135,7 @@ func (s *Service) ListUserPools(w http.ResponseWriter, r *http.Request) {
 // DeleteUserPool handles the DeleteUserPool API.
 func (s *Service) DeleteUserPool(w http.ResponseWriter, r *http.Request) {
 	var req DeleteUserPoolRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -159,9 +151,7 @@ func (s *Service) DeleteUserPool(w http.ResponseWriter, r *http.Request) {
 // CreateUserPoolClient handles the CreateUserPoolClient API.
 func (s *Service) CreateUserPoolClient(w http.ResponseWriter, r *http.Request) {
 	var req CreateUserPoolClientRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -182,9 +172,7 @@ func (s *Service) CreateUserPoolClient(w http.ResponseWriter, r *http.Request) {
 // DescribeUserPoolClient handles the DescribeUserPoolClient API.
 func (s *Service) DescribeUserPoolClient(w http.ResponseWriter, r *http.Request) {
 	var req DescribeUserPoolClientRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -205,9 +193,7 @@ func (s *Service) DescribeUserPoolClient(w http.ResponseWriter, r *http.Request)
 // ListUserPoolClients handles the ListUserPoolClients API.
 func (s *Service) ListUserPoolClients(w http.ResponseWriter, r *http.Request) {
 	var req ListUserPoolClientsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -235,9 +221,7 @@ func (s *Service) ListUserPoolClients(w http.ResponseWriter, r *http.Request) {
 // DeleteUserPoolClient handles the DeleteUserPoolClient API.
 func (s *Service) DeleteUserPoolClient(w http.ResponseWriter, r *http.Request) {
 	var req DeleteUserPoolClientRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -253,9 +237,7 @@ func (s *Service) DeleteUserPoolClient(w http.ResponseWriter, r *http.Request) {
 // AdminCreateUser handles the AdminCreateUser API.
 func (s *Service) AdminCreateUser(w http.ResponseWriter, r *http.Request) {
 	var req AdminCreateUserRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -276,9 +258,7 @@ func (s *Service) AdminCreateUser(w http.ResponseWriter, r *http.Request) {
 // AdminGetUser handles the AdminGetUser API.
 func (s *Service) AdminGetUser(w http.ResponseWriter, r *http.Request) {
 	var req AdminGetUserRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -304,9 +284,7 @@ func (s *Service) AdminGetUser(w http.ResponseWriter, r *http.Request) {
 // AdminDeleteUser handles the AdminDeleteUser API.
 func (s *Service) AdminDeleteUser(w http.ResponseWriter, r *http.Request) {
 	var req AdminDeleteUserRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -322,9 +300,7 @@ func (s *Service) AdminDeleteUser(w http.ResponseWriter, r *http.Request) {
 // ListUsers handles the ListUsers API.
 func (s *Service) ListUsers(w http.ResponseWriter, r *http.Request) {
 	var req ListUsersRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -352,9 +328,7 @@ func (s *Service) ListUsers(w http.ResponseWriter, r *http.Request) {
 // SignUp handles the SignUp API.
 func (s *Service) SignUp(w http.ResponseWriter, r *http.Request) {
 	var req SignUpRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -386,9 +360,7 @@ func (s *Service) SignUp(w http.ResponseWriter, r *http.Request) {
 // ConfirmSignUp handles the ConfirmSignUp API.
 func (s *Service) ConfirmSignUp(w http.ResponseWriter, r *http.Request) {
 	var req ConfirmSignUpRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -404,9 +376,7 @@ func (s *Service) ConfirmSignUp(w http.ResponseWriter, r *http.Request) {
 // InitiateAuth handles the InitiateAuth API.
 func (s *Service) InitiateAuth(w http.ResponseWriter, r *http.Request) {
 	var req InitiateAuthRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -652,6 +622,18 @@ func writeError(w http.ResponseWriter, code, message string, status int) {
 	service.WriteJSONError(w, service.ContentTypeAmzJSON11, code, message, status)
 }
 
+// decodeCognitoRequest decodes the JSON request body into req, writing the
+// standard Cognito decode-failure error and returning false on failure.
+func decodeCognitoRequest(w http.ResponseWriter, r *http.Request, req any) bool {
+	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
 // handleError handles service errors.
 func handleError(w http.ResponseWriter, err error) {
 	var svcErr *ServiceError
@@ -682,9 +664,7 @@ func getErrorStatus(code string) int {
 // GetUserPoolMfaConfig handles the GetUserPoolMfaConfig API.
 func (s *Service) GetUserPoolMfaConfig(w http.ResponseWriter, r *http.Request) {
 	var req GetUserPoolMfaConfigRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 
@@ -718,9 +698,7 @@ func (s *Service) GetUserPoolMfaConfig(w http.ResponseWriter, r *http.Request) {
 // SetUserPoolMfaConfig handles the SetUserPoolMfaConfig API.
 func (s *Service) SetUserPoolMfaConfig(w http.ResponseWriter, r *http.Request) {
 	var req SetUserPoolMfaConfigRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeCognitoRequest(w, r, &req) {
 		return
 	}
 

--- a/internal/service/eventbridge/handlers.go
+++ b/internal/service/eventbridge/handlers.go
@@ -59,9 +59,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateEventBus handles the CreateEventBus API.
 func (s *Service) CreateEventBus(w http.ResponseWriter, r *http.Request) {
 	var req CreateEventBusRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -82,9 +80,7 @@ func (s *Service) CreateEventBus(w http.ResponseWriter, r *http.Request) {
 // DeleteEventBus handles the DeleteEventBus API.
 func (s *Service) DeleteEventBus(w http.ResponseWriter, r *http.Request) {
 	var req DeleteEventBusRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -100,9 +96,7 @@ func (s *Service) DeleteEventBus(w http.ResponseWriter, r *http.Request) {
 // DescribeEventBus handles the DescribeEventBus API.
 func (s *Service) DescribeEventBus(w http.ResponseWriter, r *http.Request) {
 	var req DescribeEventBusRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -125,9 +119,7 @@ func (s *Service) DescribeEventBus(w http.ResponseWriter, r *http.Request) {
 // ListEventBuses handles the ListEventBuses API.
 func (s *Service) ListEventBuses(w http.ResponseWriter, r *http.Request) {
 	var req ListEventBusesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -160,9 +152,7 @@ func (s *Service) ListEventBuses(w http.ResponseWriter, r *http.Request) {
 // PutRule handles the PutRule API.
 func (s *Service) PutRule(w http.ResponseWriter, r *http.Request) {
 	var req PutRuleRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -183,9 +173,7 @@ func (s *Service) PutRule(w http.ResponseWriter, r *http.Request) {
 // DeleteRule handles the DeleteRule API.
 func (s *Service) DeleteRule(w http.ResponseWriter, r *http.Request) {
 	var req DeleteRuleRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -201,9 +189,7 @@ func (s *Service) DeleteRule(w http.ResponseWriter, r *http.Request) {
 // DescribeRule handles the DescribeRule API.
 func (s *Service) DescribeRule(w http.ResponseWriter, r *http.Request) {
 	var req DescribeRuleRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -231,9 +217,7 @@ func (s *Service) DescribeRule(w http.ResponseWriter, r *http.Request) {
 // ListRules handles the ListRules API.
 func (s *Service) ListRules(w http.ResponseWriter, r *http.Request) {
 	var req ListRulesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -270,9 +254,7 @@ func (s *Service) ListRules(w http.ResponseWriter, r *http.Request) {
 // PutTargets handles the PutTargets API.
 func (s *Service) PutTargets(w http.ResponseWriter, r *http.Request) {
 	var req PutTargetsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -294,9 +276,7 @@ func (s *Service) PutTargets(w http.ResponseWriter, r *http.Request) {
 // RemoveTargets handles the RemoveTargets API.
 func (s *Service) RemoveTargets(w http.ResponseWriter, r *http.Request) {
 	var req RemoveTargetsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -318,9 +298,7 @@ func (s *Service) RemoveTargets(w http.ResponseWriter, r *http.Request) {
 // ListTargetsByRule handles the ListTargetsByRule API.
 func (s *Service) ListTargetsByRule(w http.ResponseWriter, r *http.Request) {
 	var req ListTargetsByRuleRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -362,9 +340,7 @@ func (s *Service) ListTargetsByRule(w http.ResponseWriter, r *http.Request) {
 // PutEvents handles the PutEvents API.
 func (s *Service) PutEvents(w http.ResponseWriter, r *http.Request) {
 	var req PutEventsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -394,9 +370,7 @@ func (s *Service) PutEvents(w http.ResponseWriter, r *http.Request) {
 // CreateConnection handles the CreateConnection API.
 func (s *Service) CreateConnection(w http.ResponseWriter, r *http.Request) {
 	var req CreateConnectionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -418,9 +392,7 @@ func (s *Service) CreateConnection(w http.ResponseWriter, r *http.Request) {
 // DescribeConnection handles the DescribeConnection API.
 func (s *Service) DescribeConnection(w http.ResponseWriter, r *http.Request) {
 	var req DescribeConnectionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -445,9 +417,7 @@ func (s *Service) DescribeConnection(w http.ResponseWriter, r *http.Request) {
 // DeleteConnection handles the DeleteConnection API.
 func (s *Service) DeleteConnection(w http.ResponseWriter, r *http.Request) {
 	var req DeleteConnectionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -467,9 +437,7 @@ func (s *Service) DeleteConnection(w http.ResponseWriter, r *http.Request) {
 // CreateAPIDestination handles the CreateApiDestination API.
 func (s *Service) CreateAPIDestination(w http.ResponseWriter, r *http.Request) {
 	var req CreateAPIDestinationRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -491,9 +459,7 @@ func (s *Service) CreateAPIDestination(w http.ResponseWriter, r *http.Request) {
 // DescribeAPIDestination handles the DescribeApiDestination API.
 func (s *Service) DescribeAPIDestination(w http.ResponseWriter, r *http.Request) {
 	var req DescribeAPIDestinationRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -520,9 +486,7 @@ func (s *Service) DescribeAPIDestination(w http.ResponseWriter, r *http.Request)
 // DeleteAPIDestination handles the DeleteApiDestination API.
 func (s *Service) DeleteAPIDestination(w http.ResponseWriter, r *http.Request) {
 	var req DeleteAPIDestinationRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -538,9 +502,7 @@ func (s *Service) DeleteAPIDestination(w http.ResponseWriter, r *http.Request) {
 // ListTagsForResource handles the ListTagsForResource API.
 func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 	var req ListTagsForResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -557,9 +519,7 @@ func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 // TagResource handles the TagResource API.
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -575,9 +535,7 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 // UntagResource handles the UntagResource API.
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeEventBridgeRequest(w, r, &req) {
 		return
 	}
 
@@ -611,6 +569,18 @@ func writeResponse(w http.ResponseWriter, resp any) {
 // writeError writes an error response.
 func writeError(w http.ResponseWriter, code, message string, status int) {
 	service.WriteJSONError(w, service.ContentTypeAmzJSON11, code, message, status)
+}
+
+// decodeEventBridgeRequest decodes the JSON request body into req, writing the
+// standard EventBridge decode-failure error and returning false on failure.
+func decodeEventBridgeRequest(w http.ResponseWriter, r *http.Request, req any) bool {
+	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
 }
 
 // handleError handles service errors.

--- a/internal/service/forecast/handlers.go
+++ b/internal/service/forecast/handlers.go
@@ -57,9 +57,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateDataset handles the CreateDataset action.
 func (s *Service) CreateDataset(w http.ResponseWriter, r *http.Request) {
 	var input CreateDatasetInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -76,9 +74,7 @@ func (s *Service) CreateDataset(w http.ResponseWriter, r *http.Request) {
 // DescribeDataset handles the DescribeDataset action.
 func (s *Service) DescribeDataset(w http.ResponseWriter, r *http.Request) {
 	var input DescribeDatasetInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -106,9 +102,7 @@ func (s *Service) DescribeDataset(w http.ResponseWriter, r *http.Request) {
 // ListDatasets handles the ListDatasets action.
 func (s *Service) ListDatasets(w http.ResponseWriter, r *http.Request) {
 	var input ListDatasetsInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -125,9 +119,7 @@ func (s *Service) ListDatasets(w http.ResponseWriter, r *http.Request) {
 // DeleteDataset handles the DeleteDataset action.
 func (s *Service) DeleteDataset(w http.ResponseWriter, r *http.Request) {
 	var input DeleteDatasetInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -145,9 +137,7 @@ func (s *Service) DeleteDataset(w http.ResponseWriter, r *http.Request) {
 // CreateDatasetGroup handles the CreateDatasetGroup action.
 func (s *Service) CreateDatasetGroup(w http.ResponseWriter, r *http.Request) {
 	var input CreateDatasetGroupInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -164,9 +154,7 @@ func (s *Service) CreateDatasetGroup(w http.ResponseWriter, r *http.Request) {
 // DescribeDatasetGroup handles the DescribeDatasetGroup action.
 func (s *Service) DescribeDatasetGroup(w http.ResponseWriter, r *http.Request) {
 	var input DescribeDatasetGroupInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -191,9 +179,7 @@ func (s *Service) DescribeDatasetGroup(w http.ResponseWriter, r *http.Request) {
 // ListDatasetGroups handles the ListDatasetGroups action.
 func (s *Service) ListDatasetGroups(w http.ResponseWriter, r *http.Request) {
 	var input ListDatasetGroupsInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -210,9 +196,7 @@ func (s *Service) ListDatasetGroups(w http.ResponseWriter, r *http.Request) {
 // DeleteDatasetGroup handles the DeleteDatasetGroup action.
 func (s *Service) DeleteDatasetGroup(w http.ResponseWriter, r *http.Request) {
 	var input DeleteDatasetGroupInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -228,9 +212,7 @@ func (s *Service) DeleteDatasetGroup(w http.ResponseWriter, r *http.Request) {
 // UpdateDatasetGroup handles the UpdateDatasetGroup action.
 func (s *Service) UpdateDatasetGroup(w http.ResponseWriter, r *http.Request) {
 	var input UpdateDatasetGroupInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -248,9 +230,7 @@ func (s *Service) UpdateDatasetGroup(w http.ResponseWriter, r *http.Request) {
 // CreatePredictor handles the CreatePredictor action.
 func (s *Service) CreatePredictor(w http.ResponseWriter, r *http.Request) {
 	var input CreatePredictorInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -267,9 +247,7 @@ func (s *Service) CreatePredictor(w http.ResponseWriter, r *http.Request) {
 // DescribePredictor handles the DescribePredictor action.
 func (s *Service) DescribePredictor(w http.ResponseWriter, r *http.Request) {
 	var input DescribePredictorInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -298,9 +276,7 @@ func (s *Service) DescribePredictor(w http.ResponseWriter, r *http.Request) {
 // ListPredictors handles the ListPredictors action.
 func (s *Service) ListPredictors(w http.ResponseWriter, r *http.Request) {
 	var input ListPredictorsInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -317,9 +293,7 @@ func (s *Service) ListPredictors(w http.ResponseWriter, r *http.Request) {
 // DeletePredictor handles the DeletePredictor action.
 func (s *Service) DeletePredictor(w http.ResponseWriter, r *http.Request) {
 	var input DeletePredictorInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -337,9 +311,7 @@ func (s *Service) DeletePredictor(w http.ResponseWriter, r *http.Request) {
 // CreateForecast handles the CreateForecast action.
 func (s *Service) CreateForecast(w http.ResponseWriter, r *http.Request) {
 	var input CreateForecastInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -356,9 +328,7 @@ func (s *Service) CreateForecast(w http.ResponseWriter, r *http.Request) {
 // DescribeForecast handles the DescribeForecast action.
 func (s *Service) DescribeForecast(w http.ResponseWriter, r *http.Request) {
 	var input DescribeForecastInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -386,9 +356,7 @@ func (s *Service) DescribeForecast(w http.ResponseWriter, r *http.Request) {
 // ListForecasts handles the ListForecasts action.
 func (s *Service) ListForecasts(w http.ResponseWriter, r *http.Request) {
 	var input ListForecastsInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -405,9 +373,7 @@ func (s *Service) ListForecasts(w http.ResponseWriter, r *http.Request) {
 // DeleteForecast handles the DeleteForecast action.
 func (s *Service) DeleteForecast(w http.ResponseWriter, r *http.Request) {
 	var input DeleteForecastInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
-
+	if !decodeForecastRequest(w, r, &input) {
 		return
 	}
 
@@ -443,6 +409,18 @@ func writeError(w http.ResponseWriter, code, message string, statusCode int) {
 	if err := json.NewEncoder(w).Encode(errResp); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+// decodeForecastRequest decodes the JSON request body into input, writing
+// the standard Forecast decode-failure error and returning false on failure.
+func decodeForecastRequest(w http.ResponseWriter, r *http.Request, input any) bool {
+	if err := json.NewDecoder(r.Body).Decode(input); err != nil {
+		writeError(w, errInvalidInputException, "Invalid request body", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
 }
 
 func handleError(w http.ResponseWriter, err error) {

--- a/internal/service/kms/handlers.go
+++ b/internal/service/kms/handlers.go
@@ -65,9 +65,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateKey handles the CreateKey API.
 func (s *Service) CreateKey(w http.ResponseWriter, r *http.Request) {
 	var req CreateKeyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -88,9 +86,7 @@ func (s *Service) CreateKey(w http.ResponseWriter, r *http.Request) {
 // DescribeKey handles the DescribeKey API.
 func (s *Service) DescribeKey(w http.ResponseWriter, r *http.Request) {
 	var req DescribeKeyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -111,9 +107,7 @@ func (s *Service) DescribeKey(w http.ResponseWriter, r *http.Request) {
 // ListKeys handles the ListKeys API.
 func (s *Service) ListKeys(w http.ResponseWriter, r *http.Request) {
 	var req ListKeysRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -144,9 +138,7 @@ func (s *Service) ListKeys(w http.ResponseWriter, r *http.Request) {
 // EnableKey handles the EnableKey API.
 func (s *Service) EnableKey(w http.ResponseWriter, r *http.Request) {
 	var req EnableKeyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -162,9 +154,7 @@ func (s *Service) EnableKey(w http.ResponseWriter, r *http.Request) {
 // DisableKey handles the DisableKey API.
 func (s *Service) DisableKey(w http.ResponseWriter, r *http.Request) {
 	var req DisableKeyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -180,9 +170,7 @@ func (s *Service) DisableKey(w http.ResponseWriter, r *http.Request) {
 // ScheduleKeyDeletion handles the ScheduleKeyDeletion API.
 func (s *Service) ScheduleKeyDeletion(w http.ResponseWriter, r *http.Request) {
 	var req ScheduleKeyDeletionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -206,9 +194,7 @@ func (s *Service) ScheduleKeyDeletion(w http.ResponseWriter, r *http.Request) {
 // Encrypt handles the Encrypt API.
 func (s *Service) Encrypt(w http.ResponseWriter, r *http.Request) {
 	var req EncryptRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -238,9 +224,7 @@ func (s *Service) Encrypt(w http.ResponseWriter, r *http.Request) {
 // Decrypt handles the Decrypt API.
 func (s *Service) Decrypt(w http.ResponseWriter, r *http.Request) {
 	var req DecryptRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -270,9 +254,7 @@ func (s *Service) Decrypt(w http.ResponseWriter, r *http.Request) {
 // GenerateDataKey handles the GenerateDataKey API.
 func (s *Service) GenerateDataKey(w http.ResponseWriter, r *http.Request) {
 	var req GenerateDataKeyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -302,9 +284,7 @@ func (s *Service) GenerateDataKey(w http.ResponseWriter, r *http.Request) {
 // Sign handles the Sign API.
 func (s *Service) Sign(w http.ResponseWriter, r *http.Request) {
 	var req SignRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -330,9 +310,7 @@ func (s *Service) Sign(w http.ResponseWriter, r *http.Request) {
 // Verify handles the Verify API.
 func (s *Service) Verify(w http.ResponseWriter, r *http.Request) {
 	var req VerifyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -365,9 +343,7 @@ func (s *Service) Verify(w http.ResponseWriter, r *http.Request) {
 // GetPublicKey handles the GetPublicKey API.
 func (s *Service) GetPublicKey(w http.ResponseWriter, r *http.Request) {
 	var req GetPublicKeyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -398,9 +374,7 @@ func (s *Service) GetPublicKey(w http.ResponseWriter, r *http.Request) {
 // CreateAlias handles the CreateAlias API.
 func (s *Service) CreateAlias(w http.ResponseWriter, r *http.Request) {
 	var req CreateAliasRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -416,9 +390,7 @@ func (s *Service) CreateAlias(w http.ResponseWriter, r *http.Request) {
 // DeleteAlias handles the DeleteAlias API.
 func (s *Service) DeleteAlias(w http.ResponseWriter, r *http.Request) {
 	var req DeleteAliasRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -434,9 +406,7 @@ func (s *Service) DeleteAlias(w http.ResponseWriter, r *http.Request) {
 // ListAliases handles the ListAliases API.
 func (s *Service) ListAliases(w http.ResponseWriter, r *http.Request) {
 	var req ListAliasesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeKMSRequest(w, r, &req) {
 		return
 	}
 
@@ -515,6 +485,30 @@ func writeKMSError(w http.ResponseWriter, code, message string, status int) {
 	service.WriteJSONError(w, service.ContentTypeAmzJSON11, code, message, status)
 }
 
+// decodeKMSRequest decodes the JSON request body into req, writing the
+// standard KMS decode-failure error and returning false on failure.
+func decodeKMSRequest(w http.ResponseWriter, r *http.Request, req any) bool {
+	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
+		writeKMSError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
+// requireKMSKeyID writes the standard KMS "KeyId is required" error and
+// returns false if decodeErr is non-nil or keyID is empty.
+func requireKMSKeyID(w http.ResponseWriter, decodeErr error, keyID string) bool {
+	if decodeErr != nil || keyID == "" {
+		writeKMSError(w, "ValidationException", "KeyId is required", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
 // handleKMSError handles KMS errors.
 func handleKMSError(w http.ResponseWriter, err error) {
 	var svcErr *ServiceError
@@ -543,9 +537,9 @@ func getErrorStatus(code string) int {
 // GetKeyPolicy handles the GetKeyPolicy API.
 func (s *Service) GetKeyPolicy(w http.ResponseWriter, r *http.Request) {
 	var req GetKeyPolicyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.KeyID == "" {
-		writeKMSError(w, "ValidationException", "KeyId is required", http.StatusBadRequest)
+	err := json.NewDecoder(r.Body).Decode(&req)
 
+	if !requireKMSKeyID(w, err, req.KeyID) {
 		return
 	}
 
@@ -565,9 +559,9 @@ func (s *Service) GetKeyPolicy(w http.ResponseWriter, r *http.Request) {
 // PutKeyPolicy handles the PutKeyPolicy API.
 func (s *Service) PutKeyPolicy(w http.ResponseWriter, r *http.Request) {
 	var req PutKeyPolicyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.KeyID == "" {
-		writeKMSError(w, "ValidationException", "KeyId is required", http.StatusBadRequest)
+	err := json.NewDecoder(r.Body).Decode(&req)
 
+	if !requireKMSKeyID(w, err, req.KeyID) {
 		return
 	}
 
@@ -584,9 +578,9 @@ func (s *Service) PutKeyPolicy(w http.ResponseWriter, r *http.Request) {
 // AWS always returns a single policy named "default".
 func (s *Service) ListKeyPolicies(w http.ResponseWriter, r *http.Request) {
 	var req ListKeyPoliciesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.KeyID == "" {
-		writeKMSError(w, "ValidationException", "KeyId is required", http.StatusBadRequest)
+	err := json.NewDecoder(r.Body).Decode(&req)
 
+	if !requireKMSKeyID(w, err, req.KeyID) {
 		return
 	}
 
@@ -605,9 +599,9 @@ func (s *Service) ListKeyPolicies(w http.ResponseWriter, r *http.Request) {
 // ListResourceTags handles the ListResourceTags API.
 func (s *Service) ListResourceTags(w http.ResponseWriter, r *http.Request) {
 	var req ListResourceTagsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.KeyID == "" {
-		writeKMSError(w, "ValidationException", "KeyId is required", http.StatusBadRequest)
+	err := json.NewDecoder(r.Body).Decode(&req)
 
+	if !requireKMSKeyID(w, err, req.KeyID) {
 		return
 	}
 
@@ -627,9 +621,9 @@ func (s *Service) ListResourceTags(w http.ResponseWriter, r *http.Request) {
 // TagResource handles the TagResource API.
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.KeyID == "" {
-		writeKMSError(w, "ValidationException", "KeyId is required", http.StatusBadRequest)
+	err := json.NewDecoder(r.Body).Decode(&req)
 
+	if !requireKMSKeyID(w, err, req.KeyID) {
 		return
 	}
 
@@ -645,9 +639,9 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 // UntagResource handles the UntagResource API.
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.KeyID == "" {
-		writeKMSError(w, "ValidationException", "KeyId is required", http.StatusBadRequest)
+	err := json.NewDecoder(r.Body).Decode(&req)
 
+	if !requireKMSKeyID(w, err, req.KeyID) {
 		return
 	}
 
@@ -663,9 +657,9 @@ func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 // GetKeyRotationStatus handles the GetKeyRotationStatus API.
 func (s *Service) GetKeyRotationStatus(w http.ResponseWriter, r *http.Request) {
 	var req GetKeyRotationStatusRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.KeyID == "" {
-		writeKMSError(w, "ValidationException", "KeyId is required", http.StatusBadRequest)
+	err := json.NewDecoder(r.Body).Decode(&req)
 
+	if !requireKMSKeyID(w, err, req.KeyID) {
 		return
 	}
 

--- a/internal/service/resiliencehub/handlers.go
+++ b/internal/service/resiliencehub/handlers.go
@@ -9,21 +9,11 @@ import (
 // CreateApp handles the CreateApp API.
 func (s *Service) CreateApp(w http.ResponseWriter, r *http.Request) {
 	var req CreateAppRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.Name == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Name is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.Name, "Name") {
 		return
 	}
 
@@ -40,21 +30,11 @@ func (s *Service) CreateApp(w http.ResponseWriter, r *http.Request) {
 // DescribeApp handles the DescribeApp API.
 func (s *Service) DescribeApp(w http.ResponseWriter, r *http.Request) {
 	var req DescribeAppRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.AppARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "appArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.AppARN, "appArn") {
 		return
 	}
 
@@ -71,21 +51,11 @@ func (s *Service) DescribeApp(w http.ResponseWriter, r *http.Request) {
 // UpdateApp handles the UpdateApp API.
 func (s *Service) UpdateApp(w http.ResponseWriter, r *http.Request) {
 	var req UpdateAppRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.AppARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "appArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.AppARN, "appArn") {
 		return
 	}
 
@@ -102,21 +72,11 @@ func (s *Service) UpdateApp(w http.ResponseWriter, r *http.Request) {
 // DeleteApp handles the DeleteApp API.
 func (s *Service) DeleteApp(w http.ResponseWriter, r *http.Request) {
 	var req DeleteAppRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.AppARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "appArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.AppARN, "appArn") {
 		return
 	}
 
@@ -153,30 +113,15 @@ func (s *Service) ListApps(w http.ResponseWriter, r *http.Request) {
 // CreateResiliencyPolicy handles the CreateResiliencyPolicy API.
 func (s *Service) CreateResiliencyPolicy(w http.ResponseWriter, r *http.Request) {
 	var req CreateResiliencyPolicyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.PolicyName == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "policyName is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.PolicyName, "policyName") {
 		return
 	}
 
-	if req.Tier == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "tier is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.Tier, "tier") {
 		return
 	}
 
@@ -193,21 +138,11 @@ func (s *Service) CreateResiliencyPolicy(w http.ResponseWriter, r *http.Request)
 // DescribeResiliencyPolicy handles the DescribeResiliencyPolicy API.
 func (s *Service) DescribeResiliencyPolicy(w http.ResponseWriter, r *http.Request) {
 	var req DescribeResiliencyPolicyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.PolicyARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "policyArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.PolicyARN, "policyArn") {
 		return
 	}
 
@@ -224,21 +159,11 @@ func (s *Service) DescribeResiliencyPolicy(w http.ResponseWriter, r *http.Reques
 // UpdateResiliencyPolicy handles the UpdateResiliencyPolicy API.
 func (s *Service) UpdateResiliencyPolicy(w http.ResponseWriter, r *http.Request) {
 	var req UpdateResiliencyPolicyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.PolicyARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "policyArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.PolicyARN, "policyArn") {
 		return
 	}
 
@@ -255,21 +180,11 @@ func (s *Service) UpdateResiliencyPolicy(w http.ResponseWriter, r *http.Request)
 // DeleteResiliencyPolicy handles the DeleteResiliencyPolicy API.
 func (s *Service) DeleteResiliencyPolicy(w http.ResponseWriter, r *http.Request) {
 	var req DeleteResiliencyPolicyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.PolicyARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "policyArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.PolicyARN, "policyArn") {
 		return
 	}
 
@@ -306,39 +221,19 @@ func (s *Service) ListResiliencyPolicies(w http.ResponseWriter, r *http.Request)
 // StartAppAssessment handles the StartAppAssessment API.
 func (s *Service) StartAppAssessment(w http.ResponseWriter, r *http.Request) {
 	var req StartAppAssessmentRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.AppARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "appArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.AppARN, "appArn") {
 		return
 	}
 
-	if req.AppVersion == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "appVersion is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.AppVersion, "appVersion") {
 		return
 	}
 
-	if req.AssessmentName == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "assessmentName is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.AssessmentName, "assessmentName") {
 		return
 	}
 
@@ -355,21 +250,11 @@ func (s *Service) StartAppAssessment(w http.ResponseWriter, r *http.Request) {
 // DescribeAppAssessment handles the DescribeAppAssessment API.
 func (s *Service) DescribeAppAssessment(w http.ResponseWriter, r *http.Request) {
 	var req DescribeAppAssessmentRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.AssessmentARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "assessmentArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.AssessmentARN, "assessmentArn") {
 		return
 	}
 
@@ -386,21 +271,11 @@ func (s *Service) DescribeAppAssessment(w http.ResponseWriter, r *http.Request) 
 // DeleteAppAssessment handles the DeleteAppAssessment API.
 func (s *Service) DeleteAppAssessment(w http.ResponseWriter, r *http.Request) {
 	var req DeleteAppAssessmentRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.AssessmentARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "assessmentArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.AssessmentARN, "assessmentArn") {
 		return
 	}
 
@@ -440,21 +315,11 @@ func (s *Service) ListAppAssessments(w http.ResponseWriter, r *http.Request) {
 // TagResource handles the TagResource API.
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.ResourceARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "resourceArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.ResourceARN, "resourceArn") {
 		return
 	}
 
@@ -470,21 +335,11 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 // UntagResource handles the UntagResource API.
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.ResourceARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "resourceArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.ResourceARN, "resourceArn") {
 		return
 	}
 
@@ -500,21 +355,11 @@ func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 // ListTagsForResource handles the ListTagsForResource API.
 func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 	var req ListTagsForResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "Invalid request body",
-		})
-
+	if !decodeResilienceHubRequest(w, r, &req) {
 		return
 	}
 
-	if req.ResourceARN == "" {
-		writeError(w, http.StatusBadRequest, &Error{
-			Code:    "ValidationException",
-			Message: "resourceArn is required",
-		})
-
+	if !requireResilienceHubParameter(w, req.ResourceARN, "resourceArn") {
 		return
 	}
 
@@ -526,6 +371,37 @@ func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, &ListTagsForResourceResponse{Tags: tags})
+}
+
+// decodeResilienceHubRequest decodes the JSON request body into req, writing
+// the standard ResilienceHub decode-failure error and returning false on
+// failure.
+func decodeResilienceHubRequest(w http.ResponseWriter, r *http.Request, req any) bool {
+	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
+		writeError(w, http.StatusBadRequest, &Error{
+			Code:    "ValidationException",
+			Message: "Invalid request body",
+		})
+
+		return false
+	}
+
+	return true
+}
+
+// requireResilienceHubParameter writes the standard ResilienceHub
+// ValidationException error and returns false if value is empty.
+func requireResilienceHubParameter(w http.ResponseWriter, value, name string) bool {
+	if value == "" {
+		writeError(w, http.StatusBadRequest, &Error{
+			Code:    "ValidationException",
+			Message: name + " is required",
+		})
+
+		return false
+	}
+
+	return true
 }
 
 // writeJSON writes a JSON response.

--- a/internal/service/sfn/handlers.go
+++ b/internal/service/sfn/handlers.go
@@ -65,9 +65,7 @@ func (s *Service) DispatchAction(w http.ResponseWriter, r *http.Request) {
 // CreateStateMachine handles the CreateStateMachine API.
 func (s *Service) CreateStateMachine(w http.ResponseWriter, r *http.Request) {
 	var req CreateStateMachineRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -89,9 +87,7 @@ func (s *Service) CreateStateMachine(w http.ResponseWriter, r *http.Request) {
 // DeleteStateMachine handles the DeleteStateMachine API.
 func (s *Service) DeleteStateMachine(w http.ResponseWriter, r *http.Request) {
 	var req DeleteStateMachineRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -107,9 +103,7 @@ func (s *Service) DeleteStateMachine(w http.ResponseWriter, r *http.Request) {
 // DescribeStateMachine handles the DescribeStateMachine API.
 func (s *Service) DescribeStateMachine(w http.ResponseWriter, r *http.Request) {
 	var req DescribeStateMachineRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -141,9 +135,7 @@ func (s *Service) DescribeStateMachine(w http.ResponseWriter, r *http.Request) {
 // ListStateMachines handles the ListStateMachines API.
 func (s *Service) ListStateMachines(w http.ResponseWriter, r *http.Request) {
 	var req ListStateMachinesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -175,9 +167,7 @@ func (s *Service) ListStateMachines(w http.ResponseWriter, r *http.Request) {
 // StartExecution handles the StartExecution API.
 func (s *Service) StartExecution(w http.ResponseWriter, r *http.Request) {
 	var req StartExecutionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -199,9 +189,7 @@ func (s *Service) StartExecution(w http.ResponseWriter, r *http.Request) {
 // StopExecution handles the StopExecution API.
 func (s *Service) StopExecution(w http.ResponseWriter, r *http.Request) {
 	var req StopExecutionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -227,9 +215,7 @@ func (s *Service) StopExecution(w http.ResponseWriter, r *http.Request) {
 // DescribeExecution handles the DescribeExecution API.
 func (s *Service) DescribeExecution(w http.ResponseWriter, r *http.Request) {
 	var req DescribeExecutionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -271,9 +257,7 @@ func (s *Service) DescribeExecution(w http.ResponseWriter, r *http.Request) {
 // ListExecutions handles the ListExecutions API.
 func (s *Service) ListExecutions(w http.ResponseWriter, r *http.Request) {
 	var req ListExecutionsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -318,9 +302,7 @@ func (s *Service) ListExecutions(w http.ResponseWriter, r *http.Request) {
 // GetExecutionHistory handles the GetExecutionHistory API.
 func (s *Service) GetExecutionHistory(w http.ResponseWriter, r *http.Request) {
 	var req GetExecutionHistoryRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -357,9 +339,7 @@ func (s *Service) GetExecutionHistory(w http.ResponseWriter, r *http.Request) {
 // DescribeMapRun handles the DescribeMapRun API.
 func (s *Service) DescribeMapRun(w http.ResponseWriter, r *http.Request) {
 	var req DescribeMapRunRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -409,9 +389,7 @@ func mapRunToDescribeResponse(mr *MapRun) *DescribeMapRunResponse {
 // ListMapRuns handles the ListMapRuns API.
 func (s *Service) ListMapRuns(w http.ResponseWriter, r *http.Request) {
 	var req ListMapRunsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -455,6 +433,18 @@ func writeError(w http.ResponseWriter, code, message string, status int) {
 	service.WriteJSONError(w, service.ContentTypeAmzJSON10, code, message, status)
 }
 
+// decodeSFNRequest decodes the JSON request body into req, writing the
+// standard SFN decode-failure error and returning false on failure.
+func decodeSFNRequest(w http.ResponseWriter, r *http.Request, req any) bool {
+	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
+		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
+
+		return false
+	}
+
+	return true
+}
+
 // handleError handles service errors.
 func handleError(w http.ResponseWriter, err error) {
 	var svcErr *ServiceError
@@ -485,9 +475,7 @@ func getErrorStatus(code string) int {
 // SendTaskSuccess handles the SendTaskSuccess API.
 func (s *Service) SendTaskSuccess(w http.ResponseWriter, r *http.Request) {
 	var req SendTaskSuccessRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -503,9 +491,7 @@ func (s *Service) SendTaskSuccess(w http.ResponseWriter, r *http.Request) {
 // SendTaskFailure handles the SendTaskFailure API.
 func (s *Service) SendTaskFailure(w http.ResponseWriter, r *http.Request) {
 	var req SendTaskFailureRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -521,9 +507,7 @@ func (s *Service) SendTaskFailure(w http.ResponseWriter, r *http.Request) {
 // SendTaskHeartbeat handles the SendTaskHeartbeat API.
 func (s *Service) SendTaskHeartbeat(w http.ResponseWriter, r *http.Request) {
 	var req SendTaskHeartbeatRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -539,9 +523,7 @@ func (s *Service) SendTaskHeartbeat(w http.ResponseWriter, r *http.Request) {
 // CreateActivity handles the CreateActivity API.
 func (s *Service) CreateActivity(w http.ResponseWriter, r *http.Request) {
 	var req CreateActivityRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -561,9 +543,7 @@ func (s *Service) CreateActivity(w http.ResponseWriter, r *http.Request) {
 // DescribeActivity handles the DescribeActivity API.
 func (s *Service) DescribeActivity(w http.ResponseWriter, r *http.Request) {
 	var req DescribeActivityRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -584,9 +564,7 @@ func (s *Service) DescribeActivity(w http.ResponseWriter, r *http.Request) {
 // ListActivities handles the ListActivities API.
 func (s *Service) ListActivities(w http.ResponseWriter, r *http.Request) {
 	var req ListActivitiesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -615,9 +593,7 @@ func (s *Service) ListActivities(w http.ResponseWriter, r *http.Request) {
 // DeleteActivity handles the DeleteActivity API.
 func (s *Service) DeleteActivity(w http.ResponseWriter, r *http.Request) {
 	var req DeleteActivityRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -635,9 +611,7 @@ func (s *Service) DeleteActivity(w http.ResponseWriter, r *http.Request) {
 // only written once a task arrives or the poll window elapses.
 func (s *Service) GetActivityTask(w http.ResponseWriter, r *http.Request) {
 	var req GetActivityTaskRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -660,9 +634,7 @@ func (s *Service) GetActivityTask(w http.ResponseWriter, r *http.Request) {
 // plan` fails with InvalidAction.
 func (s *Service) ValidateStateMachineDefinition(w http.ResponseWriter, r *http.Request) {
 	var req ValidateStateMachineDefinitionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -681,9 +653,7 @@ func (s *Service) ValidateStateMachineDefinition(w http.ResponseWriter, r *http.
 // ListTagsForResource returns tags for a state machine.
 func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 	var req ListTagsForResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -700,9 +670,7 @@ func (s *Service) ListTagsForResource(w http.ResponseWriter, r *http.Request) {
 // TagResource adds tags to a state machine.
 func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 	var req TagResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -718,9 +686,7 @@ func (s *Service) TagResource(w http.ResponseWriter, r *http.Request) {
 // UntagResource removes tags from a state machine.
 func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 	var req UntagResourceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -738,9 +704,7 @@ func (s *Service) UntagResource(w http.ResponseWriter, r *http.Request) {
 // refresh and requires the field present even when empty.
 func (s *Service) ListStateMachineVersions(w http.ResponseWriter, r *http.Request) {
 	var req ListStateMachineVersionsRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 
@@ -760,9 +724,7 @@ func (s *Service) ListStateMachineVersions(w http.ResponseWriter, r *http.Reques
 // ListStateMachineAliases lists aliases for a state machine.
 func (s *Service) ListStateMachineAliases(w http.ResponseWriter, r *http.Request) {
 	var req ListStateMachineAliasesRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, "ValidationException", "Invalid request body", http.StatusBadRequest)
-
+	if !decodeSFNRequest(w, r, &req) {
 		return
 	}
 


### PR DESCRIPTION
## Summary
Extends the decode/required-field helper pattern from #892 to the next six densest packages: sfn, kms, eventbridge, resiliencehub, forecast, cognito. 143 call sites are converted; three resiliencehub list handlers with a bespoke empty-body fallback are deliberately left alone. KMS's combined decode-or-missing-KeyId idiom keeps its exact original message via a dedicated helper rather than being folded into the generic decode path.

## Test plan
- [x] `make lint` 0 issues (pre-commit hook), `go test -race -shuffle=on ./...` green, no golden changes