### PR TITLE
feat(cli): support DynamoDB item commands via a DynamoDB-JSON decoder

### DIFF
--- a/cli/gen_dynamodb.go
+++ b/cli/gen_dynamodb.go
@@ -24,16 +24,22 @@ func newDynamoDBCmd() *cobra.Command {
 		newDynamoDBBatchGetItemCmd(),
 		newDynamoDBBatchWriteItemCmd(),
 		newDynamoDBCreateTableCmd(),
+		newDynamoDBDeleteItemCmd(),
 		newDynamoDBDeleteTableCmd(),
 		newDynamoDBDescribeContinuousBackupsCmd(),
 		newDynamoDBDescribeTableCmd(),
 		newDynamoDBDescribeTimeToLiveCmd(),
+		newDynamoDBGetItemCmd(),
 		newDynamoDBListTablesCmd(),
 		newDynamoDBListTagsOfResourceCmd(),
+		newDynamoDBPutItemCmd(),
+		newDynamoDBQueryCmd(),
+		newDynamoDBScanCmd(),
 		newDynamoDBTagResourceCmd(),
 		newDynamoDBTransactGetItemsCmd(),
 		newDynamoDBTransactWriteItemsCmd(),
 		newDynamoDBUntagResourceCmd(),
+		newDynamoDBUpdateItemCmd(),
 		newDynamoDBUpdateTableCmd(),
 		newDynamoDBUpdateTimeToLiveCmd(),
 	)
@@ -333,6 +339,130 @@ func newDynamoDBCreateTableCmd() *cobra.Command {
 	return cmd
 }
 
