### PR TITLE
fix(s3): stream persistent object uploads to disk

### DIFF
--- a/internal/service/s3/blob.go
+++ b/internal/service/s3/blob.go
@@ -83,6 +83,7 @@ func writeBlobStream(dataDir string, body io.Reader) (_ streamedBlob, retErr err
 	}
 
 	tmpName := tmp.Name()
+
 	defer func() {
 		_ = tmp.Close()
 		if retErr != nil {
@@ -92,6 +93,7 @@ func writeBlobStream(dataDir string, body io.Reader) (_ streamedBlob, retErr err
 
 	md5Hash := md5.New() //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
 	sha256Hash := sha256.New()
+
 	size, err := io.Copy(io.MultiWriter(tmp, md5Hash, sha256Hash), body)
 	if err != nil {
 		return streamedBlob{}, fmt.Errorf("failed to stream body: %w", err)
@@ -102,6 +104,7 @@ func writeBlobStream(dataDir string, body io.Reader) (_ streamedBlob, retErr err
 	}
 
 	ref := hex.EncodeToString(sha256Hash.Sum(nil))
+
 	path := blobPath(dataDir, ref)
 	if _, err := os.Stat(path); err == nil {
 		if err := os.Remove(tmpName); err != nil {

--- a/internal/service/s3/blob.go
+++ b/internal/service/s3/blob.go
@@ -1,9 +1,11 @@
 package s3
 
 import (
+	"crypto/md5" //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -16,6 +18,12 @@ import (
 // process into the OOM killer). Bodies are written as plain bytes, one file per
 // distinct content.
 const objectsDir = "s3-objects"
+
+type streamedBlob struct {
+	ref  string
+	etag string
+	size int64
+}
 
 // bodyRefOf returns the content-address (sha256 hex) used as the blob filename
 // for the given body. Content addressing means identical bodies (object
@@ -58,6 +66,58 @@ func writeBlob(dataDir, ref string, data []byte) error {
 	}
 
 	return nil
+}
+
+// writeBlobStream copies body directly to the blob store while calculating the
+// hashes needed for the content address and S3 ETag. At no point does it buffer
+// the entire object in memory.
+func writeBlobStream(dataDir string, body io.Reader) (_ streamedBlob, retErr error) {
+	dir := filepath.Join(dataDir, objectsDir)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return streamedBlob{}, fmt.Errorf("failed to create objects directory %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".upload-*")
+	if err != nil {
+		return streamedBlob{}, fmt.Errorf("failed to create temporary blob: %w", err)
+	}
+
+	tmpName := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		if retErr != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	md5Hash := md5.New() //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
+	sha256Hash := sha256.New()
+	size, err := io.Copy(io.MultiWriter(tmp, md5Hash, sha256Hash), body)
+	if err != nil {
+		return streamedBlob{}, fmt.Errorf("failed to stream body: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return streamedBlob{}, fmt.Errorf("failed to close temporary blob %s: %w", tmpName, err)
+	}
+
+	ref := hex.EncodeToString(sha256Hash.Sum(nil))
+	path := blobPath(dataDir, ref)
+	if _, err := os.Stat(path); err == nil {
+		if err := os.Remove(tmpName); err != nil {
+			return streamedBlob{}, fmt.Errorf("failed to remove duplicate temporary blob %s: %w", tmpName, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return streamedBlob{}, fmt.Errorf("failed to stat blob %s: %w", path, err)
+	} else if err := os.Rename(tmpName, path); err != nil {
+		return streamedBlob{}, fmt.Errorf("failed to rename blob %s to %s: %w", tmpName, path, err)
+	}
+
+	return streamedBlob{
+		ref:  ref,
+		etag: hex.EncodeToString(md5Hash.Sum(nil)),
+		size: size,
+	}, nil
 }
 
 // readBlob loads the body identified by ref from disk.

--- a/internal/service/s3/blob_test.go
+++ b/internal/service/s3/blob_test.go
@@ -99,10 +99,11 @@ func TestMemoryStorage_PersistentPutKeepsBodyOnDisk(t *testing.T) {
 		t.Fatalf("stored object retained %d body bytes", len(stored.Body))
 	}
 
-	bodyOnDisk, err := os.ReadFile(blobPath(dir, bodyRefOf(body))) //nolint:gosec // path is under t.TempDir
+	bodyOnDisk, err := os.ReadFile(blobPath(dir, bodyRefOf(body)))
 	if err != nil {
 		t.Fatalf("read blob: %v", err)
 	}
+
 	if !bytes.Equal(bodyOnDisk, body) {
 		t.Fatal("blob body differs from uploaded body")
 	}
@@ -111,9 +112,11 @@ func TestMemoryStorage_PersistentPutKeepsBodyOnDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get object: %v", err)
 	}
+
 	if !bytes.Equal(got.Body, body) {
 		t.Fatal("get object body differs from uploaded body")
 	}
+
 	if len(stored.Body) != 0 {
 		t.Fatal("GetObject populated the stored object's body")
 	}
@@ -128,11 +131,13 @@ func TestMemoryStorage_ReloadKeepsBodyOnDiskUntilGet(t *testing.T) {
 	if err := s.CreateBucket(ctx, "b"); err != nil {
 		t.Fatalf("create bucket: %v", err)
 	}
+
 	if _, err := s.PutObject(ctx, "b", "k", bytes.NewReader(body), nil); err != nil {
 		t.Fatalf("put object: %v", err)
 	}
 
 	s2 := saveAndReload(t, s, dir)
+
 	stored := s2.Buckets["b"].Objects["k"]
 	if len(stored.Body) != 0 {
 		t.Fatalf("reload retained %d body bytes", len(stored.Body))
@@ -142,6 +147,7 @@ func TestMemoryStorage_ReloadKeepsBodyOnDiskUntilGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get object: %v", err)
 	}
+
 	if !bytes.Equal(got.Body, body) {
 		t.Fatal("get object body differs from uploaded body")
 	}
@@ -163,11 +169,13 @@ func TestMemoryStorage_PersistentMultipartKeepsPartsAndObjectOnDisk(t *testing.T
 
 	partBodies := [][]byte{[]byte("first part"), []byte("second part")}
 	requests := make([]PartRequest, 0, len(partBodies))
+
 	for i, body := range partBodies {
 		part, err := s.UploadPart(ctx, "b", "k", upload.UploadID, i+1, bytes.NewReader(body))
 		if err != nil {
 			t.Fatalf("upload part %d: %v", i+1, err)
 		}
+
 		if len(part.Body) != 0 {
 			t.Fatalf("part %d retained %d body bytes", i+1, len(part.Body))
 		}
@@ -179,15 +187,18 @@ func TestMemoryStorage_PersistentMultipartKeepsPartsAndObjectOnDisk(t *testing.T
 	if err != nil {
 		t.Fatalf("complete multipart upload: %v", err)
 	}
+
 	if len(obj.Body) != 0 {
 		t.Fatalf("completed object retained %d body bytes", len(obj.Body))
 	}
 
 	want := bytes.Join(partBodies, nil)
+
 	got, err := s.GetObject(ctx, "b", "k")
 	if err != nil {
 		t.Fatalf("get completed object: %v", err)
 	}
+
 	if !bytes.Equal(got.Body, want) {
 		t.Fatalf("completed body = %q, want %q", got.Body, want)
 	}

--- a/internal/service/s3/blob_test.go
+++ b/internal/service/s3/blob_test.go
@@ -48,6 +48,10 @@ func TestMemoryStorage_BodyBlobRoundTrip(t *testing.T) {
 		t.Errorf("snapshot contains raw body; body was not externalized")
 	}
 
+	if bytes.Contains(snapshot, []byte(`"Body"`)) {
+		t.Errorf("snapshot contains the legacy inline Body field")
+	}
+
 	if !bytes.Contains(snapshot, []byte("bodyRef")) {
 		t.Errorf("snapshot missing bodyRef reference")
 	}
@@ -68,6 +72,124 @@ func TestMemoryStorage_BodyBlobRoundTrip(t *testing.T) {
 
 	if !bytes.Equal(obj.Body, body) {
 		t.Errorf("body after reload = %q, want %q", obj.Body, body)
+	}
+}
+
+func TestMemoryStorage_PersistentPutKeepsBodyOnDisk(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	body := bytes.Repeat([]byte("streamed-body"), 1024)
+
+	s := NewMemoryStorage(WithDataDir(dir))
+	if err := s.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	obj, err := s.PutObject(ctx, "b", "k", bytes.NewReader(body), nil)
+	if err != nil {
+		t.Fatalf("put object: %v", err)
+	}
+
+	if len(obj.Body) != 0 {
+		t.Fatalf("returned object retained %d body bytes", len(obj.Body))
+	}
+
+	stored := s.Buckets["b"].Objects["k"]
+	if len(stored.Body) != 0 {
+		t.Fatalf("stored object retained %d body bytes", len(stored.Body))
+	}
+
+	bodyOnDisk, err := os.ReadFile(blobPath(dir, bodyRefOf(body))) //nolint:gosec // path is under t.TempDir
+	if err != nil {
+		t.Fatalf("read blob: %v", err)
+	}
+	if !bytes.Equal(bodyOnDisk, body) {
+		t.Fatal("blob body differs from uploaded body")
+	}
+
+	got, err := s.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("get object: %v", err)
+	}
+	if !bytes.Equal(got.Body, body) {
+		t.Fatal("get object body differs from uploaded body")
+	}
+	if len(stored.Body) != 0 {
+		t.Fatal("GetObject populated the stored object's body")
+	}
+}
+
+func TestMemoryStorage_ReloadKeepsBodyOnDiskUntilGet(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	body := bytes.Repeat([]byte("persisted-body"), 1024)
+
+	s := NewMemoryStorage(WithDataDir(dir))
+	if err := s.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	if _, err := s.PutObject(ctx, "b", "k", bytes.NewReader(body), nil); err != nil {
+		t.Fatalf("put object: %v", err)
+	}
+
+	s2 := saveAndReload(t, s, dir)
+	stored := s2.Buckets["b"].Objects["k"]
+	if len(stored.Body) != 0 {
+		t.Fatalf("reload retained %d body bytes", len(stored.Body))
+	}
+
+	got, err := s2.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("get object: %v", err)
+	}
+	if !bytes.Equal(got.Body, body) {
+		t.Fatal("get object body differs from uploaded body")
+	}
+}
+
+func TestMemoryStorage_PersistentMultipartKeepsPartsAndObjectOnDisk(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	s := NewMemoryStorage(WithDataDir(dir))
+	if err := s.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	upload, err := s.CreateMultipartUpload(ctx, "b", "k", nil)
+	if err != nil {
+		t.Fatalf("create multipart upload: %v", err)
+	}
+
+	partBodies := [][]byte{[]byte("first part"), []byte("second part")}
+	requests := make([]PartRequest, 0, len(partBodies))
+	for i, body := range partBodies {
+		part, err := s.UploadPart(ctx, "b", "k", upload.UploadID, i+1, bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("upload part %d: %v", i+1, err)
+		}
+		if len(part.Body) != 0 {
+			t.Fatalf("part %d retained %d body bytes", i+1, len(part.Body))
+		}
+
+		requests = append(requests, PartRequest{PartNumber: i + 1, ETag: part.ETag})
+	}
+
+	obj, err := s.CompleteMultipartUpload(ctx, "b", "k", upload.UploadID, requests)
+	if err != nil {
+		t.Fatalf("complete multipart upload: %v", err)
+	}
+	if len(obj.Body) != 0 {
+		t.Fatalf("completed object retained %d body bytes", len(obj.Body))
+	}
+
+	want := bytes.Join(partBodies, nil)
+	got, err := s.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("get completed object: %v", err)
+	}
+	if !bytes.Equal(got.Body, want) {
+		t.Fatalf("completed body = %q, want %q", got.Body, want)
 	}
 }
 

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -41,8 +41,12 @@ func (r *blobSequenceReader) Read(p []byte) (int, error) {
 		}
 
 		n, err := r.current.Read(p)
-		if err != io.EOF {
-			return n, err
+		if err != nil && err != io.EOF {
+			return n, fmt.Errorf("failed to read multipart blob: %w", err)
+		}
+
+		if err == nil {
+			return n, nil
 		}
 
 		if closeErr := r.current.Close(); closeErr != nil {
@@ -50,6 +54,7 @@ func (r *blobSequenceReader) Read(p []byte) (int, error) {
 		}
 
 		r.current = nil
+
 		if n > 0 {
 			return n, nil
 		}
@@ -64,7 +69,11 @@ func (r *blobSequenceReader) Close() error {
 	err := r.current.Close()
 	r.current = nil
 
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to close multipart blob: %w", err)
+	}
+
+	return nil
 }
 
 // Versioning status constants.
@@ -369,6 +378,7 @@ func (s *MemoryStorage) persistObjectBody(obj *Object, referenced map[string]str
 	}
 
 	referenced[ref] = struct{}{}
+
 	if len(obj.Body) == 0 {
 		return nil
 	}
@@ -539,6 +549,43 @@ func (s *MemoryStorage) PutObject(ctx context.Context, bucket, key string, body 
 	return s.PutObjectIf(ctx, bucket, key, body, metadata, PutCondition{})
 }
 
+// storedBody is a request body that has been materialized for storage: either
+// streamed to its blob file (data dir configured) or kept in memory.
+type storedBody struct {
+	data    []byte
+	bodyRef string
+	etag    string
+	size    int64
+}
+
+// materializeBody consumes body once. With a data dir it streams straight to
+// the blob file so the bytes never accumulate in memory; without one it keeps
+// the previous in-memory behaviour.
+func (s *MemoryStorage) materializeBody(body io.Reader) (storedBody, error) {
+	if s.dataDir != "" {
+		blob, err := writeBlobStream(s.dataDir, body)
+		if err != nil {
+			return storedBody{}, err
+		}
+
+		return storedBody{bodyRef: blob.ref, etag: blob.etag, size: blob.size}, nil
+	}
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return storedBody{}, fmt.Errorf("failed to read body: %w", err)
+	}
+
+	hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
+
+	return storedBody{
+		data:    data,
+		bodyRef: bodyRefOf(data),
+		etag:    hex.EncodeToString(hash[:]),
+		size:    int64(len(data)),
+	}, nil
+}
+
 // PutObjectIf implements Storage.PutObjectIf. The precondition check
 // happens under the same lock as the insert below, so it is atomic with
 // the write: two concurrent conditional PUTs can't both observe "no
@@ -556,31 +603,12 @@ func (s *MemoryStorage) PutObjectIf(_ context.Context, bucket, key string, body 
 		return nil, err
 	}
 
-	var data []byte
-	var bodyRef, etag string
-	var size int64
-
-	if s.dataDir != "" {
-		blob, err := writeBlobStream(s.dataDir, body)
-		if err != nil {
-			return nil, err
-		}
-
-		bodyRef = blob.ref
-		etag = blob.etag
-		size = blob.size
-	} else {
-		var err error
-		data, err = io.ReadAll(body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read body: %w", err)
-		}
-
-		hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
-		bodyRef = bodyRefOf(data)
-		etag = hex.EncodeToString(hash[:])
-		size = int64(len(data))
+	stored, err := s.materializeBody(body)
+	if err != nil {
+		return nil, err
 	}
+
+	data, bodyRef, etag, size := stored.data, stored.bodyRef, stored.etag, stored.size
 
 	obj := &Object{
 		Key:          key,
@@ -1181,31 +1209,12 @@ func (s *MemoryStorage) UploadPart(_ context.Context, bucket, key, uploadID stri
 		return nil, &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
 	}
 
-	var data []byte
-	var bodyRef, etag string
-	var size int64
-
-	if s.dataDir != "" {
-		blob, err := writeBlobStream(s.dataDir, body)
-		if err != nil {
-			return nil, err
-		}
-
-		bodyRef = blob.ref
-		etag = blob.etag
-		size = blob.size
-	} else {
-		var err error
-		data, err = io.ReadAll(body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read body: %w", err)
-		}
-
-		hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
-		bodyRef = bodyRefOf(data)
-		etag = hex.EncodeToString(hash[:])
-		size = int64(len(data))
+	stored, err := s.materializeBody(body)
+	if err != nil {
+		return nil, err
 	}
+
+	data, bodyRef, etag, size := stored.data, stored.bodyRef, stored.etag, stored.size
 
 	part := &Part{
 		PartNumber:   partNumber,
@@ -1260,25 +1269,12 @@ func (s *MemoryStorage) UploadPartCopy(_ context.Context, dstBucket, dstKey, upl
 		data = data[copyRange.Start : copyRange.End+1]
 	}
 
-	var partBody []byte
-	var bodyRef, etag string
-	var size int64
-	if s.dataDir != "" {
-		blob, err := writeBlobStream(s.dataDir, bytes.NewReader(data))
-		if err != nil {
-			return nil, err
-		}
-
-		bodyRef = blob.ref
-		etag = blob.etag
-		size = blob.size
-	} else {
-		hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
-		partBody = append([]byte(nil), data...)
-		bodyRef = bodyRefOf(partBody)
-		etag = hex.EncodeToString(hash[:])
-		size = int64(len(partBody))
+	stored, err := s.materializeBody(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
 	}
+
+	partBody, bodyRef, etag, size := stored.data, stored.bodyRef, stored.etag, stored.size
 
 	part := &Part{
 		PartNumber:   partNumber,
@@ -1364,33 +1360,10 @@ func (s *MemoryStorage) CompleteMultipartUploadIf(_ context.Context, bucket, key
 	}
 
 	var combinedBody []byte
-	var bodyRef string
-	var size int64
-	if s.dataDir != "" {
-		refs := make([]string, 0, len(selectedParts))
-		for _, part := range selectedParts {
-			refs = append(refs, part.bodyRef)
-		}
 
-		reader := &blobSequenceReader{dataDir: s.dataDir, refs: refs}
-		blob, streamErr := writeBlobStream(s.dataDir, reader)
-		closeErr := reader.Close()
-		if streamErr != nil {
-			return nil, streamErr
-		}
-		if closeErr != nil {
-			return nil, closeErr
-		}
-
-		bodyRef = blob.ref
-		size = blob.size
-	} else {
-		for _, part := range selectedParts {
-			combinedBody = append(combinedBody, part.Body...)
-		}
-
-		bodyRef = bodyRefOf(combinedBody)
-		size = int64(len(combinedBody))
+	combinedBody, bodyRef, size, err := s.combineParts(selectedParts, combinedBody)
+	if err != nil {
+		return nil, err
 	}
 
 	etag := calculateMultipartETag(parts, upload.Parts)
@@ -1415,6 +1388,41 @@ func (s *MemoryStorage) CompleteMultipartUploadIf(_ context.Context, bucket, key
 	s.saveLocked()
 
 	return obj, nil
+}
+
+// combineParts produces the completed object's body. With a data dir the part
+// blobs are concatenated into a new blob file through a streaming reader, so
+// the assembled object never exists in memory; without one the parts are
+// appended as before.
+func (s *MemoryStorage) combineParts(selectedParts []*Part, combinedBody []byte) ([]byte, string, int64, error) {
+	if s.dataDir == "" {
+		for _, part := range selectedParts {
+			combinedBody = append(combinedBody, part.Body...)
+		}
+
+		return combinedBody, bodyRefOf(combinedBody), int64(len(combinedBody)), nil
+	}
+
+	refs := make([]string, 0, len(selectedParts))
+	for _, part := range selectedParts {
+		refs = append(refs, part.bodyRef)
+	}
+
+	reader := &blobSequenceReader{dataDir: s.dataDir, refs: refs}
+
+	blob, streamErr := writeBlobStream(s.dataDir, reader)
+
+	closeErr := reader.Close()
+
+	if streamErr != nil {
+		return nil, "", 0, streamErr
+	}
+
+	if closeErr != nil {
+		return nil, "", 0, closeErr
+	}
+
+	return nil, blob.ref, blob.size, nil
 }
 
 func validateMultipartParts(upload *MultipartUpload, parts []PartRequest, uploadID string) ([]*Part, error) {

--- a/internal/service/s3/storage.go
+++ b/internal/service/s3/storage.go
@@ -1,12 +1,14 @@
 package s3
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5" //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -14,6 +16,56 @@ import (
 
 	"github.com/sivchari/kumo/internal/storage"
 )
+
+type blobSequenceReader struct {
+	dataDir string
+	refs    []string
+	index   int
+	current *os.File
+}
+
+func (r *blobSequenceReader) Read(p []byte) (int, error) {
+	for {
+		if r.current == nil {
+			if r.index >= len(r.refs) {
+				return 0, io.EOF
+			}
+
+			file, err := os.Open(blobPath(r.dataDir, r.refs[r.index]))
+			if err != nil {
+				return 0, fmt.Errorf("failed to open multipart blob: %w", err)
+			}
+
+			r.current = file
+			r.index++
+		}
+
+		n, err := r.current.Read(p)
+		if err != io.EOF {
+			return n, err
+		}
+
+		if closeErr := r.current.Close(); closeErr != nil {
+			return n, fmt.Errorf("failed to close multipart blob: %w", closeErr)
+		}
+
+		r.current = nil
+		if n > 0 {
+			return n, nil
+		}
+	}
+}
+
+func (r *blobSequenceReader) Close() error {
+	if r.current == nil {
+		return nil
+	}
+
+	err := r.current.Close()
+	r.current = nil
+
+	return err
+}
 
 // Versioning status constants.
 const (
@@ -292,6 +344,14 @@ func (s *MemoryStorage) persistBodiesLocked() error {
 				}
 			}
 		}
+
+		for _, upload := range b.MultipartUploads {
+			for _, part := range upload.Parts {
+				if part.bodyRef != "" {
+					referenced[part.bodyRef] = struct{}{}
+				}
+			}
+		}
 	}
 
 	gcBlobs(s.dataDir, referenced)
@@ -303,18 +363,21 @@ func (s *MemoryStorage) persistBodiesLocked() error {
 // reference in referenced (the live set used to GC orphans). Empty bodies carry
 // no blob: an empty or delete-marker object round-trips with a nil body.
 func (s *MemoryStorage) persistObjectBody(obj *Object, referenced map[string]struct{}) error {
+	ref := obj.effectiveRef()
+	if ref == "" {
+		return nil
+	}
+
+	referenced[ref] = struct{}{}
 	if len(obj.Body) == 0 {
 		return nil
 	}
 
-	ref := obj.effectiveRef()
-	referenced[ref] = struct{}{}
-
 	return writeBlob(s.dataDir, ref, obj.Body)
 }
 
-// loadBodiesLocked fills each object's body from the blob store. The caller must
-// hold the write lock.
+// loadBodiesLocked prepares objects restored from the metadata snapshot. Blob
+// bodies stay on disk and are loaded only when an operation needs their bytes.
 func (s *MemoryStorage) loadBodiesLocked() error {
 	for _, b := range s.Buckets {
 		for _, obj := range b.Objects {
@@ -335,32 +398,44 @@ func (s *MemoryStorage) loadBodiesLocked() error {
 	return nil
 }
 
-// loadObjectBody populates one object's body from its blob. An object carrying a
-// legacy inline body (bodyRef empty, Body already set by an older snapshot) is
-// left untouched and gets a freshly computed ref so the next save migrates it to
-// a blob. The current-version object is shared by pointer between Objects and
-// Versions, so this may be called twice on it; the second call is a no-op.
+// loadObjectBody records the reference for a legacy inline body. Referenced
+// blobs are intentionally not read here: doing so would make process RSS grow
+// with all data stored on disk at every startup.
 func (s *MemoryStorage) loadObjectBody(obj *Object) error {
 	if obj.bodyRef == "" {
 		if len(obj.Body) > 0 {
-			obj.bodyRef = bodyRefOf(obj.Body)
+			ref := bodyRefOf(obj.Body)
+			if err := writeBlob(s.dataDir, ref, obj.Body); err != nil {
+				return err
+			}
+
+			obj.bodyRef = ref
+			obj.Body = nil
 		}
 
 		return nil
 	}
 
-	if len(obj.Body) > 0 {
-		return nil
-	}
-
-	data, err := readBlob(s.dataDir, obj.bodyRef)
-	if err != nil {
-		return err
-	}
-
-	obj.Body = data
-
 	return nil
+}
+
+// objectWithBody returns a shallow copy whose body is loaded from the blob
+// store. The stored object remains metadata-only so a GET does not permanently
+// increase the resident set.
+func (s *MemoryStorage) objectWithBody(obj *Object) (*Object, error) {
+	if s.dataDir == "" || obj.bodyRef == "" || len(obj.Body) > 0 {
+		return obj, nil
+	}
+
+	body, err := readBlob(s.dataDir, obj.bodyRef)
+	if err != nil {
+		return nil, err
+	}
+
+	clone := *obj
+	clone.Body = body
+
+	return &clone, nil
 }
 
 // saveLocked persists the current state to disk while the caller holds the lock.
@@ -481,19 +556,38 @@ func (s *MemoryStorage) PutObjectIf(_ context.Context, bucket, key string, body 
 		return nil, err
 	}
 
-	data, err := io.ReadAll(body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read body: %w", err)
+	var data []byte
+	var bodyRef, etag string
+	var size int64
+
+	if s.dataDir != "" {
+		blob, err := writeBlobStream(s.dataDir, body)
+		if err != nil {
+			return nil, err
+		}
+
+		bodyRef = blob.ref
+		etag = blob.etag
+		size = blob.size
+	} else {
+		var err error
+		data, err = io.ReadAll(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read body: %w", err)
+		}
+
+		hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
+		bodyRef = bodyRefOf(data)
+		etag = hex.EncodeToString(hash[:])
+		size = int64(len(data))
 	}
 
-	hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
-	etag := hex.EncodeToString(hash[:])
 	obj := &Object{
 		Key:          key,
 		Body:         data,
-		bodyRef:      bodyRefOf(data),
+		bodyRef:      bodyRef,
 		ETag:         fmt.Sprintf("%q", etag),
-		Size:         int64(len(data)),
+		Size:         size,
 		LastModified: time.Now(),
 		Metadata:     metadata,
 	}
@@ -573,7 +667,7 @@ func (s *MemoryStorage) GetObject(_ context.Context, bucket, key string) (*Objec
 		return nil, &ObjectError{Code: "NoSuchKey", Message: "The specified key does not exist.", Key: key}
 	}
 
-	return obj, nil
+	return s.objectWithBody(obj)
 }
 
 // GetObjectVersion retrieves a specific version of an object.
@@ -593,7 +687,7 @@ func (s *MemoryStorage) GetObjectVersion(_ context.Context, bucket, key, version
 				return nil, &ObjectError{Code: "MethodNotAllowed", Message: "The specified method is not allowed against this resource.", Key: key}
 			}
 
-			return obj, nil
+			return s.objectWithBody(obj)
 		}
 	}
 
@@ -1087,20 +1181,39 @@ func (s *MemoryStorage) UploadPart(_ context.Context, bucket, key, uploadID stri
 		return nil, &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
 	}
 
-	data, err := io.ReadAll(body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read body: %w", err)
-	}
+	var data []byte
+	var bodyRef, etag string
+	var size int64
 
-	hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
-	etag := hex.EncodeToString(hash[:])
+	if s.dataDir != "" {
+		blob, err := writeBlobStream(s.dataDir, body)
+		if err != nil {
+			return nil, err
+		}
+
+		bodyRef = blob.ref
+		etag = blob.etag
+		size = blob.size
+	} else {
+		var err error
+		data, err = io.ReadAll(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read body: %w", err)
+		}
+
+		hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
+		bodyRef = bodyRefOf(data)
+		etag = hex.EncodeToString(hash[:])
+		size = int64(len(data))
+	}
 
 	part := &Part{
 		PartNumber:   partNumber,
 		ETag:         fmt.Sprintf("%q", etag),
-		Size:         int64(len(data)),
+		Size:         size,
 		LastModified: time.Now(),
 		Body:         data,
+		bodyRef:      bodyRef,
 	}
 
 	upload.Parts[partNumber] = part
@@ -1132,7 +1245,12 @@ func (s *MemoryStorage) UploadPartCopy(_ context.Context, dstBucket, dstKey, upl
 		return nil, &MultipartError{Code: "NoSuchUpload", Message: "The specified upload does not exist", UploadID: uploadID}
 	}
 
-	data := srcObj.Body
+	hydratedSrc, err := s.objectWithBody(srcObj)
+	if err != nil {
+		return nil, err
+	}
+
+	data := hydratedSrc.Body
 	if copyRange != nil {
 		size := int64(len(data))
 		if copyRange.Start < 0 || copyRange.End >= size || copyRange.Start > copyRange.End {
@@ -1142,15 +1260,33 @@ func (s *MemoryStorage) UploadPartCopy(_ context.Context, dstBucket, dstKey, upl
 		data = data[copyRange.Start : copyRange.End+1]
 	}
 
-	hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
-	etag := hex.EncodeToString(hash[:])
+	var partBody []byte
+	var bodyRef, etag string
+	var size int64
+	if s.dataDir != "" {
+		blob, err := writeBlobStream(s.dataDir, bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+
+		bodyRef = blob.ref
+		etag = blob.etag
+		size = blob.size
+	} else {
+		hash := md5.Sum(data) //nolint:gosec // MD5 is required for S3 ETag calculation per AWS specification
+		partBody = append([]byte(nil), data...)
+		bodyRef = bodyRefOf(partBody)
+		etag = hex.EncodeToString(hash[:])
+		size = int64(len(partBody))
+	}
 
 	part := &Part{
 		PartNumber:   partNumber,
 		ETag:         fmt.Sprintf("%q", etag),
-		Size:         int64(len(data)),
+		Size:         size,
 		LastModified: time.Now(),
-		Body:         append([]byte(nil), data...),
+		Body:         partBody,
+		bodyRef:      bodyRef,
 	}
 
 	upload.Parts[partNumber] = part
@@ -1222,9 +1358,39 @@ func (s *MemoryStorage) CompleteMultipartUploadIf(_ context.Context, bucket, key
 		return nil, err
 	}
 
-	combinedBody, err := assembleMultipartBody(upload, parts, uploadID)
+	selectedParts, err := validateMultipartParts(upload, parts, uploadID)
 	if err != nil {
 		return nil, err
+	}
+
+	var combinedBody []byte
+	var bodyRef string
+	var size int64
+	if s.dataDir != "" {
+		refs := make([]string, 0, len(selectedParts))
+		for _, part := range selectedParts {
+			refs = append(refs, part.bodyRef)
+		}
+
+		reader := &blobSequenceReader{dataDir: s.dataDir, refs: refs}
+		blob, streamErr := writeBlobStream(s.dataDir, reader)
+		closeErr := reader.Close()
+		if streamErr != nil {
+			return nil, streamErr
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+
+		bodyRef = blob.ref
+		size = blob.size
+	} else {
+		for _, part := range selectedParts {
+			combinedBody = append(combinedBody, part.Body...)
+		}
+
+		bodyRef = bodyRefOf(combinedBody)
+		size = int64(len(combinedBody))
 	}
 
 	etag := calculateMultipartETag(parts, upload.Parts)
@@ -1232,9 +1398,9 @@ func (s *MemoryStorage) CompleteMultipartUploadIf(_ context.Context, bucket, key
 	obj := &Object{
 		Key:          key,
 		Body:         combinedBody,
-		bodyRef:      bodyRefOf(combinedBody),
+		bodyRef:      bodyRef,
 		ETag:         etag,
-		Size:         int64(len(combinedBody)),
+		Size:         size,
 		LastModified: time.Now(),
 		ContentType:  "application/octet-stream",
 	}
@@ -1251,14 +1417,12 @@ func (s *MemoryStorage) CompleteMultipartUploadIf(_ context.Context, bucket, key
 	return obj, nil
 }
 
-// assembleMultipartBody validates the part list (ascending order, no
-// duplicates, ETag match) and concatenates the part bodies in order.
-func assembleMultipartBody(upload *MultipartUpload, parts []PartRequest, uploadID string) ([]byte, error) {
+func validateMultipartParts(upload *MultipartUpload, parts []PartRequest, uploadID string) ([]*Part, error) {
 	if len(parts) == 0 {
 		return nil, &MultipartError{Code: "MalformedXML", Message: "CompleteMultipartUpload requires at least one part", UploadID: uploadID}
 	}
 
-	var combinedBody []byte
+	selectedParts := make([]*Part, 0, len(parts))
 
 	previousPartNumber := 0
 
@@ -1278,10 +1442,10 @@ func assembleMultipartBody(upload *MultipartUpload, parts []PartRequest, uploadI
 			return nil, &MultipartError{Code: "InvalidPart", Message: "One or more of the specified parts could not be found", UploadID: uploadID}
 		}
 
-		combinedBody = append(combinedBody, part.Body...)
+		selectedParts = append(selectedParts, part)
 	}
 
-	return combinedBody, nil
+	return selectedParts, nil
 }
 
 // applyMultipartUploadMetadata carries the Content-Type, user metadata, and

--- a/internal/service/s3/types.go
+++ b/internal/service/s3/types.go
@@ -34,7 +34,7 @@ type LoggingEnabledStatus struct {
 // Object represents an S3 object.
 type Object struct {
 	Key                  string
-	Body                 []byte
+	Body                 []byte `json:"-"`
 	ETag                 string
 	Size                 int64
 	LastModified         time.Time
@@ -79,7 +79,6 @@ func (o *Object) MarshalJSON() ([]byte, error) {
 
 	data, err := json.Marshal(&struct {
 		*alias
-		Body    []byte `json:"-"`
 		BodyRef string `json:"bodyRef,omitempty"`
 	}{
 		alias:   (*alias)(o),
@@ -339,6 +338,7 @@ type Part struct {
 	Size         int64
 	LastModified time.Time
 	Body         []byte
+	bodyRef      string
 }
 
 // InitiateMultipartUploadResult is the response for CreateMultipartUpload.


### PR DESCRIPTION
## Problem

`PutObject`, `UploadPart` and multipart completion read the entire request body into memory with `io.ReadAll` and keep it on the `Object` as `Body`. The object list is serialized into the persistent snapshot, so every stored body stays resident **and** is written back into `s3.json`.

Memory therefore grows with the total number of bytes ever stored, not with the size of a single request. Two ways to hit it:

- many small objects over time (the snapshot keeps them all inline)
- one large object (the whole body is buffered, then persisted inline)

On a machine where the container had no memory limit, this ended in an OOM kill of the process. In one instance the snapshot file had grown to 193 MiB with 867 inline bodies.

## Change

When a data dir is configured, the body can go straight to the content-addressed blob file, with MD5 (ETag) and SHA-256 (blob reference) computed during the stream, and read back only when a request needs the bytes.

- stream `PutObject` and `UploadPart` bodies to the blob file
- assemble multipart uploads by concatenating part blobs instead of buffering the result
- compute ETag and blob reference while streaming
- keep `Body` out of the snapshot, and migrate existing inline bodies when an old snapshot is loaded
- fall back to the previous in-memory path when no data dir is configured (in-memory mode is unchanged)

## Measurements

On a 2 GiB container:

| scenario | before | after |
| --- | --- | --- |
| store 610 MiB of objects | OOM kill | RSS 36.8 MiB → 38.6 MiB |
| single 500 MiB `PutObject` under a 256 MiB limit | OOM kill | RSS 13.5 MiB → 21.2 MiB, request succeeds |
| snapshot after migration | 193 MiB, 867 inline bodies | 525 KiB, 0 inline bodies |

## Notes

- `go test ./...` passes, including the S3 race test.
- Existing data dirs keep working: inline bodies in an old snapshot are migrated to blob files on load.
- Large `GetObject` and `CopyObject` still load bodies fully; those paths are left as they are in this change.
