### PR TITLE
fix(test): isolate the lambda invoker test from the shared default transport

### DIFF
--- a/internal/server/s3_lambda_wiring_test.go
+++ b/internal/server/s3_lambda_wiring_test.go
@@ -50,9 +50,12 @@ func TestS3ToLambdaInvoker_InvokeAsync_StatusHandling(t *testing.T) {
 			}))
 			defer srv.Close()
 
+			// A dedicated Transport keeps the parallel subtests off the shared
+			// http.DefaultTransport: httptest's Close closes its idle
+			// connections, killing the sibling subtest's in-flight request.
 			inv := &s3ToLambdaInvoker{
 				baseURL:    srv.URL,
-				httpClient: &http.Client{Timeout: 5 * time.Second},
+				httpClient: &http.Client{Timeout: 5 * time.Second, Transport: &http.Transport{}},
 			}
 
 			err := inv.InvokeAsync(context.Background(), "arn:aws:lambda:us-east-1:123456789012:function:my-func", []byte(`{}`))


### PR DESCRIPTION
## Summary
TestS3ToLambdaInvoker_InvokeAsync_StatusHandling's parallel subtests shared http.DefaultTransport, and httptest.Server.Close closes that transport's idle connections, so one subtest's cleanup could kill the sibling's in-flight request (observed on the PR #902 unit-test run). Giving the invoker's client a dedicated Transport isolates them.

## Test plan
- [x] `go test -race -count=20 -run TestS3ToLambdaInvoker ./internal/server/` stable
- [x] `make lint` 0 issues