### PR TITLE
feat(cli-gen): add a coverage report and document the generator workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-fuzz test-integration test-terraform test-helm-e2e clean docker lint lint-fix fmt fmt-diff readme cli-gen
+.PHONY: build run test test-fuzz test-integration test-terraform test-helm-e2e clean docker lint lint-fix fmt fmt-diff readme cli-gen cli-coverage
 
 BINARY_NAME=kumo
 VERSION?=$(shell grep 'const Version' version.go | cut -d'"' -f2)
@@ -60,6 +60,11 @@ readme:
 # discovery/render diagnostics without writing any files.
 cli-gen:
 	go run ./cmd/cli-gen
+
+# Print a per-service CLI coverage table (auto-generated vs hand-written vs
+# uncovered), to spot gaps when adding a new service.
+cli-coverage:
+	go run ./cmd/cli-gen -coverage
 
 # Docker
 docker:

--- a/cmd/cli-gen/coverage.go
+++ b/cmd/cli-gen/coverage.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sivchari/kumo/cli"
+	"github.com/sivchari/kumo/internal/cligen"
+	"github.com/sivchari/kumo/internal/service"
+)
+
+// restCLIAliases maps a kumo service name to additional cli.NewRootCmd()
+// top-level command names (beyond the service name itself) that also count
+// toward that service's hand-written CLI coverage. Needed for hand-written
+// services split across more than one top-level cobra command; currently
+// only s3, which registers both "s3" (high-level, e.g. `mb`) and "s3api"
+// (API-level, e.g. `put-object`). Add an entry here if another hand-written
+// service is split the same way.
+var restCLIAliases = map[string][]string{
+	"s3": {"s3api"},
+}
+
+// skipReasonBuckets classifies a cli-gen skip Diagnostic.Reason into the
+// small, stable set of causes cligen actually produces (see
+// internal/cligen/discover.go and flags.go), so -coverage can summarize N
+// skipped actions instead of printing N distinct per-action reasons (most
+// reasons embed the specific field or action name).
+var skipReasonBuckets = []struct {
+	substr string
+	label  string
+}{
+	{substr: "no matching aws-sdk-go-v2 client method", label: "no matching SDK method"},
+	{substr: "manually overridden in cli/", label: "manual override file"},
+	{substr: "needs a hand-written override", label: "unsupported field type"},
+}
+
+func classifySkipReason(reason string) string {
+	for _, b := range skipReasonBuckets {
+		if strings.Contains(reason, b.substr) {
+			return b.label
+		}
+	}
+
+	return "other"
+}
+
+// serviceCoverage is one row of the -coverage table: how kumo's CLI covers a
+// single registered service.
+type serviceCoverage struct {
+	name      string
+	category  string // "auto-generated", "manual", or "uncovered"
+	commands  int    // commands reachable from the kumo CLI for this service
+	generated int
+	skipped   int
+	note      string
+}
+
+// runCoverage prints a per-service CLI coverage table to w: for every
+// service.Services() entry, whether its CLI commands come from cli-gen
+// auto-discovery (internal/cligen), a hand-written cli/*.go file, or
+// neither, followed by service and command totals.
+func runCoverage(w io.Writer, services []service.Service) error {
+	_, diagnostics, err := cligen.Render(services)
+	if err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+
+	autoGen, restReason := groupDiagnostics(diagnostics)
+	cmdCounts := cliTopLevelCommandCounts()
+
+	rows := make([]serviceCoverage, 0, len(services))
+
+	for _, svc := range services {
+		name := svc.Name()
+
+		if sc, ok := autoGen[name]; ok {
+			rows = append(rows, *sc)
+
+			continue
+		}
+
+		if n, ok := manualCommandCount(name, cmdCounts); ok {
+			rows = append(rows, serviceCoverage{name: name, category: "manual", commands: n})
+
+			continue
+		}
+
+		reason := restReason[name]
+		if reason == "" {
+			reason = "no CLI coverage"
+		}
+
+		rows = append(rows, serviceCoverage{name: name, category: "uncovered", note: reason})
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].name < rows[j].name })
+
+	return printCoverageTable(w, rows)
+}
+
+// groupDiagnostics splits a cligen.Render diagnostics list into per-service
+// auto-generation coverage (services with at least one per-action
+// diagnostic) and service-level skip reasons (REST-only services, or
+// Query/JSON services with no sdkBindings entry).
+func groupDiagnostics(diagnostics []cligen.Diagnostic) (autoGen map[string]*serviceCoverage, restReason map[string]string) {
+	autoGen = make(map[string]*serviceCoverage)
+	restReason = make(map[string]string)
+	skipReasons := make(map[string]map[string]int)
+
+	for _, d := range diagnostics {
+		if d.Action == "" {
+			restReason[d.Service] = d.Reason
+
+			continue
+		}
+
+		sc, ok := autoGen[d.Service]
+		if !ok {
+			sc = &serviceCoverage{name: d.Service, category: "auto-generated"}
+			autoGen[d.Service] = sc
+			skipReasons[d.Service] = make(map[string]int)
+		}
+
+		if d.Level == cligen.LevelGenerated {
+			sc.generated++
+		} else {
+			sc.skipped++
+			skipReasons[d.Service][classifySkipReason(d.Reason)]++
+		}
+	}
+
+	for name, sc := range autoGen {
+		sc.commands = sc.generated
+		sc.note = summarizeSkipReasons(skipReasons[name])
+	}
+
+	return autoGen, restReason
+}
+
+// summarizeSkipReasons renders a "label (n), label2 (n2)" summary, sorted
+// for deterministic output.
+func summarizeSkipReasons(reasons map[string]int) string {
+	if len(reasons) == 0 {
+		return ""
+	}
+
+	labels := make([]string, 0, len(reasons))
+	for label := range reasons {
+		labels = append(labels, label)
+	}
+
+	sort.Strings(labels)
+
+	parts := make([]string, 0, len(labels))
+	for _, label := range labels {
+		parts = append(parts, fmt.Sprintf("%s (%d)", label, reasons[label]))
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// cliTopLevelCommandCounts builds the fully-assembled kumo CLI command tree
+// (both cli-gen-generated and hand-written commands) and returns, per
+// top-level command name (e.g. "s3", "s3api", "amplify"), the number of
+// leaf commands (actual invokable actions) registered under it.
+func cliTopLevelCommandCounts() map[string]int {
+	root := cli.NewRootCmd()
+	counts := make(map[string]int, len(root.Commands()))
+
+	for _, top := range root.Commands() {
+		counts[top.Name()] = countLeafCommands(top)
+	}
+
+	return counts
+}
+
+// countLeafCommands returns the number of leaf commands (no children, i.e.
+// an invokable action rather than a grouping command) reachable under cmd,
+// including cmd itself if it has no children.
+func countLeafCommands(cmd *cobra.Command) int {
+	children := cmd.Commands()
+	if len(children) == 0 {
+		return 1
+	}
+
+	var n int
+
+	for _, c := range children {
+		n += countLeafCommands(c)
+	}
+
+	return n
+}
+
+// manualCommandCount reports the hand-written CLI command count for
+// serviceName (its own top-level command plus any restCLIAliases), and
+// whether serviceName has any hand-written CLI coverage at all.
+func manualCommandCount(serviceName string, cmdCounts map[string]int) (count int, found bool) {
+	if n, ok := cmdCounts[serviceName]; ok {
+		count += n
+		found = true
+	}
+
+	for _, alias := range restCLIAliases[serviceName] {
+		if n, ok := cmdCounts[alias]; ok {
+			count += n
+			found = true
+		}
+	}
+
+	return count, found
+}
+
+// printCoverageTable writes rows as an aligned table to w, followed by
+// service and command totals.
+func printCoverageTable(w io.Writer, rows []serviceCoverage) error {
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+
+	if _, err := fmt.Fprintln(tw, "SERVICE\tCATEGORY\tCOMMANDS\tGENERATED\tSKIPPED\tNOTES"); err != nil {
+		return fmt.Errorf("write coverage table header: %w", err)
+	}
+
+	var coveredServices, totalCommands int
+
+	for _, r := range rows {
+		if r.commands > 0 {
+			coveredServices++
+			totalCommands += r.commands
+		}
+
+		generated, skipped := "-", "-"
+		if r.category == "auto-generated" {
+			generated = fmt.Sprintf("%d", r.generated)
+			skipped = fmt.Sprintf("%d", r.skipped)
+		}
+
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\t%s\n", r.name, r.category, r.commands, generated, skipped, r.note); err != nil {
+			return fmt.Errorf("write coverage table row for %s: %w", r.name, err)
+		}
+	}
+
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("flush coverage table: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(w, "\ntotal: %d/%d service(s) covered, %d command(s)\n", coveredServices, len(rows), totalCommands); err != nil {
+		return fmt.Errorf("write coverage table totals: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/cli-gen/coverage_test.go
+++ b/cmd/cli-gen/coverage_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	_ "github.com/sivchari/kumo/internal/registry"
+	"github.com/sivchari/kumo/internal/service"
+)
+
+func TestClassifySkipReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		reason string
+		want   string
+	}{
+		{"no matching aws-sdk-go-v2 client method (likely a kumo-only custom endpoint)", "no matching SDK method"},
+		{"manually overridden in cli/kms_overrides.go, skipping auto-generation", "manual override file"},
+		{"field KeyId is an interface/union type (e.g. a Smithy union); it needs a hand-written override", "unsupported field type"},
+		{"some future reason cligen doesn't classify yet", "other"},
+	}
+
+	for _, tt := range tests {
+		if got := classifySkipReason(tt.reason); got != tt.want {
+			t.Errorf("classifySkipReason(%q) = %q, want %q", tt.reason, got, tt.want)
+		}
+	}
+}
+
+func TestSummarizeSkipReasons(t *testing.T) {
+	t.Parallel()
+
+	if got := summarizeSkipReasons(nil); got != "" {
+		t.Errorf("summarizeSkipReasons(nil) = %q, want empty", got)
+	}
+
+	got := summarizeSkipReasons(map[string]int{"other": 1, "no matching SDK method": 2})
+	want := "no matching SDK method (2), other (1)"
+
+	if got != want {
+		t.Errorf("summarizeSkipReasons() = %q, want %q", got, want)
+	}
+}
+
+func TestCountLeafCommands(t *testing.T) {
+	t.Parallel()
+
+	leaf := &cobra.Command{Use: "leaf"}
+	if n := countLeafCommands(leaf); n != 1 {
+		t.Errorf("countLeafCommands(leaf) = %d, want 1", n)
+	}
+
+	group := &cobra.Command{Use: "group"}
+	group.AddCommand(&cobra.Command{Use: "a"}, &cobra.Command{Use: "b"})
+
+	if n := countLeafCommands(group); n != 2 {
+		t.Errorf("countLeafCommands(group) = %d, want 2", n)
+	}
+
+	nested := &cobra.Command{Use: "nested"}
+	sub := &cobra.Command{Use: "sub"}
+	sub.AddCommand(&cobra.Command{Use: "c"}, &cobra.Command{Use: "d"})
+	nested.AddCommand(sub, &cobra.Command{Use: "e"})
+
+	if n := countLeafCommands(nested); n != 3 {
+		t.Errorf("countLeafCommands(nested) = %d, want 3", n)
+	}
+}
+
+func TestManualCommandCount(t *testing.T) {
+	t.Parallel()
+
+	counts := map[string]int{"s3": 1, "s3api": 3, "amplify": 9}
+
+	if n, ok := manualCommandCount("s3", counts); !ok || n != 4 {
+		t.Errorf("manualCommandCount(s3) = (%d, %v), want (4, true)", n, ok)
+	}
+
+	if n, ok := manualCommandCount("amplify", counts); !ok || n != 9 {
+		t.Errorf("manualCommandCount(amplify) = (%d, %v), want (9, true)", n, ok)
+	}
+
+	if _, ok := manualCommandCount("route53", counts); ok {
+		t.Error("manualCommandCount(route53) reported found, want not found")
+	}
+}
+
+// TestRunCoverage_CoversEveryService verifies runCoverage emits exactly one
+// row per registered service, categorizes every row into one of the three
+// known categories, and reports a totals line consistent with those rows.
+func TestRunCoverage_CoversEveryService(t *testing.T) {
+	services := service.Services()
+
+	var buf bytes.Buffer
+	if err := runCoverage(&buf, services); err != nil {
+		t.Fatalf("runCoverage: %v", err)
+	}
+
+	seen, totalsLine := parseCoverageOutput(t, buf.String())
+
+	for _, svc := range services {
+		if !seen[svc.Name()] {
+			t.Errorf("coverage table missing row for service %q", svc.Name())
+		}
+	}
+
+	if len(seen) != len(services) {
+		t.Errorf("coverage table has %d row(s), want %d", len(seen), len(services))
+	}
+
+	assertCoverageTotals(t, totalsLine, len(services))
+}
+
+// parseCoverageOutput extracts the set of service names seen in the
+// coverage table (validating each row's category along the way) and the
+// totals line, failing the test if either is malformed.
+func parseCoverageOutput(t *testing.T, output string) (seen map[string]bool, totalsLine string) {
+	t.Helper()
+
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected a header line, service rows, and a totals line; got:\n%s", output)
+	}
+
+	seen = make(map[string]bool)
+
+	for _, line := range lines[1:] { // skip the header row
+		if strings.HasPrefix(line, "total:") {
+			totalsLine = line
+
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		name, category := fields[0], fields[1]
+		seen[name] = true
+
+		assertKnownCategory(t, name, category)
+	}
+
+	if totalsLine == "" {
+		t.Fatalf("coverage table missing totals line, got:\n%s", output)
+	}
+
+	return seen, totalsLine
+}
+
+func assertKnownCategory(t *testing.T, name, category string) {
+	t.Helper()
+
+	switch category {
+	case "auto-generated", "manual", "uncovered":
+	default:
+		t.Errorf("service %q has unknown category %q", name, category)
+	}
+}
+
+func assertCoverageTotals(t *testing.T, totalsLine string, wantTotal int) {
+	t.Helper()
+
+	var covered, total, commands int
+	if _, err := fmt.Sscanf(totalsLine, "total: %d/%d service(s) covered, %d command(s)", &covered, &total, &commands); err != nil {
+		t.Fatalf("parse totals line %q: %v", totalsLine, err)
+	}
+
+	if total != wantTotal {
+		t.Errorf("totals service count = %d, want %d", total, wantTotal)
+	}
+
+	if covered > total {
+		t.Errorf("covered (%d) > total (%d)", covered, total)
+	}
+
+	if commands <= 0 {
+		t.Errorf("total commands = %d, want > 0", commands)
+	}
+}

--- a/cmd/cli-gen/main.go
+++ b/cmd/cli-gen/main.go
@@ -22,7 +22,17 @@ import (
 func main() {
 	outDir := flag.String("out", "cli", "directory to write generated cli/gen_*.go files into (relative paths resolve against the repo root)")
 	dryRun := flag.Bool("dry-run", false, "print discovery/render diagnostics without writing any files")
+	coverage := flag.Bool("coverage", false, "print a per-service CLI coverage table (see `make cli-coverage`) and exit without writing any files")
 	flag.Parse()
+
+	if *coverage {
+		if err := runCoverage(os.Stdout, service.Services()); err != nil {
+			fmt.Fprintln(os.Stderr, "cli-gen:", err)
+			os.Exit(1)
+		}
+
+		return
+	}
 
 	if err := run(*outDir, *dryRun); err != nil {
 		fmt.Fprintln(os.Stderr, "cli-gen:", err)


### PR DESCRIPTION
## Summary
`make cli-coverage` prints a per-service table of CLI coverage: auto-generated services with generated/skipped counts and bucketed skip reasons, hand-written REST services with exact command counts (walked from the assembled cobra tree), and the uncovered remainder. Current state: 32/82 services covered, 423 commands.

The contributor checklist update for the new-service CLI step lives in CLAUDE.md, which is untracked in this repo, so it is applied locally rather than in this PR.

## Test plan
- [x] Unit tests for the coverage classification/counting; `make cli-coverage` runs
- [x] `make lint` 0 issues, `go test -race -shuffle=on ./...` green