### PR TITLE
fix(ci): reduce fuzz test worker parallelism to avoid CI flake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test-fuzz:
 	@grep -rl '^func Fuzz' internal/ | xargs -I{} dirname {} | sort -u | while read pkg; do \
 		grep -oh 'func \(Fuzz[A-Za-z]*\)' "$$pkg"/*_test.go | sed 's/func //' | while read fn; do \
 			echo "=== fuzzing $$fn in $$pkg ==="; \
-			go test -fuzz="$$fn" -fuzztime=60s "./$$pkg/..." || exit 1; \
+			go test -fuzz="$$fn" -fuzztime=60s -parallel=2 "./$$pkg/..." || exit 1; \
 		done; \
 	done
 


### PR DESCRIPTION
## Summary
The daily fuzz job failed with `context deadline exceeded` on `FuzzParseCopySourceAndRangeNoPanic`, but no "Failing input written to testdata/fuzz/..." line was logged, meaning no crasher was actually found. This caps `go test -fuzz` worker parallelism to reduce the odds of hitting this flake.

Fixes #910

## Why
`go test -fuzz` defaults to `GOMAXPROCS` workers. Go's fuzz coordinator has a known race where, under CPU contention, the `-fuzztime` deadline's cancellation can fail to propagate to the worker context in time, so the coordinator reports a bare `context deadline exceeded` instead of suppressing it as a clean timeout (`internal/fuzz/fuzz.go` in the Go stdlib). On the 4-vCPU GitHub Actions runner this race becomes likelier. `-parallel=2` lowers scheduling contention without changing which inputs get fuzzed, and does not mask real crashers — those are persisted to `testdata/fuzz/` and still fail deterministically on the next run.

## Test plan
- [x] `go test -fuzz=FuzzParseCopySourceAndRangeNoPanic -fuzztime=5s -parallel=2 ./internal/service/s3/...` passes locally
- [ ] Fuzz workflow run is green