### PR TITLE
feat(s3): support If-Match / If-None-Match conditional writes on PutObject

### DIFF
--- a/internal/service/s3/conditional.go
+++ b/internal/service/s3/conditional.go
@@ -84,19 +84,87 @@ func evalCopySourcePreconditions(h http.Header, etag string, lastModified time.T
 // exists, which for a successful GetObject lookup is always true).
 //
 // ETag comparison is the *strong* variant per RFC 9110 §8.8.3.2 —
-// kumo doesn't emit `W/"..."` weak ETags, and AWS S3 doesn't either,
-// so quoted-string equality is sufficient.
+// kumo doesn't emit `W/"..."` weak ETags, and AWS S3 doesn't either.
+// Tokens are compared with surrounding quotes stripped so an unquoted
+// If-Match/If-None-Match value (real clients and the AWS CLI send
+// either form) still matches the quoted ETag kumo stores, matching AWS
+// S3's lenient behavior.
 func matchesAnyETag(headerValue, etag string) bool {
 	v := strings.TrimSpace(headerValue)
 	if v == "*" {
 		return true
 	}
 
+	want := strings.Trim(etag, `"`)
+
 	for _, raw := range strings.Split(v, ",") {
-		if strings.TrimSpace(raw) == etag {
+		if strings.Trim(strings.TrimSpace(raw), `"`) == want {
 			return true
 		}
 	}
 
 	return false
+}
+
+// parsePutCondition parses the If-Match / If-None-Match request headers
+// into a PutCondition for PutObject / CompleteMultipartUpload. AWS S3
+// only supports `If-None-Match: *` on writes (any other value returns
+// 501 NotImplemented instead of being evaluated), reported via the
+// second return value being false.
+func parsePutCondition(h http.Header) (PutCondition, bool) {
+	var cond PutCondition
+
+	if v := strings.TrimSpace(h.Get("If-None-Match")); v != "" {
+		if v != "*" {
+			return PutCondition{}, false
+		}
+
+		cond.IfNoneMatchAny = true
+	}
+
+	cond.IfMatch = strings.TrimSpace(h.Get("If-Match"))
+
+	return cond, true
+}
+
+// objectErrorStatus maps an *ObjectError Code produced by
+// checkPutCondition to its S3 HTTP status: PreconditionFailed is 412,
+// NoSuchKey (and anything else) is 404.
+func objectErrorStatus(code string) int {
+	if code == "PreconditionFailed" {
+		return http.StatusPreconditionFailed
+	}
+
+	return http.StatusNotFound
+}
+
+// checkPutCondition evaluates cond against bucket b's current object at
+// key, in RFC 9110 order (If-Match before If-None-Match). The caller
+// must hold s.mu (write lock) across both this check and the insert
+// that follows, so the check is atomic with the write.
+//
+// A key whose current version is a delete marker is treated as
+// non-existent (mirrors GetObject: b.Objects[key] stays populated with
+// the delete marker after a versioned delete, it isn't removed), so
+// `If-None-Match: *` succeeds and `If-Match` reports NoSuchKey just as
+// it would for a truly absent key.
+func checkPutCondition(b *MemoryBucket, key string, cond PutCondition) error {
+	current, ok := b.Objects[key]
+	exists := ok && !current.IsDeleteMarker
+
+	if cond.IfMatch != "" {
+		if !exists {
+			return &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
+		}
+
+		if !matchesAnyETag(cond.IfMatch, current.ETag) {
+			return &ObjectError{Code: "PreconditionFailed", Message: "At least one of the preconditions you specified did not hold.", Key: key}
+		}
+	}
+
+	if cond.IfNoneMatchAny && exists {
+		return &ObjectError{Code: "PreconditionFailed", Message: "At least one of the preconditions you specified did not hold.", Key: key}
+	}
+
+	return nil
 }

--- a/internal/service/s3/conditional_test.go
+++ b/internal/service/s3/conditional_test.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -198,4 +199,349 @@ func httpQueryEscape(s string) string {
 	).Replace(s)
 
 	return out
+}
+
+// TestMatchesAnyETag_QuoteNormalization confirms If-Match/If-None-Match
+// tokens compare equal to a stored ETag whether or not either side is
+// quoted, matching AWS S3's lenient comparison.
+func TestMatchesAnyETag_QuoteNormalization(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		headerValue string
+		etag        string
+		want        bool
+	}{
+		{"both quoted, match", `"abc123"`, `"abc123"`, true},
+		{"header unquoted, stored quoted", `abc123`, `"abc123"`, true},
+		{"header quoted, comma list, second matches", `"x", "abc123"`, `"abc123"`, true},
+		{"mismatch", `"xyz"`, `"abc123"`, false},
+		{"wildcard always matches", "*", `"abc123"`, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := matchesAnyETag(tc.headerValue, tc.etag); got != tc.want {
+				t.Fatalf("matchesAnyETag(%q, %q) = %v, want %v", tc.headerValue, tc.etag, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParsePutCondition covers If-Match / If-None-Match header parsing
+// for PutObject/CompleteMultipartUpload, including S3's restriction
+// that If-None-Match only supports "*" on writes.
+func TestParsePutCondition(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		hdr    http.Header
+		want   PutCondition
+		wantOK bool
+	}{
+		{"no headers", http.Header{}, PutCondition{}, true},
+		{"If-None-Match: *", http.Header{"If-None-Match": []string{"*"}}, PutCondition{IfNoneMatchAny: true}, true},
+		{"If-None-Match with an ETag is not implemented", http.Header{"If-None-Match": []string{`"abc"`}}, PutCondition{}, false},
+		{"If-Match carried through verbatim", http.Header{"If-Match": []string{`"abc123"`}}, PutCondition{IfMatch: `"abc123"`}, true},
+		{"both headers, If-Match kept and If-None-Match:* recognized", http.Header{
+			"If-Match":      []string{`"abc123"`},
+			"If-None-Match": []string{"*"},
+		}, PutCondition{IfMatch: `"abc123"`, IfNoneMatchAny: true}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parsePutCondition(tc.hdr)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCheckPutCondition exercises checkPutCondition directly against a
+// MemoryBucket, including RFC 9110 evaluation order (If-Match before
+// If-None-Match) and the delete-marker-as-absent case.
+//
+//nolint:funlen // Table of independent t.Run subtests covering every precondition/state combination.
+func TestCheckPutCondition(t *testing.T) {
+	t.Parallel()
+
+	newBucketWithObject := func() *MemoryBucket {
+		return &MemoryBucket{
+			Objects: map[string]*Object{
+				"k": {Key: "k", ETag: testETag},
+			},
+		}
+	}
+
+	t.Run("no condition always passes", func(t *testing.T) {
+		t.Parallel()
+
+		if err := checkPutCondition(newBucketWithObject(), "k", PutCondition{}); err != nil {
+			t.Fatalf("got %v, want nil", err)
+		}
+	})
+
+	t.Run("If-None-Match:* on missing key passes", func(t *testing.T) {
+		t.Parallel()
+
+		b := &MemoryBucket{Objects: map[string]*Object{}}
+		if err := checkPutCondition(b, "k", PutCondition{IfNoneMatchAny: true}); err != nil {
+			t.Fatalf("got %v, want nil", err)
+		}
+	})
+
+	t.Run("If-None-Match:* on existing key fails", func(t *testing.T) {
+		t.Parallel()
+
+		expectObjectErrorCode(t, checkPutCondition(newBucketWithObject(), "k", PutCondition{IfNoneMatchAny: true}), "PreconditionFailed")
+	})
+
+	t.Run("If-Match hit passes", func(t *testing.T) {
+		t.Parallel()
+
+		if err := checkPutCondition(newBucketWithObject(), "k", PutCondition{IfMatch: testETag}); err != nil {
+			t.Fatalf("got %v, want nil", err)
+		}
+	})
+
+	t.Run("If-Match miss fails", func(t *testing.T) {
+		t.Parallel()
+
+		expectObjectErrorCode(t, checkPutCondition(newBucketWithObject(), "k", PutCondition{IfMatch: `"never-matches"`}), "PreconditionFailed")
+	})
+
+	t.Run("If-Match on missing key is NoSuchKey", func(t *testing.T) {
+		t.Parallel()
+
+		b := &MemoryBucket{Objects: map[string]*Object{}}
+		expectObjectErrorCode(t, checkPutCondition(b, "k", PutCondition{IfMatch: testETag}), "NoSuchKey")
+	})
+
+	t.Run("If-Match evaluated before If-None-Match", func(t *testing.T) {
+		t.Parallel()
+
+		// Both conditions target the same existing key: If-Match
+		// mismatches (RFC 9110 order says it's evaluated first), so
+		// that's the failure reported even though If-None-Match:*
+		// would also fail here.
+		err := checkPutCondition(newBucketWithObject(), "k", PutCondition{IfMatch: `"never-matches"`, IfNoneMatchAny: true})
+		expectObjectErrorCode(t, err, "PreconditionFailed")
+	})
+
+	t.Run("delete marker is treated as absent", func(t *testing.T) {
+		t.Parallel()
+
+		b := &MemoryBucket{Objects: map[string]*Object{
+			"k": {Key: "k", IsDeleteMarker: true},
+		}}
+
+		if err := checkPutCondition(b, "k", PutCondition{IfNoneMatchAny: true}); err != nil {
+			t.Fatalf("If-None-Match:* over a delete marker: got %v, want nil", err)
+		}
+
+		expectObjectErrorCode(t, checkPutCondition(b, "k", PutCondition{IfMatch: testETag}), "NoSuchKey")
+	})
+}
+
+// expectObjectErrorCode asserts err is an *ObjectError with the given Code.
+func expectObjectErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+
+	var objErr *ObjectError
+	if !errors.As(err, &objErr) {
+		t.Fatalf("got err %v (%T), want *ObjectError code %s", err, err, code)
+	}
+
+	if objErr.Code != code {
+		t.Fatalf("got ObjectError code %s, want %s", objErr.Code, code)
+	}
+}
+
+// TestPutObject_ConditionalRequests confirms the HTTP-layer wiring for
+// PutObject's If-Match / If-None-Match preconditions.
+//
+//nolint:funlen // Table-driven test covering every precondition/state combination over HTTP.
+func TestPutObject_ConditionalRequests(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		seed       bool // seed an initial object at "k" before the conditional PUT
+		header     string
+		value      string // "seeded"/"seeded-unquoted" substitute the seeded object's ETag
+		wantStatus int
+	}{
+		{"no headers, no existing object", false, "", "", http.StatusOK},
+		{"no headers, existing object", true, "", "", http.StatusOK},
+		{"If-None-Match:* on missing key succeeds", false, "If-None-Match", "*", http.StatusOK},
+		{"If-None-Match:* on existing key fails", true, "If-None-Match", "*", http.StatusPreconditionFailed},
+		{"If-None-Match non-* is not implemented", false, "If-None-Match", `"abc"`, http.StatusNotImplemented},
+		{"If-Match hit succeeds", true, "If-Match", "seeded", http.StatusOK},
+		{"If-Match hit unquoted succeeds", true, "If-Match", "seeded-unquoted", http.StatusOK},
+		{"If-Match miss fails", true, "If-Match", `"never-matches"`, http.StatusPreconditionFailed},
+		{"If-Match on missing key is NoSuchKey", false, "If-Match", `"whatever"`, http.StatusNotFound},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := NewMemoryStorage()
+			svc := New(store, "")
+			ctx := context.Background()
+
+			_ = store.CreateBucket(ctx, "pb")
+
+			var seededETag string
+
+			if tc.seed {
+				obj, err := store.PutObject(ctx, "pb", "k", strings.NewReader("old"), nil)
+				if err != nil {
+					t.Fatalf("seed PutObject: %v", err)
+				}
+
+				seededETag = obj.ETag
+			}
+
+			req := httptest.NewRequest(http.MethodPut, "/pb/k", strings.NewReader("new"))
+			req.SetPathValue("bucket", "pb")
+			req.SetPathValue("key", "k")
+
+			switch tc.value {
+			case "seeded":
+				req.Header.Set(tc.header, seededETag)
+			case "seeded-unquoted":
+				req.Header.Set(tc.header, strings.Trim(seededETag, `"`))
+			default:
+				if tc.header != "" {
+					req.Header.Set(tc.header, tc.value)
+				}
+			}
+
+			w := httptest.NewRecorder()
+			svc.PutObject(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status: got %d, want %d (body=%s)", w.Code, tc.wantStatus, w.Body.String())
+			}
+
+			if tc.wantStatus == http.StatusOK && w.Header().Get("ETag") == "" {
+				t.Fatalf("expected an ETag header on success")
+			}
+		})
+	}
+}
+
+// TestPutObject_ConditionalRequests_DeleteMarker confirms a key whose
+// current version is a delete marker (versioning enabled, then deleted)
+// is treated as absent: If-None-Match:* must succeed just as it would
+// for a key that never existed.
+func TestPutObject_ConditionalRequests_DeleteMarker(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, "db")
+	_ = store.PutBucketVersioning(ctx, "db", VersioningEnabled)
+
+	if _, err := store.PutObject(ctx, "db", "k", strings.NewReader("v1"), nil); err != nil {
+		t.Fatalf("seed PutObject: %v", err)
+	}
+
+	if _, err := store.DeleteObject(ctx, "db", "k"); err != nil {
+		t.Fatalf("DeleteObject: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/db/k", strings.NewReader("v2"))
+	req.SetPathValue("bucket", "db")
+	req.SetPathValue("key", "k")
+	req.Header.Set("If-None-Match", "*")
+
+	w := httptest.NewRecorder()
+	svc.PutObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("If-None-Match:* after a versioned delete: got %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestCompleteMultipartUpload_ConditionalRequest confirms the HTTP-layer
+// wiring for CompleteMultipartUpload's If-Match / If-None-Match
+// preconditions, mirroring PutObject's.
+func TestCompleteMultipartUpload_ConditionalRequest(t *testing.T) {
+	t.Parallel()
+
+	const bucket = "cmu-cond-http"
+
+	store := NewMemoryStorage()
+	svc := New(store, "")
+	ctx := context.Background()
+
+	_ = store.CreateBucket(ctx, bucket)
+
+	if _, err := store.PutObject(ctx, bucket, "k", strings.NewReader("existing"), nil); err != nil {
+		t.Fatalf("seed PutObject: %v", err)
+	}
+
+	upload, err := store.CreateMultipartUpload(ctx, bucket, "k", nil)
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+
+	part, err := store.UploadPart(ctx, bucket, "k", upload.UploadID, 1, strings.NewReader("new body"))
+	if err != nil {
+		t.Fatalf("UploadPart: %v", err)
+	}
+
+	completeBody := `<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>` + part.ETag + `</ETag></Part></CompleteMultipartUpload>`
+
+	req := httptest.NewRequest(http.MethodPost, "/"+bucket+"/k?uploadId="+upload.UploadID, strings.NewReader(completeBody))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", "k")
+	req.Header.Set("If-None-Match", "*")
+
+	w := httptest.NewRecorder()
+	svc.CompleteMultipartUpload(w, req)
+
+	if w.Code != http.StatusPreconditionFailed {
+		t.Fatalf("status: got %d, want %d (body=%s)", w.Code, http.StatusPreconditionFailed, w.Body.String())
+	}
+
+	if !strings.Contains(w.Body.String(), "<Code>PreconditionFailed</Code>") {
+		t.Fatalf("expected PreconditionFailed error body, got %s", w.Body.String())
+	}
+
+	// The failed conditional complete must leave the in-progress upload
+	// alone so the caller can retry (e.g. after resolving the conflict).
+	if _, stillThere := store.Buckets[bucket].MultipartUploads[upload.UploadID]; !stillThere {
+		t.Fatalf("expected in-progress upload to survive a failed conditional complete")
+	}
+
+	// Retrying unconditionally succeeds and consumes the upload.
+	req2 := httptest.NewRequest(http.MethodPost, "/"+bucket+"/k?uploadId="+upload.UploadID, strings.NewReader(completeBody))
+	req2.SetPathValue("bucket", bucket)
+	req2.SetPathValue("key", "k")
+
+	w2 := httptest.NewRecorder()
+	svc.CompleteMultipartUpload(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("unconditional retry status: got %d, want %d (body=%s)", w2.Code, http.StatusOK, w2.Body.String())
+	}
+
+	if _, stillThere := store.Buckets[bucket].MultipartUploads[upload.UploadID]; stillThere {
+		t.Fatalf("expected upload to be removed after a successful complete")
+	}
 }

--- a/internal/service/s3/handlers.go
+++ b/internal/service/s3/handlers.go
@@ -741,19 +741,17 @@ func (s *Service) PutObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cond, ok := resolvePutCondition(w, r)
+	if !ok {
+		return
+	}
+
 	metadata := extractObjectMetadata(r.Header)
 	s.resolveEncryptionMetadata(r.Context(), r.Header, bucket, metadata)
 
-	obj, err := s.storage.PutObject(r.Context(), bucket, key, r.Body, metadata)
+	obj, err := s.storage.PutObjectIf(r.Context(), bucket, key, r.Body, metadata, cond)
 	if err != nil {
-		var bucketErr *BucketError
-		if errors.As(err, &bucketErr) {
-			writeS3Error(w, r, bucketErr.Code, bucketErr.Message, http.StatusNotFound)
-
-			return
-		}
-
-		writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
+		handlePutObjectError(w, r, err)
 
 		return
 	}
@@ -1157,6 +1155,42 @@ func writeNotModifiedResponse(w http.ResponseWriter, obj *Object) {
 	w.Header().Set("ETag", obj.ETag)
 	w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(timeFormatHTTP))
 	w.WriteHeader(http.StatusNotModified)
+}
+
+// resolvePutCondition parses the If-Match / If-None-Match headers for
+// PutObject/CompleteMultipartUpload. If they're malformed (S3 only
+// supports `If-None-Match: *` on writes), it writes the 501
+// NotImplemented response itself and returns ok=false so the caller
+// returns immediately without touching storage.
+func resolvePutCondition(w http.ResponseWriter, r *http.Request) (PutCondition, bool) {
+	cond, ok := parsePutCondition(r.Header)
+	if !ok {
+		writeS3Error(w, r, "NotImplemented", "A header you provided implies functionality that is not implemented", http.StatusNotImplemented)
+	}
+
+	return cond, ok
+}
+
+// handlePutObjectError maps errors from PutObjectIf to their S3 HTTP
+// response: a failed precondition (*ObjectError, see checkPutCondition)
+// keeps its Code and maps to 412/404 via objectErrorStatus, everything
+// else is the same NoSuchBucket/InternalError handling PutObject always had.
+func handlePutObjectError(w http.ResponseWriter, r *http.Request, err error) {
+	var objErr *ObjectError
+	if errors.As(err, &objErr) {
+		writeS3Error(w, r, objErr.Code, objErr.Message, objectErrorStatus(objErr.Code))
+
+		return
+	}
+
+	var bucketErr *BucketError
+	if errors.As(err, &bucketErr) {
+		writeS3Error(w, r, bucketErr.Code, bucketErr.Message, http.StatusNotFound)
+
+		return
+	}
+
+	writeS3Error(w, r, "InternalError", "Internal server error", http.StatusInternalServerError)
 }
 
 // handleGetObjectError handles errors from GetObject/GetObjectVersion.
@@ -2269,7 +2303,12 @@ func (s *Service) CompleteMultipartUpload(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	obj, err := s.storage.CompleteMultipartUpload(r.Context(), bucket, key, uploadID, req.Parts)
+	cond, ok := resolvePutCondition(w, r)
+	if !ok {
+		return
+	}
+
+	obj, err := s.storage.CompleteMultipartUploadIf(r.Context(), bucket, key, uploadID, req.Parts, cond)
 	if err != nil {
 		handleMultipartError(w, r, err)
 
@@ -2536,7 +2575,9 @@ func handleMultipartError(w http.ResponseWriter, r *http.Request, err error) {
 
 	var objectErr *ObjectError
 	if errors.As(err, &objectErr) {
-		writeS3Error(w, r, objectErr.Code, objectErr.Message, http.StatusNotFound)
+		// NoSuchKey (existing callers) is 404; PreconditionFailed
+		// (CompleteMultipartUploadIf, see checkPutCondition) is 412.
+		writeS3Error(w, r, objectErr.Code, objectErr.Message, objectErrorStatus(objectErr.Code))
 
 		return
 	}

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -32,6 +32,10 @@ type Storage interface {
 
 	// Object operations
 	PutObject(ctx context.Context, bucket, key string, body io.Reader, metadata map[string]string) (*Object, error)
+	// PutObjectIf is PutObject with S3 conditional-write preconditions
+	// (If-Match / If-None-Match: *) evaluated atomically with the insert,
+	// so two concurrent conditional PUTs can't both pass.
+	PutObjectIf(ctx context.Context, bucket, key string, body io.Reader, metadata map[string]string, cond PutCondition) (*Object, error)
 	GetObject(ctx context.Context, bucket, key string) (*Object, error)
 	GetObjectVersion(ctx context.Context, bucket, key, versionID string) (*Object, error)
 	DeleteObject(ctx context.Context, bucket, key string) (*Object, error)
@@ -48,6 +52,9 @@ type Storage interface {
 	CreateMultipartUpload(ctx context.Context, bucket, key string, metadata map[string]string) (*MultipartUpload, error)
 	UploadPart(ctx context.Context, bucket, key, uploadID string, partNumber int, body io.Reader) (*Part, error)
 	CompleteMultipartUpload(ctx context.Context, bucket, key, uploadID string, parts []PartRequest) (*Object, error)
+	// CompleteMultipartUploadIf is CompleteMultipartUpload with the same
+	// conditional-write preconditions as PutObjectIf.
+	CompleteMultipartUploadIf(ctx context.Context, bucket, key, uploadID string, parts []PartRequest, cond PutCondition) (*Object, error)
 	AbortMultipartUpload(ctx context.Context, bucket, key, uploadID string) error
 	ListMultipartUploads(ctx context.Context, bucket, prefix string, maxUploads int) ([]*MultipartUpload, error)
 	ListParts(ctx context.Context, bucket, key, uploadID string, maxParts int) ([]*Part, error)
@@ -95,6 +102,19 @@ type Storage interface {
 	DeleteBucketLifecycle(ctx context.Context, bucket string) error
 
 	PutObjectRestore(ctx context.Context, bucket, key string, state *RestoreState) (bool, error)
+}
+
+// PutCondition expresses S3 conditional-write preconditions for
+// PutObjectIf / CompleteMultipartUploadIf. The zero value imposes no
+// condition, matching plain PutObject/CompleteMultipartUpload.
+type PutCondition struct {
+	// IfMatch is the If-Match header value (quoted or unquoted ETag), or
+	// "" if the header was absent.
+	IfMatch string
+	// IfNoneMatchAny is true when the request carried
+	// `If-None-Match: *`, the only If-None-Match form S3 supports on
+	// writes.
+	IfNoneMatchAny bool
 }
 
 // Option is a configuration option for MemoryStorage.
@@ -440,13 +460,25 @@ func (s *MemoryStorage) BucketExists(_ context.Context, name string) (bool, erro
 }
 
 // PutObject stores an object.
-func (s *MemoryStorage) PutObject(_ context.Context, bucket, key string, body io.Reader, metadata map[string]string) (*Object, error) {
+func (s *MemoryStorage) PutObject(ctx context.Context, bucket, key string, body io.Reader, metadata map[string]string) (*Object, error) {
+	return s.PutObjectIf(ctx, bucket, key, body, metadata, PutCondition{})
+}
+
+// PutObjectIf implements Storage.PutObjectIf. The precondition check
+// happens under the same lock as the insert below, so it is atomic with
+// the write: two concurrent conditional PUTs can't both observe "no
+// current object" and both succeed.
+func (s *MemoryStorage) PutObjectIf(_ context.Context, bucket, key string, body io.Reader, metadata map[string]string, cond PutCondition) (*Object, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	b, exists := s.Buckets[bucket]
 	if !exists {
 		return nil, &BucketError{Code: "NoSuchBucket", Message: "The specified bucket does not exist", BucketName: bucket}
+	}
+
+	if err := checkPutCondition(b, key, cond); err != nil {
+		return nil, err
 	}
 
 	data, err := io.ReadAll(body)
@@ -1159,7 +1191,16 @@ func (s *MemoryStorage) objectForCopySourceLocked(bucket, key, versionID string)
 }
 
 // CompleteMultipartUpload completes a multipart upload by assembling parts.
-func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, uploadID string, parts []PartRequest) (*Object, error) {
+func (s *MemoryStorage) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadID string, parts []PartRequest) (*Object, error) {
+	return s.CompleteMultipartUploadIf(ctx, bucket, key, uploadID, parts, PutCondition{})
+}
+
+// CompleteMultipartUploadIf implements Storage.CompleteMultipartUploadIf.
+// Like PutObjectIf, the precondition check runs under the same lock as
+// the insert, and on failure the in-progress upload is left untouched
+// (it's deleted only after a successful complete) so the caller can
+// retry.
+func (s *MemoryStorage) CompleteMultipartUploadIf(_ context.Context, bucket, key, uploadID string, parts []PartRequest, cond PutCondition) (*Object, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1175,6 +1216,10 @@ func (s *MemoryStorage) CompleteMultipartUpload(_ context.Context, bucket, key, 
 
 	if upload.Key != key {
 		return nil, &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
+	}
+
+	if err := checkPutCondition(b, key, cond); err != nil {
+		return nil, err
 	}
 
 	combinedBody, err := assembleMultipartBody(upload, parts, uploadID)

--- a/test/integration/s3_object_ops_test.go
+++ b/test/integration/s3_object_ops_test.go
@@ -344,6 +344,112 @@ func TestS3_RestoreObject(t *testing.T) {
 	assertS3ErrorCode(t, err, "NoSuchKey")
 }
 
+// TestS3_PutObject_ConditionalWrites verifies If-Match / If-None-Match
+// conditional PutObject semantics: If-None-Match:* only succeeds when the
+// key is absent (412 PreconditionFailed otherwise), If-Match only succeeds
+// when it matches the current ETag (412 on mismatch, 404 NoSuchKey when the
+// key doesn't exist yet), and a non-"*" If-None-Match value is rejected
+// with 501 NotImplemented (the only form AWS S3 supports on writes).
+func TestS3_PutObject_ConditionalWrites(t *testing.T) {
+	client := newS3Client(t)
+	ctx := t.Context()
+	bucket := "test-put-object-conditional"
+	key := "conditional.txt"
+
+	if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Fatalf("failed to create bucket: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)})
+		_, _ = client.DeleteBucket(context.Background(), &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	})
+
+	// If-None-Match:* succeeds when the key is absent.
+	putResp, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		Body:        strings.NewReader("v1"),
+		IfNoneMatch: aws.String("*"),
+	})
+	if err != nil {
+		t.Fatalf("If-None-Match:* on a missing key: %v", err)
+	}
+
+	firstETag := aws.ToString(putResp.ETag)
+	if firstETag == "" {
+		t.Fatal("expected an ETag on a successful conditional PutObject")
+	}
+
+	// If-None-Match:* now fails: the key exists.
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		Body:        strings.NewReader("v2"),
+		IfNoneMatch: aws.String("*"),
+	})
+	if err == nil {
+		t.Fatal("expected If-None-Match:* to fail once the key exists")
+	}
+
+	assertS3ErrorCode(t, err, "PreconditionFailed")
+
+	// If-Match with a stale ETag fails.
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String(key),
+		Body:    strings.NewReader("v3"),
+		IfMatch: aws.String(`"stale-etag"`),
+	})
+	if err == nil {
+		t.Fatal("expected If-Match with a stale ETag to fail")
+	}
+
+	assertS3ErrorCode(t, err, "PreconditionFailed")
+
+	// If-Match with the current ETag succeeds and rotates the ETag.
+	putResp2, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String(key),
+		Body:    strings.NewReader("v3"),
+		IfMatch: aws.String(firstETag),
+	})
+	if err != nil {
+		t.Fatalf("If-Match with the current ETag: %v", err)
+	}
+
+	if aws.ToString(putResp2.ETag) == firstETag {
+		t.Fatal("expected a new ETag after a successful conditional PutObject")
+	}
+
+	// If-Match on a key that doesn't exist yet is NoSuchKey, not
+	// PreconditionFailed.
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String("does-not-exist.txt"),
+		Body:    strings.NewReader("x"),
+		IfMatch: aws.String(`"whatever"`),
+	})
+	if err == nil {
+		t.Fatal("expected If-Match on a missing key to fail")
+	}
+
+	assertS3ErrorCode(t, err, "NoSuchKey")
+
+	// If-None-Match with a value other than "*" is not implemented.
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		Body:        strings.NewReader("x"),
+		IfNoneMatch: aws.String(`"some-etag"`),
+	})
+	if err == nil {
+		t.Fatal("expected a non-* If-None-Match value to fail")
+	}
+
+	assertS3ErrorCode(t, err, "NotImplemented")
+}
+
 // postRestoreRequest issues a raw POST /{bucket}/{key}?restore request.
 func postRestoreRequest(t *testing.T, bucket, key, body string) *http.Response {
 	t.Helper()


### PR DESCRIPTION
## Motivation

Applications that use S3 conditional writes for optimistic concurrency
(e.g. a WAL bucket written by multiple writers, using `If-Match` ETag
CAS) can't be tested against kumo today: kumo silently ignores
`If-Match` / `If-None-Match` on `PutObject` and always returns 200.

Verified against kumo v0.28.1:

```console
$ curl -sS -o /dev/null -X PUT "http://localhost:4566/b/k" -d hello -w '%{http_code}\n'
200
$ curl -sS -o /dev/null -X PUT "http://localhost:4566/b/k" -H 'If-None-Match: *' -d again -w '%{http_code}\n'
200   # real S3: 412 PreconditionFailed
$ curl -sS -o /dev/null -X PUT "http://localhost:4566/b/k" -H 'If-Match: "deadbeef"' -d again -w '%{http_code}\n'
200   # real S3: 412 PreconditionFailed
```

Real S3 returns `412 PreconditionFailed` for both of these (and `409
ConditionalRequestConflict` when concurrent conditional writes collide
internally on the S3 side — out of scope here, see below).

## What's implemented

| Header | Object state | Result |
|---|---|---|
| `If-None-Match: *` | key absent (incl. current version is a delete marker) | 200, new ETag |
| `If-None-Match: *` | key exists | 412 `PreconditionFailed` |
| `If-None-Match: <etag>` (anything but `*`) | any | 501 `NotImplemented` — AWS S3 only supports `*` on writes |
| `If-Match: <etag>` | current ETag matches (quoted or unquoted) | 200, new ETag |
| `If-Match: <etag>` | current ETag differs | 412 `PreconditionFailed` |
| `If-Match: <etag>` | key absent | 404 `NoSuchKey` |
| both headers present | — | `If-Match` evaluated first (RFC 9110 §13.1 order) |
| neither header | — | unchanged (unconditional write) |

- The precondition check runs **inside the same storage lock as the
  insert** (`MemoryStorage.PutObjectIf`/`CompleteMultipartUploadIf`, see
  `checkPutCondition` in `internal/service/s3/conditional.go`), so two
  concurrent conditional `PUT`s can't both observe "no current object"
  and both succeed.
- `Storage.PutObject` and `Storage.CompleteMultipartUpload` are now thin
  wrappers around new `PutObjectIf` / `CompleteMultipartUploadIf` methods
  that take a `PutCondition{ IfMatch string; IfNoneMatchAny bool }`
  (zero value = unconditional), so the interface change is
  backward-compatible with every existing caller/test.
- **`CompleteMultipartUpload` is covered too**, with the same two
  headers/semantics as `PutObject`. A failed precondition leaves the
  in-progress upload untouched (it's deleted only on a successful
  complete), so the caller can resolve the conflict and retry — verified
  by a test that fails a conditional complete, confirms the upload
  still exists, then completes it unconditionally.
- `matchesAnyETag` now strips surrounding quotes before comparing, so an
  unquoted `If-Match`/`If-None-Match` value matches kumo's quoted stored
  ETag. This is a one-line change to a shared helper, so it also loosens
  the pre-existing `GetObject` conditional-GET and `CopyObject`
  `x-amz-copy-source-if-*` paths the same way — intentional, matches
  AWS S3's lenient comparison, and doesn't change behavior for any
  already-quoted value (all existing tests still pass unmodified).

## Out of scope

- **`409 ConditionalRequestConflict`** — this is S3's own internal
  concurrency-arbitration response when two conditional writes race
  inside S3 itself; not meaningful for a single-process emulator that
  already serializes the check-and-write under one lock.
- **`CopyObject` destination conditionals** — `CopyObject` doesn't
  accept `If-Match`/`If-None-Match` on the destination in the S3 API (it
  has its own `x-amz-copy-source-if-*` family for the *source*, which
  was already implemented and is untouched by this change).

## How tested

```console
$ make test   # 31 packages, exit 0, no failures
$ make lint   # golangci-lint, 0 issues
```

New unit tests in `internal/service/s3/conditional_test.go`:
`TestMatchesAnyETag_QuoteNormalization`, `TestParsePutCondition`,
`TestCheckPutCondition` (RFC 9110 order + delete-marker-as-absent),
`TestPutObject_ConditionalRequests` (table-driven, HTTP layer),
`TestPutObject_ConditionalRequests_DeleteMarker`,
`TestCompleteMultipartUpload_ConditionalRequest` (412 + upload survival
+ successful retry).

Also added `TestS3_PutObject_ConditionalWrites` to
`test/integration/s3_object_ops_test.go` (uses aws-sdk-go-v2's
`PutObjectInput.IfMatch`/`IfNoneMatch`). `make test-integration` needs
Docker per CONTRIBUTING.md, but the harness just points the SDK at
`KUMO_TEST_ENDPOINT`/`http://localhost:4566`, so I validated it for real
by building the binary and running it directly:

```console
$ go build -o /tmp/kumo-bin ./cmd/kumo && /tmp/kumo-bin serve &
$ go test -C test -tags=integration -run 'TestS3' ./integration/...
ok  	github.com/sivchari/kumo/test/integration	4.121s
```

(the full `TestS3*` suite, not just the new test, against a freshly
started server — all green)

## curl repro (after this change)

```console
$ curl -sS -X PUT "http://localhost:4566/b/k" -H 'If-None-Match: *' -d again
<Error><Code>PreconditionFailed</Code><Message>At least one of the preconditions you specified did not hold.</Message>...</Error>
# 412

$ curl -sS -X PUT "http://localhost:4566/b/k" -H 'If-Match: "deadbeef"' -d again
<Error><Code>PreconditionFailed</Code><Message>At least one of the preconditions you specified did not hold.</Message>...</Error>
# 412
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
