### PR TITLE
test(cli): add an end-to-end golden harness for generated CLI commands

### DIFF
--- a/test/integration/cli_helper_test.go
+++ b/test/integration/cli_helper_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// kumoCLIBinRelPath is where the repo Makefile's build target writes the
+// kumo CLI binary (`make build` -> bin/kumo), relative to this package.
+const kumoCLIBinRelPath = "../../bin/kumo"
+
+// resolveKumoCLIBin returns the path to the kumo CLI binary these tests
+// drive. KUMO_CLI_BIN (a bare name resolved via PATH, or an absolute path)
+// takes precedence; otherwise it looks for the binary at kumoCLIBinRelPath.
+// Tests are skipped, not failed, if neither resolves, mirroring
+// terraform/runner_test.go's resolveTFBinary.
+func resolveKumoCLIBin(t *testing.T) string {
+	t.Helper()
+
+	if override := os.Getenv("KUMO_CLI_BIN"); override != "" {
+		if filepath.IsAbs(override) {
+			return override
+		}
+
+		p, err := exec.LookPath(override)
+		if err != nil {
+			t.Fatalf("KUMO_CLI_BIN=%q not found on PATH: %v", override, err)
+		}
+
+		return p
+	}
+
+	abs, err := filepath.Abs(kumoCLIBinRelPath)
+	if err != nil {
+		t.Fatalf("resolve absolute path for %s: %v", kumoCLIBinRelPath, err)
+	}
+
+	if _, err := os.Stat(abs); err != nil {
+		t.Skipf("kumo CLI binary not found at %s; run `make build` or set KUMO_CLI_BIN", abs)
+	}
+
+	return abs
+}
+
+// runCLI runs the kumo CLI binary with args against testEndpoint() and
+// returns stdout. It fails the test, including stderr, on a non-zero exit.
+//
+// Every invocation execs the built binary as a subprocess rather than
+// calling into the cli package in-process: the generated commands
+// (cli/gen_*.go) read package-level globals such as endpointURL and region,
+// which makes concurrent in-process invocation racy across tests.
+func runCLI(t *testing.T, args ...string) []byte {
+	t.Helper()
+
+	stdout, stderr, err := execCLI(t, args...)
+	if err != nil {
+		t.Fatalf("kumo %s: %v\nstderr:\n%s", strings.Join(args, " "), err, stderr)
+	}
+
+	return stdout
+}
+
+// runCLIExpectError runs the kumo CLI binary with args against
+// testEndpoint() and returns stdout, stderr, and the exec error without
+// failing the test, for asserting on CLI failure paths.
+func runCLIExpectError(t *testing.T, args ...string) (stdout, stderr []byte, err error) {
+	t.Helper()
+
+	return execCLI(t, args...)
+}
+
+func execCLI(t *testing.T, args ...string) (stdout, stderr []byte, err error) {
+	t.Helper()
+
+	bin := resolveKumoCLIBin(t)
+
+	fullArgs := make([]string, 0, len(args)+2)
+	fullArgs = append(fullArgs, args...)
+	fullArgs = append(fullArgs, "--endpoint-url", testEndpoint())
+
+	cmd := exec.CommandContext(t.Context(), bin, fullArgs...)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err = cmd.Run()
+
+	return stdoutBuf.Bytes(), stderrBuf.Bytes(), err
+}
+
+// decodeCLIJSON unmarshals a kumo CLI JSON stdout payload into a generic
+// map so a test can pull values (QueueUrl, KeyId, ...) out to chain into
+// the next CLI invocation.
+//
+// Golden assertions in this file pass the raw stdout []byte to
+// golden.Assert instead of a decoded value: golden.Golden.Assert only
+// strips WithIgnoreFields keys at write time for a map[string]interface{}
+// or []interface{} value (see golden.Golden.formatValue /
+// filterIgnoredFields); a struct pointer - which is what every SDK-based
+// _test.go in this package passes - falls through unfiltered, same as raw
+// []byte. Passing raw bytes here keeps the CLI goldens' file format
+// consistent with the rest of the package: ignored fields still appear in
+// the committed file with a point-in-time value, and are still correctly
+// excluded from the pass/fail comparison itself, which golden's comparator
+// applies independently at compare time regardless of how the file was
+// written.
+func decodeCLIJSON(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+
+	var v map[string]any
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("decode CLI JSON output: %v\noutput:\n%s", err, data)
+	}
+
+	return v
+}

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -1,0 +1,234 @@
+//go:build integration
+
+// End-to-end goldens for the generated kumo CLI (cli/gen_*.go, see
+// cmd/cli-gen). These drive the actual kumo binary as a subprocess and
+// exercise a representative create + data-plane read/write per migrated
+// service, in addition to the direct SDK coverage in the other _test.go
+// files in this package.
+package integration
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/sivchari/golden"
+)
+
+func TestCLI_SQS_QueueLifecycle(t *testing.T) {
+	queueName := "test-cli-sqs-queue"
+
+	createOut := runCLI(t, "sqs", "create-queue", "--queue-name", queueName)
+	created := decodeCLIJSON(t, createOut)
+	golden.New(t, golden.WithIgnoreFields("QueueUrl", "ResultMetadata")).Assert(t.Name()+"_create", createOut)
+
+	queueURL, _ := created["QueueUrl"].(string)
+	if queueURL == "" {
+		t.Fatalf("create-queue: no QueueUrl in output: %s", createOut)
+	}
+
+	client := newSQSClient(t)
+	t.Cleanup(func() {
+		_, _ = client.DeleteQueue(context.Background(), &sqs.DeleteQueueInput{
+			QueueUrl: aws.String(queueURL),
+		})
+	})
+
+	sendOut := runCLI(t, "sqs", "send-message", "--queue-url", queueURL, "--message-body", "Hello, CLI SQS!")
+	golden.New(t, golden.WithIgnoreFields(
+		"MessageId", "MD5OfMessageBody", "SequenceNumber", "ResultMetadata",
+	)).Assert(t.Name()+"_send", sendOut)
+
+	recvOut := runCLI(t, "sqs", "receive-message", "--queue-url", queueURL, "--max-number-of-messages", "1")
+	golden.New(t, golden.WithIgnoreFields(
+		"MessageId", "ReceiptHandle", "MD5OfBody", "ApproximateFirstReceiveTimestamp", "SentTimestamp", "ResultMetadata",
+	)).Assert(t.Name()+"_receive", recvOut)
+}
+
+func TestCLI_SQS_GetQueueUrlNotFound(t *testing.T) {
+	_, stderr, err := runCLIExpectError(t, "sqs", "get-queue-url", "--queue-name", "nonexistent-cli-queue")
+	if err == nil {
+		t.Fatalf("expected kumo CLI to fail for a nonexistent queue, stderr:\n%s", stderr)
+	}
+
+	if len(stderr) == 0 {
+		t.Fatal("expected stderr output describing the failure")
+	}
+}
+
+func TestCLI_Kinesis_StreamLifecycle(t *testing.T) {
+	streamName := "test-cli-kinesis-stream"
+
+	runCLI(t, "kinesis", "create-stream", "--stream-name", streamName, "--shard-count", "1")
+
+	client := newKinesisClient(t)
+	t.Cleanup(func() {
+		_, _ = client.DeleteStream(context.Background(), &kinesis.DeleteStreamInput{
+			StreamName: aws.String(streamName),
+		})
+	})
+
+	data := base64.StdEncoding.EncodeToString([]byte("Hello, CLI Kinesis!"))
+
+	putOut := runCLI(t, "kinesis", "put-record", "--stream-name", streamName, "--data", data, "--partition-key", "partition-1")
+	put := decodeCLIJSON(t, putOut)
+	golden.New(t, golden.WithIgnoreFields("SequenceNumber", "ResultMetadata")).Assert(t.Name()+"_put", putOut)
+
+	shardID, _ := put["ShardId"].(string)
+	if shardID == "" {
+		t.Fatalf("put-record: no ShardId in output: %s", putOut)
+	}
+
+	iterOut := runCLI(t, "kinesis", "get-shard-iterator",
+		"--stream-name", streamName, "--shard-id", shardID, "--shard-iterator-type", "TRIM_HORIZON")
+	iter := decodeCLIJSON(t, iterOut)
+
+	shardIterator, _ := iter["ShardIterator"].(string)
+	if shardIterator == "" {
+		t.Fatalf("get-shard-iterator: no ShardIterator in output: %s", iterOut)
+	}
+
+	recordsOut := runCLI(t, "kinesis", "get-records", "--shard-iterator", shardIterator)
+	golden.New(t, golden.WithIgnoreFields(
+		"NextShardIterator", "SequenceNumber", "ApproximateArrivalTimestamp", "ResultMetadata",
+	)).Assert(t.Name()+"_records", recordsOut)
+}
+
+func TestCLI_KMS_EncryptDecryptRoundtrip(t *testing.T) {
+	createOut := runCLI(t, "kms", "create-key", "--description", "CLI test key", "--key-usage", "ENCRYPT_DECRYPT")
+	created := decodeCLIJSON(t, createOut)
+	golden.New(t, golden.WithIgnoreFields(
+		"KeyId", "Arn", "CreationDate", "ResultMetadata",
+	)).Assert(t.Name()+"_create", createOut)
+
+	keyMetadata, _ := created["KeyMetadata"].(map[string]any)
+
+	keyID, _ := keyMetadata["KeyId"].(string)
+	if keyID == "" {
+		t.Fatalf("create-key: no KeyMetadata.KeyId in output: %s", createOut)
+	}
+
+	client := newKMSClient(t)
+	t.Cleanup(func() {
+		_, _ = client.ScheduleKeyDeletion(context.Background(), &kms.ScheduleKeyDeletionInput{
+			KeyId:               aws.String(keyID),
+			PendingWindowInDays: aws.Int32(7),
+		})
+	})
+
+	plaintext := "Hello, CLI KMS!"
+	plaintextB64 := base64.StdEncoding.EncodeToString([]byte(plaintext))
+
+	encryptOut := runCLI(t, "kms", "encrypt", "--key-id", keyID, "--plaintext", plaintextB64)
+	encrypted := decodeCLIJSON(t, encryptOut)
+
+	ciphertextB64, _ := encrypted["CiphertextBlob"].(string)
+	if ciphertextB64 == "" {
+		t.Fatalf("encrypt: no CiphertextBlob in output: %s", encryptOut)
+	}
+
+	decryptOut := runCLI(t, "kms", "decrypt", "--ciphertext-blob", ciphertextB64)
+	decrypted := decodeCLIJSON(t, decryptOut)
+
+	gotPlaintextB64, _ := decrypted["Plaintext"].(string)
+
+	gotPlaintext, err := base64.StdEncoding.DecodeString(gotPlaintextB64)
+	if err != nil {
+		t.Fatalf("decode decrypted plaintext: %v", err)
+	}
+
+	if string(gotPlaintext) != plaintext {
+		t.Errorf("plaintext mismatch: got %q, want %q", gotPlaintext, plaintext)
+	}
+}
+
+func TestCLI_DynamoDB_CreateTableAndListTables(t *testing.T) {
+	tableName := "test-cli-dynamodb-table"
+
+	createOut := runCLI(t, "dynamodb", "create-table",
+		"--table-name", tableName,
+		"--attribute-definitions", "attribute-name=pk,attribute-type=S",
+		"--key-schema", "attribute-name=pk,key-type=HASH",
+		"--billing-mode", "PAY_PER_REQUEST",
+	)
+	golden.New(t, golden.WithIgnoreFields(
+		"TableArn", "TableId", "CreationDateTime", "ResultMetadata",
+	)).Assert(t.Name()+"_create", createOut)
+
+	client := newDynamoDBClient(t)
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	listOut := runCLI(t, "dynamodb", "list-tables")
+	list := decodeCLIJSON(t, listOut)
+
+	names, _ := list["TableNames"].([]any)
+
+	found := false
+
+	for _, n := range names {
+		if s, ok := n.(string); ok && s == tableName {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("table %s not found in list-tables output: %s", tableName, listOut)
+	}
+}
+
+func TestCLI_Events_CreateBusAndPutEvents(t *testing.T) {
+	busName := "test-cli-events-bus"
+
+	createOut := runCLI(t, "events", "create-event-bus", "--name", busName)
+	golden.New(t, golden.WithIgnoreFields("EventBusArn", "ResultMetadata")).Assert(t.Name()+"_create", createOut)
+
+	client := newEventBridgeClient(t)
+	t.Cleanup(func() {
+		_, _ = client.DeleteEventBus(context.Background(), &eventbridge.DeleteEventBusInput{
+			Name: aws.String(busName),
+		})
+	})
+
+	entries := `[{"Source":"cli.test","DetailType":"cli-event","Detail":"{\"key\":\"value\"}","EventBusName":"` + busName + `"}]`
+
+	putOut := runCLI(t, "events", "put-events", "--entries", entries)
+	golden.New(t, golden.WithIgnoreFields("EventId", "ResultMetadata")).Assert(t.Name()+"_put", putOut)
+}
+
+func TestCLI_ACM_RequestAndDescribeCertificate(t *testing.T) {
+	domainName := "cli-test.example.com"
+
+	requestOut := runCLI(t, "acm", "request-certificate", "--domain-name", domainName)
+	requested := decodeCLIJSON(t, requestOut)
+	golden.New(t, golden.WithIgnoreFields("CertificateArn", "ResultMetadata")).Assert(t.Name()+"_request", requestOut)
+
+	arn, _ := requested["CertificateArn"].(string)
+	if arn == "" {
+		t.Fatalf("request-certificate: no CertificateArn in output: %s", requestOut)
+	}
+
+	client := newACMClient(t)
+	t.Cleanup(func() {
+		_, _ = client.DeleteCertificate(context.Background(), &acm.DeleteCertificateInput{
+			CertificateArn: aws.String(arn),
+		})
+	})
+
+	describeOut := runCLI(t, "acm", "describe-certificate", "--certificate-arn", arn)
+	golden.New(t, golden.WithIgnoreFields(
+		"CertificateArn", "CreatedAt", "IssuedAt", "Serial", "Value", "ResultMetadata",
+	)).Assert(t.Name()+"_describe", describeOut)
+}

--- a/test/integration/kinesis_test.go
+++ b/test/integration/kinesis_test.go
@@ -42,7 +42,7 @@ func TestKinesis_CreateAndDescribeStream(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "StreamARN", "StreamCreationTimestamp")).Assert(t.Name()+"_describe", describeOutput)
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "StreamARN", "StreamCreationTimestamp", "StartingSequenceNumber")).Assert(t.Name()+"_describe", describeOutput)
 }
 
 func TestKinesis_ListStreams(t *testing.T) {
@@ -106,7 +106,7 @@ func TestKinesis_ListShards(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_list", listOutput)
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata", "StartingSequenceNumber")).Assert(t.Name()+"_list", listOutput)
 }
 
 func TestKinesis_PutAndGetRecords(t *testing.T) {

--- a/test/integration/testdata/cli_test_TestCLI_ACM_RequestAndDescribeCertificate_TestCLI_ACM_RequestAndDescribeCertificate_describe.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_ACM_RequestAndDescribeCertificate_TestCLI_ACM_RequestAndDescribeCertificate_describe.golden.go
@@ -1,0 +1,46 @@
+{
+  "Certificate": {
+    "CertificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/75a84988-284a-49ed-b91b-c86dd7ce4ae0",
+    "CertificateAuthorityArn": null,
+    "CreatedAt": "2026-08-06T07:46:54.137Z",
+    "DomainName": "cli-test.example.com",
+    "DomainValidationOptions": [
+      {
+        "DomainName": "cli-test.example.com",
+        "HttpRedirect": null,
+        "ResourceRecord": {
+          "Name": "_acme-challenge.cli-test.example.com",
+          "Type": "CNAME",
+          "Value": "_75a84988.acm-validations.aws."
+        },
+        "ValidationDomain": "cli-test.example.com",
+        "ValidationEmails": null,
+        "ValidationMethod": "DNS",
+        "ValidationStatus": "PENDING_VALIDATION"
+      }
+    ],
+    "ExtendedKeyUsages": null,
+    "FailureReason": "",
+    "ImportedAt": null,
+    "InUseBy": null,
+    "IssuedAt": null,
+    "Issuer": null,
+    "KeyAlgorithm": "RSA_2048",
+    "KeyUsages": null,
+    "ManagedBy": "",
+    "NotAfter": null,
+    "NotBefore": null,
+    "Options": null,
+    "RenewalEligibility": "INELIGIBLE",
+    "RenewalSummary": null,
+    "RevocationReason": "",
+    "RevokedAt": null,
+    "Serial": "4a4a3b7eefa5a788de7c47ab83a4da3f",
+    "SignatureAlgorithm": null,
+    "Status": "PENDING_VALIDATION",
+    "Subject": "CN=cli-test.example.com",
+    "SubjectAlternativeNames": null,
+    "Type": "AMAZON_ISSUED"
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_ACM_RequestAndDescribeCertificate_TestCLI_ACM_RequestAndDescribeCertificate_request.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_ACM_RequestAndDescribeCertificate_TestCLI_ACM_RequestAndDescribeCertificate_request.golden.go
@@ -1,0 +1,4 @@
+{
+  "CertificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/75a84988-284a-49ed-b91b-c86dd7ce4ae0",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_DynamoDB_CreateTableAndListTables_TestCLI_DynamoDB_CreateTableAndListTables_create.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_DynamoDB_CreateTableAndListTables_TestCLI_DynamoDB_CreateTableAndListTables_create.golden.go
@@ -1,0 +1,46 @@
+{
+  "ResultMetadata": {},
+  "TableDescription": {
+    "ArchivalSummary": null,
+    "AttributeDefinitions": [
+      {
+        "AttributeName": "pk",
+        "AttributeType": "S"
+      }
+    ],
+    "BillingModeSummary": {
+      "BillingMode": "PAY_PER_REQUEST",
+      "LastUpdateToPayPerRequestDateTime": null
+    },
+    "CreationDateTime": "2026-08-06T07:46:54Z",
+    "DeletionProtectionEnabled": false,
+    "GlobalSecondaryIndexes": null,
+    "GlobalTableSettingsReplicationMode": "",
+    "GlobalTableVersion": null,
+    "GlobalTableWitnesses": null,
+    "ItemCount": 0,
+    "KeySchema": [
+      {
+        "AttributeName": "pk",
+        "KeyType": "HASH"
+      }
+    ],
+    "LatestStreamArn": null,
+    "LatestStreamLabel": null,
+    "LocalSecondaryIndexes": null,
+    "MultiRegionConsistency": "",
+    "OnDemandThroughput": null,
+    "ProvisionedThroughput": null,
+    "Replicas": null,
+    "RestoreSummary": null,
+    "SSEDescription": null,
+    "StreamSpecification": null,
+    "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-cli-dynamodb-table",
+    "TableClassSummary": null,
+    "TableId": "e7f9cc35-d043-4a4a-844a-d4e55ddd7e08",
+    "TableName": "test-cli-dynamodb-table",
+    "TableSizeBytes": 0,
+    "TableStatus": "ACTIVE",
+    "WarmThroughput": null
+  }
+}

--- a/test/integration/testdata/cli_test_TestCLI_Events_CreateBusAndPutEvents_TestCLI_Events_CreateBusAndPutEvents_create.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_Events_CreateBusAndPutEvents_TestCLI_Events_CreateBusAndPutEvents_create.golden.go
@@ -1,0 +1,8 @@
+{
+  "DeadLetterConfig": null,
+  "Description": null,
+  "EventBusArn": "arn:aws:events:us-east-1:000000000000:event-bus/test-cli-events-bus",
+  "KmsKeyIdentifier": null,
+  "LogConfig": null,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_Events_CreateBusAndPutEvents_TestCLI_Events_CreateBusAndPutEvents_put.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_Events_CreateBusAndPutEvents_TestCLI_Events_CreateBusAndPutEvents_put.golden.go
@@ -1,0 +1,11 @@
+{
+  "Entries": [
+    {
+      "ErrorCode": null,
+      "ErrorMessage": null,
+      "EventId": "87443fe9-31ed-44e0-89e1-b57e919ee2a3"
+    }
+  ],
+  "FailedEntryCount": 0,
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_KMS_EncryptDecryptRoundtrip_TestCLI_KMS_EncryptDecryptRoundtrip_create.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_KMS_EncryptDecryptRoundtrip_TestCLI_KMS_EncryptDecryptRoundtrip_create.golden.go
@@ -1,0 +1,33 @@
+{
+  "KeyMetadata": {
+    "AWSAccountId": "000000000000",
+    "Arn": "arn:aws:kms:us-east-1:000000000000:key/f372e202-1379-4b0b-a885-7939ea4ccfb7",
+    "CloudHsmClusterId": null,
+    "CreationDate": "2026-08-06T07:46:54Z",
+    "CurrentKeyMaterialId": null,
+    "CustomKeyStoreId": null,
+    "CustomerMasterKeySpec": "",
+    "DeletionDate": null,
+    "Description": "CLI test key",
+    "Enabled": true,
+    "EncryptionAlgorithms": [
+      "SYMMETRIC_DEFAULT"
+    ],
+    "ExpirationModel": "",
+    "KeyAgreementAlgorithms": null,
+    "KeyId": "f372e202-1379-4b0b-a885-7939ea4ccfb7",
+    "KeyManager": "CUSTOMER",
+    "KeySpec": "SYMMETRIC_DEFAULT",
+    "KeyState": "Enabled",
+    "KeyUsage": "ENCRYPT_DECRYPT",
+    "MacAlgorithms": null,
+    "MultiRegion": null,
+    "MultiRegionConfiguration": null,
+    "Origin": "AWS_KMS",
+    "PendingDeletionWindowInDays": null,
+    "SigningAlgorithms": null,
+    "ValidTo": null,
+    "XksKeyConfiguration": null
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_Kinesis_StreamLifecycle_TestCLI_Kinesis_StreamLifecycle_put.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_Kinesis_StreamLifecycle_TestCLI_Kinesis_StreamLifecycle_put.golden.go
@@ -1,0 +1,6 @@
+{
+  "EncryptionType": "",
+  "ResultMetadata": {},
+  "SequenceNumber": "000000000000000000002",
+  "ShardId": "shardId-000000000000"
+}

--- a/test/integration/testdata/cli_test_TestCLI_Kinesis_StreamLifecycle_TestCLI_Kinesis_StreamLifecycle_records.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_Kinesis_StreamLifecycle_TestCLI_Kinesis_StreamLifecycle_records.golden.go
@@ -1,0 +1,15 @@
+{
+  "ChildShards": null,
+  "MillisBehindLatest": 0,
+  "NextShardIterator": "dGVzdC1jbGkta2luZXNpcy1zdHJlYW06c2hhcmRJZC0wMDAwMDAwMDAwMDA6MToxNzg2MDAyNDE0MDA0NzE4MDAw",
+  "Records": [
+    {
+      "ApproximateArrivalTimestamp": "2026-08-06T07:46:53Z",
+      "Data": "SGVsbG8sIENMSSBLaW5lc2lzIQ==",
+      "EncryptionType": "",
+      "PartitionKey": "partition-1",
+      "SequenceNumber": "000000000000000000002"
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_SQS_QueueLifecycle_TestCLI_SQS_QueueLifecycle_create.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_SQS_QueueLifecycle_TestCLI_SQS_QueueLifecycle_create.golden.go
@@ -1,0 +1,4 @@
+{
+  "QueueUrl": "http://localhost:4566/000000000000/test-cli-sqs-queue",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_SQS_QueueLifecycle_TestCLI_SQS_QueueLifecycle_receive.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_SQS_QueueLifecycle_TestCLI_SQS_QueueLifecycle_receive.golden.go
@@ -1,0 +1,18 @@
+{
+  "Messages": [
+    {
+      "Attributes": {
+        "ApproximateFirstReceiveTimestamp": "1786002413921",
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1786002413907"
+      },
+      "Body": "Hello, CLI SQS!",
+      "MD5OfBody": "5351b8610fc6649deff840acebb24495",
+      "MD5OfMessageAttributes": null,
+      "MessageAttributes": null,
+      "MessageId": "38f9ee67-8aa1-4e84-8a78-b35fda3d65d3",
+      "ReceiptHandle": "1c068915-d14c-4645-8fee-1b287ec202ab"
+    }
+  ],
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_SQS_QueueLifecycle_TestCLI_SQS_QueueLifecycle_send.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_SQS_QueueLifecycle_TestCLI_SQS_QueueLifecycle_send.golden.go
@@ -1,0 +1,8 @@
+{
+  "MD5OfMessageAttributes": null,
+  "MD5OfMessageBody": "5351b8610fc6649deff840acebb24495",
+  "MD5OfMessageSystemAttributes": null,
+  "MessageId": "38f9ee67-8aa1-4e84-8a78-b35fda3d65d3",
+  "ResultMetadata": {},
+  "SequenceNumber": null
+}

--- a/test/integration/testdata/kinesis_test_TestKinesis_CreateAndDescribeStream_TestKinesis_CreateAndDescribeStream_describe.golden.go
+++ b/test/integration/testdata/kinesis_test_TestKinesis_CreateAndDescribeStream_TestKinesis_CreateAndDescribeStream_describe.golden.go
@@ -23,7 +23,7 @@
       }
     ],
     "StreamARN": "arn:aws:kinesis:us-east-1:000000000000:stream/test-stream",
-    "StreamCreationTimestamp": "2026-03-23T07:45:26Z",
+    "StreamCreationTimestamp": "2026-08-06T07:42:20Z",
     "StreamName": "test-stream",
     "StreamStatus": "ACTIVE",
     "EncryptionType": "",

--- a/test/integration/testdata/kinesis_test_TestKinesis_ListShards_TestKinesis_ListShards_list.golden.go
+++ b/test/integration/testdata/kinesis_test_TestKinesis_ListShards_TestKinesis_ListShards_list.golden.go
@@ -7,7 +7,7 @@
         "StartingHashKey": "0"
       },
       "SequenceNumberRange": {
-        "StartingSequenceNumber": "000000000000000000003",
+        "StartingSequenceNumber": "000000000000000000002",
         "EndingSequenceNumber": null
       },
       "ShardId": "shardId-000000000000",
@@ -20,7 +20,7 @@
         "StartingHashKey": "170141183460469231731687303715884105727"
       },
       "SequenceNumberRange": {
-        "StartingSequenceNumber": "000000000000000000004",
+        "StartingSequenceNumber": "000000000000000000003",
         "EndingSequenceNumber": null
       },
       "ShardId": "shardId-000000000001",


### PR DESCRIPTION
## Summary
Adds a CLI E2E harness to test/integration: runCLI execs the built bin/kumo as a subprocess (KUMO_CLI_BIN override, terraform-runner-style resolution) and golden-asserts raw stdout JSON. Seven scenarios cover the generated services end to end, including the new data-plane commands: sqs create/send/receive, kinesis put-record/get-records, kms encrypt/decrypt roundtrip, events put-events, dynamodb, acm, plus a stderr error case.

Also fixes a pre-existing fragility the harness exposed: two kinesis goldens hardcoded the process-global sequence counter's absolute value and only passed by test-file ordering luck; StartingSequenceNumber is now ignored like every other dynamic identifier.

## Test plan
- [x] Goldens stable across two fresh-server re-runs; full integration + terraform suites green twice
- [x] `make lint` 0 issues, root `go test -race ./...` green