### PR TITLE
feat(cli): add sesv2, route53, and cloudfront commands

### DIFF
--- a/cli/cloudfront.go
+++ b/cli/cloudfront.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cloudfrontTypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	"github.com/spf13/cobra"
+)
+
+func newCloudFrontCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cloudfront",
+		Short: "CloudFront commands",
+	}
+
+	cmd.AddCommand(
+		newCloudFrontCreateDistributionCmd(),
+		newCloudFrontGetDistributionCmd(),
+		newCloudFrontListDistributionsCmd(),
+		newCloudFrontDeleteDistributionCmd(),
+		newCloudFrontCreateInvalidationCmd(),
+	)
+
+	return cmd
+}
+
+func newCloudFrontClient(cfg *aws.Config) *cloudfront.Client {
+	return cloudfront.NewFromConfig(*cfg, func(o *cloudfront.Options) {
+		o.BaseEndpoint = aws.String(endpointURL)
+	})
+}
+
+func newCloudFrontCreateDistributionCmd() *cobra.Command {
+	var distributionConfigJSON string
+
+	cmd := &cobra.Command{
+		Use:   "create-distribution",
+		Short: "Create a distribution",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			var distConfig cloudfrontTypes.DistributionConfig
+			if err := json.Unmarshal([]byte(distributionConfigJSON), &distConfig); err != nil {
+				return fmt.Errorf("failed to parse distribution-config: %w", err)
+			}
+
+			out, err := newCloudFrontClient(&cfg).CreateDistribution(cmd.Context(), &cloudfront.CreateDistributionInput{
+				DistributionConfig: &distConfig,
+			})
+			if err != nil {
+				return fmt.Errorf("create-distribution failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&distributionConfigJSON, "distribution-config", "", "Distribution config (JSON)")
+
+	return cmd
+}
+
+func newCloudFrontGetDistributionCmd() *cobra.Command {
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "get-distribution",
+		Short: "Get a distribution",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			out, err := newCloudFrontClient(&cfg).GetDistribution(cmd.Context(), &cloudfront.GetDistributionInput{
+				Id: aws.String(id),
+			})
+			if err != nil {
+				return fmt.Errorf("get-distribution failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&id, "id", "", "Distribution ID")
+
+	return cmd
+}
+
+func newCloudFrontListDistributionsCmd() *cobra.Command {
+	var marker string
+
+	var maxItems int32
+
+	cmd := &cobra.Command{
+		Use:   "list-distributions",
+		Short: "List distributions",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			input := &cloudfront.ListDistributionsInput{}
+			if marker != "" {
+				input.Marker = aws.String(marker)
+			}
+
+			if maxItems > 0 {
+				input.MaxItems = aws.Int32(maxItems)
+			}
+
+			out, err := newCloudFrontClient(&cfg).ListDistributions(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("list-distributions failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&marker, "marker", "", "Pagination marker")
+	cmd.Flags().Int32Var(&maxItems, "max-items", 0, "Maximum number of distributions")
+
+	return cmd
+}
+
+func newCloudFrontDeleteDistributionCmd() *cobra.Command {
+	var id, ifMatch string
+
+	cmd := &cobra.Command{
+		Use:   "delete-distribution",
+		Short: "Delete a distribution",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			_, err = newCloudFrontClient(&cfg).DeleteDistribution(cmd.Context(), &cloudfront.DeleteDistributionInput{
+				Id:      aws.String(id),
+				IfMatch: aws.String(ifMatch),
+			})
+			if err != nil {
+				return fmt.Errorf("delete-distribution failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&id, "id", "", "Distribution ID")
+	cmd.Flags().StringVar(&ifMatch, "if-match", "", "ETag of the distribution to delete")
+
+	return cmd
+}
+
+func newCloudFrontCreateInvalidationCmd() *cobra.Command {
+	var distributionID, invalidationBatchJSON string
+
+	cmd := &cobra.Command{
+		Use:   "create-invalidation",
+		Short: "Create an invalidation",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			var batch cloudfrontTypes.InvalidationBatch
+			if err := json.Unmarshal([]byte(invalidationBatchJSON), &batch); err != nil {
+				return fmt.Errorf("failed to parse invalidation-batch: %w", err)
+			}
+
+			input := &cloudfront.CreateInvalidationInput{
+				DistributionId:    aws.String(distributionID),
+				InvalidationBatch: &batch,
+			}
+
+			out, err := newCloudFrontClient(&cfg).CreateInvalidation(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("create-invalidation failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&distributionID, "distribution-id", "", "Distribution ID")
+	cmd.Flags().StringVar(&invalidationBatchJSON, "invalidation-batch", "", "Invalidation batch (JSON)")
+
+	return cmd
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -33,9 +33,12 @@ func NewRootCmd() *cobra.Command {
 		newAppMeshCmd(),
 		newAppSyncCmd(),
 		newBackupCmd(),
+		newCloudFrontCmd(),
 		newLambdaCmd(),
+		newRoute53Cmd(),
 		newS3Cmd(),
 		newS3APICmd(),
+		newSESv2Cmd(),
 	)
 
 	// Services covered by cli-gen (see internal/cligen and `make cli-gen`).

--- a/cli/route53.go
+++ b/cli/route53.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53Types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/spf13/cobra"
+)
+
+func newRoute53Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "route53",
+		Short: "Route 53 commands",
+	}
+
+	cmd.AddCommand(
+		newRoute53CreateHostedZoneCmd(),
+		newRoute53ListHostedZonesCmd(),
+		newRoute53GetHostedZoneCmd(),
+		newRoute53DeleteHostedZoneCmd(),
+		newRoute53ChangeResourceRecordSetsCmd(),
+		newRoute53ListResourceRecordSetsCmd(),
+	)
+
+	return cmd
+}
+
+func newRoute53Client(cfg *aws.Config) *route53.Client {
+	return route53.NewFromConfig(*cfg, func(o *route53.Options) {
+		o.BaseEndpoint = aws.String(endpointURL)
+	})
+}
+
+func newRoute53CreateHostedZoneCmd() *cobra.Command {
+	var name, callerReference, hostedZoneConfigJSON string
+
+	cmd := &cobra.Command{
+		Use:   "create-hosted-zone",
+		Short: "Create a hosted zone",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			input := &route53.CreateHostedZoneInput{
+				Name:            aws.String(name),
+				CallerReference: aws.String(callerReference),
+			}
+
+			if hostedZoneConfigJSON != "" {
+				var hzConfig route53Types.HostedZoneConfig
+				if err := json.Unmarshal([]byte(hostedZoneConfigJSON), &hzConfig); err != nil {
+					return fmt.Errorf("failed to parse hosted-zone-config: %w", err)
+				}
+
+				input.HostedZoneConfig = &hzConfig
+			}
+
+			out, err := newRoute53Client(&cfg).CreateHostedZone(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("create-hosted-zone failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Domain name")
+	cmd.Flags().StringVar(&callerReference, "caller-reference", "", "Unique string that identifies the request")
+	cmd.Flags().StringVar(&hostedZoneConfigJSON, "hosted-zone-config", "", "Hosted zone config (JSON)")
+
+	return cmd
+}
+
+func newRoute53ListHostedZonesCmd() *cobra.Command {
+	var marker string
+
+	var maxItems int32
+
+	cmd := &cobra.Command{
+		Use:   "list-hosted-zones",
+		Short: "List hosted zones",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			input := &route53.ListHostedZonesInput{}
+			if marker != "" {
+				input.Marker = aws.String(marker)
+			}
+
+			if maxItems > 0 {
+				input.MaxItems = aws.Int32(maxItems)
+			}
+
+			out, err := newRoute53Client(&cfg).ListHostedZones(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("list-hosted-zones failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&marker, "marker", "", "Pagination marker")
+	cmd.Flags().Int32Var(&maxItems, "max-items", 0, "Maximum number of hosted zones")
+
+	return cmd
+}
+
+func newRoute53GetHostedZoneCmd() *cobra.Command {
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "get-hosted-zone",
+		Short: "Get a hosted zone",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			out, err := newRoute53Client(&cfg).GetHostedZone(cmd.Context(), &route53.GetHostedZoneInput{
+				Id: aws.String(id),
+			})
+			if err != nil {
+				return fmt.Errorf("get-hosted-zone failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&id, "id", "", "Hosted zone ID")
+
+	return cmd
+}
+
+func newRoute53DeleteHostedZoneCmd() *cobra.Command {
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "delete-hosted-zone",
+		Short: "Delete a hosted zone",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			out, err := newRoute53Client(&cfg).DeleteHostedZone(cmd.Context(), &route53.DeleteHostedZoneInput{
+				Id: aws.String(id),
+			})
+			if err != nil {
+				return fmt.Errorf("delete-hosted-zone failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&id, "id", "", "Hosted zone ID")
+
+	return cmd
+}
+
+func newRoute53ChangeResourceRecordSetsCmd() *cobra.Command {
+	var hostedZoneID, changeBatchJSON string
+
+	cmd := &cobra.Command{
+		Use:   "change-resource-record-sets",
+		Short: "Create, update, or delete resource record sets",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			var changeBatch route53Types.ChangeBatch
+			if err := json.Unmarshal([]byte(changeBatchJSON), &changeBatch); err != nil {
+				return fmt.Errorf("failed to parse change-batch: %w", err)
+			}
+
+			input := &route53.ChangeResourceRecordSetsInput{
+				HostedZoneId: aws.String(hostedZoneID),
+				ChangeBatch:  &changeBatch,
+			}
+
+			out, err := newRoute53Client(&cfg).ChangeResourceRecordSets(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("change-resource-record-sets failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&hostedZoneID, "hosted-zone-id", "", "Hosted zone ID")
+	cmd.Flags().StringVar(&changeBatchJSON, "change-batch", "", "Change batch (JSON)")
+
+	return cmd
+}
+
+func newRoute53ListResourceRecordSetsCmd() *cobra.Command {
+	var hostedZoneID string
+
+	cmd := &cobra.Command{
+		Use:   "list-resource-record-sets",
+		Short: "List resource record sets",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			out, err := newRoute53Client(&cfg).ListResourceRecordSets(cmd.Context(), &route53.ListResourceRecordSetsInput{
+				HostedZoneId: aws.String(hostedZoneID),
+			})
+			if err != nil {
+				return fmt.Errorf("list-resource-record-sets failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&hostedZoneID, "hosted-zone-id", "", "Hosted zone ID")
+
+	return cmd
+}

--- a/cli/sesv2.go
+++ b/cli/sesv2.go
@@ -1,0 +1,318 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	sesv2Types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/spf13/cobra"
+)
+
+func newSESv2Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sesv2",
+		Short: "SES v2 commands",
+	}
+
+	cmd.AddCommand(
+		newSESv2SendEmailCmd(),
+		newSESv2CreateEmailIdentityCmd(),
+		newSESv2GetEmailIdentityCmd(),
+		newSESv2ListEmailIdentitiesCmd(),
+		newSESv2CreateEmailTemplateCmd(),
+		newSESv2GetEmailTemplateCmd(),
+		newSESv2ListEmailTemplatesCmd(),
+		newSESv2DeleteEmailTemplateCmd(),
+	)
+
+	return cmd
+}
+
+// newSESv2Client builds a SES v2 client. Kumo mounts SES v2 under the "/ses"
+// path prefix, but the AWS SDK serializes requests to "/v2/...", so the base
+// endpoint must include the "/ses" suffix.
+func newSESv2Client(cfg *aws.Config) *sesv2.Client {
+	return sesv2.NewFromConfig(*cfg, func(o *sesv2.Options) {
+		o.BaseEndpoint = aws.String(endpointURL + "/ses")
+	})
+}
+
+func newSESv2SendEmailCmd() *cobra.Command {
+	var fromEmailAddress, destinationJSON, contentJSON string
+
+	cmd := &cobra.Command{
+		Use:   "send-email",
+		Short: "Send an email",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			var destination sesv2Types.Destination
+			if destinationJSON != "" {
+				if err := json.Unmarshal([]byte(destinationJSON), &destination); err != nil {
+					return fmt.Errorf("failed to parse destination: %w", err)
+				}
+			}
+
+			var content sesv2Types.EmailContent
+			if err := json.Unmarshal([]byte(contentJSON), &content); err != nil {
+				return fmt.Errorf("failed to parse content: %w", err)
+			}
+
+			out, err := newSESv2Client(&cfg).SendEmail(cmd.Context(), &sesv2.SendEmailInput{
+				FromEmailAddress: aws.String(fromEmailAddress),
+				Destination:      &destination,
+				Content:          &content,
+			})
+			if err != nil {
+				return fmt.Errorf("send-email failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&fromEmailAddress, "from-email-address", "", "Sender email address")
+	cmd.Flags().StringVar(&destinationJSON, "destination", "", "Destination (JSON)")
+	cmd.Flags().StringVar(&contentJSON, "content", "", "Email content (JSON)")
+
+	return cmd
+}
+
+func newSESv2CreateEmailIdentityCmd() *cobra.Command {
+	var emailIdentity string
+
+	cmd := &cobra.Command{
+		Use:   "create-email-identity",
+		Short: "Create an email identity",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			out, err := newSESv2Client(&cfg).CreateEmailIdentity(cmd.Context(), &sesv2.CreateEmailIdentityInput{
+				EmailIdentity: aws.String(emailIdentity),
+			})
+			if err != nil {
+				return fmt.Errorf("create-email-identity failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&emailIdentity, "email-identity", "", "Email address or domain to verify")
+
+	return cmd
+}
+
+func newSESv2GetEmailIdentityCmd() *cobra.Command {
+	var emailIdentity string
+
+	cmd := &cobra.Command{
+		Use:   "get-email-identity",
+		Short: "Get an email identity",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			out, err := newSESv2Client(&cfg).GetEmailIdentity(cmd.Context(), &sesv2.GetEmailIdentityInput{
+				EmailIdentity: aws.String(emailIdentity),
+			})
+			if err != nil {
+				return fmt.Errorf("get-email-identity failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&emailIdentity, "email-identity", "", "Email address or domain")
+
+	return cmd
+}
+
+func newSESv2ListEmailIdentitiesCmd() *cobra.Command {
+	var nextToken string
+
+	var pageSize int32
+
+	cmd := &cobra.Command{
+		Use:   "list-email-identities",
+		Short: "List email identities",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			input := &sesv2.ListEmailIdentitiesInput{}
+			if nextToken != "" {
+				input.NextToken = aws.String(nextToken)
+			}
+
+			if pageSize > 0 {
+				input.PageSize = aws.Int32(pageSize)
+			}
+
+			out, err := newSESv2Client(&cfg).ListEmailIdentities(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("list-email-identities failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&nextToken, "next-token", "", "Pagination token")
+	cmd.Flags().Int32Var(&pageSize, "page-size", 0, "Maximum number of results")
+
+	return cmd
+}
+
+func newSESv2CreateEmailTemplateCmd() *cobra.Command {
+	var templateName, templateContentJSON string
+
+	cmd := &cobra.Command{
+		Use:   "create-email-template",
+		Short: "Create an email template",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			var content sesv2Types.EmailTemplateContent
+			if err := json.Unmarshal([]byte(templateContentJSON), &content); err != nil {
+				return fmt.Errorf("failed to parse template-content: %w", err)
+			}
+
+			out, err := newSESv2Client(&cfg).CreateEmailTemplate(cmd.Context(), &sesv2.CreateEmailTemplateInput{
+				TemplateName:    aws.String(templateName),
+				TemplateContent: &content,
+			})
+			if err != nil {
+				return fmt.Errorf("create-email-template failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&templateName, "template-name", "", "Template name")
+	cmd.Flags().StringVar(&templateContentJSON, "template-content", "", "Template content (JSON)")
+
+	return cmd
+}
+
+func newSESv2GetEmailTemplateCmd() *cobra.Command {
+	var templateName string
+
+	cmd := &cobra.Command{
+		Use:   "get-email-template",
+		Short: "Get an email template",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			out, err := newSESv2Client(&cfg).GetEmailTemplate(cmd.Context(), &sesv2.GetEmailTemplateInput{
+				TemplateName: aws.String(templateName),
+			})
+			if err != nil {
+				return fmt.Errorf("get-email-template failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&templateName, "template-name", "", "Template name")
+
+	return cmd
+}
+
+func newSESv2ListEmailTemplatesCmd() *cobra.Command {
+	var nextToken string
+
+	var pageSize int32
+
+	cmd := &cobra.Command{
+		Use:   "list-email-templates",
+		Short: "List email templates",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			input := &sesv2.ListEmailTemplatesInput{}
+			if nextToken != "" {
+				input.NextToken = aws.String(nextToken)
+			}
+
+			if pageSize > 0 {
+				input.PageSize = aws.Int32(pageSize)
+			}
+
+			out, err := newSESv2Client(&cfg).ListEmailTemplates(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("list-email-templates failed: %w", err)
+			}
+
+			return encodeJSON(out)
+		},
+	}
+
+	cmd.Flags().StringVar(&nextToken, "next-token", "", "Pagination token")
+	cmd.Flags().Int32Var(&pageSize, "page-size", 0, "Maximum number of results")
+
+	return cmd
+}
+
+func newSESv2DeleteEmailTemplateCmd() *cobra.Command {
+	var templateName string
+
+	cmd := &cobra.Command{
+		Use:   "delete-email-template",
+		Short: "Delete an email template",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			_, err = newSESv2Client(&cfg).DeleteEmailTemplate(cmd.Context(), &sesv2.DeleteEmailTemplateInput{
+				TemplateName: aws.String(templateName),
+			})
+			if err != nil {
+				return fmt.Errorf("delete-email-template failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&templateName, "template-name", "", "Template name")
+
+	return cmd
+}
+
+// encodeJSON writes v to stdout as JSON, matching the AWS CLI's default
+// output format.
+func encodeJSON(v any) error {
+	if err := json.NewEncoder(os.Stdout).Encode(v); err != nil {
+		return fmt.Errorf("failed to encode output: %w", err)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/athena v1.57.6
 	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1
+	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.67.4
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.66.3
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.81.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3
@@ -30,8 +31,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.7
 	github.com/aws/aws-sdk-go-v2/service/kms v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.101.2
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.65.6
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.4
+	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.66.4
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.45.4
 	github.com/aws/aws-sdk-go-v2/service/sns v1.42.4
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/aws/aws-sdk-go-v2/service/backup v1.55.2 h1:WhdT1PwOjTjKLGuD9lJDyNMgY
 github.com/aws/aws-sdk-go-v2/service/backup v1.55.2/go.mod h1:uMh3ZDoLKhXldYL1qcBYy1HsNQfKgL/w8iF2onOyoKY=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1 h1:UDQGJ9AuLcf4yiDKyHPGN4EirOLo/E8+Zfoii8FhyZs=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.76.1/go.mod h1:tCsJEKr4HMFIZSnXLx6rU2HlptPtLhWWfw2V2j9p7lE=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.67.4 h1:vM0MvzS7MkDHdo7Wmf8laa76iV9Q51I2+Qyfp6U+npk=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.67.4/go.mod h1:pJFmx+oQZM45GaxxMbro/1hebSe7r2HEvzRZpYfbOUo=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.66.3 h1:bpL3nRqFErK0i1AAjCnFT5hKovNOZsNzcG+U8wrCbuc=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.66.3/go.mod h1:wvC/zJUFlvcT+KTHLzpKe8PNU21NmTWrXxWBlzh0gTQ=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.81.1 h1:snTrm7koUumqi+IYoRDgsVfYBEM0naT29binkFO57M0=
@@ -68,10 +70,14 @@ github.com/aws/aws-sdk-go-v2/service/kms v1.51.1 h1:zuSf4olLKZW8cF/W9Y5wvGT+/0ra
 github.com/aws/aws-sdk-go-v2/service/kms v1.51.1/go.mod h1:Y0+uxvxz6ib4KktRdK0V4X45Vcs/JyYoz8H71pO8xeI=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.101.2 h1:CkTYIMCfXy2/Td2jLBqw341cNYbRxwSCNPxdDm5COXc=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.101.2/go.mod h1:1YzSvApzBChjIuI1UN2cN2roWoGjR/V7Ch3+pfIfyN0=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.65.6 h1:MDZUFQEVG3S6W+VmhQ9qlbprAuPZDfvvWZTg+HZU0o0=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.65.6/go.mod h1:mh85zjA/hf1PtItwFXA9Yb/2zgUCEYpkN9QmzrK4RNc=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1 h1:mxuT1xE+dI54NW3RkNjP8DUT5HXqbkiAFvfdyDFwE5c=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.4 h1:yCy8e5a6pNHJnqlPn/f9RZ2J0UMwlxA30MRiNedSwzo=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.4/go.mod h1:6DFMltRxgqNNlO+UrKGSxl3fHSAqDjDkTPoGiCLrElI=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.66.4 h1:br4Yg9yZfFggiPLgSh4ud7oLxXeG4r/UFysUiPFBYD0=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.66.4/go.mod h1:f3Jidj1KNnUeGCuKpAhazEpxIFCVyu5+RDAB6OXt1/s=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.45.4 h1:SM1kF9OLEi49bzhYW5xjexvFWKz9NhnWfN6FpWBwLJw=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.45.4/go.mod h1:Ln5QOieZkb5PrbkzHXaFpzsXJFQUn1WbShNSY+p2CcM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -19,11 +19,15 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53Types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/sivchari/golden"
 )
@@ -357,4 +361,152 @@ func TestCLI_Lambda_InvokeWithEndpoint(t *testing.T) {
 	if echoed["key"] != "value" {
 		t.Errorf("payload did not round-trip through InvokeEndpoint: %s", payloadBytes)
 	}
+}
+
+func TestCLI_SESv2_IdentityAndSendEmail(t *testing.T) {
+	emailIdentity := "cli-sender@example.com"
+
+	createOut := runCLI(t, "sesv2", "create-email-identity", "--email-identity", emailIdentity)
+	golden.New(t, golden.WithIgnoreFields("Tokens", "ResultMetadata")).Assert(t.Name()+"_create", createOut)
+
+	client := newSESv2Client(t)
+	t.Cleanup(func() {
+		_, _ = client.DeleteEmailIdentity(context.Background(), &sesv2.DeleteEmailIdentityInput{
+			EmailIdentity: aws.String(emailIdentity),
+		})
+	})
+
+	sendOut := runCLI(t, "sesv2", "send-email",
+		"--from-email-address", emailIdentity,
+		"--destination", `{"ToAddresses":["recipient@example.com"]}`,
+		"--content", `{"Simple":{"Subject":{"Data":"CLI Test Subject"},"Body":{"Text":{"Data":"CLI test body"}}}}`,
+	)
+	golden.New(t, golden.WithIgnoreFields("MessageId", "ResultMetadata")).Assert(t.Name()+"_send", sendOut)
+}
+
+func TestCLI_Route53_HostedZoneAndRecordLifecycle(t *testing.T) {
+	zoneName := "cli-test.example.com"
+
+	createOut := runCLI(t, "route53", "create-hosted-zone",
+		"--name", zoneName,
+		"--caller-reference", "test-cli-route53-create-hosted-zone",
+	)
+	created := decodeCLIJSON(t, createOut)
+	golden.New(t, golden.WithIgnoreFields(
+		"Id", "SubmittedAt", "NameServers", "Location", "ResultMetadata",
+	)).Assert(t.Name()+"_create", createOut)
+
+	hostedZone, _ := created["HostedZone"].(map[string]any)
+
+	zoneID, _ := hostedZone["Id"].(string)
+	if zoneID == "" {
+		t.Fatalf("create-hosted-zone: no HostedZone.Id in output: %s", createOut)
+	}
+
+	client := newRoute53Client(t)
+	t.Cleanup(func() {
+		_, _ = client.ChangeResourceRecordSets(context.Background(), &route53.ChangeResourceRecordSetsInput{
+			HostedZoneId: aws.String(zoneID),
+			ChangeBatch: &route53Types.ChangeBatch{
+				Changes: []route53Types.Change{
+					{
+						Action: route53Types.ChangeActionDelete,
+						ResourceRecordSet: &route53Types.ResourceRecordSet{
+							Name: aws.String("www.cli-test.example.com."),
+							Type: route53Types.RRTypeA,
+							TTL:  aws.Int64(300),
+							ResourceRecords: []route53Types.ResourceRecord{
+								{Value: aws.String("192.0.2.1")},
+							},
+						},
+					},
+				},
+			},
+		})
+		_, _ = client.DeleteHostedZone(context.Background(), &route53.DeleteHostedZoneInput{
+			Id: aws.String(zoneID),
+		})
+	})
+
+	getOut := runCLI(t, "route53", "get-hosted-zone", "--id", zoneID)
+	golden.New(t, golden.WithIgnoreFields(
+		"Id", "ResourceRecordSetCount", "NameServers", "ResultMetadata",
+	)).Assert(t.Name()+"_get", getOut)
+
+	recordChangeBatch := `{"Changes":[{"Action":"CREATE","ResourceRecordSet":` +
+		`{"Name":"www.cli-test.example.com.","Type":"A","TTL":300,"ResourceRecords":[{"Value":"192.0.2.1"}]}}]}`
+
+	changeOut := runCLI(t, "route53", "change-resource-record-sets",
+		"--hosted-zone-id", zoneID, "--change-batch", recordChangeBatch)
+	golden.New(t, golden.WithIgnoreFields("Id", "SubmittedAt", "ResultMetadata")).Assert(t.Name()+"_change", changeOut)
+
+	listOut := runCLI(t, "route53", "list-resource-record-sets", "--hosted-zone-id", zoneID)
+	if !recordSetInList(t, listOut, "www.cli-test.example.com.", "A") {
+		t.Errorf("record set should be in list-resource-record-sets output: %s", listOut)
+	}
+}
+
+// recordSetInList reports whether a resource record set with the given name
+// and type is present in a list-resource-record-sets CLI JSON output.
+func recordSetInList(t *testing.T, listOut []byte, name, recordType string) bool {
+	t.Helper()
+
+	list := decodeCLIJSON(t, listOut)
+
+	recordSets, _ := list["ResourceRecordSets"].([]any)
+
+	for _, rs := range recordSets {
+		record, ok := rs.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if record["Name"] == name && record["Type"] == recordType {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestCLI_CloudFront_DistributionCreateAndGet(t *testing.T) {
+	distributionConfig := `{` +
+		`"CallerReference":"test-cli-cloudfront-create-distribution",` +
+		`"Origins":{"Quantity":1,"Items":[{"Id":"myS3Origin","DomainName":"mybucket.s3.amazonaws.com",` +
+		`"S3OriginConfig":{"OriginAccessIdentity":""}}]},` +
+		`"DefaultCacheBehavior":{"TargetOriginId":"myS3Origin","ViewerProtocolPolicy":"allow-all",` +
+		`"CachePolicyId":"658327ea-f89d-4fab-a63d-7e88639e58f6"},` +
+		`"Comment":"CLI test distribution",` +
+		`"Enabled":true}`
+
+	createOut := runCLI(t, "cloudfront", "create-distribution", "--distribution-config", distributionConfig)
+	created := decodeCLIJSON(t, createOut)
+	golden.New(t, golden.WithIgnoreFields(
+		"Id", "ARN", "DomainName", "LastModifiedTime", "ETag", "Location", "ResultMetadata",
+	)).Assert(t.Name()+"_create", createOut)
+
+	distribution, _ := created["Distribution"].(map[string]any)
+
+	distID, _ := distribution["Id"].(string)
+	if distID == "" {
+		t.Fatalf("create-distribution: no Distribution.Id in output: %s", createOut)
+	}
+
+	etag, _ := created["ETag"].(string)
+	if etag == "" {
+		t.Fatalf("create-distribution: no ETag in output: %s", createOut)
+	}
+
+	client := newCloudFrontClient(t)
+	t.Cleanup(func() {
+		_, _ = client.DeleteDistribution(context.Background(), &cloudfront.DeleteDistributionInput{
+			Id:      aws.String(distID),
+			IfMatch: aws.String(etag),
+		})
+	})
+
+	getOut := runCLI(t, "cloudfront", "get-distribution", "--id", distID)
+	golden.New(t, golden.WithIgnoreFields(
+		"Id", "ARN", "DomainName", "LastModifiedTime", "ETag", "Location", "ResultMetadata",
+	)).Assert(t.Name()+"_get", getOut)
 }

--- a/test/integration/testdata/cli_test_TestCLI_CloudFront_DistributionCreateAndGet_TestCLI_CloudFront_DistributionCreateAndGet_create.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_CloudFront_DistributionCreateAndGet_TestCLI_CloudFront_DistributionCreateAndGet_create.golden.go
@@ -1,0 +1,100 @@
+{
+  "Distribution": {
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/Eea728034-b4d7",
+    "ActiveTrustedKeyGroups": {
+      "Enabled": false,
+      "Items": null,
+      "Quantity": 0
+    },
+    "ActiveTrustedSigners": {
+      "Enabled": false,
+      "Items": null,
+      "Quantity": 0
+    },
+    "AliasICPRecordals": null,
+    "DistributionConfig": {
+      "Aliases": null,
+      "AnycastIpListId": null,
+      "CacheBehaviors": null,
+      "CacheTagConfig": null,
+      "CallerReference": "test-cli-cloudfront-create-distribution",
+      "Comment": "CLI test distribution",
+      "ConnectionFunctionAssociation": null,
+      "ConnectionMode": "",
+      "ContinuousDeploymentPolicyId": null,
+      "CustomErrorResponses": null,
+      "DefaultCacheBehavior": {
+        "AllowedMethods": null,
+        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+        "Compress": null,
+        "DefaultTTL": null,
+        "FieldLevelEncryptionId": null,
+        "ForwardedValues": null,
+        "FunctionAssociations": null,
+        "GrpcConfig": null,
+        "LambdaFunctionAssociations": null,
+        "MaxTTL": null,
+        "MinTTL": null,
+        "OriginRequestPolicyId": null,
+        "RealtimeLogConfigArn": null,
+        "ResponseHeadersPolicyId": null,
+        "SmoothStreaming": null,
+        "TargetOriginId": "myS3Origin",
+        "TrustedKeyGroups": null,
+        "TrustedSigners": null,
+        "ViewerProtocolPolicy": "allow-all"
+      },
+      "DefaultRootObject": null,
+      "Enabled": true,
+      "HttpVersion": "http2",
+      "IsIPV6Enabled": null,
+      "Logging": null,
+      "OriginGroups": null,
+      "Origins": {
+        "Items": [
+          {
+            "ConnectionAttempts": null,
+            "ConnectionTimeout": null,
+            "CustomHeaders": null,
+            "CustomOriginConfig": null,
+            "DomainName": "mybucket.s3.amazonaws.com",
+            "Id": "myS3Origin",
+            "OriginAccessControlId": null,
+            "OriginPath": null,
+            "OriginShield": null,
+            "ResponseCompletionTimeout": null,
+            "S3OriginConfig": {
+              "OriginAccessIdentity": "",
+              "OriginReadTimeout": null
+            },
+            "VpcOriginConfig": null
+          }
+        ],
+        "Quantity": 1
+      },
+      "PriceClass": "PriceClass_All",
+      "Restrictions": null,
+      "Staging": null,
+      "TenantConfig": null,
+      "ViewerCertificate": {
+        "ACMCertificateArn": null,
+        "Certificate": null,
+        "CertificateSource": "",
+        "CloudFrontDefaultCertificate": true,
+        "IAMCertificateId": null,
+        "MinimumProtocolVersion": "TLSv1",
+        "SSLSupportMethod": ""
+      },
+      "ViewerMtlsConfig": null,
+      "WebACLId": null
+    },
+    "DomainName": "Eea728034-b4d7.cloudfront.net",
+    "Id": "Eea728034-b4d7",
+    "InProgressInvalidationBatches": null,
+    "LastModifiedTime": "2026-08-06T18:06:55+09:00",
+    "Status": "InProgress"
+  },
+  "ETag": "E42557c67-6c26-4e11-bb14-fc3cb426",
+  "Location": "/2020-05-31/distribution/Eea728034-b4d7",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_CloudFront_DistributionCreateAndGet_TestCLI_CloudFront_DistributionCreateAndGet_get.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_CloudFront_DistributionCreateAndGet_TestCLI_CloudFront_DistributionCreateAndGet_get.golden.go
@@ -1,0 +1,99 @@
+{
+  "Distribution": {
+    "ARN": "arn:aws:cloudfront::000000000000:distribution/Eea728034-b4d7",
+    "ActiveTrustedKeyGroups": {
+      "Enabled": false,
+      "Items": null,
+      "Quantity": 0
+    },
+    "ActiveTrustedSigners": {
+      "Enabled": false,
+      "Items": null,
+      "Quantity": 0
+    },
+    "AliasICPRecordals": null,
+    "DistributionConfig": {
+      "Aliases": null,
+      "AnycastIpListId": null,
+      "CacheBehaviors": null,
+      "CacheTagConfig": null,
+      "CallerReference": "test-cli-cloudfront-create-distribution",
+      "Comment": "CLI test distribution",
+      "ConnectionFunctionAssociation": null,
+      "ConnectionMode": "",
+      "ContinuousDeploymentPolicyId": null,
+      "CustomErrorResponses": null,
+      "DefaultCacheBehavior": {
+        "AllowedMethods": null,
+        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+        "Compress": null,
+        "DefaultTTL": null,
+        "FieldLevelEncryptionId": null,
+        "ForwardedValues": null,
+        "FunctionAssociations": null,
+        "GrpcConfig": null,
+        "LambdaFunctionAssociations": null,
+        "MaxTTL": null,
+        "MinTTL": null,
+        "OriginRequestPolicyId": null,
+        "RealtimeLogConfigArn": null,
+        "ResponseHeadersPolicyId": null,
+        "SmoothStreaming": null,
+        "TargetOriginId": "myS3Origin",
+        "TrustedKeyGroups": null,
+        "TrustedSigners": null,
+        "ViewerProtocolPolicy": "allow-all"
+      },
+      "DefaultRootObject": null,
+      "Enabled": true,
+      "HttpVersion": "http2",
+      "IsIPV6Enabled": null,
+      "Logging": null,
+      "OriginGroups": null,
+      "Origins": {
+        "Items": [
+          {
+            "ConnectionAttempts": null,
+            "ConnectionTimeout": null,
+            "CustomHeaders": null,
+            "CustomOriginConfig": null,
+            "DomainName": "mybucket.s3.amazonaws.com",
+            "Id": "myS3Origin",
+            "OriginAccessControlId": null,
+            "OriginPath": null,
+            "OriginShield": null,
+            "ResponseCompletionTimeout": null,
+            "S3OriginConfig": {
+              "OriginAccessIdentity": "",
+              "OriginReadTimeout": null
+            },
+            "VpcOriginConfig": null
+          }
+        ],
+        "Quantity": 1
+      },
+      "PriceClass": "PriceClass_All",
+      "Restrictions": null,
+      "Staging": null,
+      "TenantConfig": null,
+      "ViewerCertificate": {
+        "ACMCertificateArn": null,
+        "Certificate": null,
+        "CertificateSource": "",
+        "CloudFrontDefaultCertificate": true,
+        "IAMCertificateId": null,
+        "MinimumProtocolVersion": "TLSv1",
+        "SSLSupportMethod": ""
+      },
+      "ViewerMtlsConfig": null,
+      "WebACLId": null
+    },
+    "DomainName": "Eea728034-b4d7.cloudfront.net",
+    "Id": "Eea728034-b4d7",
+    "InProgressInvalidationBatches": null,
+    "LastModifiedTime": "2026-08-06T18:06:55+09:00",
+    "Status": "InProgress"
+  },
+  "ETag": "E42557c67-6c26-4e11-bb14-fc3cb426",
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_Route53_HostedZoneAndRecordLifecycle_TestCLI_Route53_HostedZoneAndRecordLifecycle_change.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_Route53_HostedZoneAndRecordLifecycle_TestCLI_Route53_HostedZoneAndRecordLifecycle_change.golden.go
@@ -1,0 +1,9 @@
+{
+  "ChangeInfo": {
+    "Comment": null,
+    "Id": "/change/57838f37-4e9d-49cf-80d3-3b190551a3af",
+    "Status": "INSYNC",
+    "SubmittedAt": "2026-08-06T09:06:55Z"
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/cli_test_TestCLI_Route53_HostedZoneAndRecordLifecycle_TestCLI_Route53_HostedZoneAndRecordLifecycle_create.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_Route53_HostedZoneAndRecordLifecycle_TestCLI_Route53_HostedZoneAndRecordLifecycle_create.golden.go
@@ -1,0 +1,30 @@
+{
+  "ChangeInfo": {
+    "Comment": null,
+    "Id": "/change/034dac13-827e-44ad-82ae-8e7a2091399d",
+    "Status": "INSYNC",
+    "SubmittedAt": "2026-08-06T09:06:55Z"
+  },
+  "DelegationSet": {
+    "CallerReference": null,
+    "Id": null,
+    "NameServers": [
+      "ns-1.kumo.local",
+      "ns-2.kumo.local",
+      "ns-3.kumo.local",
+      "ns-4.kumo.local"
+    ]
+  },
+  "HostedZone": {
+    "CallerReference": "test-cli-route53-create-hosted-zone",
+    "Config": null,
+    "Features": null,
+    "Id": "/hostedzone/bf2e12fa-274f-456f-a078-cf2fbdd9c283",
+    "LinkedService": null,
+    "Name": "cli-test.example.com.",
+    "ResourceRecordSetCount": 0
+  },
+  "Location": "https://route53.amazonaws.com/2013-04-01/hostedzone/bf2e12fa-274f-456f-a078-cf2fbdd9c283",
+  "ResultMetadata": {},
+  "VPC": null
+}

--- a/test/integration/testdata/cli_test_TestCLI_Route53_HostedZoneAndRecordLifecycle_TestCLI_Route53_HostedZoneAndRecordLifecycle_get.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_Route53_HostedZoneAndRecordLifecycle_TestCLI_Route53_HostedZoneAndRecordLifecycle_get.golden.go
@@ -1,0 +1,23 @@
+{
+  "DelegationSet": {
+    "CallerReference": null,
+    "Id": null,
+    "NameServers": [
+      "ns-1.kumo.local",
+      "ns-2.kumo.local",
+      "ns-3.kumo.local",
+      "ns-4.kumo.local"
+    ]
+  },
+  "HostedZone": {
+    "CallerReference": "test-cli-route53-create-hosted-zone",
+    "Config": null,
+    "Features": null,
+    "Id": "/hostedzone/bf2e12fa-274f-456f-a078-cf2fbdd9c283",
+    "LinkedService": null,
+    "Name": "cli-test.example.com.",
+    "ResourceRecordSetCount": 0
+  },
+  "ResultMetadata": {},
+  "VPCs": null
+}

--- a/test/integration/testdata/cli_test_TestCLI_SESv2_IdentityAndSendEmail_TestCLI_SESv2_IdentityAndSendEmail_create.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_SESv2_IdentityAndSendEmail_TestCLI_SESv2_IdentityAndSendEmail_create.golden.go
@@ -1,0 +1,17 @@
+{
+  "DkimAttributes": {
+    "CurrentSigningKeyLength": "",
+    "LastKeyGenerationTimestamp": null,
+    "NextSigningKeyLength": "",
+    "SigningAttributesOrigin": "AWS_SES",
+    "SigningEnabled": true,
+    "SigningHostedZone": null,
+    "Status": "SUCCESS",
+    "Tokens": [
+      "e5804167-30bc-4f00-a"
+    ]
+  },
+  "IdentityType": "EMAIL_ADDRESS",
+  "ResultMetadata": {},
+  "VerifiedForSendingStatus": true
+}

--- a/test/integration/testdata/cli_test_TestCLI_SESv2_IdentityAndSendEmail_TestCLI_SESv2_IdentityAndSendEmail_send.golden.go
+++ b/test/integration/testdata/cli_test_TestCLI_SESv2_IdentityAndSendEmail_TestCLI_SESv2_IdentityAndSendEmail_send.golden.go
@@ -1,0 +1,4 @@
+{
+  "MessageId": "44b0a5bb-aae5-4a91-9428-64ee0c5fd590",
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
Hand-written commands for the last three Tier-1 REST services: sesv2 (send-email, identity and template CRUD, 8 commands), route53 (hosted zone and record-set lifecycle, 6), cloudfront (distribution lifecycle and create-invalidation, 5). JSON-typed flags unmarshal directly into SDK types. sesv2's client appends /ses to the endpoint to bridge the SDK's /v2 path prefix to kumo's mount point, mirroring the integration tests.

## Test plan
- [x] E2E goldens per service (identity+send-email, zone+record roundtrip, distribution create+get); full integration suite green after rebasing onto the lambda CLI merge
- [x] Live-checked every command against a running kumo
- [x] `make lint` 0 issues, `go test -race -shuffle=on ./...` green