+func newDynamoDBDeleteItemCmd() *cobra.Command {
+	var key string
+	var tableName string
+	var conditionExpression string
+	var conditionalOperator string
+	var expected string
+	var expressionAttributeNames string
+	var expressionAttributeValues string
+	var returnConsumedCapacity string
+	var returnItemCollectionMetrics string
+	var returnValues string
+	var returnValuesOnConditionCheckFailure string
+
+	cmd := &cobra.Command{
+		Use:   "delete-item",
+		Short: "DeleteItem",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &dynamodb.DeleteItemInput{}
+
+			if key != "" {
+				decoded, err := decodeDynamoDBJSON(key)
+				if err != nil {
+					return fmt.Errorf("delete-item: parse --key: %w", err)
+				}
+				input.Key = decoded
+			}
+
+			if tableName != "" {
+				input.TableName = aws.String(tableName)
+			}
+
+			if conditionExpression != "" {
+				input.ConditionExpression = aws.String(conditionExpression)
+			}
+
+			if conditionalOperator != "" {
+				input.ConditionalOperator = types.ConditionalOperator(conditionalOperator)
+			}
+
+			if expected != "" {
+				if err := json.Unmarshal([]byte(expected), &input.Expected); err != nil {
+					return fmt.Errorf("delete-item: parse --expected: %w", err)
+				}
+			}
+
+			if expressionAttributeNames != "" {
+				if err := json.Unmarshal([]byte(expressionAttributeNames), &input.ExpressionAttributeNames); err != nil {
+					return fmt.Errorf("delete-item: parse --expression-attribute-names: %w", err)
+				}
+			}
+
+			if expressionAttributeValues != "" {
+				decoded, err := decodeDynamoDBJSON(expressionAttributeValues)
+				if err != nil {
+					return fmt.Errorf("delete-item: parse --expression-attribute-values: %w", err)
+				}
+				input.ExpressionAttributeValues = decoded
+			}
+
+			if returnConsumedCapacity != "" {
+				input.ReturnConsumedCapacity = types.ReturnConsumedCapacity(returnConsumedCapacity)
+			}
+
+			if returnItemCollectionMetrics != "" {
+				input.ReturnItemCollectionMetrics = types.ReturnItemCollectionMetrics(returnItemCollectionMetrics)
+			}
+
+			if returnValues != "" {
+				input.ReturnValues = types.ReturnValue(returnValues)
+			}
+
+			if returnValuesOnConditionCheckFailure != "" {
+				input.ReturnValuesOnConditionCheckFailure = types.ReturnValuesOnConditionCheckFailure(returnValuesOnConditionCheckFailure)
+			}
+
+			out, err := client.DeleteItem(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("delete-item failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&key, "key", "", "Key (JSON)")
+
+	cmd.Flags().StringVar(&tableName, "table-name", "", "Table name")
+
+	cmd.Flags().StringVar(&conditionExpression, "condition-expression", "", "Condition expression")
+
+	cmd.Flags().StringVar(&conditionalOperator, "conditional-operator", "", "Conditional operator")
+
+	cmd.Flags().StringVar(&expected, "expected", "", "Expected (JSON)")
+
+	cmd.Flags().StringVar(&expressionAttributeNames, "expression-attribute-names", "", "Expression attribute names (JSON)")
+
+	cmd.Flags().StringVar(&expressionAttributeValues, "expression-attribute-values", "", "Expression attribute values (JSON)")
+
+	cmd.Flags().StringVar(&returnConsumedCapacity, "return-consumed-capacity", "", "Return consumed capacity")
+
+	cmd.Flags().StringVar(&returnItemCollectionMetrics, "return-item-collection-metrics", "", "Return item collection metrics")
+
+	cmd.Flags().StringVar(&returnValues, "return-values", "", "Return values")
+
+	cmd.Flags().StringVar(&returnValuesOnConditionCheckFailure, "return-values-on-condition-check-failure", "", "Return values on condition check failure")
+
+	cmd.Flags().String("region", "", "Region override (ignored)")
+
+	return cmd
+}
+
 func newDynamoDBDeleteTableCmd() *cobra.Command {
 	var tableName string
 
@@ -501,6 +631,96 @@ func newDynamoDBDescribeTimeToLiveCmd() *cobra.Command {
 	return cmd
 }
 
+func newDynamoDBGetItemCmd() *cobra.Command {
+	var key string
+	var tableName string
+	var attributesToGet []string
+	var consistentRead bool
+	var expressionAttributeNames string
+	var projectionExpression string
+	var returnConsumedCapacity string
+
+	cmd := &cobra.Command{
+		Use:   "get-item",
+		Short: "GetItem",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &dynamodb.GetItemInput{}
+
+			if key != "" {
+				decoded, err := decodeDynamoDBJSON(key)
+				if err != nil {
+					return fmt.Errorf("get-item: parse --key: %w", err)
+				}
+				input.Key = decoded
+			}
+
+			if tableName != "" {
+				input.TableName = aws.String(tableName)
+			}
+
+			if len(attributesToGet) > 0 {
+				input.AttributesToGet = attributesToGet
+			}
+
+			if consistentRead {
+				input.ConsistentRead = aws.Bool(consistentRead)
+			}
+
+			if expressionAttributeNames != "" {
+				if err := json.Unmarshal([]byte(expressionAttributeNames), &input.ExpressionAttributeNames); err != nil {
+					return fmt.Errorf("get-item: parse --expression-attribute-names: %w", err)
+				}
+			}
+
+			if projectionExpression != "" {
+				input.ProjectionExpression = aws.String(projectionExpression)
+			}
+
+			if returnConsumedCapacity != "" {
+				input.ReturnConsumedCapacity = types.ReturnConsumedCapacity(returnConsumedCapacity)
+			}
+
+			out, err := client.GetItem(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("get-item failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&key, "key", "", "Key (JSON)")
+
+	cmd.Flags().StringVar(&tableName, "table-name", "", "Table name")
+
+	cmd.Flags().StringArrayVar(&attributesToGet, "attributes-to-get", nil, "Attributes to get")
+
+	cmd.Flags().BoolVar(&consistentRead, "consistent-read", false, "Consistent read")
+
+	cmd.Flags().StringVar(&expressionAttributeNames, "expression-attribute-names", "", "Expression attribute names (JSON)")
+
+	cmd.Flags().StringVar(&projectionExpression, "projection-expression", "", "Projection expression")
+
+	cmd.Flags().StringVar(&returnConsumedCapacity, "return-consumed-capacity", "", "Return consumed capacity")
+
+	cmd.Flags().String("region", "", "Region override (ignored)")
+
+	return cmd
+}
+
 func newDynamoDBListTablesCmd() *cobra.Command {
 	var exclusiveStartTableName string
 	var limit int32
@@ -593,6 +813,457 @@ func newDynamoDBListTagsOfResourceCmd() *cobra.Command {
 	cmd.Flags().StringVar(&resourceArn, "resource-arn", "", "Resource arn")
 
 	cmd.Flags().StringVar(&nextToken, "next-token", "", "Next token")
+
+	cmd.Flags().String("region", "", "Region override (ignored)")
+
+	return cmd
+}
+
+func newDynamoDBPutItemCmd() *cobra.Command {
+	var item string
+	var tableName string
+	var conditionExpression string
+	var conditionalOperator string
+	var expected string
+	var expressionAttributeNames string
+	var expressionAttributeValues string
+	var returnConsumedCapacity string
+	var returnItemCollectionMetrics string
+	var returnValues string
+	var returnValuesOnConditionCheckFailure string
+
+	cmd := &cobra.Command{
+		Use:   "put-item",
+		Short: "PutItem",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &dynamodb.PutItemInput{}
+
+			if item != "" {
+				decoded, err := decodeDynamoDBJSON(item)
+				if err != nil {
+					return fmt.Errorf("put-item: parse --item: %w", err)
+				}
+				input.Item = decoded
+			}
+
+			if tableName != "" {
+				input.TableName = aws.String(tableName)
+			}
+
+			if conditionExpression != "" {
+				input.ConditionExpression = aws.String(conditionExpression)
+			}
+
+			if conditionalOperator != "" {
+				input.ConditionalOperator = types.ConditionalOperator(conditionalOperator)
+			}
+
+			if expected != "" {
+				if err := json.Unmarshal([]byte(expected), &input.Expected); err != nil {
+					return fmt.Errorf("put-item: parse --expected: %w", err)
+				}
+			}
+
+			if expressionAttributeNames != "" {
+				if err := json.Unmarshal([]byte(expressionAttributeNames), &input.ExpressionAttributeNames); err != nil {
+					return fmt.Errorf("put-item: parse --expression-attribute-names: %w", err)
+				}
+			}
+
+			if expressionAttributeValues != "" {
+				decoded, err := decodeDynamoDBJSON(expressionAttributeValues)
+				if err != nil {
+					return fmt.Errorf("put-item: parse --expression-attribute-values: %w", err)
+				}
+				input.ExpressionAttributeValues = decoded
+			}
+
+			if returnConsumedCapacity != "" {
+				input.ReturnConsumedCapacity = types.ReturnConsumedCapacity(returnConsumedCapacity)
+			}
+
+			if returnItemCollectionMetrics != "" {
+				input.ReturnItemCollectionMetrics = types.ReturnItemCollectionMetrics(returnItemCollectionMetrics)
+			}
+
+			if returnValues != "" {
+				input.ReturnValues = types.ReturnValue(returnValues)
+			}
+
+			if returnValuesOnConditionCheckFailure != "" {
+				input.ReturnValuesOnConditionCheckFailure = types.ReturnValuesOnConditionCheckFailure(returnValuesOnConditionCheckFailure)
+			}
+
+			out, err := client.PutItem(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("put-item failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&item, "item", "", "Item (JSON)")
+
+	cmd.Flags().StringVar(&tableName, "table-name", "", "Table name")
+
+	cmd.Flags().StringVar(&conditionExpression, "condition-expression", "", "Condition expression")
+
+	cmd.Flags().StringVar(&conditionalOperator, "conditional-operator", "", "Conditional operator")
+
+	cmd.Flags().StringVar(&expected, "expected", "", "Expected (JSON)")
+
+	cmd.Flags().StringVar(&expressionAttributeNames, "expression-attribute-names", "", "Expression attribute names (JSON)")
+
+	cmd.Flags().StringVar(&expressionAttributeValues, "expression-attribute-values", "", "Expression attribute values (JSON)")
+
+	cmd.Flags().StringVar(&returnConsumedCapacity, "return-consumed-capacity", "", "Return consumed capacity")
+
+	cmd.Flags().StringVar(&returnItemCollectionMetrics, "return-item-collection-metrics", "", "Return item collection metrics")
+
+	cmd.Flags().StringVar(&returnValues, "return-values", "", "Return values")
+
+	cmd.Flags().StringVar(&returnValuesOnConditionCheckFailure, "return-values-on-condition-check-failure", "", "Return values on condition check failure")
+
+	cmd.Flags().String("region", "", "Region override (ignored)")
+
+	return cmd
+}
+
+func newDynamoDBQueryCmd() *cobra.Command {
+	var tableName string
+	var attributesToGet []string
+	var conditionalOperator string
+	var consistentRead bool
+	var exclusiveStartKey string
+	var expressionAttributeNames string
+	var expressionAttributeValues string
+	var filterExpression string
+	var indexName string
+	var keyConditionExpression string
+	var keyConditions string
+	var limit int32
+	var projectionExpression string
+	var queryFilter string
+	var returnConsumedCapacity string
+	var scanIndexForward bool
+	var selectValue string
+
+	cmd := &cobra.Command{
+		Use:   "query",
+		Short: "Query",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &dynamodb.QueryInput{}
+
+			if tableName != "" {
+				input.TableName = aws.String(tableName)
+			}
+
+			if len(attributesToGet) > 0 {
+				input.AttributesToGet = attributesToGet
+			}
+
+			if conditionalOperator != "" {
+				input.ConditionalOperator = types.ConditionalOperator(conditionalOperator)
+			}
+
+			if consistentRead {
+				input.ConsistentRead = aws.Bool(consistentRead)
+			}
+
+			if exclusiveStartKey != "" {
+				decoded, err := decodeDynamoDBJSON(exclusiveStartKey)
+				if err != nil {
+					return fmt.Errorf("query: parse --exclusive-start-key: %w", err)
+				}
+				input.ExclusiveStartKey = decoded
+			}
+
+			if expressionAttributeNames != "" {
+				if err := json.Unmarshal([]byte(expressionAttributeNames), &input.ExpressionAttributeNames); err != nil {
+					return fmt.Errorf("query: parse --expression-attribute-names: %w", err)
+				}
+			}
+
+			if expressionAttributeValues != "" {
+				decoded, err := decodeDynamoDBJSON(expressionAttributeValues)
+				if err != nil {
+					return fmt.Errorf("query: parse --expression-attribute-values: %w", err)
+				}
+				input.ExpressionAttributeValues = decoded
+			}
+
+			if filterExpression != "" {
+				input.FilterExpression = aws.String(filterExpression)
+			}
+
+			if indexName != "" {
+				input.IndexName = aws.String(indexName)
+			}
+
+			if keyConditionExpression != "" {
+				input.KeyConditionExpression = aws.String(keyConditionExpression)
+			}
+
+			if keyConditions != "" {
+				if err := json.Unmarshal([]byte(keyConditions), &input.KeyConditions); err != nil {
+					return fmt.Errorf("query: parse --key-conditions: %w", err)
+				}
+			}
+
+			if limit != 0 {
+				input.Limit = aws.Int32(limit)
+			}
+
+			if projectionExpression != "" {
+				input.ProjectionExpression = aws.String(projectionExpression)
+			}
+
+			if queryFilter != "" {
+				if err := json.Unmarshal([]byte(queryFilter), &input.QueryFilter); err != nil {
+					return fmt.Errorf("query: parse --query-filter: %w", err)
+				}
+			}
+
+			if returnConsumedCapacity != "" {
+				input.ReturnConsumedCapacity = types.ReturnConsumedCapacity(returnConsumedCapacity)
+			}
+
+			if scanIndexForward {
+				input.ScanIndexForward = aws.Bool(scanIndexForward)
+			}
+
+			if selectValue != "" {
+				input.Select = types.Select(selectValue)
+			}
+
+			out, err := client.Query(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("query failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&tableName, "table-name", "", "Table name")
+
+	cmd.Flags().StringArrayVar(&attributesToGet, "attributes-to-get", nil, "Attributes to get")
+
+	cmd.Flags().StringVar(&conditionalOperator, "conditional-operator", "", "Conditional operator")
+
+	cmd.Flags().BoolVar(&consistentRead, "consistent-read", false, "Consistent read")
+
+	cmd.Flags().StringVar(&exclusiveStartKey, "exclusive-start-key", "", "Exclusive start key (JSON)")
+
+	cmd.Flags().StringVar(&expressionAttributeNames, "expression-attribute-names", "", "Expression attribute names (JSON)")
+
+	cmd.Flags().StringVar(&expressionAttributeValues, "expression-attribute-values", "", "Expression attribute values (JSON)")
+
+	cmd.Flags().StringVar(&filterExpression, "filter-expression", "", "Filter expression")
+
+	cmd.Flags().StringVar(&indexName, "index-name", "", "Index name")
+
+	cmd.Flags().StringVar(&keyConditionExpression, "key-condition-expression", "", "Key condition expression")
+
+	cmd.Flags().StringVar(&keyConditions, "key-conditions", "", "Key conditions (JSON)")
+
+	cmd.Flags().Int32Var(&limit, "limit", 0, "Limit")
+
+	cmd.Flags().StringVar(&projectionExpression, "projection-expression", "", "Projection expression")
+
+	cmd.Flags().StringVar(&queryFilter, "query-filter", "", "Query filter (JSON)")
+
+	cmd.Flags().StringVar(&returnConsumedCapacity, "return-consumed-capacity", "", "Return consumed capacity")
+
+	cmd.Flags().BoolVar(&scanIndexForward, "scan-index-forward", false, "Scan index forward")
+
+	cmd.Flags().StringVar(&selectValue, "select", "", "Select")
+
+	cmd.Flags().String("region", "", "Region override (ignored)")
+
+	return cmd
+}
+
+func newDynamoDBScanCmd() *cobra.Command {
+	var tableName string
+	var attributesToGet []string
+	var conditionalOperator string
+	var consistentRead bool
+	var exclusiveStartKey string
+	var expressionAttributeNames string
+	var expressionAttributeValues string
+	var filterExpression string
+	var indexName string
+	var limit int32
+	var projectionExpression string
+	var returnConsumedCapacity string
+	var scanFilter string
+	var segment int32
+	var selectValue string
+	var totalSegments int32
+
+	cmd := &cobra.Command{
+		Use:   "scan",
+		Short: "Scan",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &dynamodb.ScanInput{}
+
+			if tableName != "" {
+				input.TableName = aws.String(tableName)
+			}
+
+			if len(attributesToGet) > 0 {
+				input.AttributesToGet = attributesToGet
+			}
+
+			if conditionalOperator != "" {
+				input.ConditionalOperator = types.ConditionalOperator(conditionalOperator)
+			}
+
+			if consistentRead {
+				input.ConsistentRead = aws.Bool(consistentRead)
+			}
+
+			if exclusiveStartKey != "" {
+				decoded, err := decodeDynamoDBJSON(exclusiveStartKey)
+				if err != nil {
+					return fmt.Errorf("scan: parse --exclusive-start-key: %w", err)
+				}
+				input.ExclusiveStartKey = decoded
+			}
+
+			if expressionAttributeNames != "" {
+				if err := json.Unmarshal([]byte(expressionAttributeNames), &input.ExpressionAttributeNames); err != nil {
+					return fmt.Errorf("scan: parse --expression-attribute-names: %w", err)
+				}
+			}
+
+			if expressionAttributeValues != "" {
+				decoded, err := decodeDynamoDBJSON(expressionAttributeValues)
+				if err != nil {
+					return fmt.Errorf("scan: parse --expression-attribute-values: %w", err)
+				}
+				input.ExpressionAttributeValues = decoded
+			}
+
+			if filterExpression != "" {
+				input.FilterExpression = aws.String(filterExpression)
+			}
+
+			if indexName != "" {
+				input.IndexName = aws.String(indexName)
+			}
+
+			if limit != 0 {
+				input.Limit = aws.Int32(limit)
+			}
+
+			if projectionExpression != "" {
+				input.ProjectionExpression = aws.String(projectionExpression)
+			}
+
+			if returnConsumedCapacity != "" {
+				input.ReturnConsumedCapacity = types.ReturnConsumedCapacity(returnConsumedCapacity)
+			}
+
+			if scanFilter != "" {
+				if err := json.Unmarshal([]byte(scanFilter), &input.ScanFilter); err != nil {
+					return fmt.Errorf("scan: parse --scan-filter: %w", err)
+				}
+			}
+
+			if segment != 0 {
+				input.Segment = aws.Int32(segment)
+			}
+
+			if selectValue != "" {
+				input.Select = types.Select(selectValue)
+			}
+
+			if totalSegments != 0 {
+				input.TotalSegments = aws.Int32(totalSegments)
+			}
+
+			out, err := client.Scan(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("scan failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&tableName, "table-name", "", "Table name")
+
+	cmd.Flags().StringArrayVar(&attributesToGet, "attributes-to-get", nil, "Attributes to get")
+
+	cmd.Flags().StringVar(&conditionalOperator, "conditional-operator", "", "Conditional operator")
+
+	cmd.Flags().BoolVar(&consistentRead, "consistent-read", false, "Consistent read")
+
+	cmd.Flags().StringVar(&exclusiveStartKey, "exclusive-start-key", "", "Exclusive start key (JSON)")
+
+	cmd.Flags().StringVar(&expressionAttributeNames, "expression-attribute-names", "", "Expression attribute names (JSON)")
+
+	cmd.Flags().StringVar(&expressionAttributeValues, "expression-attribute-values", "", "Expression attribute values (JSON)")
+
+	cmd.Flags().StringVar(&filterExpression, "filter-expression", "", "Filter expression")
+
+	cmd.Flags().StringVar(&indexName, "index-name", "", "Index name")
+
+	cmd.Flags().Int32Var(&limit, "limit", 0, "Limit")
+
+	cmd.Flags().StringVar(&projectionExpression, "projection-expression", "", "Projection expression")
+
+	cmd.Flags().StringVar(&returnConsumedCapacity, "return-consumed-capacity", "", "Return consumed capacity")
+
+	cmd.Flags().StringVar(&scanFilter, "scan-filter", "", "Scan filter (JSON)")
+
+	cmd.Flags().Int32Var(&segment, "segment", 0, "Segment")
+
+	cmd.Flags().StringVar(&selectValue, "select", "", "Select")
+
+	cmd.Flags().Int32Var(&totalSegments, "total-segments", 0, "Total segments")
 
 	cmd.Flags().String("region", "", "Region override (ignored)")
 
@@ -803,6 +1474,146 @@ func newDynamoDBUntagResourceCmd() *cobra.Command {
 	cmd.Flags().StringVar(&resourceArn, "resource-arn", "", "Resource arn")
 
 	cmd.Flags().StringArrayVar(&tagKeys, "tag-keys", nil, "Tag keys")
+
+	cmd.Flags().String("region", "", "Region override (ignored)")
+
+	return cmd
+}
+
+func newDynamoDBUpdateItemCmd() *cobra.Command {
+	var key string
+	var tableName string
+	var attributeUpdates string
+	var conditionExpression string
+	var conditionalOperator string
+	var expected string
+	var expressionAttributeNames string
+	var expressionAttributeValues string
+	var returnConsumedCapacity string
+	var returnItemCollectionMetrics string
+	var returnValues string
+	var returnValuesOnConditionCheckFailure string
+	var updateExpression string
+
+	cmd := &cobra.Command{
+		Use:   "update-item",
+		Short: "UpdateItem",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &dynamodb.UpdateItemInput{}
+
+			if key != "" {
+				decoded, err := decodeDynamoDBJSON(key)
+				if err != nil {
+					return fmt.Errorf("update-item: parse --key: %w", err)
+				}
+				input.Key = decoded
+			}
+
+			if tableName != "" {
+				input.TableName = aws.String(tableName)
+			}
+
+			if attributeUpdates != "" {
+				if err := json.Unmarshal([]byte(attributeUpdates), &input.AttributeUpdates); err != nil {
+					return fmt.Errorf("update-item: parse --attribute-updates: %w", err)
+				}
+			}
+
+			if conditionExpression != "" {
+				input.ConditionExpression = aws.String(conditionExpression)
+			}
+
+			if conditionalOperator != "" {
+				input.ConditionalOperator = types.ConditionalOperator(conditionalOperator)
+			}
+
+			if expected != "" {
+				if err := json.Unmarshal([]byte(expected), &input.Expected); err != nil {
+					return fmt.Errorf("update-item: parse --expected: %w", err)
+				}
+			}
+
+			if expressionAttributeNames != "" {
+				if err := json.Unmarshal([]byte(expressionAttributeNames), &input.ExpressionAttributeNames); err != nil {
+					return fmt.Errorf("update-item: parse --expression-attribute-names: %w", err)
+				}
+			}
+
+			if expressionAttributeValues != "" {
+				decoded, err := decodeDynamoDBJSON(expressionAttributeValues)
+				if err != nil {
+					return fmt.Errorf("update-item: parse --expression-attribute-values: %w", err)
+				}
+				input.ExpressionAttributeValues = decoded
+			}
+
+			if returnConsumedCapacity != "" {
+				input.ReturnConsumedCapacity = types.ReturnConsumedCapacity(returnConsumedCapacity)
+			}
+
+			if returnItemCollectionMetrics != "" {
+				input.ReturnItemCollectionMetrics = types.ReturnItemCollectionMetrics(returnItemCollectionMetrics)
+			}
+
+			if returnValues != "" {
+				input.ReturnValues = types.ReturnValue(returnValues)
+			}
+
+			if returnValuesOnConditionCheckFailure != "" {
+				input.ReturnValuesOnConditionCheckFailure = types.ReturnValuesOnConditionCheckFailure(returnValuesOnConditionCheckFailure)
+			}
+
+			if updateExpression != "" {
+				input.UpdateExpression = aws.String(updateExpression)
+			}
+
+			out, err := client.UpdateItem(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("update-item failed: %w", err)
+			}
+
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return fmt.Errorf("failed to encode output: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&key, "key", "", "Key (JSON)")
+
+	cmd.Flags().StringVar(&tableName, "table-name", "", "Table name")
+
+	cmd.Flags().StringVar(&attributeUpdates, "attribute-updates", "", "Attribute updates (JSON)")
+
+	cmd.Flags().StringVar(&conditionExpression, "condition-expression", "", "Condition expression")
+
+	cmd.Flags().StringVar(&conditionalOperator, "conditional-operator", "", "Conditional operator")
+
+	cmd.Flags().StringVar(&expected, "expected", "", "Expected (JSON)")
+
+	cmd.Flags().StringVar(&expressionAttributeNames, "expression-attribute-names", "", "Expression attribute names (JSON)")
+
+	cmd.Flags().StringVar(&expressionAttributeValues, "expression-attribute-values", "", "Expression attribute values (JSON)")
+
+	cmd.Flags().StringVar(&returnConsumedCapacity, "return-consumed-capacity", "", "Return consumed capacity")
+
+	cmd.Flags().StringVar(&returnItemCollectionMetrics, "return-item-collection-metrics", "", "Return item collection metrics")
+
+	cmd.Flags().StringVar(&returnValues, "return-values", "", "Return values")
+
+	cmd.Flags().StringVar(&returnValuesOnConditionCheckFailure, "return-values-on-condition-check-failure", "", "Return values on condition check failure")
+
+	cmd.Flags().StringVar(&updateExpression, "update-expression", "", "Update expression")
 
 	cmd.Flags().String("region", "", "Region override (ignored)")
 

--- a/cli/support_dynamodb.go
+++ b/cli/support_dynamodb.go
@@ -1,0 +1,230 @@
+package cli
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// decodeDynamoDBJSON decodes raw, an AWS CLI-style DynamoDB JSON document
+// (e.g. `{"pk":{"S":"a"},"n":{"N":"1"}}`), into a map of dynamodb
+// AttributeValue members.
+//
+// This is hand-written, never generated: dynamodb's AttributeValue is a
+// Smithy union (interface) type, so encoding/json cannot unmarshal directly
+// into it the way cli-gen's generic FlagJSONBlob handling does for plain
+// structs. cli-gen's FlagCustomFunc override (internal/cligen/overrides.go)
+// routes every dynamodb Input field typed map[string]types.AttributeValue
+// (Item, Key, ExpressionAttributeValues, ExclusiveStartKey) through this
+// function instead.
+func decodeDynamoDBJSON(raw string) (map[string]ddbtypes.AttributeValue, error) {
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		return nil, fmt.Errorf("decode DynamoDB JSON: %w", err)
+	}
+
+	result := make(map[string]ddbtypes.AttributeValue, len(doc))
+
+	for key, val := range doc {
+		av, err := decodeAttributeValue(val)
+		if err != nil {
+			return nil, fmt.Errorf("decode DynamoDB JSON: attribute %q: %w", key, err)
+		}
+
+		result[key] = av
+	}
+
+	return result, nil
+}
+
+// decodeAttributeValue decodes raw (one DynamoDB JSON attribute value
+// document, e.g. {"S":"a"} or {"L":[{"N":"1"},{"N":"2"}]}) into a dynamodb
+// AttributeValue member, recursing through L (list) and M (map) members.
+//
+// It decodes into a map[string]json.RawMessage rather than a tagged struct
+// so it can validate that exactly one AWS type-descriptor key (S, N, B,
+// BOOL, NULL, SS, NS, BS, L, or M) is present before dispatching on it.
+func decodeAttributeValue(raw json.RawMessage) (ddbtypes.AttributeValue, error) {
+	var members map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &members); err != nil {
+		return nil, fmt.Errorf("unmarshal attribute value: %w", err)
+	}
+
+	if len(members) != 1 {
+		return nil, fmt.Errorf("attribute value must set exactly one type (S, N, B, BOOL, NULL, SS, NS, BS, L, or M), got %d", len(members))
+	}
+
+	for kind, value := range members {
+		decode, ok := attributeValueDecoders()[kind]
+		if !ok {
+			return nil, fmt.Errorf("unknown attribute value type %q", kind)
+		}
+
+		return decode(value)
+	}
+
+	panic("unreachable: members has exactly one entry")
+}
+
+// attributeValueDecoders returns a map from each AWS DynamoDB JSON
+// type-descriptor key to the function that decodes its raw payload into the
+// matching AttributeValue member. It is a function rather than a package
+// variable because several of its entries (L, M) call back into
+// decodeAttributeValue, which would otherwise create a package-level
+// initialization cycle.
+func attributeValueDecoders() map[string]func(json.RawMessage) (ddbtypes.AttributeValue, error) {
+	return map[string]func(json.RawMessage) (ddbtypes.AttributeValue, error){
+		"S":    decodeAttributeValueS,
+		"N":    decodeAttributeValueN,
+		"B":    decodeAttributeValueB,
+		"BOOL": decodeAttributeValueBOOL,
+		"NULL": decodeAttributeValueNULL,
+		"SS":   decodeAttributeValueSS,
+		"NS":   decodeAttributeValueNS,
+		"BS":   decodeAttributeValueBS,
+		"L":    decodeAttributeValueL,
+		"M":    decodeAttributeValueM,
+	}
+}
+
+// unmarshalMember unmarshals value (the raw JSON payload for AWS
+// type-descriptor key kind) into a T, wrapping any error with kind for
+// context.
+func unmarshalMember[T any](kind string, value json.RawMessage) (T, error) {
+	var v T
+	if err := json.Unmarshal(value, &v); err != nil {
+		return v, fmt.Errorf("decode %s: %w", kind, err)
+	}
+
+	return v, nil
+}
+
+func decodeAttributeValueS(value json.RawMessage) (ddbtypes.AttributeValue, error) {
+	s, err := unmarshalMember[string]("S", value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ddbtypes.AttributeValueMemberS{Value: s}, nil
+}
+
+func decodeAttributeValueN(value json.RawMessage) (ddbtypes.AttributeValue, error) {
+	n, err := unmarshalMember[string]("N", value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ddbtypes.AttributeValueMemberN{Value: n}, nil
+}
+
+func decodeAttributeValueB(value json.RawMessage) (ddbtypes.AttributeValue, error) {
+	encoded, err := unmarshalMember[string]("B", value)
+	if err != nil {
+		return nil, err
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode B: %w", err)
+	}
+
+	return &ddbtypes.AttributeValueMemberB{Value: decoded}, nil
+}
+
+func decodeAttributeValueBOOL(value json.RawMessage) (ddbtypes.AttributeValue, error) {
+	b, err := unmarshalMember[bool]("BOOL", value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ddbtypes.AttributeValueMemberBOOL{Value: b}, nil
+}
+
+func decodeAttributeValueNULL(value json.RawMessage) (ddbtypes.AttributeValue, error) {
+	b, err := unmarshalMember[bool]("NULL", value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ddbtypes.AttributeValueMemberNULL{Value: b}, nil
+}
+
+func decodeAttributeValueSS(value json.RawMessage) (ddbtypes.AttributeValue, error) {
+	ss, err := unmarshalMember[[]string]("SS", value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ddbtypes.AttributeValueMemberSS{Value: ss}, nil
+}
+
+func decodeAttributeValueNS(value json.RawMessage) (ddbtypes.AttributeValue, error) {
+	ns, err := unmarshalMember[[]string]("NS", value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ddbtypes.AttributeValueMemberNS{Value: ns}, nil
+}
+
+func decodeAttributeValueBS(value json.RawMessage) (ddbtypes.AttributeValue, error) {
+	encoded, err := unmarshalMember[[]string]("BS", value)
+	if err != nil {
+		return nil, err
+	}
+
+	decoded := make([][]byte, len(encoded))
+
+	for i, s := range encoded {
+		b, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return nil, fmt.Errorf("decode BS element %d: %w", i, err)
+		}
+
+		decoded[i] = b
+	}
+
+	return &ddbtypes.AttributeValueMemberBS{Value: decoded}, nil
+}
+
+func decodeAttributeValueL(value json.RawMessage) (ddbtypes.AttributeValue, error) {
+	items, err := unmarshalMember[[]json.RawMessage]("L", value)
+	if err != nil {
+		return nil, err
+	}
+
+	list := make([]ddbtypes.AttributeValue, len(items))
+
+	for i, item := range items {
+		av, err := decodeAttributeValue(item)
+		if err != nil {
+			return nil, fmt.Errorf("list element %d: %w", i, err)
+		}
+
+		list[i] = av
+	}
+
+	return &ddbtypes.AttributeValueMemberL{Value: list}, nil
+}
+
+func decodeAttributeValueM(value json.RawMessage) (ddbtypes.AttributeValue, error) {
+	members, err := unmarshalMember[map[string]json.RawMessage]("M", value)
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[string]ddbtypes.AttributeValue, len(members))
+
+	for k, v := range members {
+		av, err := decodeAttributeValue(v)
+		if err != nil {
+			return nil, fmt.Errorf("map member %q: %w", k, err)
+		}
+
+		m[k] = av
+	}
+
+	return &ddbtypes.AttributeValueMemberM{Value: m}, nil
+}

--- a/cli/support_dynamodb_test.go
+++ b/cli/support_dynamodb_test.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+type decodeDynamoDBJSONTestCase struct {
+	name    string
+	raw     string
+	want    map[string]ddbtypes.AttributeValue
+	wantErr bool
+}
+
+// decodeDynamoDBJSONScalarTestCases covers each scalar AttributeValue member
+// kind (S, N, B, BOOL, NULL) in isolation.
+func decodeDynamoDBJSONScalarTestCases() []decodeDynamoDBJSONTestCase {
+	return []decodeDynamoDBJSONTestCase{
+		{
+			name: "S string member",
+			raw:  `{"pk":{"S":"a"}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"pk": &ddbtypes.AttributeValueMemberS{Value: "a"},
+			},
+		},
+		{
+			name: "N number member",
+			raw:  `{"n":{"N":"1"}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"n": &ddbtypes.AttributeValueMemberN{Value: "1"},
+			},
+		},
+		{
+			name: "B binary member",
+			raw:  `{"b":{"B":"aGVsbG8="}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"b": &ddbtypes.AttributeValueMemberB{Value: []byte("hello")},
+			},
+		},
+		{
+			name: "BOOL member true",
+			raw:  `{"flag":{"BOOL":true}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"flag": &ddbtypes.AttributeValueMemberBOOL{Value: true},
+			},
+		},
+		{
+			name: "BOOL member false",
+			raw:  `{"flag":{"BOOL":false}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"flag": &ddbtypes.AttributeValueMemberBOOL{Value: false},
+			},
+		},
+		{
+			name: "NULL member",
+			raw:  `{"n":{"NULL":true}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"n": &ddbtypes.AttributeValueMemberNULL{Value: true},
+			},
+		},
+	}
+}
+
+// decodeDynamoDBJSONCollectionTestCases covers each set-typed AttributeValue
+// member kind (SS, NS, BS).
+func decodeDynamoDBJSONCollectionTestCases() []decodeDynamoDBJSONTestCase {
+	return []decodeDynamoDBJSONTestCase{
+		{
+			name: "SS string set member",
+			raw:  `{"ss":{"SS":["a","b"]}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"ss": &ddbtypes.AttributeValueMemberSS{Value: []string{"a", "b"}},
+			},
+		},
+		{
+			name: "NS number set member",
+			raw:  `{"ns":{"NS":["1","2"]}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"ns": &ddbtypes.AttributeValueMemberNS{Value: []string{"1", "2"}},
+			},
+		},
+		{
+			name: "BS binary set member",
+			raw:  `{"bs":{"BS":["aGVsbG8=","d29ybGQ="]}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"bs": &ddbtypes.AttributeValueMemberBS{Value: [][]byte{[]byte("hello"), []byte("world")}},
+			},
+		},
+	}
+}
+
+// decodeDynamoDBJSONNestedTestCases covers L (list) and M (map) recursion,
+// including L-within-M-within-L nesting, and multiple/empty top-level
+// attributes.
+func decodeDynamoDBJSONNestedTestCases() []decodeDynamoDBJSONTestCase {
+	return []decodeDynamoDBJSONTestCase{
+		{
+			name: "L list member",
+			raw:  `{"l":{"L":[{"S":"a"},{"N":"1"}]}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"l": &ddbtypes.AttributeValueMemberL{Value: []ddbtypes.AttributeValue{
+					&ddbtypes.AttributeValueMemberS{Value: "a"},
+					&ddbtypes.AttributeValueMemberN{Value: "1"},
+				}},
+			},
+		},
+		{
+			name: "M map member",
+			raw:  `{"m":{"M":{"nested":{"S":"a"}}}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"m": &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{
+					"nested": &ddbtypes.AttributeValueMemberS{Value: "a"},
+				}},
+			},
+		},
+		{
+			name: "nested L within M within L",
+			raw:  `{"pk":{"L":[{"M":{"a":{"L":[{"S":"x"}]}}}]}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"pk": &ddbtypes.AttributeValueMemberL{Value: []ddbtypes.AttributeValue{
+					&ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{
+						"a": &ddbtypes.AttributeValueMemberL{Value: []ddbtypes.AttributeValue{
+							&ddbtypes.AttributeValueMemberS{Value: "x"},
+						}},
+					}},
+				}},
+			},
+		},
+		{
+			name: "multiple top-level attributes",
+			raw:  `{"pk":{"S":"a"},"sk":{"N":"1"}}`,
+			want: map[string]ddbtypes.AttributeValue{
+				"pk": &ddbtypes.AttributeValueMemberS{Value: "a"},
+				"sk": &ddbtypes.AttributeValueMemberN{Value: "1"},
+			},
+		},
+		{
+			name: "empty document",
+			raw:  `{}`,
+			want: map[string]ddbtypes.AttributeValue{},
+		},
+	}
+}
+
+// decodeDynamoDBJSONErrorTestCases covers malformed input at every level:
+// the top-level document, a single attribute value, and values nested inside
+// B/BS base64 and L/M recursion.
+func decodeDynamoDBJSONErrorTestCases() []decodeDynamoDBJSONTestCase {
+	return []decodeDynamoDBJSONTestCase{
+		{
+			name:    "invalid top-level JSON",
+			raw:     `not json`,
+			wantErr: true,
+		},
+		{
+			name:    "attribute value is not an object",
+			raw:     `{"pk":"a"}`,
+			wantErr: true,
+		},
+		{
+			name:    "no type member set",
+			raw:     `{"pk":{}}`,
+			wantErr: true,
+		},
+		{
+			name:    "ambiguous type members",
+			raw:     `{"pk":{"S":"a","N":"1"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid base64 for B",
+			raw:     `{"b":{"B":"not-base64!"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid base64 within BS",
+			raw:     `{"bs":{"BS":["aGVsbG8=","not-base64!"]}}`,
+			wantErr: true,
+		},
+		{
+			name:    "error inside nested L propagates",
+			raw:     `{"l":{"L":[{"S":"a"},{}]}}`,
+			wantErr: true,
+		},
+		{
+			name:    "error inside nested M propagates",
+			raw:     `{"m":{"M":{"bad":{"S":"a","N":"1"}}}}`,
+			wantErr: true,
+		},
+	}
+}
+
+func TestDecodeDynamoDBJSON(t *testing.T) {
+	t.Parallel()
+
+	scalar := decodeDynamoDBJSONScalarTestCases()
+	collection := decodeDynamoDBJSONCollectionTestCases()
+	nested := decodeDynamoDBJSONNestedTestCases()
+	errCases := decodeDynamoDBJSONErrorTestCases()
+
+	cases := make([]decodeDynamoDBJSONTestCase, 0, len(scalar)+len(collection)+len(nested)+len(errCases))
+	cases = append(cases, scalar...)
+	cases = append(cases, collection...)
+	cases = append(cases, nested...)
+	cases = append(cases, errCases...)
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checkDecodeDynamoDBJSON(t, &tt)
+		})
+	}
+}
+
+func checkDecodeDynamoDBJSON(t *testing.T, tt *decodeDynamoDBJSONTestCase) {
+	t.Helper()
+
+	got, err := decodeDynamoDBJSON(tt.raw)
+	if tt.wantErr {
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("decodeDynamoDBJSON: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, tt.want) {
+		t.Errorf("decodeDynamoDBJSON() = %#v, want %#v", got, tt.want)
+	}
+}

--- a/internal/cligen/flagcode.go
+++ b/internal/cligen/flagcode.go
@@ -22,7 +22,7 @@ var reservedLocalNames = map[string]bool{
 // buildFlagView computes the Go source snippets (variable declaration, flag
 // registration, and input-field assignment) for one derived flag, and
 // records any imports its FlagKind requires on imports.
-func buildFlagView(f FieldFlag, actionUse string, imports *importSet) (flagView, error) {
+func buildFlagView(f *FieldFlag, actionUse string, imports *importSet) (flagView, error) {
 	v := flagVarName(f.FieldName)
 	desc := toWords(f.FieldName)
 
@@ -67,6 +67,8 @@ func buildFlagView(f FieldFlag, actionUse string, imports *importSet) (flagView,
 		imports.needTypes()
 
 		return kvArrayFlag(f, v, desc, actionUse), nil
+	case FlagCustomFunc:
+		return customFuncFlag(f, v, desc, actionUse), nil
 	default:
 		return flagView{}, fmt.Errorf("unsupported flag kind %v for field %s", f.Kind, f.FieldName)
 	}
@@ -88,7 +90,7 @@ func flagVarName(fieldName string) string {
 	return v
 }
 
-func stringFlag(f FieldFlag, v, desc string) flagView {
+func stringFlag(f *FieldFlag, v, desc string) flagView {
 	assign := fmt.Sprintf("if %s != \"\" {\n\tinput.%s = %s\n}", v, f.FieldName, pointerWrap(f, "aws.String", v))
 	if !f.Pointer {
 		assign = fmt.Sprintf("if %s != \"\" {\n\tinput.%s = %s\n}", v, f.FieldName, v)
@@ -102,7 +104,7 @@ func stringFlag(f FieldFlag, v, desc string) flagView {
 	}
 }
 
-func intFlag(f FieldFlag, v, desc, registerFn, wrapFn string) flagView {
+func intFlag(f *FieldFlag, v, desc, registerFn, wrapFn string) flagView {
 	goType := "int32"
 	if registerFn == "Int64Var" {
 		goType = "int64"
@@ -121,7 +123,7 @@ func intFlag(f FieldFlag, v, desc, registerFn, wrapFn string) flagView {
 	}
 }
 
-func boolFlag(f FieldFlag, v, desc string) flagView {
+func boolFlag(f *FieldFlag, v, desc string) flagView {
 	assign := fmt.Sprintf("if %s {\n\tinput.%s = %s\n}", v, f.FieldName, pointerWrap(f, "aws.Bool", v))
 	if !f.Pointer {
 		assign = fmt.Sprintf("if %s {\n\tinput.%s = %s\n}", v, f.FieldName, v)
@@ -135,7 +137,7 @@ func boolFlag(f FieldFlag, v, desc string) flagView {
 	}
 }
 
-func stringEnumFlag(f FieldFlag, v, desc string) flagView {
+func stringEnumFlag(f *FieldFlag, v, desc string) flagView {
 	typeName := "types." + f.ElemType.Name()
 
 	assign := fmt.Sprintf("if %s != \"\" {\n\tinput.%s = %s(%s)\n}", v, f.FieldName, typeName, v)
@@ -151,7 +153,7 @@ func stringEnumFlag(f FieldFlag, v, desc string) flagView {
 	}
 }
 
-func bytesBase64Flag(f FieldFlag, v, desc, actionUse string) flagView {
+func bytesBase64Flag(f *FieldFlag, v, desc, actionUse string) flagView {
 	assign := fmt.Sprintf(
 		"if %s != \"\" {\n\tdecoded, err := base64.StdEncoding.DecodeString(%s)\n\tif err != nil {\n\t\treturn fmt.Errorf(\"%s: decode --%s: %%w\", err)\n\t}\n\tinput.%s = decoded\n}",
 		v, v, actionUse, f.FlagName, f.FieldName,
@@ -165,7 +167,7 @@ func bytesBase64Flag(f FieldFlag, v, desc, actionUse string) flagView {
 	}
 }
 
-func timeFlag(f FieldFlag, v, desc, actionUse string) flagView {
+func timeFlag(f *FieldFlag, v, desc, actionUse string) flagView {
 	set := fmt.Sprintf("input.%s = parsed", f.FieldName)
 	if f.Pointer {
 		set = fmt.Sprintf("input.%s = &parsed", f.FieldName)
@@ -184,7 +186,7 @@ func timeFlag(f FieldFlag, v, desc, actionUse string) flagView {
 	}
 }
 
-func stringArrayFlag(f FieldFlag, v, desc string) flagView {
+func stringArrayFlag(f *FieldFlag, v, desc string) flagView {
 	assign := fmt.Sprintf("if len(%s) > 0 {\n\tinput.%s = %s\n}", v, f.FieldName, v)
 
 	return flagView{
@@ -195,7 +197,7 @@ func stringArrayFlag(f FieldFlag, v, desc string) flagView {
 	}
 }
 
-func stringEnumArrayFlag(f FieldFlag, v, desc string) flagView {
+func stringEnumArrayFlag(f *FieldFlag, v, desc string) flagView {
 	typeName := "types." + f.ElemType.Name()
 
 	assign := fmt.Sprintf(
@@ -211,7 +213,7 @@ func stringEnumArrayFlag(f FieldFlag, v, desc string) flagView {
 	}
 }
 
-func jsonBlobFlag(f FieldFlag, v, desc, actionUse string) flagView {
+func jsonBlobFlag(f *FieldFlag, v, desc, actionUse string) flagView {
 	assign := fmt.Sprintf(
 		"if %s != \"\" {\n\tif err := json.Unmarshal([]byte(%s), &input.%s); err != nil {\n\t\treturn fmt.Errorf(\"%s: parse --%s: %%w\", err)\n\t}\n}",
 		v, v, f.FieldName, actionUse, f.FlagName,
@@ -225,7 +227,7 @@ func jsonBlobFlag(f FieldFlag, v, desc, actionUse string) flagView {
 	}
 }
 
-func kvFlag(f FieldFlag, v, desc, actionUse string) flagView {
+func kvFlag(f *FieldFlag, v, desc, actionUse string) flagView {
 	typeName := "types." + f.ElemType.Name()
 
 	set := fmt.Sprintf("input.%s = val", f.FieldName)
@@ -246,7 +248,7 @@ func kvFlag(f FieldFlag, v, desc, actionUse string) flagView {
 	}
 }
 
-func kvArrayFlag(f FieldFlag, v, desc, actionUse string) flagView {
+func kvArrayFlag(f *FieldFlag, v, desc, actionUse string) flagView {
 	typeName := "types." + f.ElemType.Name()
 
 	assign := fmt.Sprintf(
@@ -262,9 +264,31 @@ func kvArrayFlag(f FieldFlag, v, desc, actionUse string) flagView {
 	}
 }
 
+// customFuncFlag builds a flag for a FlagCustomFunc field: a raw string flag
+// that, when non-empty, is decoded by calling f.CustomFunc (a hand-written
+// cli package function, e.g. decodeDynamoDBJSON) instead of json.Unmarshal.
+func customFuncFlag(f *FieldFlag, v, desc, actionUse string) flagView {
+	set := fmt.Sprintf("input.%s = decoded", f.FieldName)
+	if f.Pointer {
+		set = fmt.Sprintf("input.%s = &decoded", f.FieldName)
+	}
+
+	assign := fmt.Sprintf(
+		"if %s != \"\" {\n\tdecoded, err := %s(%s)\n\tif err != nil {\n\t\treturn fmt.Errorf(\"%s: parse --%s: %%w\", err)\n\t}\n\t%s\n}",
+		v, f.CustomFunc, v, actionUse, f.FlagName, set,
+	)
+
+	return flagView{
+		VarName:  v,
+		VarDecl:  fmt.Sprintf("var %s string", v),
+		Register: fmt.Sprintf("cmd.Flags().StringVar(&%s, %q, \"\", %q)", v, f.FlagName, desc+" (JSON)"),
+		Assign:   assign,
+	}
+}
+
 // pointerWrap returns wrapFn(v) when f.Pointer is true; used by scalar flag
 // builders whose Input field is *T rather than T.
-func pointerWrap(f FieldFlag, wrapFn, v string) string {
+func pointerWrap(f *FieldFlag, wrapFn, v string) string {
 	if !f.Pointer {
 		return v
 	}

--- a/internal/cligen/flags.go
+++ b/internal/cligen/flags.go
@@ -26,10 +26,11 @@ func DeriveFields(serviceName, action string, inputType reflect.Type) FieldsResu
 
 		if override, ok := fieldOverrides[inputType][f.Name]; ok {
 			result.Flags = append(result.Flags, FieldFlag{
-				FieldName: f.Name,
-				FlagName:  toKebabCase(f.Name),
-				Kind:      override.Kind,
-				Pointer:   f.Type.Kind() == reflect.Pointer,
+				FieldName:  f.Name,
+				FlagName:   toKebabCase(f.Name),
+				Kind:       override.Kind,
+				CustomFunc: override.CustomFunc,
+				Pointer:    f.Type.Kind() == reflect.Pointer,
 			})
 
 			continue

--- a/internal/cligen/overrides.go
+++ b/internal/cligen/overrides.go
@@ -3,6 +3,8 @@ package cligen
 import (
 	"reflect"
 	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 )
 
 // FlagOverride replaces the auto-derived flag kind for a specific Input
@@ -11,11 +13,46 @@ import (
 // message bytes) can hook in without changing discover/flags logic.
 type FlagOverride struct {
 	Kind FlagKind
+	// CustomFunc is the cli package function name to call for a
+	// FlagCustomFunc override: func(raw string) (FieldType, error). Empty
+	// for every other Kind.
+	CustomFunc string
 }
+
+// decodeDynamoDBJSON is the hand-written cli.decodeDynamoDBJSON function
+// (cli/support_dynamodb.go) that every dynamodb Input field typed
+// map[string]types.AttributeValue below is routed through: AttributeValue is
+// a Smithy union (interface) type, so encoding/json cannot unmarshal
+// directly into it the way FlagJSONBlob does for plain structs.
+const decodeDynamoDBJSON = "decodeDynamoDBJSON"
 
 // fieldOverrides overrides flag derivation for specific fields, keyed by the
 // SDK Input struct's reflect.Type and then by Go field name.
-var fieldOverrides = map[reflect.Type]map[string]FlagOverride{}
+var fieldOverrides = map[reflect.Type]map[string]FlagOverride{
+	reflect.TypeOf(dynamodb.PutItemInput{}): {
+		"Item":                      {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+		"ExpressionAttributeValues": {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+	},
+	reflect.TypeOf(dynamodb.GetItemInput{}): {
+		"Key": {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+	},
+	reflect.TypeOf(dynamodb.DeleteItemInput{}): {
+		"Key":                       {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+		"ExpressionAttributeValues": {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+	},
+	reflect.TypeOf(dynamodb.UpdateItemInput{}): {
+		"Key":                       {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+		"ExpressionAttributeValues": {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+	},
+	reflect.TypeOf(dynamodb.QueryInput{}): {
+		"ExclusiveStartKey":         {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+		"ExpressionAttributeValues": {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+	},
+	reflect.TypeOf(dynamodb.ScanInput{}): {
+		"ExclusiveStartKey":         {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+		"ExpressionAttributeValues": {Kind: FlagCustomFunc, CustomFunc: decodeDynamoDBJSON},
+	},
+}
 
 // skipAutoGeneration lists, per kumo service name, the SDK action names that
 // must never be auto-generated because a hand-written

--- a/internal/cligen/render.go
+++ b/internal/cligen/render.go
@@ -221,7 +221,7 @@ func buildActionView(binding sdkBinding, action *Action, fields []FieldFlag, imp
 	}
 
 	for _, f := range fields {
-		fv, err := buildFlagView(f, use, imports)
+		fv, err := buildFlagView(&f, use, imports)
 		if err != nil {
 			return actionView{}, err
 		}

--- a/internal/cligen/types.go
+++ b/internal/cligen/types.go
@@ -91,6 +91,12 @@ const (
 	// field (nested structs, maps of structs, or anything deeper than a flat
 	// struct).
 	FlagJSONBlob
+	// FlagCustomFunc is a string flag decoded by calling a named,
+	// hand-written cli package function (see FieldFlag.CustomFunc /
+	// FlagOverride.CustomFunc), for fields no generic rule can derive (e.g.
+	// dynamodb's map[string]types.AttributeValue, decoded by
+	// cli.decodeDynamoDBJSON).
+	FlagCustomFunc
 )
 
 // FieldFlag is a single Input struct field classified as a CLI flag.
@@ -103,6 +109,9 @@ type FieldFlag struct {
 	// ElemType is set for FlagStringEnum (the named enum type), FlagKV and
 	// FlagKVArray (the flat struct type). It is nil otherwise.
 	ElemType reflect.Type
+	// CustomFunc is the cli package function name to call for FlagCustomFunc
+	// fields (see FlagOverride.CustomFunc). Empty for every other Kind.
+	CustomFunc string
 	// Pointer reports whether the struct field's Go type is a pointer
 	// (e.g. *string vs string).
 	Pointer bool


### PR DESCRIPTION
## Summary
Unlocks the six dynamodb actions the generator skipped over AttributeValue union fields: put-item, get-item, delete-item, update-item, query, and scan now accept AWS CLI's DynamoDB-JSON form ({"pk": {"S": "a"}}) through a single shared decoder in cli/support_dynamodb.go, wired via a new FlagCustomFunc override kind in the generator. dynamodb reaches 21/21 generated actions.

Known pre-existing gap left as a follow-up: batch-get/write-item and transact-get/write-items already generated JSON-blob flags, but their AttributeValue unions nest deeper than the detector checks, so those flags fail at runtime on real attribute content; fixing them needs additional bespoke decoders.

## Test plan
- [x] 27-case unit test for the decoder (every member kind, nested L/M, error paths)
- [x] Live roundtrip against kumo: create-table, put-item (nested M/SS), get-item, query with expression-attribute-values, delete-item
- [x] Drift test green, `make lint` 0 issues, `go test -race -shuffle=on ./...` green