### PR TITLE
fix(s3): round-trip and apply notification key filters (prefix/suffix)

### DIFF
--- a/internal/service/s3/notification_filter_test.go
+++ b/internal/service/s3/notification_filter_test.go
@@ -1,0 +1,248 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// filteredLambdaNotificationXML is a notification configuration with the
+// key filter shape the terraform AWS provider sends for
+// aws_s3_bucket_notification's filter_prefix/filter_suffix arguments.
+const filteredLambdaNotificationXML = `<NotificationConfiguration>` +
+	`<CloudFunctionConfiguration>` +
+	`<Id>filter-config</Id>` +
+	`<CloudFunction>` + testLambdaArn + `</CloudFunction>` +
+	`<Event>s3:ObjectCreated:*</Event>` +
+	`<Filter><S3Key>` +
+	`<FilterRule><Name>prefix</Name><Value>uploads/</Value></FilterRule>` +
+	`<FilterRule><Name>suffix</Name><Value>.jpg</Value></FilterRule>` +
+	`</S3Key></Filter>` +
+	`</CloudFunctionConfiguration></NotificationConfiguration>`
+
+func putNotificationConfigXML(t *testing.T, svc *Service, bucket, body string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"?notification", strings.NewReader(body))
+	req.SetPathValue("bucket", bucket)
+
+	w := httptest.NewRecorder()
+	svc.PutBucketNotificationConfiguration(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutBucketNotificationConfiguration status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+}
+
+// TestNotificationFilter_RoundTrip covers the read-after-write path the
+// terraform AWS provider depends on: filter rules sent in
+// PutBucketNotificationConfiguration must come back verbatim from
+// GetBucketNotificationConfiguration, otherwise every plan after apply
+// re-adds filter_prefix/filter_suffix (perpetual diff).
+func TestNotificationFilter_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const bucket = "notif-filter-roundtrip"
+
+	_, svc := newLambdaNotificationTestService(t, bucket)
+	putNotificationConfigXML(t, svc, bucket, filteredLambdaNotificationXML)
+
+	req := httptest.NewRequest(http.MethodGet, "/"+bucket+"?notification", http.NoBody)
+	req.SetPathValue("bucket", bucket)
+
+	w := httptest.NewRecorder()
+	svc.GetBucketNotificationConfiguration(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetBucketNotificationConfiguration status: got %d, want %d (body=%s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var config NotificationConfiguration
+	if err := xml.Unmarshal(w.Body.Bytes(), &config); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if len(config.LambdaFunctionConfigurations) != 1 {
+		t.Fatalf("LambdaFunctionConfigurations length = %d, want 1", len(config.LambdaFunctionConfigurations))
+	}
+
+	cfg := config.LambdaFunctionConfigurations[0]
+	if cfg.Filter == nil || cfg.Filter.S3Key == nil {
+		t.Fatalf("Filter.S3Key missing from read-back: %s", w.Body.String())
+	}
+
+	rules := cfg.Filter.S3Key.FilterRules
+	if len(rules) != 2 {
+		t.Fatalf("FilterRules length = %d, want 2 (body=%s)", len(rules), w.Body.String())
+	}
+
+	want := map[string]string{"prefix": "uploads/", "suffix": ".jpg"}
+	for _, rule := range rules {
+		if want[rule.Name] != rule.Value {
+			t.Errorf("FilterRule %q = %q, want %q", rule.Name, rule.Value, want[rule.Name])
+		}
+	}
+}
+
+// TestNotificationFilter_LambdaDelivery covers delivery-time semantics: a
+// key filter must gate Lambda invocation the way AWS does — only keys
+// matching every rule of a configuration's S3Key filter fire it.
+func TestNotificationFilter_LambdaDelivery(t *testing.T) {
+	t.Parallel()
+
+	const bucket = "notif-filter-delivery"
+
+	_, svc := newLambdaNotificationTestService(t, bucket)
+	putNotificationConfigXML(t, svc, bucket, filteredLambdaNotificationXML)
+
+	invoker := newFakeLambdaInvoker()
+	svc.SetLambdaInvoker(invoker)
+
+	for _, key := range []string{"other/cat.jpg", "uploads/cat.png"} {
+		w := httptest.NewRecorder()
+		svc.PutObject(w, putObjectRequest(bucket, key, "data"))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("PutObject(%s) status: got %d, want %d", key, w.Code, http.StatusOK)
+		}
+
+		assertNoInvocation(t, invoker)
+	}
+
+	w := httptest.NewRecorder()
+	svc.PutObject(w, putObjectRequest(bucket, "uploads/cat.jpg", "data"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want %d", w.Code, http.StatusOK)
+	}
+
+	inv := waitForInvocation(t, invoker)
+	if inv.functionArn != testLambdaArn {
+		t.Fatalf("functionArn = %q, want %q", inv.functionArn, testLambdaArn)
+	}
+
+	assertNoInvocation(t, invoker)
+}
+
+// TestNotificationFilter_URLEncodedValues covers the AWS encoding contract
+// for filter values: a space must be configured as "+" and other special
+// characters percent-encoded, so matching decodes the rule value before
+// comparing it with the raw object key.
+func TestNotificationFilter_URLEncodedValues(t *testing.T) {
+	t.Parallel()
+
+	const bucket = "notif-filter-encoded"
+
+	_, svc := newLambdaNotificationTestService(t, bucket)
+	putNotificationConfigXML(t, svc, bucket, `<NotificationConfiguration>`+
+		`<CloudFunctionConfiguration>`+
+		`<Id>encoded-config</Id>`+
+		`<CloudFunction>`+testLambdaArn+`</CloudFunction>`+
+		`<Event>s3:ObjectCreated:*</Event>`+
+		`<Filter><S3Key>`+
+		`<FilterRule><Name>prefix</Name><Value>photos+2026/a%2Bb/</Value></FilterRule>`+
+		`</S3Key></Filter>`+
+		`</CloudFunctionConfiguration></NotificationConfiguration>`)
+
+	invoker := newFakeLambdaInvoker()
+	svc.SetLambdaInvoker(invoker)
+
+	// "+" decodes to a space and "%2B" to a literal "+", so the raw
+	// configured string must not match itself as a key.
+	w := httptest.NewRecorder()
+	svc.PutObject(w, putObjectRequest(bucket, "photos+2026/a%2Bb/x.jpg", "data"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want %d", w.Code, http.StatusOK)
+	}
+
+	assertNoInvocation(t, invoker)
+
+	const matchingKey = "photos 2026/a+b/x.jpg"
+
+	req := httptest.NewRequest(http.MethodPut, "/"+bucket+"/"+url.PathEscape(matchingKey), strings.NewReader("data"))
+	req.SetPathValue("bucket", bucket)
+	req.SetPathValue("key", matchingKey)
+
+	w = httptest.NewRecorder()
+	svc.PutObject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want %d", w.Code, http.StatusOK)
+	}
+
+	if inv := waitForInvocation(t, invoker); inv.functionArn != testLambdaArn {
+		t.Fatalf("functionArn = %q, want %q", inv.functionArn, testLambdaArn)
+	}
+}
+
+// fakeSQSPublisher captures SQS deliveries on a buffered channel, mirroring
+// fakeLambdaInvoker.
+type fakeSQSPublisher struct {
+	deliveries chan string
+}
+
+func (f *fakeSQSPublisher) PublishToSQS(_ context.Context, queueArn, _ string) error {
+	f.deliveries <- queueArn
+
+	return nil
+}
+
+// TestNotificationFilter_SQSDelivery covers the same key filter gating on
+// the SQS destination path.
+func TestNotificationFilter_SQSDelivery(t *testing.T) {
+	t.Parallel()
+
+	const (
+		bucket   = "notif-filter-sqs"
+		queueArn = "arn:aws:sqs:us-east-1:000000000000:test-queue"
+	)
+
+	_, svc := newLambdaNotificationTestService(t, bucket)
+	putNotificationConfigXML(t, svc, bucket, `<NotificationConfiguration>`+
+		`<QueueConfiguration>`+
+		`<Id>filter-config</Id>`+
+		`<Queue>`+queueArn+`</Queue>`+
+		`<Event>s3:ObjectCreated:*</Event>`+
+		`<Filter><S3Key>`+
+		`<FilterRule><Name>prefix</Name><Value>uploads/</Value></FilterRule>`+
+		`</S3Key></Filter>`+
+		`</QueueConfiguration></NotificationConfiguration>`)
+
+	publisher := &fakeSQSPublisher{deliveries: make(chan string, 10)}
+	svc.SetSQSPublisher(publisher)
+
+	w := httptest.NewRecorder()
+	svc.PutObject(w, putObjectRequest(bucket, "other/cat.jpg", "data"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want %d", w.Code, http.StatusOK)
+	}
+
+	select {
+	case arn := <-publisher.deliveries:
+		t.Fatalf("unexpected SQS delivery for non-matching key: %s", arn)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	w = httptest.NewRecorder()
+	svc.PutObject(w, putObjectRequest(bucket, "uploads/cat.jpg", "data"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PutObject status: got %d, want %d", w.Code, http.StatusOK)
+	}
+
+	select {
+	case arn := <-publisher.deliveries:
+		if arn != queueArn {
+			t.Fatalf("queueArn = %q, want %q", arn, queueArn)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive SQS delivery within timeout")
+	}
+}

--- a/internal/service/s3/service.go
+++ b/internal/service/s3/service.go
@@ -175,7 +175,7 @@ func (s *Service) emitSQSNotifications(ctx context.Context, bucket, key, eventNa
 	}
 
 	for _, cfg := range configs {
-		if !matchesEventFilter(cfg.Events, eventName) {
+		if !matchesEventFilter(cfg.Events, eventName) || !matchesKeyFilter(cfg.Filter, key) {
 			continue
 		}
 
@@ -210,7 +210,7 @@ func (s *Service) emitLambdaNotifications(ctx context.Context, bucket, key, even
 	}
 
 	for _, cfg := range configs {
-		if !matchesEventFilter(cfg.Events, eventName) {
+		if !matchesEventFilter(cfg.Events, eventName) || !matchesKeyFilter(cfg.Filter, key) {
 			continue
 		}
 
@@ -247,6 +247,45 @@ func matchesEventFilter(filters []string, eventName string) bool {
 	}
 
 	return false
+}
+
+// matchesKeyFilter checks an object key against a configuration's S3Key
+// filter rules. AWS applies every rule: an object must match the prefix
+// rule and the suffix rule when both are present. Rule names are
+// case-insensitive per the S3 notification filtering documentation. A
+// missing filter matches every key.
+func matchesKeyFilter(filter *NotificationFilter, key string) bool {
+	if filter == nil || filter.S3Key == nil {
+		return true
+	}
+
+	for _, rule := range filter.S3Key.FilterRules {
+		switch {
+		case strings.EqualFold(rule.Name, "prefix"):
+			if !strings.HasPrefix(key, decodeFilterValue(rule.Value)) {
+				return false
+			}
+		case strings.EqualFold(rule.Name, "suffix"):
+			if !strings.HasSuffix(key, decodeFilterValue(rule.Value)) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// decodeFilterValue interprets a filter rule value the way AWS documents it:
+// a space is configured as "+" and other special characters are
+// percent-encoded, so the value is URL-decoded before it is compared with
+// the raw object key. A value that does not decode is used verbatim.
+func decodeFilterValue(value string) string {
+	decoded, err := url.QueryUnescape(value)
+	if err != nil {
+		return value
+	}
+
+	return decoded
 }
 
 // emitObjectCreatedEvent sends an S3 Object Created event to EventBridge.

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -453,17 +453,36 @@ type EventBridgeConfig struct{}
 // QueueConfiguration represents an SQS queue destination in the bucket
 // notification configuration.
 type QueueConfiguration struct {
-	ID       string   `xml:"Id,omitempty"       json:"id,omitempty"`
-	QueueArn string   `xml:"Queue"              json:"queue"`
-	Events   []string `xml:"Event"              json:"events"`
+	ID       string              `xml:"Id,omitempty"       json:"id,omitempty"`
+	QueueArn string              `xml:"Queue"              json:"queue"`
+	Events   []string            `xml:"Event"              json:"events"`
+	Filter   *NotificationFilter `xml:"Filter,omitempty"   json:"filter,omitempty"`
 }
 
 // LambdaFunctionConfiguration represents a Lambda destination in the bucket
 // notification configuration.
 type LambdaFunctionConfiguration struct {
-	ID                string   `xml:"Id,omitempty" json:"id,omitempty"`
-	LambdaFunctionArn string   `xml:"CloudFunction" json:"lambdaFunctionArn"`
-	Events            []string `xml:"Event"         json:"events"`
+	ID                string              `xml:"Id,omitempty"     json:"id,omitempty"`
+	LambdaFunctionArn string              `xml:"CloudFunction"    json:"lambdaFunctionArn"`
+	Events            []string            `xml:"Event"            json:"events"`
+	Filter            *NotificationFilter `xml:"Filter,omitempty" json:"filter,omitempty"`
+}
+
+// NotificationFilter restricts a notification configuration to object keys
+// matching its S3Key filter rules.
+type NotificationFilter struct {
+	S3Key *KeyFilter `xml:"S3Key,omitempty" json:"s3Key,omitempty"`
+}
+
+// KeyFilter holds the object key name filter rules.
+type KeyFilter struct {
+	FilterRules []FilterRule `xml:"FilterRule,omitempty" json:"filterRules,omitempty"`
+}
+
+// FilterRule is a single object key name prefix or suffix constraint.
+type FilterRule struct {
+	Name  string `xml:"Name"  json:"name"`
+	Value string `xml:"Value" json:"value"`
 }
 
 // EventNotification is the top-level wrapper sent to SQS when an S3

--- a/test/integration/terraform/fixtures/s3_lambda_notification/main.tf
+++ b/test/integration/terraform/fixtures/s3_lambda_notification/main.tf
@@ -1,0 +1,59 @@
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "demo" {
+  name               = "tf-s3-lambda-notification-demo"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+data "archive_file" "demo" {
+  type        = "zip"
+  output_path = "${path.module}/handler.zip"
+
+  source {
+    content  = "exports.handler = async () => ({ statusCode: 200 });"
+    filename = "index.js"
+  }
+}
+
+resource "aws_lambda_function" "demo" {
+  function_name    = "tf-s3-lambda-notification-demo"
+  role             = aws_iam_role.demo.arn
+  runtime          = "nodejs20.x"
+  handler          = "index.handler"
+  filename         = data.archive_file.demo.output_path
+  source_code_hash = data.archive_file.demo.output_base64sha256
+}
+
+resource "aws_s3_bucket" "demo" {
+  bucket = "tf-s3-lambda-notification-demo"
+}
+
+resource "aws_lambda_permission" "demo" {
+  statement_id  = "AllowS3Invoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.demo.function_name
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.demo.arn
+}
+
+resource "aws_s3_bucket_notification" "demo" {
+  bucket = aws_s3_bucket.demo.id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.demo.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "uploads/"
+    filter_suffix       = ".jpg"
+  }
+
+  depends_on = [aws_lambda_permission.demo]
+}


### PR DESCRIPTION
## Summary

- `aws_s3_bucket_notification`'s `filter_prefix`/`filter_suffix` travel as
  `Filter/S3Key/FilterRule` in PutBucketNotificationConfiguration, but
  kumo's notification types had no `Filter` field: the rules were dropped
  on write and missing from GetBucketNotificationConfiguration, so every
  post-apply plan re-added them (perpetual diff) — and kumo delivered
  events for every key, unlike AWS, which only notifies keys matching all
  filter rules. This was the known follow-up left out of scope in #842.
- Carry `Filter` through the Queue and Lambda notification configurations
  (round-trips through the existing PUT/GET handlers and storage
  persistence untouched) and gate delivery in both emitters: an object
  must match the prefix rule and the suffix rule when both are present,
  rule names are case-insensitive, and rule values are URL-decoded before
  matching — AWS documents that a space is configured as `+` and other
  special characters percent-encoded.
- Add an `s3_lambda_notification` terraform fixture covering the
  bucket + lambda + permission + filtered notification stack through
  apply -> refresh -> plan (no changes) -> destroy.

## Notes

- Before this change: `terraform plan` after apply -> `1 to change`,
  re-adding `filter_prefix`/`filter_suffix` on every run.
- AWS's overlapping prefix/suffix validation on
  PutBucketNotificationConfiguration is not implemented here (kumo stays
  lenient on write, consistent with the existing handlers); a value that
  fails to URL-decode is matched verbatim instead of being rejected.
- `TopicConfiguration` (SNS destinations) remains unsupported, unchanged.

## Test plan

- [x] `make lint` (0 issues), `go test -race ./...`
- [x] New tests: filter rules round-trip PUT -> GET; delivery fires only
      for keys matching every rule (Lambda and SQS paths); `+`/`%2B`
      values decode before matching (space and literal plus)
- [x] `make test-terraform`: new `s3_lambda_notification` fixture passes
      apply/refresh/plan/destroy with zero-change plan — verified on this
      branch standalone (without the lambda tags PR)
