### PR TITLE
fix(cli): restore v0.27.0 CLI compatibility broken by cli-gen migration

### DIFF
--- a/cli/gen_acm.go
+++ b/cli/gen_acm.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/acm/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -98,8 +97,8 @@ func newACMDescribeCertificateCmd() *cobra.Command {
 				return fmt.Errorf("describe-certificate failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -140,8 +139,8 @@ func newACMGetCertificateCmd() *cobra.Command {
 				return fmt.Errorf("get-certificate failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -218,8 +217,8 @@ func newACMImportCertificateCmd() *cobra.Command {
 				return fmt.Errorf("import-certificate failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -295,8 +294,8 @@ func newACMListCertificatesCmd() *cobra.Command {
 				return fmt.Errorf("list-certificates failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -404,8 +403,8 @@ func newACMRequestCertificateCmd() *cobra.Command {
 				return fmt.Errorf("request-certificate failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_athena.go
+++ b/cli/gen_athena.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -170,8 +169,8 @@ func newAthenaGetQueryExecutionCmd() *cobra.Command {
 				return fmt.Errorf("get-query-execution failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -227,8 +226,8 @@ func newAthenaGetQueryResultsCmd() *cobra.Command {
 				return fmt.Errorf("get-query-results failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -285,8 +284,8 @@ func newAthenaListQueryExecutionsCmd() *cobra.Command {
 				return fmt.Errorf("list-query-executions failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -376,8 +375,8 @@ func newAthenaStartQueryExecutionCmd() *cobra.Command {
 				return fmt.Errorf("start-query-execution failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_cloudformation.go
+++ b/cli/gen_cloudformation.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -170,8 +169,8 @@ func newCloudFormationCreateStackCmd() *cobra.Command {
 				return fmt.Errorf("create-stack failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -337,8 +336,8 @@ func newCloudFormationDescribeStackResourcesCmd() *cobra.Command {
 				return fmt.Errorf("describe-stack-resources failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -388,8 +387,8 @@ func newCloudFormationDescribeStacksCmd() *cobra.Command {
 				return fmt.Errorf("describe-stacks failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -442,8 +441,8 @@ func newCloudFormationGetTemplateCmd() *cobra.Command {
 				return fmt.Errorf("get-template failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -493,8 +492,8 @@ func newCloudFormationListStacksCmd() *cobra.Command {
 				return fmt.Errorf("list-stacks failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -646,8 +645,8 @@ func newCloudFormationUpdateStackCmd() *cobra.Command {
 				return fmt.Errorf("update-stack failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -731,8 +730,8 @@ func newCloudFormationValidateTemplateCmd() *cobra.Command {
 				return fmt.Errorf("validate-template failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_dynamodb.go
+++ b/cli/gen_dynamodb.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -81,8 +80,8 @@ func newDynamoDBBatchGetItemCmd() *cobra.Command {
 				return fmt.Errorf("batch-get-item failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -137,8 +136,8 @@ func newDynamoDBBatchWriteItemCmd() *cobra.Command {
 				return fmt.Errorf("batch-write-item failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -171,6 +170,7 @@ func newDynamoDBCreateTableCmd() *cobra.Command {
 	var resourcePolicy string
 	var sSESpecification string
 	var streamSpecification string
+	var tableClass string
 	var tags []string
 	var warmThroughput string
 
@@ -273,6 +273,10 @@ func newDynamoDBCreateTableCmd() *cobra.Command {
 				input.StreamSpecification = &val
 			}
 
+			if tableClass != "" {
+				input.TableClass = types.TableClass(tableClass)
+			}
+
 			for _, raw := range tags {
 				var val types.Tag
 				if err := cligen.SetFieldsFromKV(reflect.ValueOf(&val).Elem(), raw); err != nil {
@@ -294,8 +298,8 @@ func newDynamoDBCreateTableCmd() *cobra.Command {
 				return fmt.Errorf("create-table failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -329,6 +333,8 @@ func newDynamoDBCreateTableCmd() *cobra.Command {
 	cmd.Flags().StringVar(&sSESpecification, "sse-specification", "", "Sse specification (key=value,key2=value2)")
 
 	cmd.Flags().StringVar(&streamSpecification, "stream-specification", "", "Stream specification (key=value,key2=value2)")
+
+	cmd.Flags().StringVar(&tableClass, "table-class", "", "Table class")
 
 	cmd.Flags().StringArrayVar(&tags, "tags", nil, "Tags (key=value,key2=value2, repeatable)")
 
@@ -428,8 +434,8 @@ func newDynamoDBDeleteItemCmd() *cobra.Command {
 				return fmt.Errorf("delete-item failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -490,8 +496,8 @@ func newDynamoDBDeleteTableCmd() *cobra.Command {
 				return fmt.Errorf("delete-table failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -532,8 +538,8 @@ func newDynamoDBDescribeContinuousBackupsCmd() *cobra.Command {
 				return fmt.Errorf("describe-continuous-backups failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -574,8 +580,8 @@ func newDynamoDBDescribeTableCmd() *cobra.Command {
 				return fmt.Errorf("describe-table failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -616,8 +622,8 @@ func newDynamoDBDescribeTimeToLiveCmd() *cobra.Command {
 				return fmt.Errorf("describe-time-to-live failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -694,8 +700,8 @@ func newDynamoDBGetItemCmd() *cobra.Command {
 				return fmt.Errorf("get-item failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -753,8 +759,8 @@ func newDynamoDBListTablesCmd() *cobra.Command {
 				return fmt.Errorf("list-tables failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -802,8 +808,8 @@ func newDynamoDBListTagsOfResourceCmd() *cobra.Command {
 				return fmt.Errorf("list-tags-of-resource failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -908,8 +914,8 @@ func newDynamoDBPutItemCmd() *cobra.Command {
 				return fmt.Errorf("put-item failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1064,8 +1070,8 @@ func newDynamoDBQueryCmd() *cobra.Command {
 				return fmt.Errorf("query failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1225,8 +1231,8 @@ func newDynamoDBScanCmd() *cobra.Command {
 				return fmt.Errorf("scan failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1353,8 +1359,8 @@ func newDynamoDBTransactGetItemsCmd() *cobra.Command {
 				return fmt.Errorf("transact-get-items failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1414,8 +1420,8 @@ func newDynamoDBTransactWriteItemsCmd() *cobra.Command {
 				return fmt.Errorf("transact-write-items failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1581,8 +1587,8 @@ func newDynamoDBUpdateItemCmd() *cobra.Command {
 				return fmt.Errorf("update-item failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1747,8 +1753,8 @@ func newDynamoDBUpdateTableCmd() *cobra.Command {
 				return fmt.Errorf("update-table failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_dynamodbstreams.go
+++ b/cli/gen_dynamodbstreams.go
@@ -3,14 +3,12 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodbstreams"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodbstreams/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -75,8 +73,8 @@ func newDynamoDBStreamsDescribeStreamCmd() *cobra.Command {
 				return fmt.Errorf("describe-stream failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -128,8 +126,8 @@ func newDynamoDBStreamsGetRecordsCmd() *cobra.Command {
 				return fmt.Errorf("get-records failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -187,8 +185,8 @@ func newDynamoDBStreamsGetShardIteratorCmd() *cobra.Command {
 				return fmt.Errorf("get-shard-iterator failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_ec2.go
+++ b/cli/gen_ec2.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -112,8 +111,8 @@ func newEC2AssociateRouteTableCmd() *cobra.Command {
 				return fmt.Errorf("associate-route-table failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -263,8 +262,8 @@ func newEC2AuthorizeSecurityGroupEgressCmd() *cobra.Command {
 				return fmt.Errorf("authorize-security-group-egress failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -377,8 +376,8 @@ func newEC2AuthorizeSecurityGroupIngressCmd() *cobra.Command {
 				return fmt.Errorf("authorize-security-group-ingress failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -446,8 +445,8 @@ func newEC2CreateInternetGatewayCmd() *cobra.Command {
 				return fmt.Errorf("create-internet-gateway failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -512,8 +511,8 @@ func newEC2CreateKeyPairCmd() *cobra.Command {
 				return fmt.Errorf("create-key-pair failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -626,8 +625,8 @@ func newEC2CreateNatGatewayCmd() *cobra.Command {
 				return fmt.Errorf("create-nat-gateway failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -772,8 +771,8 @@ func newEC2CreateRouteCmd() *cobra.Command {
 				return fmt.Errorf("create-route failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -863,8 +862,8 @@ func newEC2CreateRouteTableCmd() *cobra.Command {
 				return fmt.Errorf("create-route-table failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -933,8 +932,8 @@ func newEC2CreateSecurityGroupCmd() *cobra.Command {
 				return fmt.Errorf("create-security-group failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1045,8 +1044,8 @@ func newEC2CreateSubnetCmd() *cobra.Command {
 				return fmt.Errorf("create-subnet failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1233,8 +1232,8 @@ func newEC2CreateVpcCmd() *cobra.Command {
 				return fmt.Errorf("create-vpc failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1354,8 +1353,8 @@ func newEC2DeleteKeyPairCmd() *cobra.Command {
 				return fmt.Errorf("delete-key-pair failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1410,8 +1409,8 @@ func newEC2DeleteSecurityGroupCmd() *cobra.Command {
 				return fmt.Errorf("delete-security-group failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1629,8 +1628,8 @@ func newEC2DescribeInstancesCmd() *cobra.Command {
 				return fmt.Errorf("describe-instances failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1703,8 +1702,8 @@ func newEC2DescribeInternetGatewaysCmd() *cobra.Command {
 				return fmt.Errorf("describe-internet-gateways failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1775,8 +1774,8 @@ func newEC2DescribeKeyPairsCmd() *cobra.Command {
 				return fmt.Errorf("describe-key-pairs failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1847,8 +1846,8 @@ func newEC2DescribeNatGatewaysCmd() *cobra.Command {
 				return fmt.Errorf("describe-nat-gateways failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1924,8 +1923,8 @@ func newEC2DescribeNetworkInterfacesCmd() *cobra.Command {
 				return fmt.Errorf("describe-network-interfaces failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1998,8 +1997,8 @@ func newEC2DescribeRouteTablesCmd() *cobra.Command {
 				return fmt.Errorf("describe-route-tables failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -2075,8 +2074,8 @@ func newEC2DescribeSecurityGroupsCmd() *cobra.Command {
 				return fmt.Errorf("describe-security-groups failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -2149,8 +2148,8 @@ func newEC2DescribeSubnetsCmd() *cobra.Command {
 				return fmt.Errorf("describe-subnets failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -2216,8 +2215,8 @@ func newEC2DescribeTagsCmd() *cobra.Command {
 				return fmt.Errorf("describe-tags failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -2274,8 +2273,8 @@ func newEC2DescribeVpcAttributeCmd() *cobra.Command {
 				return fmt.Errorf("describe-vpc-attribute failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -2342,8 +2341,8 @@ func newEC2DescribeVpcsCmd() *cobra.Command {
 				return fmt.Errorf("describe-vpcs failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -2698,8 +2697,8 @@ func newEC2RevokeSecurityGroupEgressCmd() *cobra.Command {
 				return fmt.Errorf("revoke-security-group-egress failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -2810,8 +2809,8 @@ func newEC2RevokeSecurityGroupIngressCmd() *cobra.Command {
 				return fmt.Errorf("revoke-security-group-ingress failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -3167,8 +3166,8 @@ func newEC2RunInstancesCmd() *cobra.Command {
 				return fmt.Errorf("run-instances failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -3305,8 +3304,8 @@ func newEC2StartInstancesCmd() *cobra.Command {
 				return fmt.Errorf("start-instances failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -3371,8 +3370,8 @@ func newEC2StopInstancesCmd() *cobra.Command {
 				return fmt.Errorf("stop-instances failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -3436,8 +3435,8 @@ func newEC2TerminateInstancesCmd() *cobra.Command {
 				return fmt.Errorf("terminate-instances failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_ecr.go
+++ b/cli/gen_ecr.go
@@ -3,14 +3,12 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -78,8 +76,8 @@ func newECRBatchDeleteImageCmd() *cobra.Command {
 				return fmt.Errorf("batch-delete-image failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -143,8 +141,8 @@ func newECRBatchGetImageCmd() *cobra.Command {
 				return fmt.Errorf("batch-get-image failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -237,8 +235,8 @@ func newECRCreateRepositoryCmd() *cobra.Command {
 				return fmt.Errorf("create-repository failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -296,8 +294,8 @@ func newECRDeleteLifecyclePolicyCmd() *cobra.Command {
 				return fmt.Errorf("delete-lifecycle-policy failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -350,8 +348,8 @@ func newECRDeleteRepositoryCmd() *cobra.Command {
 				return fmt.Errorf("delete-repository failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -411,8 +409,8 @@ func newECRDescribeRepositoriesCmd() *cobra.Command {
 				return fmt.Errorf("describe-repositories failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -459,8 +457,8 @@ func newECRGetAuthorizationTokenCmd() *cobra.Command {
 				return fmt.Errorf("get-authorization-token failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -506,8 +504,8 @@ func newECRGetLifecyclePolicyCmd() *cobra.Command {
 				return fmt.Errorf("get-lifecycle-policy failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -574,8 +572,8 @@ func newECRListImagesCmd() *cobra.Command {
 				return fmt.Errorf("list-images failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -649,8 +647,8 @@ func newECRPutImageCmd() *cobra.Command {
 				return fmt.Errorf("put-image failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -711,8 +709,8 @@ func newECRPutLifecyclePolicyCmd() *cobra.Command {
 				return fmt.Errorf("put-lifecycle-policy failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_ecs.go
+++ b/cli/gen_ecs.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -113,8 +112,8 @@ func newECSCreateClusterCmd() *cobra.Command {
 				return fmt.Errorf("create-cluster failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -337,8 +336,8 @@ func newECSCreateServiceCmd() *cobra.Command {
 				return fmt.Errorf("create-service failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -431,8 +430,8 @@ func newECSDeleteClusterCmd() *cobra.Command {
 				return fmt.Errorf("delete-cluster failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -483,8 +482,8 @@ func newECSDeleteServiceCmd() *cobra.Command {
 				return fmt.Errorf("delete-service failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -529,8 +528,8 @@ func newECSDeregisterTaskDefinitionCmd() *cobra.Command {
 				return fmt.Errorf("deregister-task-definition failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -576,8 +575,8 @@ func newECSDescribeClustersCmd() *cobra.Command {
 				return fmt.Errorf("describe-clusters failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -630,8 +629,8 @@ func newECSDescribeTasksCmd() *cobra.Command {
 				return fmt.Errorf("describe-tasks failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -681,8 +680,8 @@ func newECSListClustersCmd() *cobra.Command {
 				return fmt.Errorf("list-clusters failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -836,8 +835,8 @@ func newECSRegisterTaskDefinitionCmd() *cobra.Command {
 				return fmt.Errorf("register-task-definition failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1024,8 +1023,8 @@ func newECSRunTaskCmd() *cobra.Command {
 				return fmt.Errorf("run-task failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1112,8 +1111,8 @@ func newECSStopTaskCmd() *cobra.Command {
 				return fmt.Errorf("stop-task failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1304,8 +1303,8 @@ func newECSUpdateServiceCmd() *cobra.Command {
 				return fmt.Errorf("update-service failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_events.go
+++ b/cli/gen_events.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -99,8 +98,8 @@ func newEventsCreateApiDestinationCmd() *cobra.Command {
 				return fmt.Errorf("create-api-destination failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -180,8 +179,8 @@ func newEventsCreateConnectionCmd() *cobra.Command {
 				return fmt.Errorf("create-connection failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -274,8 +273,8 @@ func newEventsCreateEventBusCmd() *cobra.Command {
 				return fmt.Errorf("create-event-bus failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -366,8 +365,8 @@ func newEventsDeleteConnectionCmd() *cobra.Command {
 				return fmt.Errorf("delete-connection failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -498,8 +497,8 @@ func newEventsDescribeApiDestinationCmd() *cobra.Command {
 				return fmt.Errorf("describe-api-destination failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -540,8 +539,8 @@ func newEventsDescribeConnectionCmd() *cobra.Command {
 				return fmt.Errorf("describe-connection failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -582,8 +581,8 @@ func newEventsDescribeEventBusCmd() *cobra.Command {
 				return fmt.Errorf("describe-event-bus failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -629,8 +628,8 @@ func newEventsDescribeRuleCmd() *cobra.Command {
 				return fmt.Errorf("describe-rule failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -683,8 +682,8 @@ func newEventsListEventBusesCmd() *cobra.Command {
 				return fmt.Errorf("list-event-buses failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -744,8 +743,8 @@ func newEventsListRulesCmd() *cobra.Command {
 				return fmt.Errorf("list-rules failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -792,8 +791,8 @@ func newEventsListTagsForResourceCmd() *cobra.Command {
 				return fmt.Errorf("list-tags-for-resource failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -849,8 +848,8 @@ func newEventsListTargetsByRuleCmd() *cobra.Command {
 				return fmt.Errorf("list-targets-by-rule failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -904,8 +903,8 @@ func newEventsPutEventsCmd() *cobra.Command {
 				return fmt.Errorf("put-events failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -987,8 +986,8 @@ func newEventsPutRuleCmd() *cobra.Command {
 				return fmt.Errorf("put-rule failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1055,8 +1054,8 @@ func newEventsPutTargetsCmd() *cobra.Command {
 				return fmt.Errorf("put-targets failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1116,8 +1115,8 @@ func newEventsRemoveTargetsCmd() *cobra.Command {
 				return fmt.Errorf("remove-targets failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_firehose.go
+++ b/cli/gen_firehose.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/firehose/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -185,8 +184,8 @@ func newFirehoseCreateDeliveryStreamCmd() *cobra.Command {
 				return fmt.Errorf("create-delivery-stream failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -316,8 +315,8 @@ func newFirehoseDescribeDeliveryStreamCmd() *cobra.Command {
 				return fmt.Errorf("describe-delivery-stream failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -372,8 +371,8 @@ func newFirehoseListDeliveryStreamsCmd() *cobra.Command {
 				return fmt.Errorf("list-delivery-streams failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -427,8 +426,8 @@ func newFirehosePutRecordCmd() *cobra.Command {
 				return fmt.Errorf("put-record failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -480,8 +479,8 @@ func newFirehosePutRecordBatchCmd() *cobra.Command {
 				return fmt.Errorf("put-record-batch failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_iam.go
+++ b/cli/gen_iam.go
@@ -3,14 +3,12 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -227,8 +225,8 @@ func newIAMCreateAccessKeyCmd() *cobra.Command {
 				return fmt.Errorf("create-access-key failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -283,8 +281,8 @@ func newIAMCreateInstanceProfileCmd() *cobra.Command {
 				return fmt.Errorf("create-instance-profile failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -348,8 +346,8 @@ func newIAMCreateOpenIDConnectProviderCmd() *cobra.Command {
 				return fmt.Errorf("create-open-id-connect-provider failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -420,8 +418,8 @@ func newIAMCreatePolicyCmd() *cobra.Command {
 				return fmt.Errorf("create-policy failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -504,8 +502,8 @@ func newIAMCreateRoleCmd() *cobra.Command {
 				return fmt.Errorf("create-role failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -577,8 +575,8 @@ func newIAMCreateUserCmd() *cobra.Command {
 				return fmt.Errorf("create-user failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -995,8 +993,8 @@ func newIAMGetInstanceProfileCmd() *cobra.Command {
 				return fmt.Errorf("get-instance-profile failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1037,8 +1035,8 @@ func newIAMGetOpenIDConnectProviderCmd() *cobra.Command {
 				return fmt.Errorf("get-open-id-connect-provider failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1079,8 +1077,8 @@ func newIAMGetPolicyCmd() *cobra.Command {
 				return fmt.Errorf("get-policy failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1121,8 +1119,8 @@ func newIAMGetRoleCmd() *cobra.Command {
 				return fmt.Errorf("get-role failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1168,8 +1166,8 @@ func newIAMGetRolePolicyCmd() *cobra.Command {
 				return fmt.Errorf("get-role-policy failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1212,8 +1210,8 @@ func newIAMGetUserCmd() *cobra.Command {
 				return fmt.Errorf("get-user failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1264,8 +1262,8 @@ func newIAMListAccessKeysCmd() *cobra.Command {
 				return fmt.Errorf("list-access-keys failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1325,8 +1323,8 @@ func newIAMListAttachedRolePoliciesCmd() *cobra.Command {
 				return fmt.Errorf("list-attached-role-policies failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1383,8 +1381,8 @@ func newIAMListInstanceProfilesCmd() *cobra.Command {
 				return fmt.Errorf("list-instance-profiles failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1439,8 +1437,8 @@ func newIAMListInstanceProfilesForRoleCmd() *cobra.Command {
 				return fmt.Errorf("list-instance-profiles-for-role failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1480,8 +1478,8 @@ func newIAMListOpenIDConnectProvidersCmd() *cobra.Command {
 				return fmt.Errorf("list-open-id-connect-providers failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1545,8 +1543,8 @@ func newIAMListPoliciesCmd() *cobra.Command {
 				return fmt.Errorf("list-policies failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1607,8 +1605,8 @@ func newIAMListRolePoliciesCmd() *cobra.Command {
 				return fmt.Errorf("list-role-policies failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1663,8 +1661,8 @@ func newIAMListRolesCmd() *cobra.Command {
 				return fmt.Errorf("list-roles failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1719,8 +1717,8 @@ func newIAMListUsersCmd() *cobra.Command {
 				return fmt.Errorf("list-users failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_kinesis.go
+++ b/cli/gen_kinesis.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 	"time"
 )
@@ -223,8 +222,8 @@ func newKinesisDescribeStreamCmd() *cobra.Command {
 				return fmt.Errorf("describe-stream failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -283,8 +282,8 @@ func newKinesisDescribeStreamSummaryCmd() *cobra.Command {
 				return fmt.Errorf("describe-stream-summary failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -344,8 +343,8 @@ func newKinesisGetRecordsCmd() *cobra.Command {
 				return fmt.Errorf("get-records failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -426,8 +425,8 @@ func newKinesisGetShardIteratorCmd() *cobra.Command {
 				return fmt.Errorf("get-shard-iterator failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -521,8 +520,8 @@ func newKinesisListShardsCmd() *cobra.Command {
 				return fmt.Errorf("list-shards failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -587,8 +586,8 @@ func newKinesisListStreamsCmd() *cobra.Command {
 				return fmt.Errorf("list-streams failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -667,8 +666,8 @@ func newKinesisPutRecordCmd() *cobra.Command {
 				return fmt.Errorf("put-record failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -740,8 +739,8 @@ func newKinesisPutRecordsCmd() *cobra.Command {
 				return fmt.Errorf("put-records failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_kms.go
+++ b/cli/gen_kms.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -175,8 +174,8 @@ func newKMSCreateKeyCmd() *cobra.Command {
 				return fmt.Errorf("create-key failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -282,8 +281,8 @@ func newKMSDecryptCmd() *cobra.Command {
 				return fmt.Errorf("decrypt failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -381,8 +380,8 @@ func newKMSDescribeKeyCmd() *cobra.Command {
 				return fmt.Errorf("describe-key failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -532,8 +531,8 @@ func newKMSEncryptCmd() *cobra.Command {
 				return fmt.Errorf("encrypt failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -620,8 +619,8 @@ func newKMSGenerateDataKeyCmd() *cobra.Command {
 				return fmt.Errorf("generate-data-key failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -679,8 +678,8 @@ func newKMSGetKeyPolicyCmd() *cobra.Command {
 				return fmt.Errorf("get-key-policy failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -723,8 +722,8 @@ func newKMSGetKeyRotationStatusCmd() *cobra.Command {
 				return fmt.Errorf("get-key-rotation-status failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -770,8 +769,8 @@ func newKMSGetPublicKeyCmd() *cobra.Command {
 				return fmt.Errorf("get-public-key failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -824,8 +823,8 @@ func newKMSListAliasesCmd() *cobra.Command {
 				return fmt.Errorf("list-aliases failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -880,8 +879,8 @@ func newKMSListKeyPoliciesCmd() *cobra.Command {
 				return fmt.Errorf("list-key-policies failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -931,8 +930,8 @@ func newKMSListKeysCmd() *cobra.Command {
 				return fmt.Errorf("list-keys failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -985,8 +984,8 @@ func newKMSListResourceTagsCmd() *cobra.Command {
 				return fmt.Errorf("list-resource-tags failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1095,8 +1094,8 @@ func newKMSScheduleKeyDeletionCmd() *cobra.Command {
 				return fmt.Errorf("schedule-key-deletion failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_logs.go
+++ b/cli/gen_logs.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -333,8 +332,8 @@ func newLogsDescribeLogGroupsCmd() *cobra.Command {
 				return fmt.Errorf("describe-log-groups failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -419,8 +418,8 @@ func newLogsDescribeLogStreamsCmd() *cobra.Command {
 				return fmt.Errorf("describe-log-streams failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -528,8 +527,8 @@ func newLogsFilterLogEventsCmd() *cobra.Command {
 				return fmt.Errorf("filter-log-events failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -632,8 +631,8 @@ func newLogsGetLogEventsCmd() *cobra.Command {
 				return fmt.Errorf("get-log-events failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -716,8 +715,8 @@ func newLogsPutLogEventsCmd() *cobra.Command {
 				return fmt.Errorf("put-log-events failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_monitoring.go
+++ b/cli/gen_monitoring.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 	"time"
 )
@@ -142,8 +141,8 @@ func newCloudWatchDescribeAlarmsCmd() *cobra.Command {
 				return fmt.Errorf("describe-alarms failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -244,8 +243,8 @@ func newCloudWatchGetMetricDataCmd() *cobra.Command {
 				return fmt.Errorf("get-metric-data failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -350,8 +349,8 @@ func newCloudWatchGetMetricStatisticsCmd() *cobra.Command {
 				return fmt.Errorf("get-metric-statistics failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -442,8 +441,8 @@ func newCloudWatchListMetricsCmd() *cobra.Command {
 				return fmt.Errorf("list-metrics failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -496,8 +495,8 @@ func newCloudWatchListTagsForResourceCmd() *cobra.Command {
 				return fmt.Errorf("list-tags-for-resource failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_secretsmanager.go
+++ b/cli/gen_secretsmanager.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -122,8 +121,8 @@ func newSecretsManagerCreateSecretCmd() *cobra.Command {
 				return fmt.Errorf("create-secret failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -182,8 +181,8 @@ func newSecretsManagerDeleteResourcePolicyCmd() *cobra.Command {
 				return fmt.Errorf("delete-resource-policy failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -234,8 +233,8 @@ func newSecretsManagerDeleteSecretCmd() *cobra.Command {
 				return fmt.Errorf("delete-secret failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -280,8 +279,8 @@ func newSecretsManagerDescribeSecretCmd() *cobra.Command {
 				return fmt.Errorf("describe-secret failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -357,8 +356,8 @@ func newSecretsManagerGetRandomPasswordCmd() *cobra.Command {
 				return fmt.Errorf("get-random-password failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -413,8 +412,8 @@ func newSecretsManagerGetResourcePolicyCmd() *cobra.Command {
 				return fmt.Errorf("get-resource-policy failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -465,8 +464,8 @@ func newSecretsManagerGetSecretValueCmd() *cobra.Command {
 				return fmt.Errorf("get-secret-value failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -538,8 +537,8 @@ func newSecretsManagerListSecretsCmd() *cobra.Command {
 				return fmt.Errorf("list-secrets failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -600,8 +599,8 @@ func newSecretsManagerPutResourcePolicyCmd() *cobra.Command {
 				return fmt.Errorf("put-resource-policy failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -675,8 +674,8 @@ func newSecretsManagerPutSecretValueCmd() *cobra.Command {
 				return fmt.Errorf("put-secret-value failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -761,8 +760,8 @@ func newSecretsManagerUpdateSecretCmd() *cobra.Command {
 				return fmt.Errorf("update-secret failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_sns.go
+++ b/cli/gen_sns.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sns/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -89,8 +88,8 @@ func newSNSCreateTopicCmd() *cobra.Command {
 				return fmt.Errorf("create-topic failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -175,8 +174,8 @@ func newSNSGetSubscriptionAttributesCmd() *cobra.Command {
 				return fmt.Errorf("get-subscription-attributes failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -217,8 +216,8 @@ func newSNSGetTopicAttributesCmd() *cobra.Command {
 				return fmt.Errorf("get-topic-attributes failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -259,8 +258,8 @@ func newSNSListSubscriptionsCmd() *cobra.Command {
 				return fmt.Errorf("list-subscriptions failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -306,8 +305,8 @@ func newSNSListSubscriptionsByTopicCmd() *cobra.Command {
 				return fmt.Errorf("list-subscriptions-by-topic failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -350,8 +349,8 @@ func newSNSListTagsForResourceCmd() *cobra.Command {
 				return fmt.Errorf("list-tags-for-resource failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -392,8 +391,8 @@ func newSNSListTopicsCmd() *cobra.Command {
 				return fmt.Errorf("list-topics failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -476,8 +475,8 @@ func newSNSPublishCmd() *cobra.Command {
 				return fmt.Errorf("publish failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -660,8 +659,8 @@ func newSNSSubscribeCmd() *cobra.Command {
 				return fmt.Errorf("subscribe failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_sqs.go
+++ b/cli/gen_sqs.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -131,8 +130,8 @@ func newSQSChangeMessageVisibilityBatchCmd() *cobra.Command {
 				return fmt.Errorf("change-message-visibility-batch failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -189,8 +188,8 @@ func newSQSCreateQueueCmd() *cobra.Command {
 				return fmt.Errorf("create-queue failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -289,8 +288,8 @@ func newSQSDeleteMessageBatchCmd() *cobra.Command {
 				return fmt.Errorf("delete-message-batch failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -376,8 +375,8 @@ func newSQSGetQueueAttributesCmd() *cobra.Command {
 				return fmt.Errorf("get-queue-attributes failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -425,8 +424,8 @@ func newSQSGetQueueUrlCmd() *cobra.Command {
 				return fmt.Errorf("get-queue-url failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -469,8 +468,8 @@ func newSQSListQueueTagsCmd() *cobra.Command {
 				return fmt.Errorf("list-queue-tags failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -521,8 +520,8 @@ func newSQSListQueuesCmd() *cobra.Command {
 				return fmt.Errorf("list-queues failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -640,8 +639,8 @@ func newSQSReceiveMessageCmd() *cobra.Command {
 				return fmt.Errorf("receive-message failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -730,8 +729,8 @@ func newSQSSendMessageCmd() *cobra.Command {
 				return fmt.Errorf("send-message failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -791,8 +790,8 @@ func newSQSSendMessageBatchCmd() *cobra.Command {
 				return fmt.Errorf("send-message-batch failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_ssm.go
+++ b/cli/gen_ssm.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -157,8 +156,8 @@ func newSSMDeleteParametersCmd() *cobra.Command {
 				return fmt.Errorf("delete-parameters failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -223,8 +222,8 @@ func newSSMDescribeParametersCmd() *cobra.Command {
 				return fmt.Errorf("describe-parameters failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -278,8 +277,8 @@ func newSSMGetParameterCmd() *cobra.Command {
 				return fmt.Errorf("get-parameter failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -327,8 +326,8 @@ func newSSMGetParametersCmd() *cobra.Command {
 				return fmt.Errorf("get-parameters failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -398,8 +397,8 @@ func newSSMGetParametersByPathCmd() *cobra.Command {
 				return fmt.Errorf("get-parameters-by-path failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -455,8 +454,8 @@ func newSSMListTagsForResourceCmd() *cobra.Command {
 				return fmt.Errorf("list-tags-for-resource failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -553,8 +552,8 @@ func newSSMPutParameterCmd() *cobra.Command {
 				return fmt.Errorf("put-parameter failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_states.go
+++ b/cli/gen_states.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sfn/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -96,8 +95,8 @@ func newSFNCreateActivityCmd() *cobra.Command {
 				return fmt.Errorf("create-activity failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -201,8 +200,8 @@ func newSFNCreateStateMachineCmd() *cobra.Command {
 				return fmt.Errorf("create-state-machine failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -337,8 +336,8 @@ func newSFNDescribeActivityCmd() *cobra.Command {
 				return fmt.Errorf("describe-activity failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -384,8 +383,8 @@ func newSFNDescribeExecutionCmd() *cobra.Command {
 				return fmt.Errorf("describe-execution failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -428,8 +427,8 @@ func newSFNDescribeMapRunCmd() *cobra.Command {
 				return fmt.Errorf("describe-map-run failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -475,8 +474,8 @@ func newSFNDescribeStateMachineCmd() *cobra.Command {
 				return fmt.Errorf("describe-state-machine failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -524,8 +523,8 @@ func newSFNGetActivityTaskCmd() *cobra.Command {
 				return fmt.Errorf("get-activity-task failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -588,8 +587,8 @@ func newSFNGetExecutionHistoryCmd() *cobra.Command {
 				return fmt.Errorf("get-execution-history failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -643,8 +642,8 @@ func newSFNListActivitiesCmd() *cobra.Command {
 				return fmt.Errorf("list-activities failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -712,8 +711,8 @@ func newSFNListExecutionsCmd() *cobra.Command {
 				return fmt.Errorf("list-executions failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -774,8 +773,8 @@ func newSFNListMapRunsCmd() *cobra.Command {
 				return fmt.Errorf("list-map-runs failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -830,8 +829,8 @@ func newSFNListStateMachineAliasesCmd() *cobra.Command {
 				return fmt.Errorf("list-state-machine-aliases failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -886,8 +885,8 @@ func newSFNListStateMachineVersionsCmd() *cobra.Command {
 				return fmt.Errorf("list-state-machine-versions failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -937,8 +936,8 @@ func newSFNListStateMachinesCmd() *cobra.Command {
 				return fmt.Errorf("list-state-machines failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -981,8 +980,8 @@ func newSFNListTagsForResourceCmd() *cobra.Command {
 				return fmt.Errorf("list-tags-for-resource failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1173,8 +1172,8 @@ func newSFNStartExecutionCmd() *cobra.Command {
 				return fmt.Errorf("start-execution failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1231,8 +1230,8 @@ func newSFNStopExecutionCmd() *cobra.Command {
 				return fmt.Errorf("stop-execution failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -1386,8 +1385,8 @@ func newSFNValidateStateMachineDefinitionCmd() *cobra.Command {
 				return fmt.Errorf("validate-state-machine-definition failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/gen_states.go
+++ b/cli/gen_states.go
@@ -1121,7 +1121,7 @@ func newSFNSendTaskSuccessCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&output, "output", "", "Output")
+	cmd.Flags().StringVar(&output, "task-output", "", "Output")
 
 	cmd.Flags().StringVar(&taskToken, "task-token", "", "Task token")
 

--- a/cli/gen_sts.go
+++ b/cli/gen_sts.go
@@ -3,14 +3,12 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/sivchari/kumo/internal/cligen"
 	"github.com/spf13/cobra"
-	"os"
 	"reflect"
 )
 
@@ -126,8 +124,8 @@ func newSTSAssumeRoleCmd() *cobra.Command {
 				return fmt.Errorf("assume-role failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -219,8 +217,8 @@ func newSTSAssumeRoleWithSAMLCmd() *cobra.Command {
 				return fmt.Errorf("assume-role-with-s-a-m-l failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -305,8 +303,8 @@ func newSTSAssumeRoleWithWebIdentityCmd() *cobra.Command {
 				return fmt.Errorf("assume-role-with-web-identity failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -354,8 +352,8 @@ func newSTSGetCallerIdentityCmd() *cobra.Command {
 				return fmt.Errorf("get-caller-identity failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -422,8 +420,8 @@ func newSTSGetFederationTokenCmd() *cobra.Command {
 				return fmt.Errorf("get-federation-token failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil
@@ -482,8 +480,8 @@ func newSTSGetSessionTokenCmd() *cobra.Command {
 				return fmt.Errorf("get-session-token failed: %w", err)
 			}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 
 			return nil

--- a/cli/output.go
+++ b/cli/output.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// outputFormatText is the --output value that prints a --query result as
+// raw text instead of JSON.
+const outputFormatText = "text"
+
+// writeOutput is the single place every generated command (cli/gen_*.go)
+// funnels its API response through, honoring the --query and --output
+// persistent flags registered in NewRootCmd. With no --query it behaves like
+// the previous json.NewEncoder(os.Stdout).Encode(out); with --query set, it
+// runs a limited JMESPath-style lookup (see queryJSON) against out's JSON
+// representation and, when --output=text, prints the matched value as plain
+// text instead of JSON.
+func writeOutput(out any) error {
+	if queryFlag == "" {
+		return encodeJSON(out)
+	}
+
+	data, err := json.Marshal(out)
+	if err != nil {
+		return fmt.Errorf("failed to marshal output: %w", err)
+	}
+
+	var decoded any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return fmt.Errorf("failed to decode output: %w", err)
+	}
+
+	result, err := queryJSON(decoded, queryFlag)
+	if err != nil {
+		return err
+	}
+
+	if outputFormat != outputFormatText {
+		return encodeJSON(result)
+	}
+
+	if _, err := fmt.Fprintln(os.Stdout, formatText(result)); err != nil {
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+
+	return nil
+}
+
+// queryJSON walks query (a dot-separated path such as
+// "Table.AttributeDefinitions[0].AttributeName") over v, a value decoded
+// from JSON via json.Unmarshal into an any (so objects are map[string]any
+// and arrays are []any). This is a deliberately limited JMESPath subset:
+// only field access and numeric array indexing are supported.
+func queryJSON(v any, query string) (any, error) {
+	cur := v
+
+	for _, segment := range strings.Split(query, ".") {
+		name, indexes, err := parseQuerySegment(segment)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query %q: %w", query, err)
+		}
+
+		if name != "" {
+			m, ok := cur.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("failed to query %q: field %q is not an object", query, name)
+			}
+
+			val, ok := m[name]
+			if !ok {
+				return nil, fmt.Errorf("failed to query %q: field %q not found", query, name)
+			}
+
+			cur = val
+		}
+
+		for _, idx := range indexes {
+			arr, ok := cur.([]any)
+			if !ok {
+				return nil, fmt.Errorf("failed to query %q: index %d applied to a non-array value", query, idx)
+			}
+
+			if idx < 0 || idx >= len(arr) {
+				return nil, fmt.Errorf("failed to query %q: index %d out of range (len %d)", query, idx, len(arr))
+			}
+
+			cur = arr[idx]
+		}
+	}
+
+	return cur, nil
+}
+
+// parseQuerySegment splits one dot-separated query segment (e.g.
+// "Foo[0][1]") into its field name ("Foo") and its array indexes, in order.
+// name is empty when the segment is index-only (e.g. "[0]").
+func parseQuerySegment(segment string) (string, []int, error) {
+	name := segment
+
+	var indexes []int
+
+	for {
+		start := strings.IndexByte(name, '[')
+		if start == -1 {
+			break
+		}
+
+		end := strings.IndexByte(name[start:], ']')
+		if end == -1 {
+			return "", nil, fmt.Errorf("unterminated %q in %q", "[", segment)
+		}
+
+		end += start
+
+		idx, err := strconv.Atoi(name[start+1 : end])
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid array index in %q: %w", segment, err)
+		}
+
+		indexes = append(indexes, idx)
+		name = name[:start] + name[end+1:]
+	}
+
+	return name, indexes, nil
+}
+
+// formatText renders v (a value produced by queryJSON) as plain text for
+// --output=text: strings and scalars print unquoted, everything else falls
+// back to compact JSON.
+func formatText(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	default:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return fmt.Sprintf("%v", t)
+		}
+
+		return string(b)
+	}
+}

--- a/cli/output_test.go
+++ b/cli/output_test.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+)
+
+// testConnectionArn and testConnectionArnField are shared across the
+// queryJSON / formatText / writeOutput test tables below.
+const (
+	testConnectionArn      = "arn:aws:events:us-east-1:123456789012:connection/x"
+	testConnectionArnField = "ConnectionArn"
+)
+
+type queryJSONTestCase struct {
+	name    string
+	query   string
+	want    any
+	wantErr bool
+}
+
+func queryJSONTestCases() []queryJSONTestCase {
+	return []queryJSONTestCase{
+		{
+			name:  "top-level field",
+			query: testConnectionArnField,
+			want:  testConnectionArn,
+		},
+		{
+			name:  "nested field",
+			query: "Nested.Inner",
+			want:  "value",
+		},
+		{
+			name:  "array index",
+			query: "AttributeDefinitions[0].AttributeName",
+			want:  "pk",
+		},
+		{
+			name:  "second array index",
+			query: "AttributeDefinitions[1].AttributeName",
+			want:  "sk",
+		},
+		{
+			name:    "unknown field",
+			query:   "DoesNotExist",
+			wantErr: true,
+		},
+		{
+			name:    "index out of range",
+			query:   "AttributeDefinitions[5].AttributeName",
+			wantErr: true,
+		},
+		{
+			name:    "index on non-array",
+			query:   "ConnectionArn[0]",
+			wantErr: true,
+		},
+	}
+}
+
+func TestQueryJSON(t *testing.T) {
+	var doc any
+
+	raw := fmt.Sprintf(`{%q:%q,"AttributeDefinitions":[{"AttributeName":"pk"},{"AttributeName":"sk"}],"Nested":{"Inner":"value"}}`,
+		testConnectionArnField, testConnectionArn)
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	for _, tt := range queryJSONTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := queryJSON(doc, tt.query)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("queryJSON(%q): want error, got nil", tt.query)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("queryJSON(%q): %v", tt.query, err)
+			}
+
+			if got != tt.want {
+				t.Errorf("queryJSON(%q) = %v, want %v", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{name: "string", in: testConnectionArn, want: testConnectionArn},
+		{name: "nil", in: nil, want: ""},
+		{name: "bool", in: true, want: "true"},
+		{name: "number", in: float64(42), want: "42"},
+		{name: "object falls back to JSON", in: map[string]any{"A": "b"}, want: `{"A":"b"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatText(tt.in); got != tt.want {
+				t.Errorf("formatText(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// sample mirrors an aws-sdk-go-v2 Output struct, which carries no json
+// struct tags: encoding/json then marshals it using the Go field name
+// verbatim (PascalCase), the same shape real generated commands pass to
+// writeOutput.
+type sample struct {
+	ConnectionArn string
+}
+
+func TestWriteOutput(t *testing.T) {
+	tests := []struct {
+		name         string
+		queryFlag    string
+		outputFormat string
+		want         string
+	}{
+		{
+			name: "no query prints JSON",
+			want: "{\"ConnectionArn\":\"arn:aws:events:us-east-1:123456789012:connection/x\"}\n",
+		},
+		{
+			name:      "query without --output=text still prints JSON",
+			queryFlag: testConnectionArnField,
+			want:      "\"arn:aws:events:us-east-1:123456789012:connection/x\"\n",
+		},
+		{
+			name:         "query with --output=text prints raw text",
+			queryFlag:    testConnectionArnField,
+			outputFormat: outputFormatText,
+			want:         "arn:aws:events:us-east-1:123456789012:connection/x\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				queryFlag = ""
+				outputFormat = ""
+			})
+
+			queryFlag = tt.queryFlag
+			outputFormat = tt.outputFormat
+
+			got := captureStdout(t, func() {
+				if err := writeOutput(sample{ConnectionArn: testConnectionArn}); err != nil {
+					t.Fatalf("writeOutput: %v", err)
+				}
+			})
+
+			if got != tt.want {
+				t.Errorf("writeOutput output = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteOutput_QueryNotFound(t *testing.T) {
+	t.Cleanup(func() {
+		queryFlag = ""
+		outputFormat = ""
+	})
+
+	queryFlag = "DoesNotExist"
+
+	err := writeOutput(sample{ConnectionArn: "x"})
+	if err == nil {
+		t.Fatal("writeOutput: want error for unmatched query, got nil")
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+
+	os.Stdout = orig
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+
+	return buf.String()
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -12,8 +12,10 @@ import (
 )
 
 var (
-	endpointURL string
-	region      string
+	endpointURL  string
+	region       string
+	queryFlag    string
+	outputFormat string
 )
 
 // NewRootCmd creates the root kumo CLI command.
@@ -25,6 +27,8 @@ func NewRootCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&endpointURL, "endpoint-url", "http://localhost:4566", "kumo endpoint URL")
 	cmd.PersistentFlags().StringVar(&region, "region", "ap-northeast-1", "AWS region")
+	cmd.PersistentFlags().StringVar(&queryFlag, "query", "", "JMESPath query (limited support)")
+	cmd.PersistentFlags().StringVar(&outputFormat, "output", "", "Output format (json|text)")
 
 	cmd.AddCommand(
 		newAmplifyCmd(),

--- a/internal/cligen/flags.go
+++ b/internal/cligen/flags.go
@@ -27,7 +27,7 @@ func DeriveFields(serviceName, action string, inputType reflect.Type) FieldsResu
 		if override, ok := fieldOverrides[inputType][f.Name]; ok {
 			result.Flags = append(result.Flags, FieldFlag{
 				FieldName:  f.Name,
-				FlagName:   toKebabCase(f.Name),
+				FlagName:   overriddenFlagName(serviceName, action, f.Name, toKebabCase(f.Name)),
 				Kind:       override.Kind,
 				CustomFunc: override.CustomFunc,
 				Pointer:    f.Type.Kind() == reflect.Pointer,
@@ -43,6 +43,8 @@ func DeriveFields(serviceName, action string, inputType reflect.Type) FieldsResu
 
 			continue
 		}
+
+		flag.FlagName = overriddenFlagName(serviceName, action, f.Name, flag.FlagName)
 
 		result.Flags = append(result.Flags, flag)
 	}

--- a/internal/cligen/flags_test.go
+++ b/internal/cligen/flags_test.go
@@ -233,6 +233,28 @@ func TestSetFieldsFromKV_UnknownField(t *testing.T) {
 	}
 }
 
+// TestSetFieldsFromKV_PascalCaseKeys proves the AWS CLI's standard shorthand
+// casing (SDK member names, e.g. "ReadCapacityUnits=5") is accepted
+// alongside the kebab-case flag names cli-gen otherwise derives, since real
+// AWS CLI users and scripts routinely pass PascalCase keys.
+func TestSetFieldsFromKV_PascalCaseKeys(t *testing.T) {
+	t.Parallel()
+
+	var pt dynamodbtypes.ProvisionedThroughput
+
+	if err := SetFieldsFromKV(reflect.ValueOf(&pt).Elem(), "ReadCapacityUnits=5,WriteCapacityUnits=10"); err != nil {
+		t.Fatalf("SetFieldsFromKV: %v", err)
+	}
+
+	if pt.ReadCapacityUnits == nil || *pt.ReadCapacityUnits != 5 {
+		t.Errorf("ReadCapacityUnits = %v, want 5", pt.ReadCapacityUnits)
+	}
+
+	if pt.WriteCapacityUnits == nil || *pt.WriteCapacityUnits != 10 {
+		t.Errorf("WriteCapacityUnits = %v, want 10", pt.WriteCapacityUnits)
+	}
+}
+
 // TestJSONUnmarshalIntoSDKStruct proves the assumption FlagJSONBlob relies
 // on: aws-sdk-go-v2 generated types carry no json struct tags, but
 // encoding/json matches field names case-insensitively by default, so a raw

--- a/internal/cligen/flags_test.go
+++ b/internal/cligen/flags_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 )
 
@@ -202,6 +203,37 @@ func TestHasOutputContent(t *testing.T) {
 
 	if !hasOutputContent(reflect.TypeOf(sqs.CreateQueueOutput{})) {
 		t.Error("CreateQueueOutput has QueueUrl beyond ResultMetadata, want hasOutputContent = true")
+	}
+}
+
+// TestDeriveFields_FlagNameOverride proves states.SendTaskSuccessInput's
+// Output field is renamed to --task-output (the AWS CLI's own name for that
+// flag), since the auto-derived --output would otherwise collide with the
+// root command's persistent --output format flag.
+func TestDeriveFields_FlagNameOverride(t *testing.T) {
+	t.Parallel()
+
+	result := DeriveFields("states", "SendTaskSuccess", reflect.TypeOf(sfn.SendTaskSuccessInput{}))
+	if result.RequiresOverride {
+		t.Fatalf("SendTaskSuccessInput unexpectedly requires an override: %s", result.OverrideReason)
+	}
+
+	var found bool
+
+	for _, f := range result.Flags {
+		if f.FieldName != "Output" {
+			continue
+		}
+
+		found = true
+
+		if f.FlagName != "task-output" {
+			t.Errorf("Output field FlagName = %q, want %q", f.FlagName, "task-output")
+		}
+	}
+
+	if !found {
+		t.Fatal("no Output field found in derived flags")
 	}
 }
 

--- a/internal/cligen/imports.go
+++ b/internal/cligen/imports.go
@@ -27,11 +27,6 @@ func newImportSet(sdkImportPath string) *importSet {
 	return s
 }
 
-func (s *importSet) needJSONEncode() {
-	s.std["encoding/json"] = true
-	s.std["os"] = true
-}
-
 func (s *importSet) needJSON() {
 	s.std["encoding/json"] = true
 }

--- a/internal/cligen/kv.go
+++ b/internal/cligen/kv.go
@@ -10,9 +10,11 @@ import (
 
 // SetFieldsFromKV parses a "key=value,key2=value2" string and sets the
 // matching exported fields of target (a struct or pointer-to-struct
-// reflect.Value, addressable and settable). Keys are matched against each
-// field's kebab-case flag name (see toKebabCase), case-insensitively, so
-// "queue-url=..." matches a QueueUrl field.
+// reflect.Value, addressable and settable). Keys are matched
+// case-insensitively against either the field's kebab-case flag name (see
+// toKebabCase) or its raw Go/SDK member name, so both "queue-url=..." and
+// the AWS CLI's standard PascalCase shorthand "QueueUrl=..." match a
+// QueueUrl field.
 //
 // It is the single generic parser used both for flat-struct flags (FlagKV)
 // and for each element of repeated flat-struct flags (FlagKVArray); it is
@@ -62,6 +64,10 @@ func SetFieldsFromKV(target reflect.Value, kv string) error {
 	return nil
 }
 
+// findFieldByFlagKey resolves key against target's exported fields, matching
+// either the kebab-case flag name (e.g. "queue-url") or the raw Go/SDK
+// member name (e.g. "QueueUrl", the AWS CLI's standard shorthand casing),
+// case-insensitively.
 func findFieldByFlagKey(target reflect.Value, key string) (reflect.Value, error) {
 	t := target.Type()
 
@@ -71,7 +77,7 @@ func findFieldByFlagKey(target reflect.Value, key string) (reflect.Value, error)
 			continue
 		}
 
-		if strings.EqualFold(toKebabCase(f.Name), key) {
+		if strings.EqualFold(toKebabCase(f.Name), key) || strings.EqualFold(f.Name, key) {
 			return target.Field(i), nil
 		}
 	}

--- a/internal/cligen/overrides.go
+++ b/internal/cligen/overrides.go
@@ -123,3 +123,27 @@ func isIgnoredBackCompatFlag(serviceName, action, fieldName string) bool {
 
 	return false
 }
+
+// flagNameOverrides overrides the derived kebab-case flag name for specific
+// fields, keyed by kumo service name, then SDK action name, then Go field
+// name. It exists for cases where the auto-derived name collides with a
+// root-level persistent flag (e.g. sfn's SendTaskSuccess.Output field would
+// otherwise become --output, colliding with the global --output format
+// flag); the AWS CLI's own name for that flag, --task-output, is used
+// instead (see
+// https://docs.aws.amazon.com/cli/latest/reference/stepfunctions/send-task-success.html).
+var flagNameOverrides = map[string]map[string]map[string]string{
+	"states": {
+		"SendTaskSuccess": {"Output": "task-output"},
+	},
+}
+
+// overriddenFlagName returns the overridden flag name for serviceName's
+// action/fieldName, or defaultName when no override exists.
+func overriddenFlagName(serviceName, action, fieldName, defaultName string) string {
+	if name, ok := flagNameOverrides[serviceName][action][fieldName]; ok {
+		return name
+	}
+
+	return defaultName
+}

--- a/internal/cligen/overrides.go
+++ b/internal/cligen/overrides.go
@@ -67,11 +67,7 @@ var skipAutoGeneration = map[string][]string{
 // fields the generator intentionally does not expose as flags, to preserve
 // existing hand-written CLI behavior once a service migrates to generated
 // commands.
-var ignoredBackCompatFlags = map[string]map[string][]string{
-	"dynamodb": {
-		"CreateTable": {"TableClass"},
-	},
-}
+var ignoredBackCompatFlags = map[string]map[string][]string{}
 
 // overrideServices lists kumo service names whose generated parent command
 // must also call {CLIName}OverrideCommands() (implemented in a hand-written

--- a/internal/cligen/render.go
+++ b/internal/cligen/render.go
@@ -216,10 +216,6 @@ func buildActionView(binding sdkBinding, action *Action, fields []FieldFlag, imp
 		HasOutput:      hasOutputContent(action.OutputType) && !isOutputPrintSuppressed(action.ServiceName, action.SDKMethod),
 	}
 
-	if av.HasOutput {
-		imports.needJSONEncode()
-	}
-
 	for _, f := range fields {
 		fv, err := buildFlagView(&f, use, imports)
 		if err != nil {

--- a/internal/cligen/templates/service.go.tmpl
+++ b/internal/cligen/templates/service.go.tmpl
@@ -60,8 +60,8 @@ func {{.FuncName}}() *cobra.Command {
 			}
 {{- if .HasOutput}}
 
-			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
-				return fmt.Errorf("failed to encode output: %w", err)
+			if err := writeOutput(out); err != nil {
+				return err
 			}
 {{- end}}
 

--- a/internal/service/dynamodb/handlers.go
+++ b/internal/service/dynamodb/handlers.go
@@ -439,6 +439,13 @@ func tableToDescription(table *Table) TableDescription {
 		}
 	}
 
+	if table.TableClass != "" {
+		desc.TableClassSummary = &TableClassSummary{
+			TableClass:         table.TableClass,
+			LastUpdateDateTime: float64(table.TableClassUpdatedAt.Unix()),
+		}
+	}
+
 	for i := range table.GlobalSecondaryIndexes {
 		desc.GlobalSecondaryIndexes = append(desc.GlobalSecondaryIndexes, gsiToDescription(table, &table.GlobalSecondaryIndexes[i]))
 	}
@@ -866,11 +873,13 @@ func convertAttributeUpdates(req *UpdateItemRequest) {
 	req.UpdateExpression = strings.Join(parts, " ")
 }
 
-// UpdateTable is a no-op that returns the current table description.
+// UpdateTable applies the requested changes (currently: TableClass) and
+// returns the updated table description.
 //
-// terraform-provider-aws calls UpdateTable during terraform destroy to
-// remove GSIs before deleting the table. Without this handler, kumo returns
-// UnknownOperationException and destroy fails.
+// terraform-provider-aws also calls UpdateTable during terraform destroy to
+// remove GSIs before deleting the table; fields it doesn't recognize (e.g.
+// GlobalSecondaryIndexUpdates) are accepted but not applied, matching the
+// previous no-op behavior for that case.
 func (s *Service) UpdateTable(w http.ResponseWriter, r *http.Request) {
 	var req UpdateTableRequest
 	if err := service.ReadJSONRequest(r, &req); err != nil || req.TableName == "" {
@@ -879,15 +888,22 @@ func (s *Service) UpdateTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	table, err := s.storage.DescribeTable(r.Context(), req.TableName)
+	table, err := s.storage.UpdateTable(r.Context(), &req)
 	if err != nil {
-		writeDynamoDBError(w, "ResourceNotFoundException", "Table not found: "+req.TableName, http.StatusBadRequest)
+		var tErr *TableError
+		if errors.As(err, &tErr) {
+			writeDynamoDBError(w, tErr.Code, tErr.Message, http.StatusBadRequest)
+
+			return
+		}
+
+		writeDynamoDBError(w, "InternalServerError", "Internal server error", http.StatusInternalServerError)
 
 		return
 	}
 
-	writeJSONResponse(w, DescribeTableResponse{
-		Table: tableToDescription(table),
+	writeJSONResponse(w, UpdateTableResponse{
+		TableDescription: tableToDescription(table),
 	})
 }
 

--- a/internal/service/dynamodb/storage.go
+++ b/internal/service/dynamodb/storage.go
@@ -33,6 +33,7 @@ type Storage interface {
 	DeleteTable(ctx context.Context, tableName string) (*Table, error)
 	ListTables(ctx context.Context, exclusiveStartTableName string, limit int) ([]string, string, error)
 	DescribeTable(ctx context.Context, tableName string) (*Table, error)
+	UpdateTable(ctx context.Context, req *UpdateTableRequest) (*Table, error)
 	PutItem(ctx context.Context, tableName string, item Item, returnOld bool, cond ConditionInput) (Item, error)
 	GetItem(ctx context.Context, tableName string, key Item) (Item, error)
 	DeleteItem(ctx context.Context, tableName string, key Item, returnOld bool, cond ConditionInput) (Item, error)
@@ -245,6 +246,13 @@ func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) 
 		billingMode = "PROVISIONED"
 	}
 
+	tableClass := req.TableClass
+	if tableClass == "" {
+		tableClass = "STANDARD"
+	}
+
+	now := time.Now()
+
 	table := &Table{
 		Name:                   req.TableName,
 		KeySchema:              req.KeySchema,
@@ -252,13 +260,15 @@ func (m *MemoryStorage) CreateTable(_ context.Context, req *CreateTableRequest) 
 		ProvisionedThroughput:  req.ProvisionedThroughput,
 		GlobalSecondaryIndexes: req.GlobalSecondaryIndexes,
 		LocalSecondaryIndexes:  req.LocalSecondaryIndexes,
-		CreationDateTime:       time.Now(),
+		CreationDateTime:       now,
 		TableStatus:            "ACTIVE",
 		ItemCount:              0,
 		TableSizeBytes:         0,
 		TableARN:               fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", m.region, defaultAccountID, req.TableName),
 		BillingMode:            billingMode,
 		DeletionProtection:     req.DeletionProtectionEnabled,
+		TableClass:             tableClass,
+		TableClassUpdatedAt:    now,
 	}
 
 	m.setupTableStream(table, req)
@@ -387,6 +397,31 @@ func (m *MemoryStorage) DescribeTable(_ context.Context, tableName string) (*Tab
 	}
 
 	td.Table.ItemCount = int64(len(td.Items))
+
+	return td.Table, nil
+}
+
+// UpdateTable applies UpdateTable request changes to a table.
+func (m *MemoryStorage) UpdateTable(_ context.Context, req *UpdateTableRequest) (*Table, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.Tables[req.TableName]
+	if !exists {
+		return nil, &TableError{
+			Code:    "ResourceNotFoundException",
+			Message: fmt.Sprintf("Requested resource not found: Table: %s not found", req.TableName),
+		}
+	}
+
+	if req.TableClass != "" && req.TableClass != td.Table.TableClass {
+		td.Table.TableClass = req.TableClass
+		td.Table.TableClassUpdatedAt = time.Now()
+	}
+
+	td.Table.ItemCount = int64(len(td.Items))
+
+	m.saveLocked()
 
 	return td.Table, nil
 }

--- a/internal/service/dynamodb/types.go
+++ b/internal/service/dynamodb/types.go
@@ -215,6 +215,8 @@ type Table struct {
 	StreamEnabled          bool
 	StreamViewType         string
 	LatestStreamArn        string
+	TableClass             string
+	TableClassUpdatedAt    time.Time
 }
 
 // StreamSpecification represents DynamoDB stream settings.
@@ -241,6 +243,13 @@ type TableDescription struct {
 	StreamSpecification       *StreamSpecification              `json:"StreamSpecification,omitempty"`
 	LatestStreamArn           string                            `json:"LatestStreamArn,omitempty"`
 	DeletionProtectionEnabled bool                              `json:"DeletionProtectionEnabled"`
+	TableClassSummary         *TableClassSummary                `json:"TableClassSummary,omitempty"`
+}
+
+// TableClassSummary represents the table class in responses.
+type TableClassSummary struct {
+	TableClass         string  `json:"TableClass"`
+	LastUpdateDateTime float64 `json:"LastUpdateDateTime,omitempty"`
 }
 
 // BillingModeSummary represents billing mode summary.
@@ -266,6 +275,7 @@ type CreateTableRequest struct {
 	DeletionProtectionEnabled bool                   `json:"DeletionProtectionEnabled,omitempty"`
 	StreamSpecification       *StreamSpecification   `json:"StreamSpecification,omitempty"`
 	Tags                      []Tag                  `json:"Tags,omitempty"`
+	TableClass                string                 `json:"TableClass,omitempty"`
 }
 
 // CreateTableResponse is the response for CreateTable.
@@ -622,7 +632,13 @@ type Tag struct {
 
 // UpdateTableRequest is the request for UpdateTable.
 type UpdateTableRequest struct {
-	TableName string `json:"TableName"`
+	TableName  string `json:"TableName"`
+	TableClass string `json:"TableClass,omitempty"`
+}
+
+// UpdateTableResponse is the response for UpdateTable.
+type UpdateTableResponse struct {
+	TableDescription TableDescription `json:"TableDescription"`
 }
 
 // ListTagsOfResourceRequest is the request for ListTagsOfResource.

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -169,7 +169,7 @@ func TestCLI_DynamoDB_CreateTableAndListTables(t *testing.T) {
 		"--billing-mode", "PAY_PER_REQUEST",
 	)
 	golden.New(t, golden.WithIgnoreFields(
-		"TableArn", "TableId", "CreationDateTime", "ResultMetadata",
+		"TableArn", "TableId", "CreationDateTime", "ResultMetadata", "LastUpdateDateTime",
 	)).Assert(t.Name()+"_create", createOut)
 
 	client := newDynamoDBClient(t)

--- a/test/integration/dynamodb_test.go
+++ b/test/integration/dynamodb_test.go
@@ -68,7 +68,7 @@ func TestDynamoDB_CreateAndDeleteTable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	golden.New(t, golden.WithIgnoreFields("TableArn", "TableId", "CreationDateTime", "ResultMetadata")).Assert(t.Name()+"_create", createOutput)
+	golden.New(t, golden.WithIgnoreFields("TableArn", "TableId", "CreationDateTime", "ResultMetadata", "LastUpdateDateTime")).Assert(t.Name()+"_create", createOutput)
 
 	// Delete table.
 	_, err = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
@@ -157,7 +157,7 @@ func TestDynamoDB_DescribeTable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	golden.New(t, golden.WithIgnoreFields("TableArn", "TableId", "CreationDateTime", "TableSizeBytes", "ItemCount", "ResultMetadata")).Assert(t.Name(), descOutput)
+	golden.New(t, golden.WithIgnoreFields("TableArn", "TableId", "CreationDateTime", "TableSizeBytes", "ItemCount", "ResultMetadata", "LastUpdateDateTime")).Assert(t.Name(), descOutput)
 }
 
 func TestDynamoDB_PutAndGetItem(t *testing.T) {
@@ -1116,7 +1116,7 @@ func TestDynamoDB_GlobalSecondaryIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	golden.New(t, golden.WithIgnoreFields("TableArn", "TableId", "CreationDateTime", "ResultMetadata", "IndexArn")).Assert(t.Name()+"_create", createOutput)
+	golden.New(t, golden.WithIgnoreFields("TableArn", "TableId", "CreationDateTime", "ResultMetadata", "IndexArn", "LastUpdateDateTime")).Assert(t.Name()+"_create", createOutput)
 
 	t.Cleanup(func() {
 		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
@@ -1418,8 +1418,66 @@ func TestDynamoDB_UpdateTable(t *testing.T) {
 		t.Fatal(err)
 	}
 	golden.New(t, golden.WithIgnoreFields(
-		"TableArn", "TableId", "CreationDateTime", "TableSizeBytes", "ItemCount", "ResultMetadata",
+		"TableArn", "TableId", "CreationDateTime", "TableSizeBytes", "ItemCount", "ResultMetadata", "LastUpdateDateTime",
 	)).Assert(t.Name(), updateOutput)
+}
+
+func TestDynamoDB_TableClass(t *testing.T) {
+	client := newDynamoDBClient(t)
+	ctx := t.Context()
+	tableName := "test-table-class"
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String(tableName),
+		BillingMode: types.BillingModePayPerRequest,
+		TableClass:  types.TableClassStandardInfrequentAccess,
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteTable(context.Background(), &dynamodb.DeleteTableInput{
+			TableName: aws.String(tableName),
+		})
+	})
+
+	describeOutput, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if describeOutput.Table.TableClassSummary == nil || describeOutput.Table.TableClassSummary.TableClass != types.TableClassStandardInfrequentAccess {
+		t.Fatalf("TableClassSummary = %+v, want TableClass = %s", describeOutput.Table.TableClassSummary, types.TableClassStandardInfrequentAccess)
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"TableArn", "TableId", "CreationDateTime", "TableSizeBytes", "ItemCount", "ResultMetadata", "LastUpdateDateTime",
+	)).Assert(t.Name()+"_describe_infrequent_access", describeOutput)
+
+	updateOutput, err := client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName:  aws.String(tableName),
+		TableClass: types.TableClassStandard,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if updateOutput.TableDescription.TableClassSummary == nil || updateOutput.TableDescription.TableClassSummary.TableClass != types.TableClassStandard {
+		t.Fatalf("after UpdateTable, TableClassSummary = %+v, want TableClass = %s", updateOutput.TableDescription.TableClassSummary, types.TableClassStandard)
+	}
+
+	golden.New(t, golden.WithIgnoreFields(
+		"TableArn", "TableId", "CreationDateTime", "TableSizeBytes", "ItemCount", "ResultMetadata", "LastUpdateDateTime",
+	)).Assert(t.Name()+"_update_standard", updateOutput)
 }
 
 func TestDynamoDB_StreamSpecification(t *testing.T) {
@@ -1453,7 +1511,7 @@ func TestDynamoDB_StreamSpecification(t *testing.T) {
 
 	golden.New(t, golden.WithIgnoreFields(
 		"TableArn", "TableId", "CreationDateTime", "LatestStreamArn",
-		"TableSizeBytes", "ItemCount", "ResultMetadata",
+		"TableSizeBytes", "ItemCount", "ResultMetadata", "LastUpdateDateTime",
 	)).Assert(t.Name()+"_create", createOutput)
 
 	// DescribeTable should also include stream info.

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_CreateAndDeleteTable_TestDynamoDB_CreateAndDeleteTable_create.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_CreateAndDeleteTable_TestDynamoDB_CreateAndDeleteTable_create.golden.go
@@ -11,7 +11,7 @@
       "BillingMode": "PAY_PER_REQUEST",
       "LastUpdateToPayPerRequestDateTime": null
     },
-    "CreationDateTime": "2026-03-23T07:45:25Z",
+    "CreationDateTime": "2026-08-07T03:56:47Z",
     "DeletionProtectionEnabled": false,
     "GlobalSecondaryIndexes": null,
     "GlobalTableSettingsReplicationMode": "",
@@ -35,8 +35,11 @@
     "SSEDescription": null,
     "StreamSpecification": null,
     "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-table-create-delete",
-    "TableClassSummary": null,
-    "TableId": "67576723-e3a5-4cd0-8f81-ab9cd0687a2b",
+    "TableClassSummary": {
+      "LastUpdateDateTime": "2026-08-07T03:56:47Z",
+      "TableClass": "STANDARD"
+    },
+    "TableId": "aaa6a656-623e-4712-9893-ce0f1006c654",
     "TableName": "test-table-create-delete",
     "TableSizeBytes": 0,
     "TableStatus": "ACTIVE",

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_DescribeTable_TestDynamoDB_DescribeTable.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_DescribeTable_TestDynamoDB_DescribeTable.golden.go
@@ -11,7 +11,7 @@
       "BillingMode": "PAY_PER_REQUEST",
       "LastUpdateToPayPerRequestDateTime": null
     },
-    "CreationDateTime": "2026-03-23T07:45:25Z",
+    "CreationDateTime": "2026-08-07T03:56:04Z",
     "DeletionProtectionEnabled": false,
     "GlobalSecondaryIndexes": null,
     "GlobalTableSettingsReplicationMode": "",
@@ -35,8 +35,11 @@
     "SSEDescription": null,
     "StreamSpecification": null,
     "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-table-describe",
-    "TableClassSummary": null,
-    "TableId": "84a11a4b-9f24-4431-b1ad-13cf481e7a22",
+    "TableClassSummary": {
+      "LastUpdateDateTime": "2026-08-07T03:56:04Z",
+      "TableClass": "STANDARD"
+    },
+    "TableId": "88f70a6d-1af6-4503-ae3d-bedec4a98c89",
     "TableName": "test-table-describe",
     "TableSizeBytes": 0,
     "TableStatus": "ACTIVE",

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_create.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_GlobalSecondaryIndex_TestDynamoDB_GlobalSecondaryIndex_create.golden.go
@@ -19,7 +19,7 @@
       "BillingMode": "PAY_PER_REQUEST",
       "LastUpdateToPayPerRequestDateTime": null
     },
-    "CreationDateTime": "2026-07-27T02:29:09Z",
+    "CreationDateTime": "2026-08-07T03:56:47Z",
     "DeletionProtectionEnabled": false,
     "GlobalSecondaryIndexes": [
       {
@@ -69,8 +69,11 @@
     "SSEDescription": null,
     "StreamSpecification": null,
     "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-table-gsi",
-    "TableClassSummary": null,
-    "TableId": "d7d5a4a8-aae4-4faf-a4bd-b740bfbce644",
+    "TableClassSummary": {
+      "LastUpdateDateTime": "2026-08-07T03:56:47Z",
+      "TableClass": "STANDARD"
+    },
+    "TableId": "07befce0-967d-4ea6-899d-765bb3f3b12a",
     "TableName": "test-table-gsi",
     "TableSizeBytes": 0,
     "TableStatus": "ACTIVE",

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_StreamSpecification_TestDynamoDB_StreamSpecification_create.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_StreamSpecification_TestDynamoDB_StreamSpecification_create.golden.go
@@ -11,7 +11,7 @@
       "BillingMode": "PAY_PER_REQUEST",
       "LastUpdateToPayPerRequestDateTime": null
     },
-    "CreationDateTime": "2026-05-13T07:41:02Z",
+    "CreationDateTime": "2026-08-07T03:56:04Z",
     "DeletionProtectionEnabled": false,
     "GlobalSecondaryIndexes": null,
     "GlobalTableSettingsReplicationMode": "",
@@ -24,7 +24,7 @@
         "KeyType": "HASH"
       }
     ],
-    "LatestStreamArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-stream-spec/stream/2026-05-13T16:41:02.021",
+    "LatestStreamArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-stream-spec/stream/2026-08-07T12:56:04.944",
     "LatestStreamLabel": null,
     "LocalSecondaryIndexes": null,
     "MultiRegionConsistency": "",
@@ -38,8 +38,11 @@
       "StreamViewType": "NEW_AND_OLD_IMAGES"
     },
     "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-stream-spec",
-    "TableClassSummary": null,
-    "TableId": "7a088cd1-f11d-461b-bd4c-c02a23dd8b93",
+    "TableClassSummary": {
+      "LastUpdateDateTime": "2026-08-07T03:56:04Z",
+      "TableClass": "STANDARD"
+    },
+    "TableId": "01caccc3-5e61-4fbe-97d5-84e29e0e64be",
     "TableName": "test-stream-spec",
     "TableSizeBytes": 0,
     "TableStatus": "ACTIVE",

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_TableClass_TestDynamoDB_TableClass_describe_infrequent_access.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_TableClass_TestDynamoDB_TableClass_describe_infrequent_access.golden.go
@@ -1,6 +1,5 @@
 {
-  "ResultMetadata": {},
-  "TableDescription": {
+  "Table": {
     "ArchivalSummary": null,
     "AttributeDefinitions": [
       {
@@ -12,7 +11,7 @@
       "BillingMode": "PAY_PER_REQUEST",
       "LastUpdateToPayPerRequestDateTime": null
     },
-    "CreationDateTime": "2026-08-07T03:58:42Z",
+    "CreationDateTime": "2026-08-07T03:52:30Z",
     "DeletionProtectionEnabled": false,
     "GlobalSecondaryIndexes": null,
     "GlobalTableSettingsReplicationMode": "",
@@ -35,15 +34,16 @@
     "RestoreSummary": null,
     "SSEDescription": null,
     "StreamSpecification": null,
-    "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-cli-dynamodb-table",
+    "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-table-class",
     "TableClassSummary": {
-      "LastUpdateDateTime": "2026-08-07T03:58:42Z",
-      "TableClass": "STANDARD"
+      "LastUpdateDateTime": "2026-08-07T03:52:30Z",
+      "TableClass": "STANDARD_INFREQUENT_ACCESS"
     },
-    "TableId": "3f296e46-1101-4df5-84ff-8615daa5b6cf",
-    "TableName": "test-cli-dynamodb-table",
+    "TableId": "482fb416-a61a-45e7-b8e3-4304ae028e05",
+    "TableName": "test-table-class",
     "TableSizeBytes": 0,
     "TableStatus": "ACTIVE",
     "WarmThroughput": null
-  }
+  },
+  "ResultMetadata": {}
 }

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_TableClass_TestDynamoDB_TableClass_update_standard.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_TableClass_TestDynamoDB_TableClass_update_standard.golden.go
@@ -1,5 +1,4 @@
 {
-  "ResultMetadata": {},
   "TableDescription": {
     "ArchivalSummary": null,
     "AttributeDefinitions": [
@@ -12,7 +11,7 @@
       "BillingMode": "PAY_PER_REQUEST",
       "LastUpdateToPayPerRequestDateTime": null
     },
-    "CreationDateTime": "2026-08-07T03:58:42Z",
+    "CreationDateTime": "2026-08-07T03:52:30Z",
     "DeletionProtectionEnabled": false,
     "GlobalSecondaryIndexes": null,
     "GlobalTableSettingsReplicationMode": "",
@@ -35,15 +34,16 @@
     "RestoreSummary": null,
     "SSEDescription": null,
     "StreamSpecification": null,
-    "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-cli-dynamodb-table",
+    "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-table-class",
     "TableClassSummary": {
-      "LastUpdateDateTime": "2026-08-07T03:58:42Z",
+      "LastUpdateDateTime": "2026-08-07T03:52:30Z",
       "TableClass": "STANDARD"
     },
-    "TableId": "3f296e46-1101-4df5-84ff-8615daa5b6cf",
-    "TableName": "test-cli-dynamodb-table",
+    "TableId": "f0a78e1d-1b95-4d56-8569-3f6661358953",
+    "TableName": "test-table-class",
     "TableSizeBytes": 0,
     "TableStatus": "ACTIVE",
     "WarmThroughput": null
-  }
+  },
+  "ResultMetadata": {}
 }

--- a/test/integration/testdata/dynamodb_test_TestDynamoDB_UpdateTable_TestDynamoDB_UpdateTable.golden.go
+++ b/test/integration/testdata/dynamodb_test_TestDynamoDB_UpdateTable_TestDynamoDB_UpdateTable.golden.go
@@ -1,4 +1,49 @@
 {
-  "TableDescription": null,
+  "TableDescription": {
+    "ArchivalSummary": null,
+    "AttributeDefinitions": [
+      {
+        "AttributeName": "pk",
+        "AttributeType": "S"
+      }
+    ],
+    "BillingModeSummary": {
+      "BillingMode": "PAY_PER_REQUEST",
+      "LastUpdateToPayPerRequestDateTime": null
+    },
+    "CreationDateTime": "2026-08-07T03:56:04Z",
+    "DeletionProtectionEnabled": false,
+    "GlobalSecondaryIndexes": null,
+    "GlobalTableSettingsReplicationMode": "",
+    "GlobalTableVersion": null,
+    "GlobalTableWitnesses": null,
+    "ItemCount": 0,
+    "KeySchema": [
+      {
+        "AttributeName": "pk",
+        "KeyType": "HASH"
+      }
+    ],
+    "LatestStreamArn": null,
+    "LatestStreamLabel": null,
+    "LocalSecondaryIndexes": null,
+    "MultiRegionConsistency": "",
+    "OnDemandThroughput": null,
+    "ProvisionedThroughput": null,
+    "Replicas": null,
+    "RestoreSummary": null,
+    "SSEDescription": null,
+    "StreamSpecification": null,
+    "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/test-update-table",
+    "TableClassSummary": {
+      "LastUpdateDateTime": "2026-08-07T03:56:04Z",
+      "TableClass": "STANDARD"
+    },
+    "TableId": "46372af0-6c9d-41b0-a87d-3714e6e053a7",
+    "TableName": "test-update-table",
+    "TableSizeBytes": 0,
+    "TableStatus": "ACTIVE",
+    "WarmThroughput": null
+  },
   "ResultMetadata": {}
 }


### PR DESCRIPTION
## Summary
v0.28.0's migration to auto-generated CLI commands (cli-gen) introduced three regressions versus the hand-written v0.27.0 CLI. This restores all three for a v0.28.1 patch release.

- KV shorthand flags (e.g. `--attribute-definitions`) rejected the AWS CLI's standard PascalCase shorthand (`AttributeName=pk,AttributeType=S`), accepting only kebab-case. `findFieldByFlagKey` now also matches the raw SDK member name, keeping kebab-case support for backward compatibility.
- `--query` / `--output` were dropped entirely. Every generated command now funnels its response through a new `writeOutput` helper (`cli/output.go`) that supports a limited JMESPath-style `--query` (dot-path with optional `[n]` array indexing) and `--output=text`. `states send-task-success`'s own `--output` field is renamed to `--task-output` (matching the AWS CLI) to avoid colliding with this new global flag; `internal/cligen` gained a small `flagNameOverrides` map for this kind of per-command rename.
- `dynamodb create-table` lost `--table-class`. It's no longer just accepted and dropped: `TableClass` is now persisted server-side and returned as `TableClassSummary` by `CreateTable`, `DescribeTable`, and `UpdateTable`. Fixing `UpdateTable` also surfaced a pre-existing bug where its response used the wrong top-level JSON key (`Table` instead of `TableDescription`), silently discarding the response on the SDK side; that's fixed too.

## Test plan
- [x] `go build ./...`
- [x] `go test -race -shuffle=on -count=1 ./...`
- [x] `golangci-lint run ./...` (no new issues; remaining findings are pre-existing baseline)
- [x] Integration golden tests: `dynamodb` and `TestCLI_*` suites green against a running kumo server, including a new `TestDynamoDB_TableClass` round-trip
- [x] Manual verification against a running kumo server: `dynamodb create-table --table-class STANDARD_INFREQUENT_ACCESS` round-trips through `describe-table`; `stepfunctions send-task-success --task-output '...'` reaches the server without a flag collision; `--query`/`--output` work as global flags
