### PR TITLE
feat(sqs): add AddPermission and RemovePermission

### DIFF
--- a/cli/gen_sqs.go
+++ b/cli/gen_sqs.go
@@ -20,6 +20,7 @@ func newSQSCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
+		newSQSAddPermissionCmd(),
 		newSQSChangeMessageVisibilityCmd(),
 		newSQSChangeMessageVisibilityBatchCmd(),
 		newSQSCreateQueueCmd(),
@@ -32,12 +33,72 @@ func newSQSCmd() *cobra.Command {
 		newSQSListQueuesCmd(),
 		newSQSPurgeQueueCmd(),
 		newSQSReceiveMessageCmd(),
+		newSQSRemovePermissionCmd(),
 		newSQSSendMessageCmd(),
 		newSQSSendMessageBatchCmd(),
 		newSQSSetQueueAttributesCmd(),
 		newSQSTagQueueCmd(),
 		newSQSUntagQueueCmd(),
 	)
+
+	return cmd
+}
+
+func newSQSAddPermissionCmd() *cobra.Command {
+	var aWSAccountIds []string
+	var actions []string
+	var label string
+	var queueUrl string
+
+	cmd := &cobra.Command{
+		Use:   "add-permission",
+		Short: "AddPermission",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &sqs.AddPermissionInput{}
+
+			if len(aWSAccountIds) > 0 {
+				input.AWSAccountIds = aWSAccountIds
+			}
+
+			if len(actions) > 0 {
+				input.Actions = actions
+			}
+
+			if label != "" {
+				input.Label = aws.String(label)
+			}
+
+			if queueUrl != "" {
+				input.QueueUrl = aws.String(queueUrl)
+			}
+
+			_, err = client.AddPermission(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("add-permission failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&aWSAccountIds, "aws-account-ids", nil, "Aws account ids")
+
+	cmd.Flags().StringArrayVar(&actions, "actions", nil, "Actions")
+
+	cmd.Flags().StringVar(&label, "label", "", "Label")
+
+	cmd.Flags().StringVar(&queueUrl, "queue-url", "", "Queue url")
+
+	cmd.Flags().String("region", "", "Region override (ignored)")
 
 	return cmd
 }
@@ -662,6 +723,51 @@ func newSQSReceiveMessageCmd() *cobra.Command {
 	cmd.Flags().Int32Var(&visibilityTimeout, "visibility-timeout", 0, "Visibility timeout")
 
 	cmd.Flags().Int32Var(&waitTimeSeconds, "wait-time-seconds", 0, "Wait time seconds")
+
+	cmd.Flags().String("region", "", "Region override (ignored)")
+
+	return cmd
+}
+
+func newSQSRemovePermissionCmd() *cobra.Command {
+	var label string
+	var queueUrl string
+
+	cmd := &cobra.Command{
+		Use:   "remove-permission",
+		Short: "RemovePermission",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := newAWSConfig(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			client := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
+				o.BaseEndpoint = aws.String(endpointURL)
+			})
+
+			input := &sqs.RemovePermissionInput{}
+
+			if label != "" {
+				input.Label = aws.String(label)
+			}
+
+			if queueUrl != "" {
+				input.QueueUrl = aws.String(queueUrl)
+			}
+
+			_, err = client.RemovePermission(cmd.Context(), input)
+			if err != nil {
+				return fmt.Errorf("remove-permission failed: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&label, "label", "", "Label")
+
+	cmd.Flags().StringVar(&queueUrl, "queue-url", "", "Queue url")
 
 	cmd.Flags().String("region", "", "Region override (ignored)")
 

--- a/internal/service/sqs/handlers.go
+++ b/internal/service/sqs/handlers.go
@@ -283,7 +283,7 @@ func (s *Service) processBatchEntries(ctx context.Context, queueURL string, entr
 			resp.Failed = append(resp.Failed, BatchResultErrorEntry{
 				ID:          entry.ID,
 				SenderFault: true,
-				Code:        "MissingParameter",
+				Code:        errCodeMissingParameter,
 				Message:     "The request must contain the parameter MessageBody",
 			})
 
@@ -465,7 +465,7 @@ func (s *Service) processDeleteBatchEntries(ctx context.Context, queueURL string
 			resp.Failed = append(resp.Failed, BatchResultErrorEntry{
 				ID:          entry.ID,
 				SenderFault: true,
-				Code:        "MissingParameter",
+				Code:        errCodeMissingParameter,
 				Message:     "The request must contain the parameter ReceiptHandle",
 			})
 
@@ -635,6 +635,68 @@ func (s *Service) SetQueueAttributes(w http.ResponseWriter, r *http.Request) {
 	writeJSONResponse(w, struct{}{})
 }
 
+// AddPermission handles the AddPermission action.
+func (s *Service) AddPermission(w http.ResponseWriter, r *http.Request) {
+	var req AddPermissionRequest
+	if !decodeSQSRequest(w, r, &req) {
+		return
+	}
+
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
+		return
+	}
+
+	if !requireSQSParameter(w, req.Label, "Label") {
+		return
+	}
+
+	if err := s.storage.AddPermission(r.Context(), req.QueueURL, req.Label, req.AWSAccountIDs, req.Actions); err != nil {
+		var qErr *QueueError
+		if errors.As(err, &qErr) {
+			writeSQSError(w, qErr.Code, qErr.Message, http.StatusBadRequest)
+
+			return
+		}
+
+		writeSQSError(w, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, struct{}{})
+}
+
+// RemovePermission handles the RemovePermission action.
+func (s *Service) RemovePermission(w http.ResponseWriter, r *http.Request) {
+	var req RemovePermissionRequest
+	if !decodeSQSRequest(w, r, &req) {
+		return
+	}
+
+	if !requireSQSParameter(w, req.QueueURL, "QueueUrl") {
+		return
+	}
+
+	if !requireSQSParameter(w, req.Label, "Label") {
+		return
+	}
+
+	if err := s.storage.RemovePermission(r.Context(), req.QueueURL, req.Label); err != nil {
+		var qErr *QueueError
+		if errors.As(err, &qErr) {
+			writeSQSError(w, qErr.Code, qErr.Message, http.StatusBadRequest)
+
+			return
+		}
+
+		writeSQSError(w, "InternalError", "Internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	writeJSONResponse(w, struct{}{})
+}
+
 // writeJSONResponse writes a JSON response with HTTP 200 OK.
 func writeJSONResponse(w http.ResponseWriter, v any) {
 	service.WriteJSONResponse(w, service.ContentTypeAmzJSON10, v)
@@ -649,7 +711,7 @@ func writeSQSError(w http.ResponseWriter, code, message string, status int) {
 // standard SQS decode-failure error and returning false on failure.
 func decodeSQSRequest(w http.ResponseWriter, r *http.Request, req any) bool {
 	if err := service.ReadJSONRequest(r, req); err != nil {
-		writeSQSError(w, "InvalidParameterValue", "Failed to parse request body", http.StatusBadRequest)
+		writeSQSError(w, errCodeInvalidParameterValue, "Failed to parse request body", http.StatusBadRequest)
 
 		return false
 	}
@@ -661,7 +723,7 @@ func decodeSQSRequest(w http.ResponseWriter, r *http.Request, req any) bool {
 // returns false if value is empty.
 func requireSQSParameter(w http.ResponseWriter, value, name string) bool {
 	if value == "" {
-		writeSQSError(w, "MissingParameter", name+" is required", http.StatusBadRequest)
+		writeSQSError(w, errCodeMissingParameter, name+" is required", http.StatusBadRequest)
 
 		return false
 	}
@@ -671,22 +733,24 @@ func requireSQSParameter(w http.ResponseWriter, value, name string) bool {
 
 // sqsActions maps an X-Amz-Target action name to its handler method.
 var sqsActions = map[string]func(*Service, http.ResponseWriter, *http.Request){
+	"AddPermission":                (*Service).AddPermission,
+	"RemovePermission":             (*Service).RemovePermission,
 	"CreateQueue":                  (*Service).CreateQueue,
 	"ListQueueTags":                (*Service).ListQueueTags,
 	"TagQueue":                     (*Service).TagQueue,
 	"UntagQueue":                   (*Service).UntagQueue,
 	"DeleteQueue":                  (*Service).DeleteQueue,
 	"ListQueues":                   (*Service).ListQueues,
-	"GetQueueUrl":                  (*Service).GetQueueURL,
-	"SendMessage":                  (*Service).SendMessage,
+	actionGetQueueURL:              (*Service).GetQueueURL,
+	actionSendMessage:              (*Service).SendMessage,
 	"SendMessageBatch":             (*Service).SendMessageBatch,
-	"ReceiveMessage":               (*Service).ReceiveMessage,
-	"DeleteMessage":                (*Service).DeleteMessage,
+	actionReceiveMessage:           (*Service).ReceiveMessage,
+	actionDeleteMessage:            (*Service).DeleteMessage,
 	"DeleteMessageBatch":           (*Service).DeleteMessageBatch,
-	"PurgeQueue":                   (*Service).PurgeQueue,
-	"GetQueueAttributes":           (*Service).GetQueueAttributes,
+	actionPurgeQueue:               (*Service).PurgeQueue,
+	actionGetQueueAttributes:       (*Service).GetQueueAttributes,
 	"SetQueueAttributes":           (*Service).SetQueueAttributes,
-	"ChangeMessageVisibility":      (*Service).ChangeMessageVisibility,
+	actionChangeMessageVisibility:  (*Service).ChangeMessageVisibility,
 	"ChangeMessageVisibilityBatch": (*Service).ChangeMessageVisibilityBatch,
 }
 

--- a/internal/service/sqs/policy.go
+++ b/internal/service/sqs/policy.go
@@ -1,0 +1,155 @@
+package sqs
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// policyVersion is the IAM policy language version AddPermission-generated
+// documents use.
+const policyVersion = "2012-10-17"
+
+// policyActionPrefix is prepended to each action name AddPermission grants.
+const policyActionPrefix = "SQS:"
+
+// policyPrincipalARNFormat builds the root-account principal AddPermission
+// grants access to, per AWS's documented AddPermission-generated policies.
+const policyPrincipalARNFormat = "arn:aws:iam::%s:root"
+
+// policyMaxActionsPerStatement is the documented limit on the number of
+// actions a single AddPermission call may grant.
+// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_AddPermission.html
+const policyMaxActionsPerStatement = 7
+
+// policyDefaultIDSuffix names the Id AWS assigns to an AddPermission-generated
+// policy that had no prior custom policy.
+const policyDefaultIDSuffix = "/SQSDefaultPolicy"
+
+// policyStatementSidKey is the JSON key identifying a statement's label
+// within a policy document.
+const policyStatementSidKey = "Sid"
+
+// SQS action names, shared between the DispatchAction target-name dispatch
+// table (handlers.go) and the AddPermission-grantable action set below. Both
+// refer to the same AWS SQS API action names.
+const (
+	actionChangeMessageVisibility = "ChangeMessageVisibility"
+	actionDeleteMessage           = "DeleteMessage"
+	actionGetQueueAttributes      = "GetQueueAttributes"
+	actionGetQueueURL             = "GetQueueUrl"
+	actionPurgeQueue              = "PurgeQueue"
+	actionReceiveMessage          = "ReceiveMessage"
+	actionSendMessage             = "SendMessage"
+)
+
+// permissionActions are the actions eligible for cross-account sharing via
+// AddPermission. Cross-account sharing does not apply to queue-management
+// actions (AddPermission, CreateQueue, DeleteQueue, ListQueues,
+// ListQueueTags, RemovePermission, SetQueueAttributes, TagQueue, UntagQueue).
+// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-customer-managed-policy-examples.html
+var permissionActions = map[string]struct{}{
+	"*":                           {},
+	actionChangeMessageVisibility: {},
+	actionDeleteMessage:           {},
+	actionGetQueueAttributes:      {},
+	actionGetQueueURL:             {},
+	"ListDeadLetterSourceQueues":  {},
+	actionPurgeQueue:              {},
+	actionReceiveMessage:          {},
+	actionSendMessage:             {},
+}
+
+// parsePolicy parses raw (a queue's stored Policy attribute) into a
+// policyDocument, returning a fresh empty document if raw is unset.
+func parsePolicy(raw, queueARN string) (*policyDocument, error) {
+	if raw == "" {
+		return &policyDocument{
+			Version: policyVersion,
+			ID:      queueARN + policyDefaultIDSuffix,
+		}, nil
+	}
+
+	var doc policyDocument
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		return nil, fmt.Errorf("failed to parse queue policy: %w", err)
+	}
+
+	return &doc, nil
+}
+
+// marshal serializes d back to its string form. An empty statement list
+// marshals to "" so GetQueueAttributes omits the Policy attribute, matching
+// a queue that has never had a custom policy set.
+func (d *policyDocument) marshal() (string, error) {
+	if len(d.Statement) == 0 {
+		return "", nil
+	}
+
+	data, err := json.Marshal(d)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal queue policy: %w", err)
+	}
+
+	return string(data), nil
+}
+
+// hasStatement reports whether a statement with the given Sid exists.
+func (d *policyDocument) hasStatement(label string) bool {
+	for _, stmt := range d.Statement {
+		if sid, _ := stmt[policyStatementSidKey].(string); sid == label {
+			return true
+		}
+	}
+
+	return false
+}
+
+// removeStatement removes the statement with the given Sid, reporting
+// whether one was found.
+func (d *policyDocument) removeStatement(label string) bool {
+	for i, stmt := range d.Statement {
+		sid, _ := stmt[policyStatementSidKey].(string)
+		if sid != label {
+			continue
+		}
+
+		d.Statement = append(d.Statement[:i], d.Statement[i+1:]...)
+
+		return true
+	}
+
+	return false
+}
+
+// buildPermissionStatement builds the policy statement AddPermission
+// generates for label/awsAccountIDs/actions against queueARN.
+func buildPermissionStatement(label, queueARN string, awsAccountIDs, actions []string) map[string]any {
+	principals := make([]string, len(awsAccountIDs))
+	for i, id := range awsAccountIDs {
+		principals[i] = fmt.Sprintf(policyPrincipalARNFormat, id)
+	}
+
+	statementActions := make([]string, len(actions))
+	for i, action := range actions {
+		statementActions[i] = policyActionPrefix + action
+	}
+
+	return map[string]any{
+		policyStatementSidKey: label,
+		"Effect":              "Allow",
+		"Principal":           map[string]any{"AWS": collapse(principals)},
+		"Action":              collapse(statementActions),
+		"Resource":            queueARN,
+	}
+}
+
+// collapse returns values[0] when there is exactly one element, matching the
+// policy AWS generates: single-member Principal/Action lists are stored as a
+// plain string rather than a one-item array.
+func collapse(values []string) any {
+	if len(values) == 1 {
+		return values[0]
+	}
+
+	return values
+}

--- a/internal/service/sqs/policy_test.go
+++ b/internal/service/sqs/policy_test.go
@@ -1,0 +1,168 @@
+package sqs
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParsePolicy_EmptyGeneratesDefaultID(t *testing.T) {
+	t.Parallel()
+
+	doc, err := parsePolicy("", "arn:aws:sqs:us-east-1:000000000000:my-queue")
+	if err != nil {
+		t.Fatalf("parsePolicy() error = %v", err)
+	}
+
+	if doc.ID != "arn:aws:sqs:us-east-1:000000000000:my-queue/SQSDefaultPolicy" {
+		t.Fatalf("doc.ID = %q, want default SQSDefaultPolicy ID", doc.ID)
+	}
+
+	if len(doc.Statement) != 0 {
+		t.Fatalf("doc.Statement = %v, want empty", doc.Statement)
+	}
+}
+
+func TestParsePolicy_PreservesUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"Version":"2012-10-17","Statement":[{"Sid":"AllowSNS","Effect":"Allow","Principal":{"Service":"sns.amazonaws.com"},"Action":"sqs:SendMessage","Resource":"*","Condition":{"ArnEquals":{"aws:SourceArn":"arn:aws:sns:us-east-1:000000000000:my-topic"}}}]}`
+
+	doc, err := parsePolicy(raw, "arn:aws:sqs:us-east-1:000000000000:my-queue")
+	if err != nil {
+		t.Fatalf("parsePolicy() error = %v", err)
+	}
+
+	if len(doc.Statement) != 1 {
+		t.Fatalf("doc.Statement = %v, want 1 entry", doc.Statement)
+	}
+
+	if _, ok := doc.Statement[0]["Condition"]; !ok {
+		t.Fatalf("doc.Statement[0] lost Condition field: %v", doc.Statement[0])
+	}
+
+	marshaled, err := doc.marshal()
+	if err != nil {
+		t.Fatalf("marshal() error = %v", err)
+	}
+
+	var roundTrip map[string]any
+	if err := json.Unmarshal([]byte(marshaled), &roundTrip); err != nil {
+		t.Fatalf("unmarshal roundtrip: %v", err)
+	}
+
+	stmts, _ := roundTrip["Statement"].([]any)
+	if len(stmts) != 1 {
+		t.Fatalf("round-tripped Statement = %v, want 1 entry", roundTrip["Statement"])
+	}
+}
+
+func TestPolicyDocument_MarshalEmptyStatementsReturnsEmptyString(t *testing.T) {
+	t.Parallel()
+
+	doc, err := parsePolicy("", "arn:aws:sqs:us-east-1:000000000000:my-queue")
+	if err != nil {
+		t.Fatalf("parsePolicy() error = %v", err)
+	}
+
+	got, err := doc.marshal()
+	if err != nil {
+		t.Fatalf("marshal() error = %v", err)
+	}
+
+	if got != "" {
+		t.Fatalf("marshal() = %q, want empty string for a policy with no statements", got)
+	}
+}
+
+func TestPolicyDocument_HasAndRemoveStatement(t *testing.T) {
+	t.Parallel()
+
+	doc := &policyDocument{
+		Version: policyVersion,
+		Statement: []map[string]any{
+			{policyStatementSidKey: "LabelA"},
+			{policyStatementSidKey: "LabelB"},
+		},
+	}
+
+	if !doc.hasStatement("LabelA") {
+		t.Fatal("hasStatement(LabelA) = false, want true")
+	}
+
+	if doc.hasStatement("Missing") {
+		t.Fatal("hasStatement(Missing) = true, want false")
+	}
+
+	if !doc.removeStatement("LabelA") {
+		t.Fatal("removeStatement(LabelA) = false, want true")
+	}
+
+	if doc.hasStatement("LabelA") {
+		t.Fatal("hasStatement(LabelA) after removal = true, want false")
+	}
+
+	if len(doc.Statement) != 1 {
+		t.Fatalf("doc.Statement = %v, want 1 remaining entry", doc.Statement)
+	}
+
+	if doc.removeStatement("Missing") {
+		t.Fatal("removeStatement(Missing) = true, want false")
+	}
+}
+
+func TestBuildPermissionStatement_SingleValuesCollapseToStrings(t *testing.T) {
+	t.Parallel()
+
+	stmt := buildPermissionStatement("AliceSendMessage", "arn:aws:sqs:us-east-1:000000000000:my-queue", []string{"111111111111"}, []string{actionSendMessage})
+
+	if stmt[policyStatementSidKey] != "AliceSendMessage" {
+		t.Fatalf("Sid = %v, want AliceSendMessage", stmt[policyStatementSidKey])
+	}
+
+	if stmt["Effect"] != "Allow" {
+		t.Fatalf("Effect = %v, want Allow", stmt["Effect"])
+	}
+
+	principal, ok := stmt["Principal"].(map[string]any)
+	if !ok {
+		t.Fatalf("Principal = %v, want map[string]any", stmt["Principal"])
+	}
+
+	if principal["AWS"] != "arn:aws:iam::111111111111:root" {
+		t.Fatalf("Principal.AWS = %v, want single root ARN string", principal["AWS"])
+	}
+
+	if stmt["Action"] != "SQS:SendMessage" {
+		t.Fatalf("Action = %v, want single SQS:SendMessage string", stmt["Action"])
+	}
+
+	if stmt["Resource"] != "arn:aws:sqs:us-east-1:000000000000:my-queue" {
+		t.Fatalf("Resource = %v, want queue ARN", stmt["Resource"])
+	}
+}
+
+func TestBuildPermissionStatement_MultipleValuesStayAsSlices(t *testing.T) {
+	t.Parallel()
+
+	stmt := buildPermissionStatement(
+		"MultiAccount",
+		"arn:aws:sqs:us-east-1:000000000000:my-queue",
+		[]string{"111111111111", "222222222222"},
+		[]string{actionSendMessage, actionReceiveMessage},
+	)
+
+	principal, ok := stmt["Principal"].(map[string]any)
+	if !ok {
+		t.Fatalf("Principal = %v, want map[string]any", stmt["Principal"])
+	}
+
+	awsPrincipals, ok := principal["AWS"].([]string)
+	if !ok || len(awsPrincipals) != 2 {
+		t.Fatalf("Principal.AWS = %v, want 2-element slice", principal["AWS"])
+	}
+
+	actions, ok := stmt["Action"].([]string)
+	if !ok || len(actions) != 2 || actions[0] != "SQS:SendMessage" || actions[1] != "SQS:ReceiveMessage" {
+		t.Fatalf("Action = %v, want [SQS:SendMessage SQS:ReceiveMessage]", stmt["Action"])
+	}
+}

--- a/internal/service/sqs/storage.go
+++ b/internal/service/sqs/storage.go
@@ -43,6 +43,8 @@ type Storage interface {
 	PurgeQueue(ctx context.Context, queueURL string) error
 	GetQueueAttributes(ctx context.Context, queueURL string, attributeNames []string) (map[string]string, error)
 	SetQueueAttributes(ctx context.Context, queueURL string, attributes map[string]string) error
+	AddPermission(ctx context.Context, queueURL, label string, awsAccountIDs, actions []string) error
+	RemovePermission(ctx context.Context, queueURL, label string) error
 }
 
 // QueueError represents an SQS queue error.
@@ -57,6 +59,16 @@ func (e *QueueError) Error() string {
 
 // Attribute value for boolean true.
 const attrValueTrue = "true"
+
+// Common error codes shared across QueueError instances.
+const (
+	errCodeInvalidParameterValue = "InvalidParameterValue"
+	errCodeMissingParameter      = "MissingParameter"
+)
+
+// attrPolicy is the GetQueueAttributes/SetQueueAttributes attribute name for
+// a queue's access policy document.
+const attrPolicy = "Policy"
 
 // Common error codes.
 var (
@@ -230,7 +242,7 @@ func (s *MemoryStorage) CreateQueue(_ context.Context, name string, attributes, 
 
 	if !isValidQueueName(name) {
 		return nil, &QueueError{
-			Code:    "InvalidParameterValue",
+			Code:    errCodeInvalidParameterValue,
 			Message: "Queue name contains invalid characters",
 		}
 	}
@@ -244,7 +256,7 @@ func (s *MemoryStorage) CreateQueue(_ context.Context, name string, attributes, 
 	isFifo := strings.HasSuffix(name, ".fifo")
 	if attributes["FifoQueue"] == attrValueTrue && !isFifo {
 		return nil, &QueueError{
-			Code:    "InvalidParameterValue",
+			Code:    errCodeInvalidParameterValue,
 			Message: "The queue name must end with .fifo for FIFO queues",
 		}
 	}
@@ -418,7 +430,7 @@ type FifoResult struct {
 func (qd *QueueData) validateFIFO(body, messageGroupID, messageDeduplicationID string, now time.Time) (*FifoResult, error) {
 	if messageGroupID == "" {
 		return nil, &QueueError{
-			Code:    "MissingParameter",
+			Code:    errCodeMissingParameter,
 			Message: "The request must contain the parameter MessageGroupId",
 		}
 	}
@@ -430,7 +442,7 @@ func (qd *QueueData) validateFIFO(body, messageGroupID, messageDeduplicationID s
 			dedupID = hex.EncodeToString(hash[:])
 		} else {
 			return nil, &QueueError{
-				Code:    "InvalidParameterValue",
+				Code:    errCodeInvalidParameterValue,
 				Message: "The queue should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
 			}
 		}
@@ -767,7 +779,7 @@ func (s *MemoryStorage) GetQueueAttributes(_ context.Context, queueURL string, a
 	}
 
 	if q.Policy != "" {
-		allAttrs["Policy"] = q.Policy
+		allAttrs[attrPolicy] = q.Policy
 	}
 
 	if q.RedrivePolicy != "" {
@@ -807,6 +819,107 @@ func (s *MemoryStorage) SetQueueAttributes(_ context.Context, queueURL string, a
 	return nil
 }
 
+// AddPermission adds a cross-account permission statement to a queue's
+// access policy.
+func (s *MemoryStorage) AddPermission(_ context.Context, queueURL, label string, awsAccountIDs, actions []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, qd, err := s.resolveQueueData(queueURL)
+	if err != nil {
+		return err
+	}
+
+	if len(actions) == 0 {
+		return &QueueError{Code: errCodeMissingParameter, Message: "The request must contain the parameter Actions."}
+	}
+
+	if len(actions) > policyMaxActionsPerStatement {
+		return &QueueError{
+			Code:    "OverLimit",
+			Message: fmt.Sprintf("%d Actions were found, maximum allowed is %d.", len(actions), policyMaxActionsPerStatement),
+		}
+	}
+
+	if len(awsAccountIDs) == 0 {
+		return &QueueError{
+			Code:    errCodeInvalidParameterValue,
+			Message: "Value [] for parameter PrincipalId is invalid. Reason: Unable to verify.",
+		}
+	}
+
+	for _, action := range actions {
+		if _, ok := permissionActions[action]; !ok {
+			return &QueueError{
+				Code:    errCodeInvalidParameterValue,
+				Message: fmt.Sprintf("Value SQS:%s for parameter ActionName is invalid. Reason: Only the queue owner is allowed to invoke this action.", action),
+			}
+		}
+	}
+
+	doc, err := parsePolicy(qd.Queue.Policy, qd.Queue.ARN)
+	if err != nil {
+		return err
+	}
+
+	if doc.hasStatement(label) {
+		return &QueueError{
+			Code:    errCodeInvalidParameterValue,
+			Message: fmt.Sprintf("Value %s for parameter Label is invalid. Reason: Already exists.", label),
+		}
+	}
+
+	doc.Statement = append(doc.Statement, buildPermissionStatement(label, qd.Queue.ARN, awsAccountIDs, actions))
+
+	policy, err := doc.marshal()
+	if err != nil {
+		return err
+	}
+
+	qd.Queue.Policy = policy
+	qd.Queue.LastModifiedTimestamp = time.Now()
+
+	s.saveLocked()
+
+	return nil
+}
+
+// RemovePermission removes the permission statement identified by label from
+// a queue's access policy.
+func (s *MemoryStorage) RemovePermission(_ context.Context, queueURL, label string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, qd, err := s.resolveQueueData(queueURL)
+	if err != nil {
+		return err
+	}
+
+	doc, err := parsePolicy(qd.Queue.Policy, qd.Queue.ARN)
+	if err != nil {
+		return err
+	}
+
+	if !doc.removeStatement(label) {
+		return &QueueError{
+			Code:    errCodeInvalidParameterValue,
+			Message: fmt.Sprintf("Value %s for parameter Label is invalid. Reason: can't find label on existing policy.", label),
+		}
+	}
+
+	policy, err := doc.marshal()
+	if err != nil {
+		return err
+	}
+
+	qd.Queue.Policy = policy
+	qd.Queue.LastModifiedTimestamp = time.Now()
+
+	s.saveLocked()
+
+	return nil
+}
+
 func applyQueueAttributes(q *Queue, attrs map[string]string) {
 	for key, val := range attrs {
 		switch key {
@@ -822,7 +935,7 @@ func applyQueueAttributes(q *Queue, attrs map[string]string) {
 			_, _ = fmt.Sscanf(val, "%d", &q.ReceiveWaitTimeSeconds)
 		case "ContentBasedDeduplication":
 			q.ContentBasedDeduplication = val == "true"
-		case "Policy":
+		case attrPolicy:
 			q.Policy = val
 		case "RedrivePolicy":
 			q.RedrivePolicy = val

--- a/internal/service/sqs/storage_test.go
+++ b/internal/service/sqs/storage_test.go
@@ -21,7 +21,7 @@ func TestMemoryStorage_CreateQueueRejectsDelimiterNames(t *testing.T) {
 			s := NewMemoryStorage("http://localhost:4566")
 
 			_, err := s.CreateQueue(t.Context(), name, nil, nil)
-			expectQueueErrorCode(t, err, "InvalidParameterValue")
+			expectQueueErrorCode(t, err, errCodeInvalidParameterValue)
 		})
 	}
 }
@@ -185,6 +185,151 @@ func TestMemoryStorage_TagsLifecycle(t *testing.T) {
 	if len(tags) != 1 || tags["key2"] != tagValue2 {
 		t.Fatalf("unexpected tags after untag: %#v", tags)
 	}
+}
+
+func TestMemoryStorage_PermissionLifecycle(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := t.Context()
+
+	_, err := s.CreateQueue(ctx, "permission-queue", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queueURL := "http://localhost:4566/000000000000/permission-queue"
+
+	attrsBefore, err := s.GetQueueAttributes(ctx, queueURL, []string{attrPolicy})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes() error = %v", err)
+	}
+
+	if _, ok := attrsBefore[attrPolicy]; ok {
+		t.Fatalf("Policy attribute present before AddPermission: %v", attrsBefore)
+	}
+
+	if err := s.AddPermission(ctx, queueURL, "AliceSendMessage", []string{"111111111111"}, []string{actionSendMessage}); err != nil {
+		t.Fatalf("AddPermission() error = %v", err)
+	}
+
+	attrsAfter, err := s.GetQueueAttributes(ctx, queueURL, []string{attrPolicy})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes() error = %v", err)
+	}
+
+	if attrsAfter[attrPolicy] == "" {
+		t.Fatal("Policy attribute missing after AddPermission")
+	}
+
+	if err := s.RemovePermission(ctx, queueURL, "AliceSendMessage"); err != nil {
+		t.Fatalf("RemovePermission() error = %v", err)
+	}
+
+	attrsFinal, err := s.GetQueueAttributes(ctx, queueURL, []string{attrPolicy})
+	if err != nil {
+		t.Fatalf("GetQueueAttributes() error = %v", err)
+	}
+
+	if _, ok := attrsFinal[attrPolicy]; ok {
+		t.Fatalf("Policy attribute still present after removing the only statement: %v", attrsFinal)
+	}
+}
+
+func TestMemoryStorage_AddPermissionErrors(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := t.Context()
+
+	_, err := s.CreateQueue(ctx, "permission-errors-queue", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queueURL := "http://localhost:4566/000000000000/permission-errors-queue"
+
+	tests := []struct {
+		name          string
+		label         string
+		awsAccountIDs []string
+		actions       []string
+		wantCode      string
+	}{
+		{
+			name:     "empty actions",
+			label:    "Label1",
+			actions:  nil,
+			wantCode: errCodeMissingParameter,
+		},
+		{
+			name:     "too many actions",
+			label:    "Label2",
+			actions:  []string{actionSendMessage, actionReceiveMessage, actionDeleteMessage, actionGetQueueAttributes, actionGetQueueURL, actionPurgeQueue, "ListDeadLetterSourceQueues", actionChangeMessageVisibility},
+			wantCode: "OverLimit",
+		},
+		{
+			name:          "no account ids",
+			label:         "Label3",
+			awsAccountIDs: nil,
+			actions:       []string{actionSendMessage},
+			wantCode:      errCodeInvalidParameterValue,
+		},
+		{
+			name:          "invalid action",
+			label:         "Label4",
+			awsAccountIDs: []string{"111111111111"},
+			actions:       []string{"CreateQueue"},
+			wantCode:      errCodeInvalidParameterValue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := s.AddPermission(ctx, queueURL, tt.label, tt.awsAccountIDs, tt.actions)
+			expectQueueErrorCode(t, err, tt.wantCode)
+		})
+	}
+}
+
+func TestMemoryStorage_AddPermissionDuplicateLabel(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := t.Context()
+
+	_, err := s.CreateQueue(ctx, "permission-dup-queue", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queueURL := "http://localhost:4566/000000000000/permission-dup-queue"
+
+	if err := s.AddPermission(ctx, queueURL, "DupLabel", []string{"111111111111"}, []string{actionSendMessage}); err != nil {
+		t.Fatalf("AddPermission() error = %v", err)
+	}
+
+	err = s.AddPermission(ctx, queueURL, "DupLabel", []string{"222222222222"}, []string{actionReceiveMessage})
+	expectQueueErrorCode(t, err, errCodeInvalidParameterValue)
+}
+
+func TestMemoryStorage_RemovePermissionUnknownLabel(t *testing.T) {
+	t.Parallel()
+
+	s := NewMemoryStorage("http://localhost:4566")
+	ctx := t.Context()
+
+	_, err := s.CreateQueue(ctx, "permission-remove-queue", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queueURL := "http://localhost:4566/000000000000/permission-remove-queue"
+
+	err = s.RemovePermission(ctx, queueURL, "NoSuchLabel")
+	expectQueueErrorCode(t, err, errCodeInvalidParameterValue)
 }
 
 func expectQueueErrorCode(t *testing.T, err error, code string) {

--- a/internal/service/sqs/types.go
+++ b/internal/service/sqs/types.go
@@ -288,3 +288,28 @@ type ErrorResponse struct {
 	Type    string `json:"__type"`
 	Message string `json:"message"`
 }
+
+// AddPermissionRequest is the request for AddPermission.
+type AddPermissionRequest struct {
+	QueueURL      string   `json:"QueueUrl"`
+	Label         string   `json:"Label"`
+	AWSAccountIDs []string `json:"AWSAccountIds"`
+	Actions       []string `json:"Actions"`
+}
+
+// RemovePermissionRequest is the request for RemovePermission.
+type RemovePermissionRequest struct {
+	QueueURL string `json:"QueueUrl"`
+	Label    string `json:"Label"`
+}
+
+// policyDocument is a minimal representation of an SQS access policy.
+// Statement entries are kept as generic maps so that fields kumo doesn't
+// model (e.g. Condition, NotPrincipal) written via a raw SetQueueAttributes
+// Policy value are preserved verbatim across AddPermission/RemovePermission
+// calls.
+type policyDocument struct {
+	Version   string           `json:"Version"`
+	ID        string           `json:"Id,omitempty"`
+	Statement []map[string]any `json:"Statement"`
+}

--- a/test/integration/sqs_test.go
+++ b/test/integration/sqs_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/aws/smithy-go"
 	"github.com/sivchari/golden"
 )
 
@@ -1018,5 +1020,130 @@ func TestSQS_VisibilityTimeoutDLQRedrive(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSQS_AddAndRemovePermission(t *testing.T) {
+	client := newSQSClient(t)
+	ctx := t.Context()
+	queueName := "test-queue-add-remove-permission"
+
+	createOutput, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteQueue(context.Background(), &sqs.DeleteQueueInput{
+			QueueUrl: createOutput.QueueUrl,
+		})
+	})
+
+	// AddPermission grants SendMessage to one account and ReceiveMessage to
+	// another, per the AWS API reference example.
+	_, err = client.AddPermission(ctx, &sqs.AddPermissionInput{
+		QueueUrl:      createOutput.QueueUrl,
+		Label:         aws.String("TestSharedAccess"),
+		AWSAccountIds: []string{"177715257436", "111111111111"},
+		Actions:       []string{"SendMessage", "ReceiveMessage"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// GetQueueAttributes should reflect the generated Policy.
+	afterAdd, err := client.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       createOutput.QueueUrl,
+		AttributeNames: []types.QueueAttributeName{types.QueueAttributeNamePolicy},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_after_add", afterAdd)
+
+	// RemovePermission removes the statement by Label.
+	_, err = client.RemovePermission(ctx, &sqs.RemovePermissionInput{
+		QueueUrl: createOutput.QueueUrl,
+		Label:    aws.String("TestSharedAccess"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The Policy attribute should be gone now that the only statement was removed.
+	afterRemove, err := client.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       createOutput.QueueUrl,
+		AttributeNames: []types.QueueAttributeName{types.QueueAttributeNamePolicy},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	golden.New(t, golden.WithIgnoreFields("ResultMetadata")).Assert(t.Name()+"_after_remove", afterRemove)
+}
+
+func TestSQS_AddPermissionErrors(t *testing.T) {
+	client := newSQSClient(t)
+	ctx := t.Context()
+	queueName := "test-queue-add-permission-errors"
+
+	createOutput, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteQueue(context.Background(), &sqs.DeleteQueueInput{
+			QueueUrl: createOutput.QueueUrl,
+		})
+	})
+
+	// Too many actions in a single statement (limit is 7).
+	_, err = client.AddPermission(ctx, &sqs.AddPermissionInput{
+		QueueUrl:      createOutput.QueueUrl,
+		Label:         aws.String("TooManyActions"),
+		AWSAccountIds: []string{"111111111111"},
+		Actions: []string{
+			"SendMessage", "ReceiveMessage", "DeleteMessage", "GetQueueAttributes",
+			"GetQueueUrl", "PurgeQueue", "ChangeMessageVisibility", "ListDeadLetterSourceQueues",
+		},
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "OverLimit" {
+		t.Fatalf("expected OverLimit error, got %v", err)
+	}
+
+	// Duplicate label.
+	_, err = client.AddPermission(ctx, &sqs.AddPermissionInput{
+		QueueUrl:      createOutput.QueueUrl,
+		Label:         aws.String("DupLabel"),
+		AWSAccountIds: []string{"111111111111"},
+		Actions:       []string{"SendMessage"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.AddPermission(ctx, &sqs.AddPermissionInput{
+		QueueUrl:      createOutput.QueueUrl,
+		Label:         aws.String("DupLabel"),
+		AWSAccountIds: []string{"222222222222"},
+		Actions:       []string{"ReceiveMessage"},
+	})
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("expected InvalidParameterValue error for duplicate label, got %v", err)
+	}
+
+	// RemovePermission with an unknown label.
+	_, err = client.RemovePermission(ctx, &sqs.RemovePermissionInput{
+		QueueUrl: createOutput.QueueUrl,
+		Label:    aws.String("NoSuchLabel"),
+	})
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValue" {
+		t.Fatalf("expected InvalidParameterValue error for unknown label, got %v", err)
 	}
 }

--- a/test/integration/testdata/sqs_test_TestSQS_AddAndRemovePermission_TestSQS_AddAndRemovePermission_after_add.golden.go
+++ b/test/integration/testdata/sqs_test_TestSQS_AddAndRemovePermission_TestSQS_AddAndRemovePermission_after_add.golden.go
@@ -1,0 +1,6 @@
+{
+  "Attributes": {
+    "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"arn:aws:sqs:us-east-1:000000000000:test-queue-add-remove-permission/SQSDefaultPolicy\",\"Statement\":[{\"Action\":[\"SQS:SendMessage\",\"SQS:ReceiveMessage\"],\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam::177715257436:root\",\"arn:aws:iam::111111111111:root\"]},\"Resource\":\"arn:aws:sqs:us-east-1:000000000000:test-queue-add-remove-permission\",\"Sid\":\"TestSharedAccess\"}]}"
+  },
+  "ResultMetadata": {}
+}

--- a/test/integration/testdata/sqs_test_TestSQS_AddAndRemovePermission_TestSQS_AddAndRemovePermission_after_remove.golden.go
+++ b/test/integration/testdata/sqs_test_TestSQS_AddAndRemovePermission_TestSQS_AddAndRemovePermission_after_remove.golden.go
@@ -1,0 +1,4 @@
+{
+  "Attributes": null,
+  "ResultMetadata": {}
+}


### PR DESCRIPTION
## Summary
Adds SQS `AddPermission` and `RemovePermission`, the remaining operations from #406. `AddPermission` appends an AWS-generated statement to the queue's `Policy` attribute (`Sid=Label`, `Principal.AWS` as root-account ARNs, `Action=SQS:<name>`, `Resource=<queue ARN>`); `RemovePermission` removes a statement by `Label`. Both coexist with policies set directly via `SetQueueAttributes`.

## Test plan
- [x] `go test -race ./internal/service/sqs/...` (unit tests, incl. policy statement generation)
- [x] `golangci-lint run ./...`
- [x] Integration golden tests (`TestSQS_AddAndRemovePermission`, `TestSQS_AddPermissionErrors`) against a running kumo server
- [x] `make cli-gen` — `add-permission` / `remove-permission` auto-generated, `TestGeneratedCLIUpToDate` green

## References
- https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_AddPermission.html
- https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_RemovePermission.html

Fixes #406